### PR TITLE
Add sparse parameters to CVXPY

### DIFF
--- a/cvxpy/expressions/constants/parameter.py
+++ b/cvxpy/expressions/constants/parameter.py
@@ -93,7 +93,7 @@ class Parameter(Leaf):
         """NumPy.ndarray or None: The numeric value of the parameter.
         """
         if self.sparse:
-            return self.Indexer @ self._parameter.value
+            return (self.Indexer @ self._parameter.value).reshape(self.shape, order='C')
         else:
             return self._value
 


### PR DESCRIPTION
Here's my first pass (it doesn't work.)

Here's the API I'm proposing:
```python
import cvxpy as cp
import numpy as np
import scipy.sparse

m, n = 50, 10

b = np.random.randn(m)
Avalue = scipy.sparse.random(m, n, density=.5, format='coo')

x = cp.Variable(n)
A = cp.Parameter((m, n), sparse=True, nonzero=Avalue.nonzero())
problem2 = cp.Problem(cp.Minimize(cp.sum_squares(A @ x - b)))
A.value = Avalue.data
problem2.solve()
```