### PR TITLE
Help page pointing to cvxpy analyzer

### DIFF
--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -109,7 +109,7 @@ class QuadForm(Atom):
     def _grad(self, values):
         x = np.array(values[0])
         P = np.array(values[1])
-        D = (P + P.H) @ x.T
+        D = (P + np.conj(P).T) @ x.T
         return [sp.csc_matrix(D.ravel(order='F')).T]
 
     def shape_from_args(self):

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -17,7 +17,7 @@ limitations under the License.
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 import scipy.sparse as sp
 import cvxpy
 from cvxpy.settings import EIGVAL_TOL

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -17,7 +17,7 @@ limitations under the License.
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal
+from numpy.testing import assert_allclose
 import scipy.sparse as sp
 import cvxpy
 from cvxpy.settings import EIGVAL_TOL

--- a/doc/source/help/index.rst
+++ b/doc/source/help/index.rst
@@ -1,0 +1,30 @@
+.. _help:
+
+Help
+====
+
+If you need help with CVXPY, first try using the [CVXPY analyzer](https://github.com/cvxgrp/cvxpyanalyzer). Simply install the package via
+
+  ::
+
+      pip install cvxpyanalyzer
+
+Then pass the CVXPY problem you need help with to the ``tech_support`` function.
+
+.. code:: python
+
+  from analyzer import tech_support
+
+  # Construct CVXPY problem.
+  ...
+
+  # Analyze the problem.
+  tech_support(problem)
+
+The ``tech_support`` function will guide you through a process of debugging
+and analyzing the problem.
+
+If you still need help after using the CVXPY analyzer,
+you can post a question on [StackOverflow](https://stackoverflow.com/search?q=cvxpy) or on the `CVXPY mailing list <https://groups.google.com/forum/#!forum/cvxpy>`_.
+If you've found a bug in CVXPY or have a feature request,
+create an issue on the `CVXPY Github issue tracker <https://github.com/cvxgrp/cvxpy/issues>`_.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -129,6 +129,12 @@ guide </contributing/index>`.
    :maxdepth: 1
    :hidden:
 
+   help/index
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
    faq/index
 
 .. toctree::


### PR DESCRIPTION
I'd like to promote the [cvxpy analyzer](https://github.com/cvxgrp/cvxpyanalyzer) as a debugging tool for users. The center of the repo right now is a debugging/analyzer function. Right now it checks if you have the latest cvxpy version, if your problem is convex, and guides you through using different solvers if you're getting a bad answer.  Feel free to suggest additional checks.

The repository is also for useful scripts that might in the future be included in cvxpy. #1168 is an example.