### PR TITLE
Allow zero length variables

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -94,7 +94,7 @@ class Leaf(expression.Expression):
             raise ValueError("Expressions of dimension greater than 2 "
                              "are not supported.")
         for d in shape:
-            if not isinstance(d, numbers.Integral) or d <= 0:
+            if not isinstance(d, numbers.Integral) or d < 0:
                 raise ValueError("Invalid dimensions %s." % (shape,))
         self._shape = tuple(np.int32(d) for d in shape)
 

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -88,8 +88,8 @@ class TestExpressions(BaseTest):
                          "Cannot set more than one special attribute in Variable.")
 
         with self.assertRaises(Exception) as cm:
-            Variable((2, 0))
-        self.assertEqual(str(cm.exception), "Invalid dimensions (2, 0).")
+            Variable((2, -1))
+        self.assertEqual(str(cm.exception), "Invalid dimensions (2, -1).")
 
         with self.assertRaises(Exception) as cm:
             Variable((2, .5))


### PR DESCRIPTION
Allows zero-length `cvxpy.Variable`s.

This is to increase consistency with other standard libraries that deal with matrix concepts (e.g. `numpy`, `scipy` and `pandas`).