### PR TITLE
Fix CVXOPT's handling of degenerate problems

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
@@ -118,7 +118,7 @@ class CVXOPT(ECOS):
         data[s.B] = b[:len_eq].flatten()
         if data[s.B].shape[0] == 0:
             data[s.B] = None
-        if len_eq > A.shape[1]:
+        if len_eq >= A.shape[0]:
             # Then the given optimization problem has no conic constraints.
             # This is certainly a degenerate case, but we'll handle it downstream.
             data[s.G] = sp.csc_matrix((1, A.shape[1]))


### PR DESCRIPTION
For #1147. The case-check at line 121 was meant to identify when a problem had no conic constraints. However, it actually identified when a problem had more linear equations than variables (in which case the constraints are either redundant or the problem is trivially infeasible). This change should get us the behavior that was intended from the start.

Despite the simplicity of this change, this PR should not be merged until (1) all CI tests pass and (2) some reviewers approve (I'll request reviewers once tests pass).

Edit: I realize this PR was made on a branch of the main cvxpy repository, rather than my fork. That wasn't intended and I'll avoid that in the future. That said, I see no harm in continuing with this as-is.