### PR TITLE
Logistic atom - improved gradient calculation

### DIFF
--- a/cvxpy/atoms/elementwise/logistic.py
+++ b/cvxpy/atoms/elementwise/logistic.py
@@ -75,6 +75,5 @@ class logistic(Elementwise):
         """
         rows = self.args[0].size
         cols = self.size
-        exp_val = np.exp(values[0])
-        grad_vals = exp_val/(1 + exp_val)
+        grad_vals = np.exp(values[0] - np.logaddexp(0, values[0]))
         return [logistic.elemwise_grad_to_diag(grad_vals, rows, cols)]


### PR DESCRIPTION
Connected to this question on Stack Overflow: https://stackoverflow.com/questions/67062485/overflow-while-using-logistic-function-in-cvxpy.

Current implementation of logistic atom overflows when one of the elements in the input vector exceeds ~710 due to np.exp invocation. Atom evaluation doesn't have this problem - it uses np.logaddexp to handle big values.

I've rewritten gradient implementation to utilize np.logaddexp call, which prevents overflow from happening. First we calculate the solution in the logarithmic scale, and only after we take an exponent of the resulting value.