### PR TITLE
use flexible numpy version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
 requires = [
-    "numpy==1.15; python_version=='3.6'",
-    "numpy==1.15; python_version=='3.7'",
-    "numpy==1.16; python_version=='3.8'",
-    "numpy==1.19; python_version=='3.9'",
+    "numpy>=1.15,<1.16; python_version=='3.6'",
+    "numpy>=1.15,<1.16; python_version=='3.7'",
+    "numpy>=1.16,<1.17; python_version=='3.8'",
+    "numpy>=1.19,<1.20; python_version=='3.9'",
     "scipy >= 1.1.0",
     "setuptools>=40.8.0",
     "wheel"


### PR DESCRIPTION
the only version number that matters for ABI interface purposes is the first minor version number. Therefore, use flexible versions here to allow pip to select a newer version of numpy if it so wishes. This speeds up the install time on linux for python 3.9 because a pre-built numpy wheel for 1.19.0 does not exist at that python version, but 1.19.5 does exist.