### PR TITLE
Remove Python 3.5 references

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-18.04, macos-10.15 ]
-        python-version: [ 3.5, 3.6, 3.7, 3.9 ]
+        python-version: [ 3.6, 3.7, 3.9 ]
         include:
           - os: ubuntu-18.04
             python-version: 3.8

--- a/README.md
+++ b/README.md
@@ -68,11 +68,10 @@ conda install -c conda-forge cvxpy
 
 CVXPY has the following dependencies:
 
-- Python >= 3.5
-- multiprocess
-- OSQP
+- Python >= 3.6
+- OSQP >= 0.4.1
 - ECOS >= 2
-- SCS >= 1.1.3
+- SCS >= 1.1.6
 - NumPy >= 1.15
 - SciPy >= 1.1.0
 

--- a/continuous_integration/GitHub/install_dependencies.sh
+++ b/continuous_integration/GitHub/install_dependencies.sh
@@ -10,9 +10,7 @@ if [[ "$RUNNER_OS" == "Linux" ]]; then
     sudo apt-get install -qq gfortran libgfortran3
 fi
 
-if [[ "$PYTHON_VERSION" == "3.5" ]]; then
-  conda install mkl pip pytest scipy=1.1 numpy=1.15 lapack ecos scs osqp flake8 cvxopt
-elif [[ "$PYTHON_VERSION" == "3.6" ]]; then
+if [[ "$PYTHON_VERSION" == "3.6" ]]; then
   conda install mkl pip pytest scipy=1.1 numpy=1.15 lapack ecos scs osqp flake8 cvxopt
 elif [[ "$PYTHON_VERSION" == "3.7" ]]; then
   conda install mkl pip pytest scipy=1.1 numpy=1.15 lapack ecos scs osqp flake8 cvxopt

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -69,7 +69,7 @@ We strongly recommend using a fresh virtual environment (virtualenv or conda) wh
 
 CVXPY has the following dependencies:
 
- * Python >= 3.5
+ * Python >= 3.6
  * `OSQP`_
  * `ECOS`_ >= 2
  * `SCS`_ >= 1.1.3

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -70,9 +70,9 @@ We strongly recommend using a fresh virtual environment (virtualenv or conda) wh
 CVXPY has the following dependencies:
 
  * Python >= 3.6
- * `OSQP`_
+ * `OSQP`_ >= 0.4.1
  * `ECOS`_ >= 2
- * `SCS`_ >= 1.1.3
+ * `SCS`_ >= 1.1.6
  * `NumPy`_ >= 1.15
  * `SciPy`_ >= 1.1.0
 

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     zip_safe=False,
     description='A domain-specific language for modeling convex optimization '
                 'problems in Python.',
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     install_requires=["osqp >= 0.4.1",
                       "ecos >= 2",
                       "scs >= 1.1.6",


### PR DESCRIPTION
@rileyjmurray @SteveDiamond as per discussion in #1375, this PR drops Python 3.5 support from the CI and updates the docs.