### PR TITLE
remove model update within soc constraint for loop

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -329,7 +329,6 @@ class GUROBI(SCS):
                     lb=-gp.GRB.INFINITY,
                     ub=gp.GRB.INFINITY)
             ]
-        model.update()
 
         new_lin_constrs = []
         for i, row in enumerate(rows):


### PR DESCRIPTION
I'm working on a model with > 10k SOC constraints. The model updates are adding 60s and there's a warning from Gurobi that says
```
Warning: excessive time spent in model updates.
```
In the for loop while adding SOC constraints, there's a Gurobi `model.update()` that's causing this.
Since you're not using the model to get anything between adding these constraints and then optimizing, there's no real reason to have it there at all.