### PR TITLE
More Solvers for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,6 @@ jobs:
 
       - name: Install
         run: |
-          if [ "$RUNNER_OS" = "macOS" ]; then CC=gcc ; fi
-          if [ "$RUNNER_OS" = "macOS" ]; then CXX=g++; fi
           source continuous_integration/install_dependencies.sh
 
       - name: Test

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -5,33 +5,35 @@
 
 set -e
 
-if [[ "$RUNNER_OS" == "Linux" ]]; then
-    sudo apt-get update -qq
-    sudo apt-get install -qq gfortran libgfortran3
-fi
-
-
-if [[ "$PYTHON_VERSION" == "3.6" ]]; then
+if [[ "$PYTHON_VERSION" == "3.6" ]] || [[ "$PYTHON_VERSION" == "3.7" ]] || [[ "$PYTHON_VERSION" == "3.8" ]]; then
   conda install scipy=1.3 numpy=1.16 mkl pip pytest lapack ecos scs osqp flake8 cvxopt
-elif [[ "$PYTHON_VERSION" == "3.7" ]]; then
-  conda install scipy=1.3 numpy=1.16 mkl pip pytest lapack ecos scs osqp flake8 cvxopt
-elif [[ "$PYTHON_VERSION" == "3.8" ]]; then
-  # There is a config that works with numpy 1.14, but not 1.15!
-  # So we fix things at 1.16.
-  # Assuming we use numpy 1.16, the earliest version of scipy we can use is 1.3.
-  conda install scipy=1.3 numpy=1.16 mkl pip pytest lapack ecos scs osqp flake8 cvxopt
+  python -m pip install cplex  # CPLEX is not available yet on 3.9
 elif [[ "$PYTHON_VERSION" == "3.9" ]]; then
   # The earliest version of numpy that works is 1.19.
   # Given numpy 1.19, the earliest version of scipy we can use is 1.5.
   conda install scipy=1.5 numpy=1.19 mkl pip pytest lapack ecos scs osqp flake8 cvxopt
 fi
 
-if [[ "$USE_OPENMP" == "True" ]]; then
-    conda install -c conda-forge openmp
+# CBC comes with wheels for windows and needs coin-or-cbc to compile otherwise
+# conda-forge in progress: https://github.com/conda-forge/staged-recipes/pull/14950
+if [[ "$RUNNER_OS" != "Windows" ]]; then
+  conda install coin-or-cbc
+fi
+if [[ "$PYTHON_VERSION" != "3.6" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then
+  python -m pip install cylp
 fi
 
-python -m pip install diffcp gurobipy
+# SCIP only works with scipy >= 1.5 due to dependency conflicts when installing on Linux/macOS
+if [[ "$PYTHON_VERSION" == "3.9" ]] || [[ "$RUNNER_OS" == "Windows" ]]; then
+  conda install pyscipopt
+fi
+
+python -m pip install diffcp gurobipy xpress
+
+if [[ "$USE_OPENMP" == "True" ]]; then
+  conda install -c conda-forge openmp
+fi
 
 if [[ "$COVERAGE" == "True" ]]; then
-    python -m pip install coverage coveralls
+  python -m pip install coverage coveralls
 fi

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -13,8 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import numpy as np
 import warnings
+
+import numpy as np
+
 import cvxpy as cp
 from cvxpy.tests.base_test import BaseTest
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -625,7 +625,7 @@ class TestCBC(BaseTest):
         StandardTestLPs.test_lp_4(solver='CBC')
 
     def test_cbc_lp_5(self) -> None:
-        StandardTestLPs.test_lp_5(solver='CBC')
+        StandardTestLPs.test_lp_5(solver='CBC', duals=False)
 
     def test_cbc_mi_lp_0(self) -> None:
         StandardTestLPs.test_mi_lp_0(solver='CBC')
@@ -1233,13 +1233,13 @@ class TestSCIP(unittest.TestCase):
         StandardTestSOCPs.test_socp_1(solver="SCIP", places=3, duals=False)
 
     def test_scip_socp_2(self) -> None:
-        StandardTestSOCPs.test_socp_2(solver="SCIP", places=2)
+        StandardTestSOCPs.test_socp_2(solver="SCIP", places=2, duals=False)
 
     def test_scip_socp_3(self) -> None:
         # axis 0
-        StandardTestSOCPs.test_socp_3ax0(solver="SCIP")
+        StandardTestSOCPs.test_socp_3ax0(solver="SCIP", duals=False)
         # axis 1
-        StandardTestSOCPs.test_socp_3ax1(solver="SCIP")
+        StandardTestSOCPs.test_socp_3ax1(solver="SCIP", duals=False)
 
     def test_scip_mi_lp_0(self) -> None:
         StandardTestLPs.test_mi_lp_0(solver="SCIP")


### PR DESCRIPTION
This is the follow-up to #1413.

The following solvers are added to the CI:

Platform | XPRESS | CPLEX | CBC | SCIP
-- | -- | -- | -- | --
Linux 3.6 | yes | yes | yes | no
Linux 3.7 | yes | yes | yes | no
Linux 3.8 | yes | yes | yes | no
Linux 3.9 | yes | no | yes | yes
macOS 3.6 | yes | yes | yes | no
macOS 3.7 | yes | yes | yes | no
macOS 3.8 | yes | yes | yes | no
macOS 3.9 | yes | no | yes | yes
Windows 3.6 | yes | yes | no | yes
Windows 3.7 | yes | yes | yes | yes
Windows 3.8 | yes | yes | yes | yes
Windows 3.9 | yes | no | yes | yes

I have added a short description of the exclusion criteria to the code, such that one can easily see when those restrictions are lifted in the future. 