### PR TITLE
Adding dual variables for SciPy LP solver interfaces #1425

### DIFF
--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1434,13 +1434,13 @@ class TestECOS_BB(unittest.TestCase):
 class TestSCIPY(unittest.TestCase):
 
     def test_scipy_lp_0(self) -> None:
-        StandardTestLPs.test_lp_0(solver='SCIPY')
+        StandardTestLPs.test_lp_0(solver='SCIPY', duals=False)
 
     def test_scipy_lp_1(self) -> None:
-        StandardTestLPs.test_lp_1(solver='SCIPY')
+        StandardTestLPs.test_lp_1(solver='SCIPY', duals=False)
 
     def test_scipy_lp_2(self) -> None:
-        StandardTestLPs.test_lp_2(solver='SCIPY')
+        StandardTestLPs.test_lp_2(solver='SCIPY', duals=False)
 
     def test_scipy_lp_3(self) -> None:
         StandardTestLPs.test_lp_3(solver='SCIPY')
@@ -1449,4 +1449,4 @@ class TestSCIPY(unittest.TestCase):
         StandardTestLPs.test_lp_4(solver='SCIPY')
 
     def test_scipy_lp_5(self) -> None:
-        StandardTestLPs.test_lp_5(solver='SCIPY')
+        StandardTestLPs.test_lp_5(solver='SCIPY', duals=False)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1434,13 +1434,13 @@ class TestECOS_BB(unittest.TestCase):
 class TestSCIPY(unittest.TestCase):
 
     def test_scipy_lp_0(self) -> None:
-        StandardTestLPs.test_lp_0(solver='SCIPY', duals=False)
+        StandardTestLPs.test_lp_0(solver='SCIPY')
 
     def test_scipy_lp_1(self) -> None:
-        StandardTestLPs.test_lp_1(solver='SCIPY', duals=False)
+        StandardTestLPs.test_lp_1(solver='SCIPY')
 
     def test_scipy_lp_2(self) -> None:
-        StandardTestLPs.test_lp_2(solver='SCIPY', duals=False)
+        StandardTestLPs.test_lp_2(solver='SCIPY')
 
     def test_scipy_lp_3(self) -> None:
         StandardTestLPs.test_lp_3(solver='SCIPY')
@@ -1449,4 +1449,4 @@ class TestSCIPY(unittest.TestCase):
         StandardTestLPs.test_lp_4(solver='SCIPY')
 
     def test_scipy_lp_5(self) -> None:
-        StandardTestLPs.test_lp_5(solver='SCIPY', duals=False)
+        StandardTestLPs.test_lp_5(solver='SCIPY')

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -33,6 +33,7 @@ from cvxpy.tests.solver_test_helpers import (
     StandardTestSOCPs,
     StandardTestPCPs
 )
+from distutils.version import StrictVersion
 
 
 class TestECOS(BaseTest):
@@ -1433,14 +1434,18 @@ class TestECOS_BB(unittest.TestCase):
 
 class TestSCIPY(unittest.TestCase):
 
+    def setUp(self):
+        import scipy
+        self.d = StrictVersion(scipy.__version__) >= StrictVersion('1.7.0')
+
     def test_scipy_lp_0(self) -> None:
-        StandardTestLPs.test_lp_0(solver='SCIPY', duals=False)
+        StandardTestLPs.test_lp_0(solver='SCIPY', duals=self.d)
 
     def test_scipy_lp_1(self) -> None:
-        StandardTestLPs.test_lp_1(solver='SCIPY', duals=False)
+        StandardTestLPs.test_lp_1(solver='SCIPY', duals=self.d)
 
     def test_scipy_lp_2(self) -> None:
-        StandardTestLPs.test_lp_2(solver='SCIPY', duals=False)
+        StandardTestLPs.test_lp_2(solver='SCIPY', duals=self.d)
 
     def test_scipy_lp_3(self) -> None:
         StandardTestLPs.test_lp_3(solver='SCIPY')
@@ -1449,4 +1454,4 @@ class TestSCIPY(unittest.TestCase):
         StandardTestLPs.test_lp_4(solver='SCIPY')
 
     def test_scipy_lp_5(self) -> None:
-        StandardTestLPs.test_lp_5(solver='SCIPY', duals=False)
+        StandardTestLPs.test_lp_5(solver='SCIPY', duals=self.d)


### PR DESCRIPTION
Adding dual variables when the SciPy solver is used with methods "highs", "highs-ds" or "highs-ipm" and the Scipy version is >= 1.7.0 . Linked to Issue #1425 .