### PR TITLE
Specify solvers in tests

### DIFF
--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -926,13 +926,13 @@ class TestAtoms(BaseTest):
         # Solve the (simple) two-stage problem by "combining" the two stages
         # (i.e., by solving a single linear program)
         p1 = Problem(Minimize(x+y), [x+y >= 3, y >= 4, x >= 5])
-        p1.solve(solver=cp.SCS)
+        p1.solve(solver=cp.ECOS)
 
         # Solve the two-stage problem via partial_optimize
         p2 = Problem(Minimize(y), [x+y >= 3, y >= 4])
         g = partial_optimize(p2, [y], [x], solver='ECOS')
         p3 = Problem(Minimize(x+g), [x >= 5])
-        p3.solve(solver=cp.SCS)
+        p3.solve(solver=cp.ECOS)
         self.assertAlmostEqual(p1.value, p3.value)
 
     @unittest.skipUnless(len(INSTALLED_MI_SOLVERS) > 0, 'No mixed-integer solver is installed.')

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -534,7 +534,7 @@ class TestAtoms(BaseTest):
 
         X = cp.Variable((5, 2))
         prob = cp.Problem(cp.Minimize(0), [X == A_cp])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(A_np, X.value)
 
         a_np = np.reshape(A_np, 10, order='C')
@@ -544,7 +544,7 @@ class TestAtoms(BaseTest):
 
         x = cp.Variable(10)
         prob = cp.Problem(cp.Minimize(0), [x == a_cp])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(a_np, x.value)
 
         # Test more complex C-style reshape: matrix to another matrix
@@ -558,7 +558,7 @@ class TestAtoms(BaseTest):
         X = cp.Variable(b.shape)
         X_reshaped = cp.reshape(X, (2, 6), order='C')
         prob = cp.Problem(cp.Minimize(0), [X_reshaped == b_reshaped])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(b_reshaped, X_reshaped.value)
         self.assertItemsAlmostEqual(b, X.value)
 
@@ -863,44 +863,44 @@ class TestAtoms(BaseTest):
         x, t = Variable(dims), Variable(dims)
         xval = [-5]*dims
         p1 = Problem(cp.Minimize(cp.sum(t)), [-t <= xval, xval <= t])
-        p1.solve()
+        p1.solve(solver='ECOS')
 
         # Minimize the 1-norm via partial_optimize.
         p2 = Problem(cp.Minimize(cp.sum(t)), [-t <= x, x <= t])
-        g = partial_optimize(p2, [t], [x])
+        g = partial_optimize(p2, [t], [x], solver='ECOS')
         p3 = Problem(cp.Minimize(g), [x == xval])
-        p3.solve()
+        p3.solve(solver='ECOS')
         self.assertAlmostEqual(p1.value, p3.value)
 
         # Minimize the 1-norm using maximize.
         p2 = Problem(cp.Maximize(cp.sum(-t)), [-t <= x, x <= t])
-        g = partial_optimize(p2, opt_vars=[t])
+        g = partial_optimize(p2, opt_vars=[t], solver='ECOS')
         p3 = Problem(cp.Maximize(g), [x == xval])
-        p3.solve()
+        p3.solve(solver='ECOS')
         self.assertAlmostEqual(p1.value, -p3.value)
 
         # Try leaving out args.
 
         # Minimize the 1-norm via partial_optimize.
         p2 = Problem(cp.Minimize(cp.sum(t)), [-t <= x, x <= t])
-        g = partial_optimize(p2, opt_vars=[t])
+        g = partial_optimize(p2, opt_vars=[t], solver='ECOS')
         p3 = Problem(cp.Minimize(g), [x == xval])
-        p3.solve()
+        p3.solve(solver='ECOS')
         self.assertAlmostEqual(p1.value, p3.value)
 
         # Minimize the 1-norm via partial_optimize.
-        g = partial_optimize(p2, dont_opt_vars=[x])
+        g = partial_optimize(p2, dont_opt_vars=[x], solver='ECOS')
         p3 = Problem(cp.Minimize(g), [x == xval])
-        p3.solve()
+        p3.solve(solver='ECOS')
         self.assertAlmostEqual(p1.value, p3.value)
 
         with self.assertRaises(Exception) as cm:
-            g = partial_optimize(p2)
+            g = partial_optimize(p2, solver='ECOS')
         self.assertEqual(str(cm.exception),
                          "partial_optimize called with neither opt_vars nor dont_opt_vars.")
 
         with self.assertRaises(Exception) as cm:
-            g = partial_optimize(p2, [], [x])
+            g = partial_optimize(p2, [], [x], solver='ECOS')
         self.assertEqual(str(cm.exception),
                          ("If opt_vars and new_opt_vars are both specified, "
                           "they must contain all variables in the problem.")
@@ -913,11 +913,11 @@ class TestAtoms(BaseTest):
         p1 = Problem(Minimize(cp.sum(t)), [-t <= x, x <= t])
 
         # Minimize the 1-norm via partial_optimize
-        g = partial_optimize(p1, [t], [x])
+        g = partial_optimize(p1, [t], [x], solver='ECOS')
         p2 = Problem(Minimize(g))
-        p2.solve()
+        p2.solve(solver='ECOS')
 
-        p1.solve()
+        p1.solve(solver='ECOS')
         self.assertAlmostEqual(p1.value, p2.value)
 
     def test_partial_optimize_simple_problem(self) -> None:
@@ -926,13 +926,13 @@ class TestAtoms(BaseTest):
         # Solve the (simple) two-stage problem by "combining" the two stages
         # (i.e., by solving a single linear program)
         p1 = Problem(Minimize(x+y), [x+y >= 3, y >= 4, x >= 5])
-        p1.solve()
+        p1.solve(solver=cp.SCS)
 
         # Solve the two-stage problem via partial_optimize
         p2 = Problem(Minimize(y), [x+y >= 3, y >= 4])
-        g = partial_optimize(p2, [y], [x])
+        g = partial_optimize(p2, [y], [x], solver='ECOS')
         p3 = Problem(Minimize(x+g), [x >= 5])
-        p3.solve()
+        p3.solve(solver=cp.SCS)
         self.assertAlmostEqual(p1.value, p3.value)
 
     @unittest.skipUnless(len(INSTALLED_MI_SOLVERS) > 0, 'No mixed-integer solver is installed.')
@@ -957,13 +957,13 @@ class TestAtoms(BaseTest):
         # Solve the (simple) two-stage problem by "combining" the two stages
         # (i.e., by solving a single linear program)
         p1 = Problem(Minimize(x + cp.exp(y)), [x+y >= 3, y >= 4, x >= 5])
-        p1.solve()
+        p1.solve(solver=cp.SCS)
 
         # Solve the two-stage problem via partial_optimize
         p2 = Problem(Minimize(cp.exp(y)), [x+y >= 3, y >= 4])
-        g = partial_optimize(p2, [y], [x])
+        g = partial_optimize(p2, [y], [x], solver=cp.SCS)
         p3 = Problem(Minimize(x+g), [x >= 5])
-        p3.solve()
+        p3.solve(solver=cp.SCS)
         self.assertAlmostEqual(p1.value, p3.value)
 
     def test_partial_optimize_params(self) -> None:
@@ -976,13 +976,13 @@ class TestAtoms(BaseTest):
         # (i.e., by solving a single linear program)
         p1 = Problem(Minimize(x+y), [x+y >= gamma, y >= 4, x >= 5])
         gamma.value = 3
-        p1.solve()
+        p1.solve(solver=cp.SCS)
 
         # Solve the two-stage problem via partial_optimize
         p2 = Problem(Minimize(y), [x+y >= gamma, y >= 4])
-        g = partial_optimize(p2, [y], [x])
+        g = partial_optimize(p2, [y], [x], solver=cp.SCS)
         p3 = Problem(Minimize(x+g), [x >= 5])
-        p3.solve()
+        p3.solve(solver=cp.SCS)
         self.assertAlmostEqual(p1.value, p3.value)
 
     def test_partial_optimize_numeric_fn(self) -> None:
@@ -992,12 +992,12 @@ class TestAtoms(BaseTest):
         # Solve the (simple) two-stage problem by "combining" the two stages
         # (i.e., by solving a single linear program)
         p1 = Problem(Minimize(y), [xval+y >= 3])
-        p1.solve()
+        p1.solve(solver=cp.SCS)
 
         # Solve the two-stage problem via partial_optimize
         constr = [y >= -100]
         p2 = Problem(Minimize(y), [x+y >= 3] + constr)
-        g = partial_optimize(p2, [y], [x])
+        g = partial_optimize(p2, [y], [x], solver=cp.SCS)
         x.value = xval
         y.value = 42
         constr[0].dual_variables[0].value = 42
@@ -1008,7 +1008,7 @@ class TestAtoms(BaseTest):
 
         # No variables optimized over.
         p2 = Problem(Minimize(y), [x+y >= 3])
-        g = partial_optimize(p2, [], [x, y])
+        g = partial_optimize(p2, [], [x, y], solver=cp.SCS)
         x.value = xval
         y.value = 42
         p2.constraints[0].dual_variables[0].value = 42
@@ -1026,12 +1026,12 @@ class TestAtoms(BaseTest):
         p1 = Problem(Minimize(cp.sum(t)), [-t <= x, x <= t])
 
         # Minimize the 1-norm via partial_optimize
-        g = partial_optimize(p1, [t], [x])
-        g2 = partial_optimize(Problem(Minimize(g)), [x])
+        g = partial_optimize(p1, [t], [x], solver='ECOS')
+        g2 = partial_optimize(Problem(Minimize(g)), [x], solver='ECOS')
         p2 = Problem(Minimize(g2))
-        p2.solve()
+        p2.solve(solver='ECOS')
 
-        p1.solve()
+        p1.solve(solver='ECOS')
         self.assertAlmostEqual(p1.value, p2.value)
 
     def test_nonnegative_variable(self) -> None:
@@ -1039,7 +1039,7 @@ class TestAtoms(BaseTest):
         """
         x = Variable(nonneg=True)
         p = Problem(Minimize(5+x), [x >= 3])
-        p.solve()
+        p.solve(solver=cp.SCS)
         self.assertAlmostEqual(p.value, 8)
         self.assertAlmostEqual(x.value, 3)
 
@@ -1049,7 +1049,7 @@ class TestAtoms(BaseTest):
         y = Variable((5, 5))
         obj = Minimize(cp.mixed_norm(y, "inf", 1))
         prob = Problem(obj, [y == np.ones((5, 5))])
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 5)
 
     def test_mat_norms(self) -> None:
@@ -1060,13 +1060,13 @@ class TestAtoms(BaseTest):
         X = Variable((2, 2))
         obj = Minimize(cp.norm(X, 1))
         prob = cp.Problem(obj, [X == A])
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         print(result)
         self.assertAlmostEqual(result, cp.norm(A, 1).value, places=3)
 
         obj = Minimize(cp.norm(X, np.inf))
         prob = cp.Problem(obj, [X == A])
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         print(result)
         self.assertAlmostEqual(result, cp.norm(A, np.inf).value, places=3)
 
@@ -1117,7 +1117,7 @@ class TestAtoms(BaseTest):
         y = Variable((2, 2))
         obj = Minimize(cp.sum(-cp.log_normcdf(y)))
         prob = Problem(obj, [y == 2])
-        result = prob.solve()
+        result = prob.solve(solver=cp.ECOS)
         self.assertAlmostEqual(
             -result, 4 * np.log(scipy.stats.norm.cdf(2)), places=None, delta=1e-2
         )
@@ -1131,7 +1131,7 @@ class TestAtoms(BaseTest):
         p = np.ones((4,))
         obj = cp.Minimize(cp.scalar_product(v, p))
         prob = cp.Problem(obj, [v >= 1])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         assert np.allclose(v.value, p)
 
         # With a parameter.
@@ -1141,7 +1141,7 @@ class TestAtoms(BaseTest):
         p.value = np.ones((4,))
         obj = cp.Minimize(cp.scalar_product(v, p))
         prob = cp.Problem(obj, [v >= 1])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         assert np.allclose(v.value, p.value)
 
     def test_conj(self) -> None:
@@ -1150,7 +1150,7 @@ class TestAtoms(BaseTest):
         v = cp.Variable((4,))
         obj = cp.Minimize(cp.sum(v))
         prob = cp.Problem(obj, [cp.conj(v) >= 1])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         assert np.allclose(v.value, np.ones((4,)))
 
     def test_loggamma(self) -> None:
@@ -1167,5 +1167,5 @@ class TestAtoms(BaseTest):
         cost = cp.sum(cp.loggamma(X))
         prob = cp.Problem(cp.Minimize(cost),
                           [X == A])
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         assert np.isclose(result, true_val.sum(), atol=1e0)

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -185,28 +185,28 @@ class TestComplex(BaseTest):
         x = Variable()
         expr = cvx.imag(x + 1j*x)
         prob = Problem(Minimize(expr), [x >= 0])
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, 0)
         self.assertAlmostEqual(x.value, 0)
 
         x = Variable(imag=True)
         expr = 1j*x
         prob = Problem(Minimize(expr), [cvx.imag(x) <= 1])
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, -1)
         self.assertAlmostEqual(x.value, 1j)
 
         x = Variable(2)
         expr = x*1j
         prob = Problem(Minimize(expr[0]*1j + expr[1]*1j), [cvx.real(x + 1j) >= 1])
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, -np.inf)
         prob = Problem(Minimize(expr[0]*1j + expr[1]*1j), [cvx.real(x + 1j) <= 1])
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, -2)
         self.assertItemsAlmostEqual(x.value, [1, 1])
         prob = Problem(Minimize(expr[0]*1j + expr[1]*1j), [cvx.real(x + 1j) >= 1, cvx.conj(x) <= 0])
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, np.inf)
 
         x = Variable((2, 2))
@@ -214,7 +214,7 @@ class TestComplex(BaseTest):
         expr = cvx.vstack([x, y])
         prob = Problem(Minimize(cvx.sum(cvx.imag(cvx.conj(expr)))),
                        [x == 0, cvx.real(y) == 0, cvx.imag(y) <= 1])
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, -6)
         self.assertItemsAlmostEqual(y.value, 1j*np.ones((3, 2)))
         self.assertItemsAlmostEqual(x.value, np.zeros((2, 2)))
@@ -224,7 +224,7 @@ class TestComplex(BaseTest):
         expr = cvx.vstack([x, y])
         prob = Problem(Minimize(cvx.sum(cvx.imag(expr.H))),
                        [x == 0, cvx.real(y) == 0, cvx.imag(y) <= 1])
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, -6)
         self.assertItemsAlmostEqual(y.value, 1j*np.ones((3, 2)))
         self.assertItemsAlmostEqual(x.value, np.zeros((2, 2)))
@@ -235,7 +235,7 @@ class TestComplex(BaseTest):
         p = cvx.Parameter(imag=True, value=1j)
         x = Variable(2, complex=True)
         prob = Problem(cvx.Maximize(cvx.sum(cvx.imag(x) + cvx.real(x))), [cvx.abs(p*x) <= 2])
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, 4*np.sqrt(2))
         val = np.ones(2)*np.sqrt(2)
         self.assertItemsAlmostEqual(x.value, val + 1j*val)
@@ -247,12 +247,12 @@ class TestComplex(BaseTest):
         constraints = [cvx.trace(cvx.real(Z)) == 1]
         obj = cvx.Minimize(0)
         prob = cvx.Problem(obj, constraints)
-        prob.solve()
+        prob.solve(solver="SCS")
 
         Z = Variable((2, 2), imag=True)
         obj = cvx.Minimize(cvx.trace(cvx.real(Z)))
         prob = cvx.Problem(obj, constraints)
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, 0)
 
     def test_abs(self) -> None:
@@ -260,7 +260,7 @@ class TestComplex(BaseTest):
         """
         x = Variable(2, complex=True)
         prob = Problem(cvx.Maximize(cvx.sum(cvx.imag(x) + cvx.real(x))), [cvx.abs(x) <= 2])
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, 4*np.sqrt(2))
         val = np.ones(2)*np.sqrt(2)
         self.assertItemsAlmostEqual(x.value, val + 1j*val)
@@ -271,7 +271,7 @@ class TestComplex(BaseTest):
         x = Variable(2, complex=True)
         t = Variable()
         prob = Problem(cvx.Minimize(t), [cvx.SOC(t, x), x == 2j])
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, 2*np.sqrt(2))
         self.assertItemsAlmostEqual(x.value, [2j, 2j])
 
@@ -280,7 +280,7 @@ class TestComplex(BaseTest):
         """
         x = Variable((1, 2), complex=True)
         prob = Problem(cvx.Maximize(cvx.sum(cvx.imag(x) + cvx.real(x))), [cvx.norm1(x) <= 2])
-        result = prob.solve()
+        result = prob.solve(solver="ECOS")
         self.assertAlmostEqual(result, 2*np.sqrt(2))
         val = np.ones(2)*np.sqrt(2)/2
         # self.assertItemsAlmostEqual(x.value, val + 1j*val)
@@ -288,7 +288,7 @@ class TestComplex(BaseTest):
         x = Variable((2, 2), complex=True)
         prob = Problem(cvx.Maximize(cvx.sum(cvx.imag(x) + cvx.real(x))),
                        [cvx.pnorm(x, p=2) <= np.sqrt(8)])
-        result = prob.solve()
+        result = prob.solve(solver="ECOS")
         self.assertAlmostEqual(result, 8)
         val = np.ones((2, 2))
         self.assertItemsAlmostEqual(x.value, val + 1j*val)
@@ -301,7 +301,7 @@ class TestComplex(BaseTest):
         sigma_max = np.linalg.norm(P, 2)
         X = Variable((2, 4), complex=True)
         prob = Problem(Minimize(cvx.norm(X, 2)), [X == P])
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, sigma_max, places=1)
 
         norm_nuc = np.linalg.norm(P, 'nuc')
@@ -363,7 +363,7 @@ class TestComplex(BaseTest):
         x = Variable(3, complex=False)
         value = cvx.quad_form(b, P).value
         prob = Problem(cvx.Minimize(cvx.quad_form(x, P)), [x == b])
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, value)
 
         # Solve a problem with complex variable
@@ -371,7 +371,7 @@ class TestComplex(BaseTest):
         x = Variable(3, complex=True)
         value = cvx.quad_form(b, P).value
         prob = Problem(cvx.Minimize(cvx.quad_form(x, P)), [x == b])
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         normalization = max(abs(result), abs(value))
         self.assertAlmostEqual(result / normalization, value / normalization, places=5)
 
@@ -381,7 +381,7 @@ class TestComplex(BaseTest):
         value = cvx.quad_form(b, P).value
         expr = cvx.quad_form(x, P)
         prob = Problem(cvx.Minimize(expr), [x == b])
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         normalization = max(abs(result), abs(value))
         self.assertAlmostEqual(result / normalization, value / normalization)
 
@@ -440,7 +440,7 @@ class TestComplex(BaseTest):
         X = Variable((2, 2), hermitian=True)
         prob = Problem(cvx.Minimize(cvx.imag(X[1, 0])),
                        [X[0, 0] == 2, X[1, 1] == 3, X[0, 1] == 1+1j])
-        prob.solve()
+        prob.solve(solver="SCS")
         self.assertItemsAlmostEqual(X.value, [2, 1-1j, 1+1j, 3])
 
     def test_psd(self) -> None:
@@ -449,7 +449,7 @@ class TestComplex(BaseTest):
         X = Variable((2, 2), hermitian=True)
         prob = Problem(cvx.Minimize(cvx.imag(X[1, 0])),
                        [X >> 0, X[0, 0] == -1])
-        prob.solve()
+        prob.solve(solver="SCS")
         assert prob.status is cvx.INFEASIBLE
 
     def test_promote(self) -> None:
@@ -459,7 +459,7 @@ class TestComplex(BaseTest):
         obj = cvx.Maximize(cvx.real(cvx.sum(v * np.ones((2, 2)))))
         con = [cvx.norm(v) <= 1]
         prob = cvx.Problem(obj, con)
-        result = prob.solve()
+        result = prob.solve(solver="ECOS")
         self.assertAlmostEqual(result, 4.0)
 
     def test_sparse(self) -> None:
@@ -477,7 +477,7 @@ class TestComplex(BaseTest):
         obj = cvx.Maximize(0)
         cons = [A @ rho == Id]
         prob = cvx.Problem(obj, cons)
-        prob.solve()
+        prob.solve(solver="SCS")
         rho_sparse = rho.value
         # infeasible here, which is wrong!
 
@@ -487,7 +487,7 @@ class TestComplex(BaseTest):
         obj = cvx.Maximize(0)
         cons = [A.toarray() @ rho == Id]
         prob = cvx.Problem(obj, cons)
-        prob.solve()
+        prob.solve(solver="SCS")
         self.assertItemsAlmostEqual(rho.value, rho_sparse)
 
     def test_special_idx(self) -> None:
@@ -506,7 +506,7 @@ class TestComplex(BaseTest):
         obj = cvx.Maximize(c[0] - cvx.real(cvx.trace(f)))
         # Form and solve problem.
         prob = cvx.Problem(obj, constraints)
-        prob.solve()
+        prob.solve(solver="SCS")
 
     def test_validation(self) -> None:
         """Test that complex arguments are rejected.
@@ -562,7 +562,7 @@ class TestComplex(BaseTest):
         obj = cvx.Maximize(cvx.trace(cvx.real(X)))
         cons = [cvx.diag(X) == 1]
         prob = cvx.Problem(obj, cons)
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, 2)
 
         x = cvx.Variable(2, complex=True)
@@ -570,7 +570,7 @@ class TestComplex(BaseTest):
         obj = cvx.Maximize(cvx.trace(cvx.real(X)))
         cons = [cvx.diag(X) == 1]
         prob = cvx.Problem(obj, cons)
-        result = prob.solve()
+        result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, 2)
 
     def test_complex_qp(self) -> None:
@@ -584,11 +584,11 @@ class TestComplex(BaseTest):
 
         objective = cvx.Minimize(cvx.sum_squares(A0*Z + A1@X - B))
         prob = cvx.Problem(objective)
-        prob.solve()
+        prob.solve(solver="SCS")
         self.assertEqual(prob.status, cvx.OPTIMAL)
 
         constraints = [X >= 0]
         prob = cvx.Problem(objective, constraints)
-        prob.solve()
+        prob.solve(solver="SCS")
         self.assertEqual(prob.status, cvx.OPTIMAL)
         assert constraints[0].dual_value is not None

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -363,7 +363,7 @@ class TestComplex(BaseTest):
         x = Variable(3, complex=False)
         value = cvx.quad_form(b, P).value
         prob = Problem(cvx.Minimize(cvx.quad_form(x, P)), [x == b])
-        result = prob.solve(solver="SCS")
+        result = prob.solve(solver="ECOS")
         self.assertAlmostEqual(result, value)
 
         # Solve a problem with complex variable
@@ -371,7 +371,7 @@ class TestComplex(BaseTest):
         x = Variable(3, complex=True)
         value = cvx.quad_form(b, P).value
         prob = Problem(cvx.Minimize(cvx.quad_form(x, P)), [x == b])
-        result = prob.solve(solver="SCS")
+        result = prob.solve(solver="ECOS")
         normalization = max(abs(result), abs(value))
         self.assertAlmostEqual(result / normalization, value / normalization, places=5)
 
@@ -381,7 +381,7 @@ class TestComplex(BaseTest):
         value = cvx.quad_form(b, P).value
         expr = cvx.quad_form(x, P)
         prob = Problem(cvx.Minimize(expr), [x == b])
-        result = prob.solve(solver="SCS")
+        result = prob.solve(solver="ECOS")
         normalization = max(abs(result), abs(value))
         self.assertAlmostEqual(result / normalization, value / normalization)
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1348,13 +1348,10 @@ class TestAllSolvers(BaseTest):
         x = cp.Variable(2, name='x', integer=True)
         objective = cp.Minimize(cp.sum(x))
         prob = cp.Problem(objective, [x >= 0])
-        if len(INSTALLED_MI_SOLVERS) == 1:
-            try:
+        if INSTALLED_MI_SOLVERS == [cp.ECOS_BB]:
+            with self.assertRaisesRegex(cp.error.SolverError, "You need a mixed-integer" 
+                                                              "solver for this model.*"):
                 prob.solve()
-                assert False
-            except SolverError as err:
-                msg = str(err)
-                self.assertTrue("a mixed-integer solver" in msg)
         else:
             prob.solve()
             self.assertItemsAlmostEqual(x.value, [0, 0])
@@ -1366,14 +1363,15 @@ class TestECOS_BB(unittest.TestCase):
         """Test that ECOS_BB isn't chosen by default.
         """
         x = cp.Variable(1, name='x', integer=True)
-        objective = cp.Minimize(cp.exp(x))
+        objective = cp.Minimize(cp.sum(x))
         prob = cp.Problem(objective, [x >= 0])
-        if cp.MOSEK not in INSTALLED_MI_SOLVERS:
-            try:
+        if INSTALLED_MI_SOLVERS != [cp.ECOS_BB]:
+            prob.solve()
+            assert prob.solver_stats.solver_name != cp.ECOS_BB
+        else:
+            with self.assertRaisesRegex(cp.error.SolverError, "You need a mixed-integer" 
+                                                              "solver for this model.*"):
                 prob.solve()
-                assert False
-            except SolverError:
-                pass
 
     def test_ecos_bb_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='ECOS_BB')

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -22,7 +22,6 @@ import scipy.linalg as la
 import pytest
 
 import cvxpy as cp
-from cvxpy.error import SolverError
 from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS, INSTALLED_SOLVERS
 from cvxpy.tests.base_test import BaseTest
 from cvxpy.tests.solver_test_helpers import (
@@ -1349,7 +1348,7 @@ class TestAllSolvers(BaseTest):
         objective = cp.Minimize(cp.sum(x))
         prob = cp.Problem(objective, [x >= 0])
         if INSTALLED_MI_SOLVERS == [cp.ECOS_BB]:
-            with self.assertRaisesRegex(cp.error.SolverError, "You need a mixed-integer" 
+            with self.assertRaisesRegex(cp.error.SolverError, "You need a mixed-integer"
                                                               "solver for this model.*"):
                 prob.solve()
         else:
@@ -1369,7 +1368,7 @@ class TestECOS_BB(unittest.TestCase):
             prob.solve()
             assert prob.solver_stats.solver_name != cp.ECOS_BB
         else:
-            with self.assertRaisesRegex(cp.error.SolverError, "You need a mixed-integer" 
+            with self.assertRaisesRegex(cp.error.SolverError, "You need a mixed-integer"
                                                               "solver for this model.*"):
                 prob.solve()
 

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -300,7 +300,7 @@ class TestConstraints(BaseTest):
         c = np.arange(n)
         prob = cp.Problem(cp.Maximize(cp.sum(x)),
                           [(x - c) <= 0])
-        prob.solve()
+        prob.solve(solver=cp.ECOS)
         dual = prob.constraints[0].dual_value
         prob = cp.Problem(cp.Maximize(cp.sum(x)),
                           [cp.NonPos(x - c)])

--- a/cvxpy/tests/test_convolution.py
+++ b/cvxpy/tests/test_convolution.py
@@ -44,7 +44,7 @@ class TestConvolution(BaseTest):
         # Matrix stuffing.
         prob = cvx.Problem(cvx.Minimize(cvx.norm(expr, 1)),
                            [x == g])
-        result = prob.solve()
+        result = prob.solve(solver=cvx.SCS)
         self.assertAlmostEqual(result, sum(f_conv_g), places=3)
         self.assertItemsAlmostEqual(expr.value, f_conv_g)
 
@@ -107,4 +107,4 @@ class TestConvolution(BaseTest):
         x = cvx.Variable(N)
         v = cvx.conv(h, x)
         obj = cvx.Minimize(cvx.sum(cvx.multiply(y, v[0:N])))
-        print(cvx.Problem(obj, []).solve())
+        print(cvx.Problem(obj, []).solve(solver=cvx.ECOS))

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -608,6 +608,6 @@ class TestDgp2Dcp(BaseTest):
         x.value = None
 
         prob = cvxpy.Problem(cvxpy.Minimize(1.0), [expr == b])
-        prob.solve(gp=True)
+        prob.solve(solver=SOLVER, gp=True)
         sltn = np.exp(np.linalg.solve(A, np.log(b)))
         self.assertItemsAlmostEqual(x.value, sltn)

--- a/cvxpy/tests/test_domain.py
+++ b/cvxpy/tests/test_domain.py
@@ -46,7 +46,7 @@ class TestDomain(BaseTest):
             dom = expr.domain
             constr = [self.a >= -100, self.x >= 0]
             prob = Problem(Minimize(sum(self.x + self.a)), dom + constr)
-            prob.solve()
+            prob.solve(solver=cp.SCS)
             self.assertAlmostEqual(prob.value, 13)
             assert self.a.value >= 0
             assert np.all((self.x + self.a - [5, 8]).value >= -1e-3)
@@ -75,27 +75,27 @@ class TestDomain(BaseTest):
         """
         dom = cp.geo_mean(self.x).domain
         prob = Problem(Minimize(sum(self.x)), dom)
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(prob.value, 0)
 
         # No special case for only one weight.
         dom = cp.geo_mean(self.x, [0, 2]).domain
         dom.append(self.x >= -1)
         prob = Problem(Minimize(sum(self.x)), dom)
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(self.x.value, [-1, 0])
 
         dom = cp.geo_mean(self.z, [0, 1, 1]).domain
         dom.append(self.z >= -1)
         prob = Problem(Minimize(sum(self.z)), dom)
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(self.z.value, [-1, 0, 0])
 
     def test_quad_over_lin(self) -> None:
         """Test domain for quad_over_lin
         """
         dom = cp.quad_over_lin(self.x, self.a).domain
-        Problem(Minimize(self.a), dom).solve()
+        Problem(Minimize(self.a), dom).solve(solver=cp.SCS)
         self.assertAlmostEqual(self.a.value, 0)
 
     # Throws Segfault from Eigen
@@ -104,7 +104,7 @@ class TestDomain(BaseTest):
     #     """
     #     dom = lambda_max(self.A).domain
     #     A0 = [[1, 2], [3, 4]]
-    #     Problem(Minimize(norm2(self.A-A0)), dom).solve()
+    #     Problem(Minimize(norm2(self.A-A0)), dom).solve(solver=cp.SCS)
     #     self.assertItemsAlmostEqual(self.A.value, np.array([[1, 2.5], [2.5, 4]]))
 
     def test_pnorm(self) -> None:
@@ -112,28 +112,28 @@ class TestDomain(BaseTest):
         """
         dom = cp.pnorm(self.a, -0.5).domain
         prob = Problem(Minimize(self.a), dom)
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(prob.value, 0)
 
     def test_log(self) -> None:
         """Test domain for log.
         """
         dom = cp.log(self.a).domain
-        Problem(Minimize(self.a), dom).solve()
+        Problem(Minimize(self.a), dom).solve(solver=cp.SCS)
         self.assertAlmostEqual(self.a.value, 0)
 
     def test_log1p(self) -> None:
         """Test domain for log1p.
         """
         dom = cp.log1p(self.a).domain
-        Problem(Minimize(self.a), dom).solve()
+        Problem(Minimize(self.a), dom).solve(solver=cp.SCS)
         self.assertAlmostEqual(self.a.value, -1)
 
     def test_entr(self) -> None:
         """Test domain for entr.
         """
         dom = cp.entr(self.a).domain
-        Problem(Minimize(self.a), dom).solve()
+        Problem(Minimize(self.a), dom).solve(solver=cp.SCS)
         self.assertAlmostEqual(self.a.value, 0)
 
     def test_kl_div(self) -> None:
@@ -141,7 +141,7 @@ class TestDomain(BaseTest):
         """
         b = Variable()
         dom = cp.kl_div(self.a, b).domain
-        Problem(Minimize(self.a + b), dom).solve()
+        Problem(Minimize(self.a + b), dom).solve(solver=cp.SCS)
         self.assertAlmostEqual(self.a.value, 0)
         self.assertAlmostEqual(b.value, 0)
 
@@ -149,19 +149,19 @@ class TestDomain(BaseTest):
         """Test domain for power.
         """
         dom = cp.sqrt(self.a).domain
-        Problem(Minimize(self.a), dom).solve()
+        Problem(Minimize(self.a), dom).solve(solver=cp.SCS)
         self.assertAlmostEqual(self.a.value, 0)
 
         dom = cp.square(self.a).domain
-        Problem(Minimize(self.a), dom + [self.a >= -100]).solve()
+        Problem(Minimize(self.a), dom + [self.a >= -100]).solve(solver=cp.SCS)
         self.assertAlmostEqual(self.a.value, -100)
 
         dom = ((self.a)**-1).domain
-        Problem(Minimize(self.a), dom + [self.a >= -100]).solve()
+        Problem(Minimize(self.a), dom + [self.a >= -100]).solve(solver=cp.SCS)
         self.assertAlmostEqual(self.a.value, 0)
 
         dom = ((self.a)**3).domain
-        Problem(Minimize(self.a), dom + [self.a >= -100]).solve()
+        Problem(Minimize(self.a), dom + [self.a >= -100]).solve(solver=cp.SCS)
         self.assertAlmostEqual(self.a.value, 0)
 
     def test_log_det(self) -> None:

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -298,11 +298,11 @@ class TestDgp(BaseTest):
         dcp = dgp2dcp.reduce()
         self.assertTrue(dcp.is_dpp())
 
-        dgp.solve(gp=True, enforce_dpp=True)
+        dgp.solve(solver=cp.SCS, gp=True, enforce_dpp=True)
         self.assertAlmostEqual(x.value, 1.0)
 
         alpha.value = 2.0
-        dgp.solve(gp=True, enforce_dpp=True)
+        dgp.solve(solver=cp.SCS, gp=True, enforce_dpp=True)
         self.assertAlmostEqual(x.value, 2.0)
 
     def test_basic_inequality_constraint(self) -> None:
@@ -380,11 +380,11 @@ class TestDgp(BaseTest):
         self.assertFalse(dgp.objective.is_dgp(dpp=True))
 
         with self.assertRaises(error.DPPError):
-            dgp.solve(gp=True, enforce_dpp=True)
+            dgp.solve(solver=cp.SCS, gp=True, enforce_dpp=True)
 
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            dgp.solve(gp=True, enforce_dpp=False)
+            dgp.solve(solver=cp.SCS, gp=True, enforce_dpp=False)
             self.assertAlmostEqual(x.value, 1.0)
 
     def test_basic_monomial(self) -> None:
@@ -398,12 +398,12 @@ class TestDgp(BaseTest):
         self.assertTrue(problem.is_dgp(dpp=True))
         self.assertFalse(problem.is_dpp('dcp'))
 
-        problem.solve(gp=True, enforce_dpp=True)
+        problem.solve(solver=cp.SCS, gp=True, enforce_dpp=True)
         self.assertAlmostEqual(x.value, 1.0)
         self.assertAlmostEqual(problem.value, 2.0)
 
         alpha.value = 3.0
-        problem.solve(gp=True, enforce_dpp=True)
+        problem.solve(solver=cp.SCS, gp=True, enforce_dpp=True)
         self.assertAlmostEqual(x.value, 3.0)
         # 3 * 2 * 3 == 18
         self.assertAlmostEqual(problem.value, 18.0)
@@ -425,7 +425,7 @@ class TestDgp(BaseTest):
         self.assertTrue(problem.is_dgp(dpp=True))
         self.assertFalse(problem.is_dpp('dcp'))
 
-        problem.solve(gp=True, enforce_dpp=True)
+        problem.solve(solver=cp.SCS, gp=True, enforce_dpp=True)
         self.assertAlmostEqual(x.value, 1.0)
         self.assertAlmostEqual(y.value, 2.0)
         # 1*2*1 + 2*3*1*2 == 2 + 12 == 14
@@ -433,7 +433,7 @@ class TestDgp(BaseTest):
 
         alpha.value = 4.0
         beta.value = 5.0
-        problem.solve(gp=True, enforce_dpp=True)
+        problem.solve(solver=cp.SCS, gp=True, enforce_dpp=True)
         self.assertAlmostEqual(x.value, 4.0)
         self.assertAlmostEqual(y.value, 5.0)
         # 4*5*4 + 5*3*4*5 == 80 + 300 == 380
@@ -519,17 +519,17 @@ class TestDgp(BaseTest):
         problem = cp.Problem(cp.Minimize(x**alpha), [x == alpha])
 
         self.assertTrue(problem.is_dgp(dpp=True))
-        problem.solve(gp=True, enforce_dpp=True)
+        problem.solve(solver=cp.SCS, gp=True, enforce_dpp=True)
         self.assertAlmostEqual(problem.value, 1.0)
         self.assertAlmostEqual(x.value, 1.0)
 
         # re-solve (which goes through a separate code path)
-        problem.solve(gp=True, enforce_dpp=True)
+        problem.solve(solver=cp.SCS, gp=True, enforce_dpp=True)
         self.assertAlmostEqual(problem.value, 1.0)
         self.assertAlmostEqual(x.value, 1.0)
 
         alpha.value = 3.0
-        problem.solve(gp=True, enforce_dpp=True)
+        problem.solve(solver=cp.SCS, gp=True, enforce_dpp=True)
         self.assertAlmostEqual(problem.value, 27.0)
         self.assertAlmostEqual(x.value, 3.0)
 
@@ -811,7 +811,7 @@ class TestDgp(BaseTest):
         expr = cp.gmatmul(A, x)
         problem = cp.Problem(cp.Minimize(1.0), [expr == b])
         self.assertTrue(problem.is_dgp(dpp=True))
-        problem.solve(gp=True, enforce_dpp=True)
+        problem.solve(solver=cp.SCS, gp=True, enforce_dpp=True)
         sltn = np.exp(np.linalg.solve(A.value, np.log(b)))
         self.assertItemsAlmostEqual(x.value, sltn)
 

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -46,7 +46,7 @@ class TestDqcp(base_test.BaseTest):
         reduced = red.reduce()
         self.assertTrue(reduced.is_dcp())
         self.assertEqual(len(reduced.parameters()), 1)
-        soln = bisection.bisect(reduced, low=12, high=17)
+        soln = bisection.bisect(reduced, low=12, high=17, solver=cp.SCS)
         self.assertAlmostEqual(soln.opt_val, 12.0, places=3)
 
         problem.unpack(soln)
@@ -74,7 +74,7 @@ class TestDqcp(base_test.BaseTest):
         reduced = red.reduce()
         self.assertTrue(reduced.is_dcp())
         self.assertEqual(len(reduced.parameters()), 1)
-        soln = bisection.bisect(reduced)
+        soln = bisection.bisect(reduced, solver=cp.SCS)
         self.assertAlmostEqual(soln.opt_val, 12.0, places=3)
 
         problem.unpack(soln)
@@ -408,7 +408,7 @@ class TestDqcp(base_test.BaseTest):
         variable = cp.Variable(len(vector))
         problem = cp.Problem(cp.Maximize(vector @ variable),
                              [cp.norm2(variable) <= 1.])
-        problem.solve()
+        problem.solve(solver=cp.SCS)
 
         value = variable.value.copy()
         cp.sign(variable).value

--- a/cvxpy/tests/test_examples.py
+++ b/cvxpy/tests/test_examples.py
@@ -51,7 +51,7 @@ class TestExamples(BaseTest):
         ]
 
         p = cvx.Problem(obj, constraints)
-        result = p.solve()
+        result = p.solve(solver=cvx.SCS)
         self.assertAlmostEqual(result, 0.447214)
         self.assertAlmostEqual(r.value, result)
         self.assertItemsAlmostEqual(x_c.value, [0, 0])
@@ -96,7 +96,7 @@ class TestExamples(BaseTest):
         # We now find the primal result and compare it to the dual result
         # to check if strong duality holds i.e. the duality gap is effectively zero
         p = cvx.Problem(objective, constraints)
-        p.solve()
+        p.solve(solver=cvx.SCS)
 
         # Note that since our data is random,
         # we may need to run this program multiple times to get a feasible primal
@@ -131,7 +131,7 @@ class TestExamples(BaseTest):
         p = cvx.Problem(objective, constraints)
 
         # The optimal objective is returned by p.solve().
-        p.solve()
+        p.solve(solver=cvx.SCS)
         # The optimal value for x is stored in x.value.
         print(x.value)
         # The optimal Lagrange multiplier for a constraint
@@ -196,7 +196,7 @@ class TestExamples(BaseTest):
         # Assign a value to gamma and find the optimal x.
         def get_x(gamma_value):
             gamma.value = gamma_value
-            p.solve()
+            p.solve(solver=cvx.SCS)
             return x.value
 
         gammas = np.logspace(-1, 2, num=2)
@@ -226,7 +226,7 @@ class TestExamples(BaseTest):
 
         objective = cvx.Maximize(expected_return - gamma*risk)
         p = cvx.Problem(objective, [cvx.sum(x) == 1])
-        p.solve()
+        p.solve(solver=cvx.SCS)
 
         # The optimal expected return.
         print(expected_return.value)
@@ -257,7 +257,7 @@ class TestExamples(BaseTest):
         p = cvx.Problem(objective)
         # Extensions can attach new solve methods to the CVXPY cvx.Problem class.
         # p.solve(method="admm")
-        p.solve()
+        p.solve(solver=cvx.SCS)
 
         # Count misclassifications.
         errors = 0
@@ -343,7 +343,7 @@ class TestExamples(BaseTest):
         for i in range(m):
             constraints.append(cvx.norm(A @ x[:, i] + b) <= 1)
         p = cvx.Problem(obj, constraints)
-        result = p.solve()
+        result = p.solve(solver=cvx.SCS)
         self.assertAlmostEqual(result, 1.9746, places=2)
 
     def test_portfolio_problem(self) -> None:
@@ -388,7 +388,7 @@ class TestExamples(BaseTest):
         prob = cvx.Problem(objective, constraints)
 
         # The optimal objective is returned by p.solve().
-        prob.solve()
+        prob.solve(solver=cvx.SCS)
         # The optimal value for x is stored in x.value.
         print(x.value)
         # The optimal Lagrange multiplier for a constraint
@@ -410,7 +410,7 @@ class TestExamples(BaseTest):
 
         # Form and solve problem.
         prob = cvx.Problem(obj, constraints)
-        prob.solve()  # Returns the optimal value.
+        prob.solve(solver=cvx.SCS)  # Returns the optimal value.
         print("status:", prob.status)
         print("optimal value", prob.value)
         print("optimal var", x.value, y.value)
@@ -430,7 +430,7 @@ class TestExamples(BaseTest):
 
         # Form and solve problem.
         prob = cvx.Problem(obj, constraints)
-        prob.solve()  # Returns the optimal value.
+        prob.solve(solver=cvx.SCS)  # Returns the optimal value.
         print("status:", prob.status)
         print("optimal value", prob.value)
         print("optimal var", x.value, y.value)
@@ -444,7 +444,7 @@ class TestExamples(BaseTest):
 
         # Replace the objective.
         prob = cvx.Problem(cvx.Maximize(x + y), prob.constraints)
-        print("optimal value", prob.solve())
+        print("optimal value", prob.solve(solver=cvx.SCS))
 
         self.assertAlmostEqual(prob.value, 1.0, places=3)
 
@@ -452,7 +452,7 @@ class TestExamples(BaseTest):
         constraints = prob.constraints
         constraints[0] = (x + y <= 3)
         prob = cvx.Problem(prob.objective, constraints)
-        print("optimal value", prob.solve())
+        print("optimal value", prob.solve(solver=cvx.SCS))
 
         self.assertAlmostEqual(prob.value, 3.0, places=2)
 
@@ -462,7 +462,7 @@ class TestExamples(BaseTest):
 
         # An infeasible problem.
         prob = cvx.Problem(cvx.Minimize(x), [x >= 1, x <= 0])
-        prob.solve()
+        prob.solve(solver=cvx.SCS)
         print("status:", prob.status)
         print("optimal value", prob.value)
 
@@ -471,7 +471,7 @@ class TestExamples(BaseTest):
 
         # An unbounded problem.
         prob = cvx.Problem(cvx.Minimize(x))
-        prob.solve()
+        prob.solve(solver=cvx.ECOS)
         print("status:", prob.status)
         print("optimal value", prob.value)
 
@@ -505,7 +505,7 @@ class TestExamples(BaseTest):
         constraints = [0 <= x, x <= 1]
         prob = cvx.Problem(objective, constraints)
 
-        print("Optimal value", prob.solve())
+        print("Optimal value", prob.solve(solver=cvx.SCS))
         print("Optimal var")
         print(x.value)  # A numpy matrix.
 
@@ -558,7 +558,7 @@ class TestExamples(BaseTest):
         gamma_vals = numpy.logspace(-4, 6)
         for val in gamma_vals:
             gamma.value = val
-            prob.solve()
+            prob.solve(solver=cvx.SCS)
             # Use expr.value to get the numerical value of
             # an expression in the problem.
             sq_penalty.append(error.value)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -950,7 +950,7 @@ class TestExpressions(BaseTest):
 
         x = Variable(4)
         self.assertEqual(x[::-1].shape, (4,))
-        Problem(Minimize(0), [x[::-1] == c]).solve()
+        Problem(Minimize(0), [x[::-1] == c]).solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(x.value, [4, 3, 2, 1])
 
         x = Variable(2)
@@ -1154,7 +1154,7 @@ class TestExpressions(BaseTest):
         self.assertItemsAlmostEqual(expr.value, y.value * z.value)
 
         prob = cp.Problem(cp.Minimize(cp.sum(expr)), [z == z.value])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(expr.value, y.value * z.value)
 
         np.random.seed(0)
@@ -1186,7 +1186,7 @@ class TestExpressions(BaseTest):
         self.assertItemsAlmostEqual(expr.value, y.value + z.value)
 
         prob = cp.Problem(cp.Minimize(cp.sum(expr)), [z == z.value])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(expr.value, y.value + z.value)
 
         np.random.seed(0)

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -250,7 +250,7 @@ class TestGrad(BaseTest):
                           [cp.norm(x, 1) <= 1.0,
                            cp.quad_form(x, P) <= 10,   # quad form constraint
                            cp.abs(x) <= 0.01])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
 
         # access quad_form.expr.grad without error
         prob.constraints[1].expr.grad
@@ -698,7 +698,7 @@ class TestGrad(BaseTest):
         for obj in [Minimize((self.a)**-1), Maximize(cp.entr(self.a))]:
             prob = Problem(obj, [self.x + self.a >= [5, 8]])
             # Optimize over nothing.
-            expr = partial_optimize(prob, dont_opt_vars=[self.x, self.a])
+            expr = partial_optimize(prob, dont_opt_vars=[self.x, self.a], solver=cp.ECOS)
             self.a.value = None
             self.x.value = None
             grad = expr.grad
@@ -718,7 +718,7 @@ class TestGrad(BaseTest):
             self.assertItemsAlmostEqual(grad[self.x].toarray(), [0, 0, 0, 0])
 
             # Optimize over x.
-            expr = partial_optimize(prob, opt_vars=[self.x])
+            expr = partial_optimize(prob, opt_vars=[self.x], solver=cp.ECOS)
             self.a.value = 1
             grad = expr.grad
             self.assertAlmostEqual(grad[self.a], obj.args[0].grad[self.a] + 0)
@@ -733,7 +733,7 @@ class TestGrad(BaseTest):
             self.assertItemsAlmostEqual(grad[self.x].toarray(), dual_val)
 
             # Optimize over x and a.
-            expr = partial_optimize(prob, opt_vars=[self.x, self.a])
+            expr = partial_optimize(prob, opt_vars=[self.x, self.a], solver=cp.ECOS)
             grad = expr.grad
             self.assertAlmostEqual(grad, {})
 

--- a/cvxpy/tests/test_nonlinear_atoms.py
+++ b/cvxpy/tests/test_nonlinear_atoms.py
@@ -36,7 +36,7 @@ class TestNonlinearAtoms(BaseTest):
         obj = cvx.Maximize(cvx.sum(cvx.log(self.x)))
         constr = [self.x <= [1, math.e]]
         p = cvx.Problem(obj, constr)
-        result = p.solve()
+        result = p.solve(solver=cvx.ECOS)
         self.assertAlmostEqual(result, 1)
         self.assertItemsAlmostEqual(self.x.value, [1, math.e])
 
@@ -44,7 +44,7 @@ class TestNonlinearAtoms(BaseTest):
         obj = cvx.Minimize(cvx.sum(self.x))
         constr = [cvx.log(self.x) >= 0, self.x <= [1, 1]]
         p = cvx.Problem(obj, constr)
-        result = p.solve()
+        result = p.solve(solver=cvx.ECOS)
         self.assertAlmostEqual(result, 2)
         self.assertItemsAlmostEqual(self.x.value, [1, 1])
 
@@ -52,14 +52,14 @@ class TestNonlinearAtoms(BaseTest):
         obj = cvx.Maximize(cvx.log(self.x)[1])
         constr = [self.x <= [1, math.e]]
         p = cvx.Problem(obj, constr)
-        result = p.solve()
+        result = p.solve(solver=cvx.ECOS)
         self.assertAlmostEqual(result, 1)
 
         # Scalar log.
         obj = cvx.Maximize(cvx.log(self.x[1]))
         constr = [self.x <= [1, math.e]]
         p = cvx.Problem(obj, constr)
-        result = p.solve()
+        result = p.solve(solver=cvx.ECOS)
         self.assertAlmostEqual(result, 1)
 
     def test_entr(self) -> None:

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1758,41 +1758,41 @@ class TestProblem(BaseTest):
         """
         x = cp.Variable(pos=True)
         prob = cp.Problem(cp.Minimize(x), [True])
-        prob.solve(solver=cp.SCS)
+        prob.solve(solver=cp.ECOS)
         self.assertAlmostEqual(x.value, 0)
 
         x = cp.Variable(pos=True)
         prob = cp.Problem(cp.Minimize(x), [True]*10)
-        prob.solve(solver=cp.SCS)
+        prob.solve(solver=cp.ECOS)
         self.assertAlmostEqual(x.value, 0)
 
         prob = cp.Problem(cp.Minimize(x), [42 <= x] + [True]*10)
-        prob.solve(solver=cp.SCS)
+        prob.solve(solver=cp.ECOS)
         self.assertAlmostEqual(x.value, 42)
 
         prob = cp.Problem(cp.Minimize(x), [True] + [42 <= x] + [True] * 10)
-        prob.solve(solver=cp.SCS)
+        prob.solve(solver=cp.ECOS)
         self.assertAlmostEqual(x.value, 42)
 
         prob = cp.Problem(cp.Minimize(x), [False])
-        prob.solve(solver=cp.SCS)
+        prob.solve(solver=cp.ECOS)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
         prob = cp.Problem(cp.Minimize(x), [False]*10)
-        prob.solve(solver=cp.SCS)
+        prob.solve(solver=cp.ECOS)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
         prob = cp.Problem(cp.Minimize(x), [True]*10 + [False] + [True]*10)
-        prob.solve(solver=cp.SCS)
+        prob.solve(solver=cp.ECOS)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
         prob = cp.Problem(cp.Minimize(x), [42 <= x] + [True]*10 + [False])
-        prob.solve(solver=cp.SCS)
+        prob.solve(solver=cp.ECOS)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
         # only Trues, but infeasible solution since x must be non-negative.
         prob = cp.Problem(cp.Minimize(x), [True] + [x <= -42] + [True]*10)
-        prob.solve(solver=cp.SCS)
+        prob.solve(solver=cp.ECOS)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
     def test_pos(self) -> None:

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -112,7 +112,7 @@ class TestProblem(BaseTest):
         problem = cp.Problem(cp.Minimize(param), [])
         with self.assertRaises(
               ParameterError, msg="A Parameter (whose name is 'lambda').*"):
-            problem.solve()
+            problem.solve(solver=cp.SCS)
 
     def test_constants(self) -> None:
         """Test the constants method.
@@ -401,7 +401,7 @@ class TestProblem(BaseTest):
         p = Problem(cp.Maximize(cp.norm_inf(self.a)))
         self.assertEqual(p.is_dcp(), False)
         with self.assertRaises(DCPError):
-            p.solve()
+            p.solve(solver=cp.SCS)
 
     # Test the is_qp method.
     def test_is_qp(self) -> None:
@@ -456,7 +456,7 @@ class TestProblem(BaseTest):
     def test_variable_name_conflict(self) -> None:
         var = Variable(name='a')
         p = Problem(cp.Maximize(self.a + var), [var == 2 + self.a, var <= 3])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 4.0)
         self.assertAlmostEqual(self.a.value, 1)
         self.assertAlmostEqual(var.value, 3)
@@ -467,18 +467,18 @@ class TestProblem(BaseTest):
         prob2 = Problem(cp.Minimize(2*self.b), [self.a >= 1, self.b >= 2])
         prob_minimize = prob1 + prob2
         self.assertEqual(len(prob_minimize.constraints), 3)
-        self.assertAlmostEqual(prob_minimize.solve(), 6)
+        self.assertAlmostEqual(prob_minimize.solve(solver=cp.SCS), 6)
         prob3 = Problem(cp.Maximize(self.a), [self.b <= 1])
         prob4 = Problem(cp.Maximize(2*self.b), [self.a <= 2])
         prob_maximize = prob3 + prob4
         self.assertEqual(len(prob_maximize.constraints), 2)
-        self.assertAlmostEqual(prob_maximize.solve(), 4)
+        self.assertAlmostEqual(prob_maximize.solve(solver=cp.SCS), 4)
 
         # Test using sum function
         prob5 = Problem(cp.Minimize(3*self.a))
         prob_sum = sum([prob1, prob2, prob5])
         self.assertEqual(len(prob_sum.constraints), 3)
-        self.assertAlmostEqual(prob_sum.solve(), 12)
+        self.assertAlmostEqual(prob_sum.solve(solver=cp.SCS), 12)
         prob_sum = sum([prob1])
         self.assertEqual(len(prob_sum.constraints), 1)
 
@@ -490,11 +490,11 @@ class TestProblem(BaseTest):
     # Test problem multiplication by scalar
     def test_mul_problems(self) -> None:
         prob1 = Problem(cp.Minimize(pow(self.a, 2)), [self.a >= 2])
-        answer = prob1.solve()
+        answer = prob1.solve(solver=cp.SCS)
         factors = [0, 1, 2.3, -4.321]
         for f in factors:
-            self.assertAlmostEqual((f * prob1).solve(), f * answer)
-            self.assertAlmostEqual((prob1 * f).solve(), f * answer)
+            self.assertAlmostEqual((f * prob1).solve(solver=cp.SCS), f * answer)
+            self.assertAlmostEqual((prob1 * f).solve(solver=cp.SCS), f * answer)
 
     # Test problem linear combinations
     def test_lin_combination_problems(self) -> None:
@@ -506,30 +506,30 @@ class TestProblem(BaseTest):
         combo1 = prob1 + 2 * prob2
         combo1_ref = Problem(cp.Minimize(self.a + 4 * self.b),
                              [self.a >= self.b, self.a >= 1, self.b >= 2])
-        self.assertAlmostEqual(combo1.solve(), combo1_ref.solve())
+        self.assertAlmostEqual(combo1.solve(solver=cp.ECOS), combo1_ref.solve(solver=cp.ECOS))
 
         # division and subtraction
         combo2 = prob1 - prob3/2
         combo2_ref = Problem(cp.Minimize(self.a + pow(self.b + self.a, 2)/2),
                              [self.b >= 3, self.a >= self.b])
-        self.assertAlmostEqual(combo2.solve(), combo2_ref.solve())
+        self.assertAlmostEqual(combo2.solve(solver=cp.ECOS), combo2_ref.solve(solver=cp.ECOS))
 
         # multiplication with 0 (prob2's constraints should still hold)
         combo3 = prob1 + 0 * prob2 - 3 * prob3
         combo3_ref = Problem(cp.Minimize(self.a + 3 * pow(self.b + self.a, 2)),
                              [self.a >= self.b, self.a >= 1, self.b >= 3])
-        self.assertAlmostEqual(combo3.solve(), combo3_ref.solve())
+        self.assertAlmostEqual(combo3.solve(solver=cp.ECOS), combo3_ref.solve(solver=cp.ECOS))
 
     # Test scalar LP problems.
     def test_scalar_lp(self) -> None:
         p = Problem(cp.Minimize(3*self.a), [self.a >= 2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 6)
         self.assertAlmostEqual(self.a.value, 2)
 
         p = Problem(cp.Maximize(3*self.a - self.b),
                     [self.a <= 2, self.b == self.a, self.b <= 5])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 4.0)
         self.assertAlmostEqual(self.a.value, 2)
         self.assertAlmostEqual(self.b.value, 2)
@@ -539,7 +539,7 @@ class TestProblem(BaseTest):
                     [self.a >= 2,
                      self.b + 5*self.c - 2 == self.a,
                      self.b <= 5 + self.c])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 101 + 1.0/6)
         self.assertAlmostEqual(self.a.value, 2)
         self.assertAlmostEqual(self.b.value, 5-1.0/6)
@@ -595,7 +595,7 @@ class TestProblem(BaseTest):
     def test_vector_lp(self) -> None:
         c = Constant(numpy.array([[1, 2]]).T).value
         p = Problem(cp.Minimize(c.T @ self.x), [self.x[:, None] >= c])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 5)
         self.assertItemsAlmostEqual(self.x.value, [1, 2])
 
@@ -606,7 +606,7 @@ class TestProblem(BaseTest):
                      4*Imat @ self.z == self.x,
                      self.z >= [2, 2],
                      self.a >= 2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 26, places=3)
         obj = (c.T @ self.x + self.a).value[0]
         self.assertAlmostEqual(obj, result)
@@ -626,7 +626,7 @@ class TestProblem(BaseTest):
     def test_matrix_lp(self) -> None:
         T = Constant(numpy.ones((2, 2))).value
         p = Problem(cp.Minimize(1), [self.A == T])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 1)
         self.assertItemsAlmostEqual(self.A.value, T)
 
@@ -645,7 +645,7 @@ class TestProblem(BaseTest):
     # Test variable promotion.
     def test_variable_promotion(self) -> None:
         p = Problem(cp.Minimize(self.a), [self.x <= self.a, self.x == [1, 2]])
-        result = p.solve()
+        result = p.solve(solver=cp.ECOS)
         self.assertAlmostEqual(result, 2)
         self.assertAlmostEqual(self.a.value, 2)
 
@@ -653,14 +653,14 @@ class TestProblem(BaseTest):
                     [self.A <= self.a,
                      self.A == [[1, 2], [3, 4]]
                      ])
-        result = p.solve()
+        result = p.solve(solver=cp.ECOS)
         self.assertAlmostEqual(result, 4)
         self.assertAlmostEqual(self.a.value, 4)
 
         # Promotion must happen before the multiplication.
         p = Problem(cp.Minimize([[1], [1]] @ (self.x + self.a + 1)),
                     [self.a + self.x >= [1, 2]])
-        result = p.solve()
+        result = p.solve(solver=cp.ECOS)
         self.assertAlmostEqual(result, 5)
 
     # Test parameter promotion.
@@ -680,36 +680,36 @@ class TestProblem(BaseTest):
         p1.value = 2
         p2.value = -numpy.ones((3,))
         p3.value = numpy.ones((4, 4))
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, -6)
 
         p1.value = None
         with self.assertRaises(ParameterError):
-            p.solve()
+            p.solve(solver=cp.SCS)
 
     # Test problems with norm_inf
     def test_norm_inf(self) -> None:
         # Constant argument.
         p = Problem(cp.Minimize(cp.norm_inf(-2)))
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 2)
 
         # Scalar arguments.
         p = Problem(cp.Minimize(cp.norm_inf(self.a)), [self.a >= 2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 2)
         self.assertAlmostEqual(self.a.value, 2)
 
         p = Problem(cp.Minimize(3*cp.norm_inf(self.a + 2*self.b) + self.c),
                     [self.a >= 2, self.b <= -1, self.c == 3])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 3)
         self.assertAlmostEqual(self.a.value + 2*self.b.value, 0)
         self.assertAlmostEqual(self.c.value, 3)
 
         # cp.Maximize
         p = Problem(cp.Maximize(-cp.norm_inf(self.a)), [self.a <= -2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, -2)
         self.assertAlmostEqual(self.a.value, -2)
 
@@ -724,25 +724,25 @@ class TestProblem(BaseTest):
     def test_norm1(self) -> None:
         # Constant argument.
         p = Problem(cp.Minimize(cp.norm1(-2)))
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 2)
 
         # Scalar arguments.
         p = Problem(cp.Minimize(cp.norm1(self.a)), [self.a <= -2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 2)
         self.assertAlmostEqual(self.a.value, -2)
 
         # cp.Maximize
         p = Problem(cp.Maximize(-cp.norm1(self.a)), [self.a <= -2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, -2)
         self.assertAlmostEqual(self.a.value, -2)
 
         # Vector arguments.
         p = Problem(cp.Minimize(cp.norm1(self.x - self.z) + 5),
                     [self.x >= [2, 3], self.z <= [-1, -4]])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(float(result), 15)
         self.assertAlmostEqual(float(list(self.x.value)[1] - list(self.z.value)[1]), 7)
 
@@ -750,25 +750,25 @@ class TestProblem(BaseTest):
     def test_norm2(self) -> None:
         # Constant argument.
         p = Problem(cp.Minimize(cp.pnorm(-2, p=2)))
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 2)
 
         # Scalar arguments.
         p = Problem(cp.Minimize(cp.pnorm(self.a, p=2)), [self.a <= -2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 2)
         self.assertAlmostEqual(self.a.value, -2)
 
         # cp.Maximize
         p = Problem(cp.Maximize(-cp.pnorm(self.a, p=2)), [self.a <= -2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, -2)
         self.assertAlmostEqual(self.a.value, -2)
 
         # Vector arguments.
         p = Problem(cp.Minimize(cp.pnorm(self.x - self.z, p=2) + 5),
                     [self.x >= [2, 3], self.z <= [-1, -4]])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 12.61577)
         self.assertItemsAlmostEqual(self.x.value, [2, 3])
         self.assertItemsAlmostEqual(self.z.value, [-1, -4])
@@ -776,7 +776,7 @@ class TestProblem(BaseTest):
         # Row  arguments.
         p = Problem(cp.Minimize(cp.pnorm((self.x - self.z).T, p=2) + 5),
                     [self.x >= [2, 3], self.z <= [-1, -4]])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 12.61577)
         self.assertItemsAlmostEqual(self.x.value, [2, 3])
         self.assertItemsAlmostEqual(self.z.value, [-1, -4])
@@ -784,44 +784,44 @@ class TestProblem(BaseTest):
     # Test problems with abs
     def test_abs(self) -> None:
         p = Problem(cp.Minimize(cp.sum(cp.abs(self.A))), [-2 >= self.A])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 8)
         self.assertItemsAlmostEqual(self.A.value, [-2, -2, -2, -2])
 
     # Test problems with quad_form.
     def test_quad_form(self) -> None:
         with self.assertRaises(Exception) as cm:
-            Problem(cp.Minimize(cp.quad_form(self.x, self.A))).solve()
+            Problem(cp.Minimize(cp.quad_form(self.x, self.A))).solve(solver=cp.SCS)
         self.assertEqual(
             str(cm.exception),
             "At least one argument to quad_form must be non-variable."
         )
 
         with self.assertRaises(Exception) as cm:
-            Problem(cp.Minimize(cp.quad_form(1, self.A))).solve()
+            Problem(cp.Minimize(cp.quad_form(1, self.A))).solve(solver=cp.SCS)
         self.assertEqual(str(cm.exception), "Invalid dimensions for arguments.")
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             with self.assertRaises(Exception) as cm:
-                Problem(cp.Minimize(cp.quad_form(self.x, [[-1, 0], [0, 9]]))).solve()
+                Problem(cp.Minimize(cp.quad_form(self.x, [[-1, 0], [0, 9]]))).solve(solver=cp.SCS)
             self.assertTrue("Problem does not follow DCP rules."
                             in str(cm.exception))
 
         P = [[4, 0], [0, 9]]
         p = Problem(cp.Minimize(cp.quad_form(self.x, P)), [self.x >= 1])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 13, places=3)
 
         c = [1, 2]
         p = Problem(cp.Minimize(cp.quad_form(c, self.A)), [self.A >= 1])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 9)
 
         c = [1, 2]
         P = [[4, 0], [0, 9]]
         p = Problem(cp.Minimize(cp.quad_form(c, P)))
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 40)
 
     # Test combining atoms
@@ -830,7 +830,7 @@ class TestProblem(BaseTest):
                                          + cp.norm1(self.x) +
                                          cp.norm_inf(self.x - self.z), p=2)),
                     [self.x >= [2, 3], self.z <= [-1, -4], cp.pnorm(self.x + self.z, p=2) <= 2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 22)
         self.assertItemsAlmostEqual(self.x.value, [2, 3])
         self.assertItemsAlmostEqual(self.z.value, [-1, -4])
@@ -838,7 +838,7 @@ class TestProblem(BaseTest):
     # Test multiplying by constant atoms.
     def test_mult_constant_atoms(self) -> None:
         p = Problem(cp.Minimize(cp.pnorm([3, 4], p=2)*self.a), [self.a >= 2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 10)
         self.assertAlmostEqual(self.a.value, 2)
 
@@ -879,7 +879,7 @@ class TestProblem(BaseTest):
     def test_indexing(self) -> None:
         # Vector variables
         p = Problem(cp.Maximize(self.x[0]), [self.x[0] <= 2, self.x[1] == 3])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 2)
         self.assertItemsAlmostEqual(self.x.value, [2, 3])
 
@@ -888,21 +888,21 @@ class TestProblem(BaseTest):
         A = numpy.reshape(A, (n, n))
         x = Variable((n, n))
         p = Problem(cp.Minimize(cp.sum(x)), [x == A])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         answer = n*n*(n*n+1)/2 - n*n
         self.assertAlmostEqual(result, answer)
 
         # Matrix variables
         p = Problem(cp.Maximize(sum(self.A[i, i] + self.A[i, 1-i] for i in range(2))),
                     [self.A <= [[1, -2], [-3, 4]]])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 0)
         self.assertItemsAlmostEqual(self.A.value, [1, -2, -3, 4])
 
         # Indexing arithmetic expressions.
         expr = [[1, 2], [3, 4]] @ self.z + self.x
         p = Problem(cp.Minimize(expr[1]), [self.x == self.z, self.z == [1, 2]])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 12)
         self.assertItemsAlmostEqual(self.x.value, self.z.value)
 
@@ -917,27 +917,27 @@ class TestProblem(BaseTest):
         # Test with long indices.
         cost = self.x[0:my_long(2)][0]
         p = Problem(cp.Minimize(cost), [self.x == 1])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 1)
         self.assertItemsAlmostEqual(self.x.value, [1, 1])
 
         # Test with numpy64 indices.
         cost = self.x[0:numpy.int64(2)][0]
         p = Problem(cp.Minimize(cost), [self.x == 1])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 1)
         self.assertItemsAlmostEqual(self.x.value, [1, 1])
 
     # Test problems with slicing.
     def test_slicing(self) -> None:
         p = Problem(cp.Maximize(cp.sum(self.C)), [self.C[1:3, :] <= 2, self.C[0, :] == 1])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(self.C.value, 2*[1, 2, 2])
 
         p = Problem(cp.Maximize(cp.sum(self.C[0:3:2, 1])),
                     [self.C[1:3, :] <= 2, self.C[0, :] == 1])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 3)
         self.assertItemsAlmostEqual(self.C.value[0:3:2, 1], [1, 2])
 
@@ -945,7 +945,7 @@ class TestProblem(BaseTest):
                     [self.C[1:3, :] <= 2, self.C[0, :] == 1,
                      (self.A + self.B)[:, 0] == 3, (self.A + self.B)[:, 1] == 2,
                      self.B == 1])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 12)
         self.assertItemsAlmostEqual(self.C.value[0:2, :], [1, 2, 1, 2])
         self.assertItemsAlmostEqual(self.A.value, [2, 2, 1, 1])
@@ -954,7 +954,7 @@ class TestProblem(BaseTest):
                     [self.C[1:3, :] <= 2, self.C[0, :] == 1,
                      [[1], [2]] @ (self.A + self.B)[:, 0] == 3, (self.A + self.B)[:, 1] == 2,
                      self.B == 1, 3*self.A[:, 0] <= 3])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 12)
         self.assertItemsAlmostEqual(self.C.value[0:2, 0], [1, 2])
         self.assertItemsAlmostEqual(self.A.value, [1, -.5, 1, 1])
@@ -963,14 +963,14 @@ class TestProblem(BaseTest):
                     [self.C[1:3, :] <= 2, self.C[0, :] == 1,
                      (self.A + self.B)[:, 0] == 3, (self.A + self.B)[:, 1] == 2,
                      self.B == 1])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 3)
         self.assertItemsAlmostEqual(self.C.value[0:2, 0], [1, -2], places=3)
         self.assertItemsAlmostEqual(self.A.value, [2, 2, 1, 1])
 
         # Transpose of slice.
         p = Problem(cp.Maximize(cp.sum(self.C)), [self.C[1:3, :].T <= 2, self.C[0, :].T == 1])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(self.C.value, 2*[1, 2, 2])
 
@@ -986,27 +986,27 @@ class TestProblem(BaseTest):
         p = Problem(cp.Minimize(c @ cp.vstack([x, y])),
                     [x == [[1, 2]],
                      y == [[3, 4, 5]]])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 15)
 
         c = numpy.ones((1, 4))
         p = Problem(cp.Minimize(c @ cp.vstack([x, x])),
                     [x == [[1, 2]]])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 6)
 
         c = numpy.ones((2, 2))
         p = Problem(cp.Minimize(cp.sum(cp.vstack([self.A, self.C]))),
                     [self.A >= 2*c,
                      self.C == -2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, -4)
 
         c = numpy.ones((1, 2))
         p = Problem(cp.Minimize(cp.sum(cp.vstack([c @ self.A, c @ self.B]))),
                     [self.A >= 2,
                      self.B == -2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 0)
 
         c = numpy.array([[1, -1]]).T
@@ -1014,7 +1014,7 @@ class TestProblem(BaseTest):
                     [a == 2,
                      b == 16])
         with self.assertRaises(Exception) as cm:
-            p.solve()
+            p.solve(solver=cp.SCS)
         self.assertTrue("Problem does not follow DCP rules."
                         in str(cm.exception))
 
@@ -1030,20 +1030,20 @@ class TestProblem(BaseTest):
         p = Problem(cp.Minimize(c @ cp.hstack([x.T, y.T]).T),
                     [x == [[1, 2]],
                      y == [[3, 4, 5]]])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 15)
 
         c = numpy.ones((1, 4))
         p = Problem(cp.Minimize(c @ cp.hstack([x.T, x.T]).T),
                     [x == [[1, 2]]])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 6)
 
         c = numpy.ones((2, 2))
         p = Problem(cp.Minimize(cp.sum(cp.hstack([self.A.T, self.C.T]))),
                     [self.A >= 2*c,
                      self.C == -2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, -4)
 
         D = Variable((3, 3))
@@ -1051,7 +1051,7 @@ class TestProblem(BaseTest):
         p = Problem(cp.Minimize(expr[0, 1] + cp.sum(cp.hstack([expr, expr]))),
                     [self.C >= 0,
                      D >= 0, D[0, 0] == 2, self.C[0, 1] == 3])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 13)
 
         c = numpy.array([[1, -1]]).T
@@ -1059,7 +1059,7 @@ class TestProblem(BaseTest):
                     [a == 2,
                      b == 16])
         with self.assertRaises(Exception) as cm:
-            p.solve()
+            p.solve(solver=cp.SCS)
         self.assertTrue("Problem does not follow DCP rules."
                         in str(cm.exception))
 
@@ -1074,48 +1074,48 @@ class TestProblem(BaseTest):
     def test_transpose(self) -> None:
         p = Problem(cp.Minimize(cp.sum(self.x)),
                     [self.x[None, :] >= numpy.array([[1, 2]])])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 3)
         self.assertItemsAlmostEqual(self.x.value, [1, 2])
 
         p = Problem(cp.Minimize(cp.sum(self.C)),
                     [numpy.array([[1, 1]]) @ self.C.T >= numpy.array([[0, 1, 2]])])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         value = self.C.value
 
         constraints = [1*self.C[i, 0] + 1*self.C[i, 1] >= i for i in range(3)]
         p = Problem(cp.Minimize(cp.sum(self.C)), constraints)
-        result2 = p.solve()
+        result2 = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, result2)
         self.assertItemsAlmostEqual(self.C.value, value)
 
         p = Problem(cp.Minimize(self.A[0, 1] - self.A.T[1, 0]),
                     [self.A == [[1, 2], [3, 4]]])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 0)
 
         p = Problem(cp.Minimize(cp.sum(self.x)), [(-self.x).T <= 1])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, -2)
 
         c = numpy.array([[1, -1]]).T
         p = Problem(cp.Minimize(cp.maximum(c.T, 2, 2 + c.T)[0, 1]))
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 2)
 
         c = numpy.array([[1, -1, 2], [1, -1, 2]]).T
         p = Problem(cp.Minimize(cp.sum(cp.maximum(c, 2, 2 + c).T[:, 0])))
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 6)
 
         c = numpy.array([[1, -1, 2], [1, -1, 2]]).T
         p = Problem(cp.Minimize(cp.sum(cp.square(c.T).T[:, 0])))
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 6)
 
         # Slice of transpose.
         p = Problem(cp.Maximize(cp.sum(self.C)), [self.C.T[:, 1:3] <= 2, self.C.T[:, 0] == 1])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(self.C.value, 2*[1, 2, 2])
 
@@ -1124,27 +1124,27 @@ class TestProblem(BaseTest):
         """
         c = numpy.array([[1, 2]]).T
         p = Problem(cp.Minimize(c.T @ self.A @ c), [self.A >= 2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 18)
 
         p = Problem(cp.Minimize(self.a*2), [self.a >= 2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 4)
 
         p = Problem(cp.Minimize(self.x.T @ c), [self.x >= 2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 6)
 
         p = Problem(cp.Minimize((self.x.T + self.z.T) @ c),
                     [self.x >= 2, self.z >= 1])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 9)
 
         # TODO segfaults in Python 3
         A = numpy.ones((5, 10))
         x = Variable(5)
         p = cp.Problem(cp.Minimize(cp.sum(x @ A)), [x >= 0])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 0)
 
     # Test redundant constraints in cpopt.
@@ -1175,11 +1175,11 @@ class TestProblem(BaseTest):
     # Test that symmetry is enforced.
     def test_sdp_symmetry(self) -> None:
         p = Problem(cp.Minimize(cp.lambda_max(self.A)), [self.A >= 2])
-        p.solve()
+        p.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(self.A.value, self.A.value.T, places=3)
 
         p = Problem(cp.Minimize(cp.lambda_max(self.A)), [self.A == [[1, 2], [3, 4]]])
-        p.solve()
+        p.solve(solver=cp.SCS)
         self.assertEqual(p.status, s.INFEASIBLE)
 
     # Test PSD
@@ -1190,7 +1190,7 @@ class TestProblem(BaseTest):
                           self.A[0, 0] == 2,
                           self.A[1, 1] == 2,
                           self.A[1, 0] == 2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 0, places=3)
 
     # Test getting values for expressions.
@@ -1202,7 +1202,7 @@ class TestProblem(BaseTest):
         obj = cp.pnorm(sum_exp, p=2)
         p = Problem(cp.Minimize(obj),
                     [self.x >= [2, 3], self.z <= [-1, -4], constr_exp <= 2])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 22)
         self.assertItemsAlmostEqual(self.x.value, [2, 3])
         self.assertItemsAlmostEqual(self.z.value, [-1, -4])
@@ -1225,7 +1225,7 @@ class TestProblem(BaseTest):
         self.assertEqual(exp.value, 0)
         obj = cp.Minimize(exp)
         p = Problem(obj)
-        result = p.solve()
+        result = p.solve(solver=cp.ECOS)
         self.assertAlmostEqual(result, 0)
         assert self.a.value is not None
 
@@ -1234,14 +1234,14 @@ class TestProblem(BaseTest):
         """
         obj = cp.Minimize(cp.norm_inf(self.A/5))
         p = Problem(obj, [self.A >= 5])
-        result = p.solve()
+        result = p.solve(solver=cp.ECOS)
         self.assertAlmostEqual(result, 1)
 
         c = cp.Constant([[1., -1], [2, -2]])
         expr = self.A/(1./c)
         obj = cp.Minimize(cp.norm_inf(expr))
         p = Problem(obj, [self.A == 5])
-        result = p.solve()
+        result = p.solve(solver=cp.ECOS)
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(expr.value, [5, -5] + [10, -10])
 
@@ -1253,7 +1253,7 @@ class TestProblem(BaseTest):
         expr = self.x[:, None]/(1/c)
         obj = cp.Minimize(cp.norm_inf(expr))
         p = Problem(obj, [self.x == 5])
-        result = p.solve()
+        result = p.solve(solver=cp.ECOS)
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(expr.value, [5, 10])
 
@@ -1263,7 +1263,7 @@ class TestProblem(BaseTest):
         expr = self.a/(1/c)
         obj = cp.Minimize(cp.norm_inf(expr))
         p = Problem(obj, [self.a == 5])
-        result = p.solve()
+        result = p.solve(solver=cp.ECOS)
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(expr.value, [5, -5] + [10, -10])
 
@@ -1274,7 +1274,7 @@ class TestProblem(BaseTest):
         expr = cp.multiply(c, self.A)
         obj = cp.Minimize(cp.norm_inf(expr))
         p = Problem(obj, [self.A == 5])
-        result = p.solve()
+        result = p.solve(solver=cp.ECOS)
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(expr.value, [5, -5] + [10, -10])
 
@@ -1285,7 +1285,7 @@ class TestProblem(BaseTest):
         expr = cp.multiply(c, self.x[:, None])
         obj = cp.Minimize(cp.norm_inf(expr))
         p = Problem(obj, [self.x == 5])
-        result = p.solve()
+        result = p.solve(solver=cp.ECOS)
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(expr.value.toarray(), [5, 10])
 
@@ -1294,7 +1294,7 @@ class TestProblem(BaseTest):
         expr = cp.multiply(c, self.a)
         obj = cp.Minimize(cp.norm_inf(expr))
         p = Problem(obj, [self.a == 5])
-        result = p.solve()
+        result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(expr.value, [5, -5] + [10, -10])
 
@@ -1335,7 +1335,7 @@ class TestProblem(BaseTest):
         expr = cp.reshape(x, (2, 2))
         obj = cp.Minimize(cp.sum(mat @ expr))
         prob = Problem(obj, [x[:, None] == vec])
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, numpy.sum(mat.dot(vec_mat)))
 
         # Test on matrix to vector.
@@ -1344,7 +1344,7 @@ class TestProblem(BaseTest):
         obj = cp.Minimize(expr.T @ c)
         constraints = [self.A == [[-1, -2], [3, 4]]]
         prob = Problem(obj, constraints)
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 20)
         self.assertItemsAlmostEqual(expr.value, [-1, -2, 3, 4])
         self.assertItemsAlmostEqual(cp.reshape(expr, (2, 2)).value, [-1, -2, 3, 4])
@@ -1355,7 +1355,7 @@ class TestProblem(BaseTest):
         C_mat = numpy.array([[1, 4], [2, 5], [3, 6]])
         obj = cp.Minimize(cp.sum(mat @ expr))
         prob = Problem(obj, [self.C == C_mat])
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         reshaped = numpy.reshape(C_mat, (2, 3), 'F')
         self.assertAlmostEqual(result, (mat.dot(reshaped)).sum())
         self.assertItemsAlmostEqual(expr.value, C_mat)
@@ -1365,14 +1365,14 @@ class TestProblem(BaseTest):
         expr = cp.reshape(c * self.a, (1, 4))
         obj = cp.Minimize(expr @ [1, 2, 3, 4])
         prob = Problem(obj, [self.a == 2])
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, -6)
         self.assertItemsAlmostEqual(expr.value, 2*c)
 
         expr = cp.reshape(c * self.a, (4, 1))
         obj = cp.Minimize(expr.T @ [1, 2, 3, 4])
         prob = Problem(obj, [self.a == 2])
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, -6)
         self.assertItemsAlmostEqual(expr.value, 2*c)
 
@@ -1382,7 +1382,7 @@ class TestProblem(BaseTest):
         tt = cp.Variable(5)
         prob = cp.Problem(cp.Minimize(cp.sum(tt)),
                           [cp.cumsum(tt, 0) >= -0.0001])
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, -0.0001)
 
     def test_cummax(self) -> None:
@@ -1391,7 +1391,7 @@ class TestProblem(BaseTest):
         tt = cp.Variable(5)
         prob = cp.Problem(cp.Maximize(cp.sum(tt)),
                           [cp.cummax(tt, 0) <= numpy.array([1, 2, 3, 4, 5])])
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 15)
 
     def test_vec(self) -> None:
@@ -1402,7 +1402,7 @@ class TestProblem(BaseTest):
         obj = cp.Minimize(expr.T @ c)
         constraints = [self.A == [[-1, -2], [3, 4]]]
         prob = Problem(obj, constraints)
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 20)
         self.assertItemsAlmostEqual(expr.value, [-1, -2, 3, 4])
 
@@ -1416,7 +1416,7 @@ class TestProblem(BaseTest):
                        C[1, 2] == -0.3,
                        C == Variable((3, 3), PSD=True)]
         prob = Problem(obj, constraints)
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 0.583151, places=2)
 
     def test_presolve_parameters(self) -> None:
@@ -1459,7 +1459,7 @@ class TestProblem(BaseTest):
         x0.value = 1
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            prob.solve()
+            prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(g.value, 0)
 
         # Test multiplication.
@@ -1467,11 +1467,11 @@ class TestProblem(BaseTest):
         x0.value = 2
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            prob.solve()
+            prob.solve(solver=cp.SCS)
         x0.value = 1
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            prob.solve()
+            prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(prob.value, 1, places=2)
 
     def test_psd_constraints(self) -> None:
@@ -1485,21 +1485,21 @@ class TestProblem(BaseTest):
                        C == C.T,
                        C >> 0]
         prob = Problem(obj, constraints)
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 0.583151, places=2)
 
         C = Variable((2, 2))
         obj = cp.Maximize(C[0, 1])
         constraints = [C == 1, C >> [[2, 0], [0, 2]]]
         prob = Problem(obj, constraints)
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
         C = Variable((2, 2), symmetric=True)
         obj = cp.Minimize(C[0, 0])
         constraints = [C << [[2, 0], [0, 2]]]
         prob = Problem(obj, constraints)
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         self.assertEqual(prob.status, s.UNBOUNDED)
 
     def test_psd_duals(self) -> None:
@@ -1564,11 +1564,11 @@ class TestProblem(BaseTest):
         x = Variable(2)
         cost = cp.geo_mean(x)
         prob = Problem(cp.Maximize(cost), [x <= 1])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(prob.value, 1)
 
         prob = Problem(cp.Maximize(cost), [cp.sum(x) <= 1])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(x.value, [.5, .5])
 
         x = Variable((3, 3))
@@ -1593,7 +1593,7 @@ class TestProblem(BaseTest):
 
         x = Variable(5)
         prob = Problem(cp.Maximize(cp.geo_mean(x, p)), [cp.sum(x) <= 1])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         x = np.array(x.value).flatten()
         x_true = p/sum(p)
 
@@ -1605,7 +1605,7 @@ class TestProblem(BaseTest):
         # max geo_mean(x) s.t. norm(x) <= 1
         x = Variable(5)
         prob = Problem(cp.Maximize(cp.geo_mean(x, p)), [cp.norm(x) <= 1])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         x = np.array(x.value).flatten()
         x_true = np.sqrt(p/sum(p))
 
@@ -1619,17 +1619,17 @@ class TestProblem(BaseTest):
         x_true = np.ones(n)
         x = Variable(n)
 
-        Problem(cp.Maximize(cp.geo_mean(x)), [x <= 1]).solve()
+        Problem(cp.Maximize(cp.geo_mean(x)), [x <= 1]).solve(solver=cp.SCS)
         xval = np.array(x.value).flatten()
         self.assertTrue(np.allclose(xval, x_true, 1e-3))
 
         y = cp.vstack([x[i] for i in range(n)])
-        Problem(cp.Maximize(cp.geo_mean(y)), [x <= 1]).solve()
+        Problem(cp.Maximize(cp.geo_mean(y)), [x <= 1]).solve(solver=cp.SCS)
         xval = np.array(x.value).flatten()
         self.assertTrue(np.allclose(xval, x_true, 1e-3))
 
         y = cp.hstack([x[i] for i in range(n)])
-        Problem(cp.Maximize(cp.geo_mean(y)), [x <= 1]).solve()
+        Problem(cp.Maximize(cp.geo_mean(y)), [x <= 1]).solve(solver=cp.SCS)
         xval = np.array(x.value).flatten()
         self.assertTrue(np.allclose(xval, x_true, 1e-3))
 
@@ -1644,7 +1644,7 @@ class TestProblem(BaseTest):
 
         for p in (1, 1.6, 1.3, 2, 1.99, 3, 3.7, np.inf):
             prob = Problem(cp.Minimize(cp.pnorm(x, p=p)), [x.T @ a >= 1])
-            prob.solve(verbose=True)
+            prob.solve(solver=cp.ECOS, verbose=True)
 
             # formula is true for any a >= 0 with p > 1
             if p == np.inf:
@@ -1669,21 +1669,21 @@ class TestProblem(BaseTest):
         a = np.array([-1.0, 2, 3])
         for p in (-1, .5, .3, -2.3):
             prob = Problem(cp.Minimize(cp.sum(cp.abs(x-a))), [cp.pnorm(x, p) >= 0])
-            prob.solve()
+            prob.solve(solver=cp.ECOS)
 
             self.assertTrue(np.allclose(prob.value, 1))
 
         a = np.array([1.0, 2, 3])
         for p in (-1, .5, .3, -2.3):
             prob = Problem(cp.Minimize(cp.sum(cp.abs(x-a))), [cp.pnorm(x, p) >= 0])
-            prob.solve()
+            prob.solve(solver=cp.ECOS)
 
             self.assertAlmostEqual(prob.value, 0, places=6)
 
     def test_power(self) -> None:
         x = Variable()
         prob = Problem(cp.Minimize(cp.power(x, 1.7) + cp.power(x, -2.3) - cp.power(x, .45)))
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         x = x.value
         self.assertTrue(builtins.abs(1.7*x**.7 - 2.3*x**-3.3 - .45*x**-.55) <= 1e-3)
 
@@ -1710,7 +1710,7 @@ class TestProblem(BaseTest):
 
         obj = cp.Minimize(cp.sum(cp.multiply(2, self.x)))
         prob = Problem(obj, [self.x == 2])
-        result = prob.solve()
+        result = prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 8)
 
     def test_int64(self) -> None:
@@ -1719,7 +1719,7 @@ class TestProblem(BaseTest):
         q = cp.Variable(numpy.int64(2))
         objective = cp.Minimize(cp.norm(q, 1))
         problem = cp.Problem(objective)
-        problem.solve()
+        problem.solve(solver=cp.SCS)
         print(q.value)
 
     def test_neg_slice(self) -> None:
@@ -1729,7 +1729,7 @@ class TestProblem(BaseTest):
         objective = cp.Minimize(x[0] + x[1])
         constraints = [x[-2:] >= 1]
         problem = cp.Problem(objective, constraints)
-        problem.solve()
+        problem.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(x.value, [1, 1])
 
     def test_pnorm_axis(self) -> None:
@@ -1741,7 +1741,7 @@ class TestProblem(BaseTest):
         con = [expr <= 0]
         obj = cp.Maximize(cp.sum(X))
         prob = cp.Problem(obj, con)
-        prob.solve(solver='ECOS')
+        prob.solve(solver=cp.ECOS)
         self.assertItemsAlmostEqual(expr.value, numpy.zeros(2))
 
         b = numpy.arange(10)
@@ -1750,7 +1750,7 @@ class TestProblem(BaseTest):
         con = [expr <= 0]
         obj = cp.Maximize(cp.sum(X))
         prob = cp.Problem(obj, con)
-        prob.solve(solver='ECOS')
+        prob.solve(solver=cp.ECOS)
         self.assertItemsAlmostEqual(expr.value, numpy.zeros(10))
 
     def test_bool_constr(self) -> None:
@@ -1758,41 +1758,41 @@ class TestProblem(BaseTest):
         """
         x = cp.Variable(pos=True)
         prob = cp.Problem(cp.Minimize(x), [True])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(x.value, 0)
 
         x = cp.Variable(pos=True)
         prob = cp.Problem(cp.Minimize(x), [True]*10)
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(x.value, 0)
 
         prob = cp.Problem(cp.Minimize(x), [42 <= x] + [True]*10)
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(x.value, 42)
 
         prob = cp.Problem(cp.Minimize(x), [True] + [42 <= x] + [True] * 10)
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(x.value, 42)
 
         prob = cp.Problem(cp.Minimize(x), [False])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
         prob = cp.Problem(cp.Minimize(x), [False]*10)
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
         prob = cp.Problem(cp.Minimize(x), [True]*10 + [False] + [True]*10)
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
         prob = cp.Problem(cp.Minimize(x), [42 <= x] + [True]*10 + [False])
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
         # only Trues, but infeasible solution since x must be non-negative.
         prob = cp.Problem(cp.Minimize(x), [True] + [x <= -42] + [True]*10)
-        prob.solve()
+        prob.solve(solver=cp.SCS)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
     def test_pos(self) -> None:
@@ -1800,12 +1800,12 @@ class TestProblem(BaseTest):
         """
         x = cp.Variable(pos=True)
         prob = cp.Problem(cp.Minimize(x))
-        prob.solve()
+        prob.solve(solver=cp.ECOS)
         self.assertAlmostEqual(x.value, 0)
 
         x = cp.Variable(neg=True)
         prob = cp.Problem(cp.Maximize(x))
-        prob.solve()
+        prob.solve(solver=cp.ECOS)
         self.assertAlmostEqual(x.value, 0)
 
     def test_pickle(self) -> None:
@@ -1815,7 +1815,7 @@ class TestProblem(BaseTest):
                           [self.a >= 1])
         prob_str = pickle.dumps(prob)
         new_prob = pickle.loads(prob_str)
-        result = new_prob.solve()
+        result = new_prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 5.0)
         self.assertAlmostEqual(new_prob.variables()[0].value, 1.0)
 
@@ -1865,13 +1865,13 @@ class TestProblem(BaseTest):
         y = cp.sum(x[:, 0:2], axis=1)
         cost = cp.QuadForm(y, np.diag([1]))
         prob = cp.Problem(cp.Minimize(cost))
-        result1 = prob.solve()
+        result1 = prob.solve(solver=cp.SCS)
 
         x = cp.Variable((1, 3))
         y = cp.sum(x[:, [0, 1]], axis=1)
         cost = cp.QuadForm(y, np.diag([1]))
         prob = cp.Problem(cp.Minimize(cost))
-        result2 = prob.solve()
+        result2 = prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result1, result2)
 
     def test_indicator(self) -> None:
@@ -1886,12 +1886,12 @@ class TestProblem(BaseTest):
         constraints = [a @ x == b]
         objective = cp.Minimize((1/2) * cp.square(q.T @ x) + cp.transforms.indicator(constraints))
         problem = cp.Problem(objective)
-        solution1 = problem.solve()
+        solution1 = problem.solve(solver=cp.SCS)
 
         # Without indicators.
         objective = cp.Minimize((1/2) * cp.square(q.T @ x))
         problem = cp.Problem(objective, constraints)
-        solution2 = problem.solve()
+        solution2 = problem.solve(solver=cp.SCS)
         self.assertAlmostEqual(solution1, solution2)
 
     def test_rmul_scalar_mats(self) -> None:
@@ -1903,7 +1903,7 @@ class TestProblem(BaseTest):
         objective = cp.Minimize(cp.quad_form(z, x) - 2 * z.T @ y)
 
         prob = cp.Problem(objective)
-        prob.solve('OSQP', verbose=True)
+        prob.solve(cp.OSQP, verbose=True)
         result1 = prob.value
 
         x = 4144.30127531
@@ -1912,7 +1912,7 @@ class TestProblem(BaseTest):
         objective = cp.Minimize(x*z**2 - 2 * z * y)
 
         prob = cp.Problem(objective)
-        prob.solve('OSQP', verbose=True)
+        prob.solve(cp.OSQP, verbose=True)
         self.assertAlmostEqual(prob.value, result1)
 
     def test_min_with_axis(self) -> None:
@@ -1927,14 +1927,14 @@ class TestProblem(BaseTest):
 
         obj = cp.sum(reshaped_minimum)
         problem = cp.Problem(cp.Maximize(obj), [x == 1, y == 2])
-        result = problem.solve()
+        result = problem.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 10)
 
     def test_constant_infeasible(self) -> None:
         """Test a problem with constant values only that is infeasible.
         """
         p = cp.Problem(cp.Maximize(0), [cp.Constant(0) == 1])
-        p.solve()
+        p.solve(solver=cp.SCS)
         self.assertEquals(p.status, cp.INFEASIBLE)
 
     def test_huber_scs(self) -> None:

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -440,12 +440,12 @@ class TestQp(BaseTest):
         prob = Problem(Minimize(sum_squares(A @ x - b)))
 
         b.value = np.random.randn(m)
-        result = prob.solve(solver="SCS", warm_start=False)
-        result2 = prob.solve(solver="SCS", warm_start=True)
+        result = prob.solve(solver="OSQP", warm_start=False)
+        result2 = prob.solve(solver="OSQP", warm_start=True)
         self.assertAlmostEqual(result, result2)
         b.value = np.random.randn(m)
-        result = prob.solve(solver="SCS", warm_start=True)
-        result2 = prob.solve(solver="SCS", warm_start=False)
+        result = prob.solve(solver="OSQP", warm_start=True)
+        result2 = prob.solve(solver="OSQP", warm_start=False)
         self.assertAlmostEqual(result, result2)
         pass
 

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -440,12 +440,12 @@ class TestQp(BaseTest):
         prob = Problem(Minimize(sum_squares(A @ x - b)))
 
         b.value = np.random.randn(m)
-        result = prob.solve(warm_start=False)
-        result2 = prob.solve(warm_start=True)
+        result = prob.solve(solver="SCS", warm_start=False)
+        result2 = prob.solve(solver="SCS", warm_start=True)
         self.assertAlmostEqual(result, result2)
         b.value = np.random.randn(m)
-        result = prob.solve(warm_start=True)
-        result2 = prob.solve(warm_start=False)
+        result = prob.solve(solver="SCS", warm_start=True)
+        result2 = prob.solve(solver="SCS", warm_start=False)
         self.assertAlmostEqual(result, result2)
         pass
 
@@ -497,7 +497,7 @@ class TestQp(BaseTest):
 
         obj = Minimize(b ** 2 + abs(a))
         prob = Problem(obj)
-        prob.solve()
+        prob.solve(solver="SCS")
         self.assertAlmostEqual(obj.value, 1.0)
 
     def test_gurobi_time_limit_no_solution(self) -> None:

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -64,7 +64,7 @@ class TestNonOptimal(BaseTest):
                         objective = cvxpy.Maximize(q)
                     constraints = [0 <= x, cvxpy.sum(x) == 1]
                     p = cvxpy.Problem(objective, constraints)
-                    p.solve()
+                    p.solve(solver=cvxpy.SCS)
 
                     # check that cvxpy found the right answer
                     xopt = x.value.flatten()
@@ -79,7 +79,7 @@ class TestNonOptimal(BaseTest):
         x = cvxpy.Variable(2)
         cost = cvxpy.quad_form(x, Q)
         prob = cvxpy.Problem(cvxpy.Minimize(cost), [x == [1, 2]])
-        self.assertAlmostEqual(prob.solve(), 5)
+        self.assertAlmostEqual(prob.solve(solver=cvxpy.SCS), 5)
 
         # Here are our QP factors
         A = cvxpy.Constant(sp.eye(4))
@@ -93,7 +93,7 @@ class TestNonOptimal(BaseTest):
         objective = cvxpy.Minimize(function)
         problem = cvxpy.Problem(objective)
 
-        problem.solve()
+        problem.solve(solver=cvxpy.SCS)
         self.assertEqual(len(function.value), 1)
 
     def test_param_quad_form(self) -> None:
@@ -107,7 +107,7 @@ class TestNonOptimal(BaseTest):
         prob = cvxpy.Problem(cvxpy.Minimize(cost), [x == [1, 2]])
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            self.assertAlmostEqual(prob.solve(), 5)
+            self.assertAlmostEqual(prob.solve(solver=cvxpy.SCS), 5)
 
     def test_non_symmetric(self) -> None:
         """Test when P is constant and not symmetric.
@@ -130,7 +130,7 @@ class TestNonOptimal(BaseTest):
             cost = cvxpy.quad_form(x, P)
         prob = cvxpy.Problem(cvxpy.Minimize(cost), [x == [1, 2]])
         with self.assertRaises(Exception) as cm:
-            prob.solve()
+            prob.solve(solver=cvxpy.SCS)
         self.assertTrue("Problem does not follow DCP rules."
                         in str(cm.exception))
 
@@ -144,7 +144,7 @@ class TestNonOptimal(BaseTest):
             warnings.simplefilter("ignore")
             cost = cvxpy.quad_form(x, P)
             prob = cvxpy.Problem(cvxpy.Minimize(cost), [x == [1, 2]])
-            prob.solve()
+            prob.solve(solver=cvxpy.SCS)
 
     def test_nsd_exactly_tolerance(self) -> None:
         """Test that NSD check when eigenvalue is exactly EIGVAL_TOL
@@ -156,7 +156,7 @@ class TestNonOptimal(BaseTest):
             warnings.simplefilter("ignore")
             cost = cvxpy.quad_form(x, P)
             prob = cvxpy.Problem(cvxpy.Maximize(cost), [x == [1, 2]])
-            prob.solve()
+            prob.solve(solver=cvxpy.SCS)
 
     def test_obj_eval(self) -> None:
         """Test case where objective evaluation differs from result.
@@ -167,7 +167,7 @@ class TestNonOptimal(BaseTest):
         obj0 = -B.T @ x
         obj1 = cvxpy.quad_form(B.T @ x, A)
         prob = cvxpy.Problem(cvxpy.Minimize(obj0 + obj1))
-        prob.solve()
+        prob.solve(solver=cvxpy.SCS)
         self.assertAlmostEqual(prob.value, prob.objective.value)
 
     def test_zero_term(self) -> None:
@@ -185,7 +185,7 @@ class TestNonOptimal(BaseTest):
         )
         constraints = [(M[0] @ c) == 1]  # (K * c) >= -0.1]
         prob = cvxpy.Problem(objective, constraints)
-        prob.solve()
+        prob.solve(solver=cvxpy.SCS)
 
     def test_zero_matrix(self) -> None:
         """Test quad_form with P = 0.

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -64,7 +64,7 @@ class TestNonOptimal(BaseTest):
                         objective = cvxpy.Maximize(q)
                     constraints = [0 <= x, cvxpy.sum(x) == 1]
                     p = cvxpy.Problem(objective, constraints)
-                    p.solve(solver=cvxpy.SCS)
+                    p.solve(solver=cvxpy.OSQP)
 
                     # check that cvxpy found the right answer
                     xopt = x.value.flatten()
@@ -79,7 +79,7 @@ class TestNonOptimal(BaseTest):
         x = cvxpy.Variable(2)
         cost = cvxpy.quad_form(x, Q)
         prob = cvxpy.Problem(cvxpy.Minimize(cost), [x == [1, 2]])
-        self.assertAlmostEqual(prob.solve(solver=cvxpy.SCS), 5)
+        self.assertAlmostEqual(prob.solve(solver=cvxpy.OSQP), 5)
 
         # Here are our QP factors
         A = cvxpy.Constant(sp.eye(4))
@@ -93,7 +93,7 @@ class TestNonOptimal(BaseTest):
         objective = cvxpy.Minimize(function)
         problem = cvxpy.Problem(objective)
 
-        problem.solve(solver=cvxpy.SCS)
+        problem.solve(solver=cvxpy.OSQP)
         self.assertEqual(len(function.value), 1)
 
     def test_param_quad_form(self) -> None:

--- a/cvxpy/tests/test_semidefinite_vars.py
+++ b/cvxpy/tests/test_semidefinite_vars.py
@@ -40,14 +40,14 @@ class TestSemidefiniteVariable(BaseTest):
         constraints += [M + C2 == x2]
         objective = cvx.Minimize(cvx.trace(M))
         prob = cvx.Problem(objective, constraints)
-        prob.solve()
+        prob.solve(solver="SCS")
         assert (M.value == M.T.value).all()
 
     def test_sdp_problem(self) -> None:
         # PSD in objective.
         obj = cvx.Minimize(cvx.sum(cvx.square(self.X - self.F)))
         p = cvx.Problem(obj, [])
-        result = p.solve()
+        result = p.solve(solver="SCS")
         self.assertAlmostEqual(result, 1, places=4)
 
         self.assertAlmostEqual(self.X.value[0, 0], 1, places=3)
@@ -59,7 +59,7 @@ class TestSemidefiniteVariable(BaseTest):
         # ECHU: note to self, apparently this is a source of redundancy
         obj = cvx.Minimize(cvx.sum(cvx.square(self.Y - self.F)))
         p = cvx.Problem(obj, [self.Y == Variable((2, 2), PSD=True)])
-        result = p.solve()
+        result = p.solve(solver="SCS")
         self.assertAlmostEqual(result, 1, places=2)
 
         self.assertAlmostEqual(self.Y.value[0, 0], 1, places=3)
@@ -73,7 +73,7 @@ class TestSemidefiniteVariable(BaseTest):
                            # square(self.X[0,1] - 3) +
                            cvx.square(self.X[1, 1] - 4))
         p = cvx.Problem(obj, [])
-        result = p.solve()
+        result = p.solve(solver="SCS")
         print(self.X.value)
         self.assertAlmostEqual(result, 0)
 


### PR DESCRIPTION
As suggested by @SteveDiamond, this PR defines solvers for all tests which currently don't specify a solver.
The idea is that a test should not depend on the users' setups.
