### PR TITLE
[CI] Only install Mosek if license is available

### DIFF
--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -30,6 +30,7 @@ fi
 
 python -m pip install diffcp gurobipy xpress
 
+# Only install Mosek if license is available (secret is not copied to forks)
 if [[ -n "$MOSEK_CI_BASE64" ]]; then
     python -m pip install mosek
 fi

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -28,7 +28,11 @@ if [[ "$PYTHON_VERSION" == "3.9" ]] || [[ "$RUNNER_OS" == "Windows" ]]; then
   conda install pyscipopt
 fi
 
-python -m pip install diffcp gurobipy xpress mosek
+python -m pip install diffcp gurobipy xpress
+
+if [[ -n "$MOSEK_CI_BASE64" ]]; then
+    python -m pip install mosek
+fi
 
 if [[ "$USE_OPENMP" == "True" ]]; then
   conda install -c conda-forge openmp


### PR DESCRIPTION
Since Github action secrets are not copied to forks, the CI fails on PRs after adding Mosek.

This PR skips the Mosek install in case the secret is not available. It is not an ideal solution, as there is some chance that a test only fails on Mosek after the PR is merged. 