### PR TITLE
Support for Gurobi Environments

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -154,7 +154,17 @@ class GUROBI(SCS):
 
         n = c.shape[0]
 
-        model = gurobipy.Model()
+        # Create a new model
+        if 'env' in solver_opts:
+            # Specifies environment to create Gurobi model for control over licensing and parameters
+            # https://www.gurobi.com/documentation/9.1/refman/environments.html
+            default_env = solver_opts['env']
+            del solver_opts['env']
+            model = gurobipy.Model(env=default_env)
+        else:
+            # Create Gurobi model using default (unspecified) environment
+            model = gurobipy.Model()
+
         # Pass through verbosity
         model.setParam("OutputFlag", verbose)
 

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -118,7 +118,16 @@ class GUROBI(QpSolver):
         constrain_gurobi_infty(g)
 
         # Create a new model
-        model = grb.Model()
+        if 'env' in solver_opts:
+            # Specifies environment to create Gurobi model for control over licensing and parameters
+            # https://www.gurobi.com/documentation/9.1/refman/environments.html
+            default_env = solver_opts['env']
+            del solver_opts['env']
+            model = grb.Model(env=default_env)
+        else:
+            # Create Gurobi model using default (unspecified) environment
+            model = grb.Model()
+
         # Pass through verbosity
         model.setParam("OutputFlag", verbose)
 

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -703,46 +703,51 @@ def mi_pcp_0() -> SolverTestHelper:
 class StandardTestLPs:
 
     @staticmethod
-    def test_lp_0(solver, places: int = 4, duals: bool = True, **kwargs) -> None:
+    def test_lp_0(solver, places: int = 4, duals: bool = True, **kwargs) -> SolverTestHelper:
         sth = lp_0()
         sth.solve(solver, **kwargs)
         sth.verify_primal_values(places)
         sth.verify_objective(places)
         if duals:
             sth.check_complementarity(places)
+        return sth
 
     @staticmethod
-    def test_lp_1(solver, places: int = 4, duals: bool = True, **kwargs) -> None:
+    def test_lp_1(solver, places: int = 4, duals: bool = True, **kwargs) -> SolverTestHelper:
         sth = lp_1()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)
         if duals:
             sth.verify_dual_values(places)
+        return sth
 
     @staticmethod
-    def test_lp_2(solver, places: int = 4, duals: bool = True, **kwargs) -> None:
+    def test_lp_2(solver, places: int = 4, duals: bool = True, **kwargs) -> SolverTestHelper:
         sth = lp_2()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)
         if duals:
             sth.verify_dual_values(places)
+        return sth
 
     @staticmethod
-    def test_lp_3(solver, places: int = 4, **kwargs) -> None:
+    def test_lp_3(solver, places: int = 4, **kwargs) -> SolverTestHelper:
         sth = lp_3()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
+        return sth
 
     @staticmethod
-    def test_lp_4(solver, places: int = 4, **kwargs) -> None:
+    def test_lp_4(solver, places: int = 4, **kwargs) -> SolverTestHelper:
         sth = lp_4()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
+        return sth
 
     @staticmethod
-    def test_lp_5(solver, places: int = 4, duals: bool = True,  **kwargs) -> None:
+    def test_lp_5(solver, places: int = 4, duals: bool = True,  **kwargs) -> SolverTestHelper:
         sth = lp_5()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -750,49 +755,55 @@ class StandardTestLPs:
         if duals:
             sth.check_complementarity(places)
             sth.check_dual_domains(places)
+        return sth
 
     @staticmethod
-    def test_mi_lp_0(solver, places: int = 4, **kwargs) -> None:
+    def test_mi_lp_0(solver, places: int = 4, **kwargs) -> SolverTestHelper:
         sth = mi_lp_0()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)
+        return sth
 
     @staticmethod
-    def test_mi_lp_1(solver, places: int = 4, **kwargs) -> None:
+    def test_mi_lp_1(solver, places: int = 4, **kwargs) -> SolverTestHelper:
         sth = mi_lp_1()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)
+        return sth
 
     @staticmethod
-    def test_mi_lp_2(solver, places: int = 4, **kwargs) -> None:
+    def test_mi_lp_2(solver, places: int = 4, **kwargs) -> SolverTestHelper:
         sth = mi_lp_2()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)
+        return sth
 
     @staticmethod
-    def test_mi_lp_3(solver, places: int = 4, **kwargs) -> None:
+    def test_mi_lp_3(solver, places: int = 4, **kwargs) -> SolverTestHelper:
         sth = mi_lp_3()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)
+        return sth
 
 
 class StandardTestSOCPs:
 
     @staticmethod
-    def test_socp_0(solver, places: int = 4, duals: bool = True, **kwargs) -> None:
+    def test_socp_0(solver, places: int = 4, duals: bool = True, **kwargs) -> SolverTestHelper:
         sth = socp_0()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)
         if duals:
             sth.check_complementarity(places)
+        return sth
 
     @staticmethod
-    def test_socp_1(solver, places: int = 4, duals: bool = True, **kwargs) -> None:
+    def test_socp_1(solver, places: int = 4, duals: bool = True, **kwargs) -> SolverTestHelper:
         sth = socp_1()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -800,9 +811,10 @@ class StandardTestSOCPs:
         if duals:
             sth.check_complementarity(places)
             sth.verify_dual_values(places)
+        return sth
 
     @staticmethod
-    def test_socp_2(solver, places: int = 4, duals: bool = True, **kwargs) -> None:
+    def test_socp_2(solver, places: int = 4, duals: bool = True, **kwargs) -> SolverTestHelper:
         sth = socp_2()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -810,9 +822,10 @@ class StandardTestSOCPs:
         if duals:
             sth.check_complementarity(places)
             sth.verify_dual_values(places)
+        return sth
 
     @staticmethod
-    def test_socp_3ax0(solver, places: int = 3, duals: bool = True, **kwargs) -> None:
+    def test_socp_3ax0(solver, places: int = 3, duals: bool = True, **kwargs) -> SolverTestHelper:
         sth = socp_3(axis=0)
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -820,9 +833,10 @@ class StandardTestSOCPs:
         if duals:
             sth.check_complementarity(places)
             sth.verify_dual_values(places)
+        return sth
 
     @staticmethod
-    def test_socp_3ax1(solver, places: int = 3, duals: bool = True, **kwargs) -> None:
+    def test_socp_3ax1(solver, places: int = 3, duals: bool = True, **kwargs) -> SolverTestHelper:
         sth = socp_3(axis=1)
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -830,26 +844,29 @@ class StandardTestSOCPs:
         if duals:
             sth.check_complementarity(places)
             sth.verify_dual_values(places)
+        return sth
 
     @staticmethod
-    def test_mi_socp_1(solver, places: int = 4, **kwargs) -> None:
+    def test_mi_socp_1(solver, places: int = 4, **kwargs) -> SolverTestHelper:
         sth = mi_socp_1()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)
+        return sth
 
     @staticmethod
-    def test_mi_socp_2(solver, places: int = 4, **kwargs) -> None:
+    def test_mi_socp_2(solver, places: int = 4, **kwargs) -> SolverTestHelper:
         sth = mi_socp_2()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)
+        return sth
 
 
 class StandardTestSDPs:
 
     @staticmethod
-    def test_sdp_1min(solver, places: int = 4, duals: bool = True, **kwargs) -> None:
+    def test_sdp_1min(solver, places: int = 4, duals: bool = True, **kwargs) -> SolverTestHelper:
         sth = sdp_1('min')
         sth.solve(solver, **kwargs)
         sth.verify_objective(places=2)  # only 2 digits recorded.
@@ -857,9 +874,10 @@ class StandardTestSDPs:
         if duals:
             sth.check_complementarity(places)
             sth.check_dual_domains(places)
+        return sth
 
     @staticmethod
-    def test_sdp_1max(solver, places: int = 4, duals: bool = True, **kwargs) -> None:
+    def test_sdp_1max(solver, places: int = 4, duals: bool = True, **kwargs) -> SolverTestHelper:
         sth = sdp_1('max')
         sth.solve(solver, **kwargs)
         sth.verify_objective(places=2)  # only 2 digits recorded.
@@ -867,9 +885,10 @@ class StandardTestSDPs:
         if duals:
             sth.check_complementarity(places)
             sth.check_dual_domains(places)
+        return sth
 
     @staticmethod
-    def test_sdp_2(solver, places: int = 3, duals: bool = True, **kwargs) -> None:
+    def test_sdp_2(solver, places: int = 3, duals: bool = True, **kwargs) -> SolverTestHelper:
         # places is set to 3 rather than 4, because analytic solution isn't known.
         sth = sdp_2()
         sth.solve(solver, **kwargs)
@@ -879,12 +898,13 @@ class StandardTestSDPs:
         if duals:
             sth.check_complementarity(places)
             sth.check_dual_domains(places)
+        return sth
 
 
 class StandardTestECPs:
 
     @staticmethod
-    def test_expcone_1(solver, places: int = 4, duals: bool = True, **kwargs) -> None:
+    def test_expcone_1(solver, places: int = 4, duals: bool = True, **kwargs) -> SolverTestHelper:
         sth = expcone_1()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -892,12 +912,13 @@ class StandardTestECPs:
         if duals:
             sth.check_complementarity(places)
             sth.verify_dual_values(places)
+        return sth
 
 
 class StandardTestMixedCPs:
 
     @staticmethod
-    def test_exp_soc_1(solver, places: int = 3, duals: bool = True, **kwargs) -> None:
+    def test_exp_soc_1(solver, places: int = 3, duals: bool = True, **kwargs) -> SolverTestHelper:
         sth = expcone_socp_1()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -905,12 +926,13 @@ class StandardTestMixedCPs:
         if duals:
             sth.check_complementarity(places)
             sth.verify_dual_values(places)
+        return sth
 
 
 class StandardTestPCPs:
 
     @staticmethod
-    def test_pcp_1(solver, places: int = 3, duals: bool = True, **kwargs) -> None:
+    def test_pcp_1(solver, places: int = 3, duals: bool = True, **kwargs) -> SolverTestHelper:
         sth = pcp_1()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -918,9 +940,10 @@ class StandardTestPCPs:
         if duals:
             sth.check_complementarity(places)
             sth.verify_dual_values(places)
+        return sth
 
     @staticmethod
-    def test_pcp_2(solver, places: int = 3, duals: bool = True, **kwargs) -> None:
+    def test_pcp_2(solver, places: int = 3, duals: bool = True, **kwargs) -> SolverTestHelper:
         sth = pcp_2()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
@@ -928,10 +951,12 @@ class StandardTestPCPs:
         if duals:
             sth.check_complementarity(places)
             sth.verify_dual_values(places)
+        return sth
 
     @staticmethod
-    def test_mi_pcp_0(solver, places: int = 3, **kwargs) -> None:
+    def test_mi_pcp_0(solver, places: int = 3, **kwargs) -> SolverTestHelper:
         sth = mi_pcp_0()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)
+        return sth

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -947,6 +947,39 @@ class TestGUROBI(BaseTest):
                 prob.solve(solver=cp.GUROBI, TimeLimit=0)
             self.assertEqual(str(cm.exception), "The solver %s is not installed." % cp.GUROBI)
 
+    def test_gurobi_environment(self) -> None:
+        """Tests that Gurobi environments can be passed to Model.
+        Gurobi environments can include licensing and model parameter data.
+        """
+        if cp.GUROBI in INSTALLED_SOLVERS:
+            import gurobipy
+
+            # Set a few parameters to random values close to their defaults
+            params = {
+                'MIPGap': np.random.random(),  # range {0, INFINITY}
+                'AggFill': np.random.randint(10),  # range {-1, MAXINT}
+                'PerturbValue': np.random.random(),  # range: {0, INFINITY}
+            }
+
+            # Create a custom environment and set some parameters
+            custom_env = gurobipy.Env()
+            for k, v in params.items():
+                custom_env.setParam(k, v)
+
+            # Testing Conic Solver Interface
+            sth = StandardTestSOCPs.test_socp_0(solver='GUROBI', env=custom_env)
+            model = sth.prob.solver_stats.extra_stats
+            for k, v in params.items():
+                # https://www.gurobi.com/documentation/9.1/refman/py_model_getparaminfo.html
+                name, p_type, p_val, p_min, p_max, p_def = model.getParamInfo(k)
+                self.assertEqual(v, p_val)
+
+        else:
+            with self.assertRaises(Exception) as cm:
+                prob = cp.Problem(cp.Minimize(cp.norm(self.x, 1)), [self.x == 0])
+                prob.solve(solver=cp.GUROBI, TimeLimit=0)
+            self.assertEqual(str(cm.exception), "The solver %s is not installed." % cp.GUROBI)
+
     def test_gurobi_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='GUROBI')
 

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -28,6 +28,9 @@ from cvxpy.atoms import (QuadForm, abs, power,
 from cvxpy.reductions.solvers.defines import QP_SOLVERS, INSTALLED_SOLVERS
 from cvxpy.expressions.variable import Variable
 from cvxpy.tests.base_test import BaseTest
+from cvxpy.tests.solver_test_helpers import (
+    StandardTestLPs,
+)
 
 
 class TestQp(BaseTest):
@@ -533,6 +536,40 @@ class TestQp(BaseTest):
             if solver_status != gurobipy.StatusConstClass.TIME_LIMIT:
                 self.skipTest("Gurobi terminated for a different reason than reaching time limit, "
                               "the test is not relevant anymore.")
+
+        else:
+            with self.assertRaises(Exception) as cm:
+                prob = Problem(Minimize(norm(self.x, 1)), [self.x == 0])
+                prob.solve(solver=GUROBI, TimeLimit=0)
+            self.assertEqual(str(cm.exception), "The solver %s is not installed." % GUROBI)
+
+    def test_gurobi_environment(self) -> None:
+        """Tests that Gurobi environments can be passed to Model.
+        Gurobi environments can include licensing and model parameter data.
+        """
+        from cvxpy import GUROBI
+        if GUROBI in INSTALLED_SOLVERS:
+            import gurobipy
+
+            # Set a few parameters to random values close to their defaults
+            params = {
+                'MIPGap': np.random.random(),  # range {0, INFINITY}
+                'AggFill': np.random.randint(10),  # range {-1, MAXINT}
+                'PerturbValue': np.random.random(),  # range: {0, INFINITY}
+            }
+
+            # Create a custom environment and set some parameters
+            custom_env = gurobipy.Env()
+            for k, v in params.items():
+                custom_env.setParam(k, v)
+
+            # Testing QP Solver Interface
+            sth = StandardTestLPs.test_lp_0(solver='GUROBI', env=custom_env)
+            model = sth.prob.solver_stats.extra_stats
+            for k, v in params.items():
+                # https://www.gurobi.com/documentation/9.1/refman/py_model_getparaminfo.html
+                name, p_type, p_val, p_min, p_max, p_def = model.getParamInfo(k)
+                self.assertEqual(v, p_val)
 
         else:
             with self.assertRaises(Exception) as cm:

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -873,6 +873,7 @@ SCIP_ options:
 * **Please note**: All options should be listed as key-value pairs within the ``'scipy_options'`` dictionary and there should not be a nested dictionary called options. Some of the methods have different parameters so please check the parameters for the method you wish to use e.g. for method = 'highs-ipm'.
 
 * The main advantage of this solver is its ability to use the `HiGHS`_ LP solvers which are coded in C++, however these require a version of SciPy larger than 1.6.1. To use the `HiGHS`_ solvers simply set the method parameter to 'highs-ds' (for dual-simplex), 'highs-ipm' (for interior-point method) or 'highs' (which will choose either 'highs-ds' or 'highs-ipm' for you). 
+
 `GUROBI`_ options:
 
 Gurobi solver options are specified in CVXPY as keyword arguments. The full list of Gurobi parameters with defaults is listed `here <https://www.gurobi.com/documentation/9.1/refman/parameters.html>`_.

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -645,7 +645,7 @@ warm start would only be a good initial point.
 Setting solver options
 ----------------------
 
-The `OSQP`_, `ECOS`_, `MOSEK`_, `CBC`_, `CVXOPT`_, `NAG`_, and `SCS`_ Python interfaces allow you to set solver options such as the maximum number of iterations. You can pass these options along through CVXPY as keyword arguments.
+The `OSQP`_, `ECOS`_, `MOSEK`_, `CBC`_, `CVXOPT`_, `NAG`_, `GUROBI`_, and `SCS`_ Python interfaces allow you to set solver options such as the maximum number of iterations. You can pass these options along through CVXPY as keyword arguments.
 
 For example, here we tell SCS to use an indirect method for solving linear equations rather than a direct method.
 
@@ -873,6 +873,14 @@ SCIP_ options:
 * **Please note**: All options should be listed as key-value pairs within the ``'scipy_options'`` dictionary and there should not be a nested dictionary called options. Some of the methods have different parameters so please check the parameters for the method you wish to use e.g. for method = 'highs-ipm'.
 
 * The main advantage of this solver is its ability to use the `HiGHS`_ LP solvers which are coded in C++, however these require a version of SciPy larger than 1.6.1. To use the `HiGHS`_ solvers simply set the method parameter to 'highs-ds' (for dual-simplex), 'highs-ipm' (for interior-point method) or 'highs' (which will choose either 'highs-ds' or 'highs-ipm' for you). 
+`GUROBI`_ options:
+
+Gurobi solver options are specified in CVXPY as keyword arguments. The full list of Gurobi parameters with defaults is listed `here <https://www.gurobi.com/documentation/9.1/refman/parameters.html>`_.
+
+In addition to Gurobi's parameters, the following options are available:
+
+``'env'``
+    Allows for the passage of a Gurobi Environment, which specifies parameters and license information.  Keyword arguments will override any settings in this environment.
 
 Getting the standard form
 -------------------------


### PR DESCRIPTION
Adds support for Gurobi Environments: https://www.gurobi.com/documentation/9.1/refman/environments.html

Environments store configuration parameters, licensing information, and provide other capabilities.  This is critical for Gurobi ISV licenses, which may not have a license file that is set via an environmental variable.

The environment is specified in the cp.solve() method with an optional 'env' argument that is detected in the solver_opts dict.  StandardTests are employed to detect changes to the parameters in the resulting model.  The StandardTest methods were modified to return a SolverTestHelper rather than None.  Although the tests only use two of these methods, all methods were modified to consistency and to encourage re-use of these StandardTests.