### PR TITLE
Fix Constant.is_psd() and Constant.is_nsd()

### DIFF
--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -24,7 +24,6 @@ from cvxpy.expressions.leaf import Leaf
 from cvxpy.settings import EIGVAL_TOL
 from cvxpy.utilities import performance_utils as perf
 from scipy.sparse.linalg import eigsh
-from scipy.sparse.linalg.eigen.arpack.arpack import ArpackError
 
 
 class Constant(Leaf):
@@ -214,9 +213,6 @@ class Constant(Leaf):
         # Compute bottom eigenvalue if absent.
         if self._psd_test is None:
             self._psd_test = is_psd_within_tol(self.value, EIGVAL_TOL)
-        #if self._bottom_eig is None:
-        #    ev = extremal_eig_near_ref(self.value, EIGVAL_TOL, low=True)
-        #    self._bottom_eig = ev
 
         return self._psd_test
 
@@ -239,9 +235,6 @@ class Constant(Leaf):
         # Compute top eigenvalue if absent.
         if self._nsd_test is None:
             self._nsd_test = is_psd_within_tol(-self.value, EIGVAL_TOL)
-        #if self._top_eig is None:
-            #ev = extremal_eig_near_ref(self.value, EIGVAL_TOL, low=False)
-            #self._top_eig = ev
 
         return self._nsd_test
 
@@ -274,4 +267,3 @@ def is_psd_within_tol(A, tol):
             ev = SA_eigsh(-temp)
 
     return ev >= -tol
-

--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -245,6 +245,7 @@ class Constant(Leaf):
 def extremal_eig_near_ref(A, ref, low: bool = True):
 
     which = 'SA' if low else 'LA'
+
     def SA_eigsh(sigma):
         return eigsh(A, k=1, sigma=sigma, which=which, return_eigenvectors=False)
     # Run eigsh in shift-invert mode, since we're particularly interested in finding

--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -52,8 +52,8 @@ class Constant(Leaf):
         self._nonpos: Optional[bool] = None
         self._symm: Optional[bool] = None
         self._herm: Optional[bool] = None
-        self._top_eig: Optional[float] = None
-        self._bottom_eig: Optional[float] = None
+        self._psd_test: Optional[bool] = None
+        self._nsd_test: Optional[bool] = None
         self._cached_is_pos = None
         super(Constant, self).__init__(intf.shape(self.value))
 
@@ -212,11 +212,13 @@ class Constant(Leaf):
             return False
 
         # Compute bottom eigenvalue if absent.
-        if self._bottom_eig is None:
-            ev = extremal_eig_near_ref(self.value, EIGVAL_TOL, low=True)
-            self._bottom_eig = ev
+        if self._psd_test is None:
+            self._psd_test = is_psd_within_tol(self.value, EIGVAL_TOL)
+        #if self._bottom_eig is None:
+        #    ev = extremal_eig_near_ref(self.value, EIGVAL_TOL, low=True)
+        #    self._bottom_eig = ev
 
-        return self._bottom_eig >= -EIGVAL_TOL
+        return self._psd_test
 
     @perf.compute_once
     def is_nsd(self) -> bool:
@@ -235,32 +237,41 @@ class Constant(Leaf):
             return False
 
         # Compute top eigenvalue if absent.
-        if self._top_eig is None:
-            ev = extremal_eig_near_ref(self.value, EIGVAL_TOL, low=False)
-            self._top_eig = ev
+        if self._nsd_test is None:
+            self._nsd_test = is_psd_within_tol(-self.value, EIGVAL_TOL)
+        #if self._top_eig is None:
+            #ev = extremal_eig_near_ref(self.value, EIGVAL_TOL, low=False)
+            #self._top_eig = ev
 
-        return self._top_eig <= EIGVAL_TOL
+        return self._nsd_test
 
 
-def extremal_eig_near_ref(A, ref, low: bool = True):
-
-    which = 'SA' if low else 'LA'
+def is_psd_within_tol(A, tol):
 
     def SA_eigsh(sigma):
-        return eigsh(A, k=1, sigma=sigma, which=which, return_eigenvectors=False)
-    # Run eigsh in shift-invert mode, since we're particularly interested in finding
-    # eigenvalues in a certain region.
+        return eigsh(A, k=1, sigma=sigma, which='SA', return_eigenvectors=False)
+        # Returns the eigenvalue w[i] of A where 1/(w[i] - sigma) is minimized.
+        #
+        # If A - sigma*I is PSD, then w[i] should be equal to the largest
+        # eigenvalue of A.
+        #
+        # If A - sigma*I is not PSD, then w[i] should be the largest eigenvalue
+        # of A where w[i] - sigma < 0.
+        #
+        # We should only call this function with sigma < 0. In this case, if
+        # A - sigma*I is not PSD then A is not PSD, and w[i] < -abs(sigma) is
+        # a negative eigenvalue of A. If A - sigma*I is PSD, then we obviously
+        # have that the smallest eigenvalue of A is >= sigma.
+
+    ev = np.NaN
     try:
-        sigma = -ref if low else ref
-        ev = SA_eigsh(sigma)
-    except ArpackError:
-        temp = ref - np.finfo(A.dtype).eps
-        sigma = -temp if low else temp
-        ev = SA_eigsh(sigma)
-    else:
+        ev = SA_eigsh(-tol)  # might return np.NaN, or raise exception
+    finally:
         if np.isnan(ev):
-            # will be NaN if A has an eigenvalue which is exactly tol
-            temp = ref - np.finfo(A.dtype).eps
-            sigma = -temp if low else temp
-            ev = SA_eigsh(sigma)
-    return ev
+            # will be NaN if A has an eigenvalue which is exactly -tol
+            # (We might also hit this code block for other reasons.)
+            temp = tol - np.finfo(A.dtype).eps
+            ev = SA_eigsh(-temp)
+
+    return ev >= -tol
+

--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -244,8 +244,9 @@ class Constant(Leaf):
 
 def extremal_eig_near_ref(A, ref, low: bool = True):
 
+    which = 'SA' if low else 'LA'
     def SA_eigsh(sigma):
-        return eigsh(A, k=1, sigma=sigma, return_eigenvectors=False)
+        return eigsh(A, k=1, sigma=sigma, which=which, return_eigenvectors=False)
     # Run eigsh in shift-invert mode, since we're particularly interested in finding
     # eigenvalues in a certain region.
     try:

--- a/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
@@ -23,7 +23,7 @@ from cvxpy.reductions.solvers.conic_solvers.ecos_conif import ECOS
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.compr_matrix import compress_matrix
 from cvxpy.reductions.solvers.kktsolver import setup_ldl_factor
-from cvxpy.expressions.constants.constant import extremal_eig_near_ref
+from scipy.sparse.linalg import eigsh
 from typing import Dict, List, Union
 
 import scipy.sparse as sp
@@ -285,7 +285,7 @@ class CVXOPT(ECOS):
                 data[s.A] = None
                 data[s.B] = None
                 return s.OPTIMAL
-        eig = extremal_eig_near_ref(gram, ref=TOL)
+        eig = eigsh(gram, k=1, which='SM', return_eigenvectors=False)
         if eig > TOL:
             return s.OPTIMAL
         #

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -214,6 +214,50 @@ class TestExpressions(BaseTest):
         # Test repr.
         self.assertEqual(repr(c), "Constant(CONSTANT, NONNEGATIVE, (2,))")
 
+    def test_constant_psd_nsd(self):
+        n = 5
+        np.random.randn(0)
+        U = np.random.randn(n, n)
+        U = U @ U.T
+        (evals, U) = np.linalg.eigh(U)  # U is now an orthogonal matrix
+
+        # Try four indefinite matrices with different eigenvalue
+        # spread around the origin.
+        v1 = np.array([3, 2, 1, 1e-8, -1])
+        P = Constant(U @ np.diag(v1) @ U.T)
+        self.assertFalse(P.is_psd())
+        self.assertFalse(P.is_nsd())
+        v2 = np.array([3, 2, 2, 1e-6, -1])
+        P = Constant(U @ np.diag(v2) @ U.T)
+        self.assertFalse(P.is_psd())
+        self.assertFalse(P.is_nsd())
+        v3 = np.array([3, 2, 2, 1e-4, -1e-6])
+        P = Constant(U @ np.diag(v3) @ U.T)
+        self.assertFalse(P.is_psd())
+        self.assertFalse(P.is_nsd())
+        v4 = np.array([-1, 3, 0, 0, 0])
+        P = Constant(U @ np.diag(v4) @ U.T)
+        self.assertFalse(P.is_psd())
+        self.assertFalse(P.is_nsd())
+
+        # Try a test case given in GitHub issue 1451.
+        # (Should be equivalent to v4 above).
+        P = Constant(np.array([[1, 2], [2, 1]]))
+        x = Variable(shape=(2,))
+        expr = cp.quad_form(x, P)
+        self.assertFalse(expr.is_dcp())
+        self.assertFalse((-expr).is_dcp())
+
+        # Verify good behavior for large eigenvalues
+        P = Constant(np.diag(9*[1e-4] + [-1e4]))
+        self.assertFalse(P.is_psd())
+        self.assertFalse(P.is_nsd())
+
+        # Check a case when the matrix is in fact PSD.
+        P = Constant(np.ones(shape=(5, 5)))
+        self.assertTrue(P.is_psd())
+        self.assertFalse(P.is_nsd())
+
     def test_1D_array(self) -> None:
         """Test NumPy 1D arrays as constants.
         """
@@ -290,7 +334,8 @@ class TestExpressions(BaseTest):
         v1 = np.array([3, 2, 1, 1e-8, -1])
         v2 = np.array([3, 2, 2, 1e-6, -1])
         v3 = np.array([3, 2, 2, 1e-4, -1e-6])
-        vs = [v1, v2, v3]
+        v4 = np.array([-1, 3, 0, 0, 0])
+        vs = [v1, v2, v3, v4]
         for vi in vs:
             with self.assertRaises(Exception) as cm:
                 P.value = U @ np.diag(vi) @ U.T
@@ -298,8 +343,28 @@ class TestExpressions(BaseTest):
             with self.assertRaises(Exception) as cm:
                 N.value = -U @ np.diag(vi) @ U.T
             self.assertEqual(str(cm.exception), "Parameter value must be negative semidefinite.")
+        with self.assertRaises(Exception) as cm:
+            P = Parameter(shape=(2, 2), PSD=True)
+            P.value = np.array([[1, 2], [2, 1]])
+        self.assertEqual(str(cm.exception), "Parameter value must be positive semidefinite.")
+        with self.assertRaises(Exception) as cm:
+            P = Parameter(shape=(2, 2), NSD=True)
+            P.value = np.array([[1, 2], [2, 1]])
+        self.assertEqual(str(cm.exception), "Parameter value must be negative semidefinite.")
+        x = Variable(shape=(2,))
+        P = Parameter(shape=(2, 2), symmetric=True)
+        P.value = np.array([[1, 2], [2, 1]])
+        expr = cp.quad_form(x, P)
+        self.assertFalse(expr.is_dcp())
+        self.assertFalse((-expr).is_dcp())
+        self.assertTrue(cp.quad_form(x, P + np.diag([5,5])).is_dcp())
+        P = Constant(np.array([[1, 2], [2, 1]]))
+        expr = cp.quad_form(x, P)
+        self.assertFalse(expr.is_dcp())
+        self.assertFalse((-expr).is_dcp())
 
-    # Test the Parameter class on bad inputs.
+
+                # Test the Parameter class on bad inputs.
     def test_parameters_failures(self) -> None:
         p = Parameter(name='p')
         self.assertEqual(p.name(), "p")

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -343,28 +343,9 @@ class TestExpressions(BaseTest):
             with self.assertRaises(Exception) as cm:
                 N.value = -U @ np.diag(vi) @ U.T
             self.assertEqual(str(cm.exception), "Parameter value must be negative semidefinite.")
-        with self.assertRaises(Exception) as cm:
-            P = Parameter(shape=(2, 2), PSD=True)
-            P.value = np.array([[1, 2], [2, 1]])
-        self.assertEqual(str(cm.exception), "Parameter value must be positive semidefinite.")
-        with self.assertRaises(Exception) as cm:
-            P = Parameter(shape=(2, 2), NSD=True)
-            P.value = np.array([[1, 2], [2, 1]])
-        self.assertEqual(str(cm.exception), "Parameter value must be negative semidefinite.")
-        x = Variable(shape=(2,))
-        P = Parameter(shape=(2, 2), symmetric=True)
-        P.value = np.array([[1, 2], [2, 1]])
-        expr = cp.quad_form(x, P)
-        self.assertFalse(expr.is_dcp())
-        self.assertFalse((-expr).is_dcp())
-        self.assertTrue(cp.quad_form(x, P + np.diag([5,5])).is_dcp())
-        P = Constant(np.array([[1, 2], [2, 1]]))
-        expr = cp.quad_form(x, P)
-        self.assertFalse(expr.is_dcp())
-        self.assertFalse((-expr).is_dcp())
 
 
-                # Test the Parameter class on bad inputs.
+    # Test the Parameter class on bad inputs.
     def test_parameters_failures(self) -> None:
         p = Parameter(name='p')
         self.assertEqual(p.name(), "p")

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -344,7 +344,6 @@ class TestExpressions(BaseTest):
                 N.value = -U @ np.diag(vi) @ U.T
             self.assertEqual(str(cm.exception), "Parameter value must be negative semidefinite.")
 
-
     # Test the Parameter class on bad inputs.
     def test_parameters_failures(self) -> None:
         p = Parameter(name='p')

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1521,7 +1521,11 @@ class TestProblem(BaseTest):
             constraints = [X == [[2, 0], [0, 2]] - C]
             prob = Problem(obj, constraints)
             result = prob.solve(solver=s.CVXOPT)
-            self.assertItemsAlmostEqual(constraints[0].dual_value, psd_constr_dual)
+            new_constr_dual = (constraints[0].dual_value + constraints[0].dual_value.T)/2
+            # ^ Symmetrizing is valid, because the dual variable is with respect to an
+            #   unstructured equality constraint. Dual optimal solutions are non-unique
+            #   in this formulation, up to symmetrizing the dual variable.
+            self.assertItemsAlmostEqual(new_constr_dual, psd_constr_dual)
 
         # Test the dual values with SCS.
         C = Variable((2, 2), symmetric=True)

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -137,7 +137,7 @@ class TestNonOptimal(BaseTest):
     def test_psd_exactly_tolerance(self) -> None:
         """Test that PSD check when eigenvalue is exactly -EIGVAL_TOL
         """
-        P = np.array([[-EIGVAL_TOL, 0], [0, 10]])
+        P = np.array([[-0.999*EIGVAL_TOL, 0], [0, 10]])
         x = cvxpy.Variable(2)
         # Forming quad_form is okay
         with warnings.catch_warnings():
@@ -149,7 +149,7 @@ class TestNonOptimal(BaseTest):
     def test_nsd_exactly_tolerance(self) -> None:
         """Test that NSD check when eigenvalue is exactly EIGVAL_TOL
         """
-        P = np.array([[EIGVAL_TOL, 0], [0, -10]])
+        P = np.array([[0.999*EIGVAL_TOL, 0], [0, -10]])
         x = cvxpy.Variable(2)
         # Forming quad_form is okay
         with warnings.catch_warnings():


### PR DESCRIPTION
This fixes #1451. The only change to non-test code is to apply a keyword argument to SciPy's ``eigsh`` so that it returns eigenvalues sorted by value rather than absolute value. Some earlier tests should have caught the bug in #1451, but they tested Parameter objects rather than Constant objects.

We should revisit this in the near future. The largest or smallest eigenvalues returned by ``eigsh`` when running in shift-invert mode are sorted differently than if we don't use shift-invert mode. Although (updated!) tests are passing, we should take a more careful look to make sure we won't run into issues with this different sorting. 

We should also add tests for semidefiniteness based on the Gershgorin Circle Theorem, as I mentioned in #1451.

Edit: I've marked this as work-in-progress to make sure we have appropriate discussions.