### PR TITLE
Validate constraints on problem creation

### DIFF
--- a/cvxpy/reductions/dqcp2dcp/dqcp2dcp.py
+++ b/cvxpy/reductions/dqcp2dcp/dqcp2dcp.py
@@ -29,7 +29,6 @@ from cvxpy.reductions.dqcp2dcp import tighten
 from cvxpy.reductions.dqcp2dcp import sets
 from cvxpy.reductions.inverse_data import InverseData
 from cvxpy.reductions.solution import Solution
-import cvxpy.settings as s
 
 from collections import namedtuple
 from typing import Any, List, Tuple
@@ -52,6 +51,17 @@ import numpy as np
 BisectionData = namedtuple(
     "BisectionData",
     ['feas_problem', 'param', 'tighten_lower', 'tighten_upper'])
+
+
+def _get_lazy_and_real_constraints(constraints):
+    lazy_constraints = []
+    real_constraints = []
+    for c in constraints:
+        if callable(c):
+            lazy_constraints.append(c)
+        else:
+            real_constraints.append(c)
+    return lazy_constraints, real_constraints
 
 
 class Dqcp2Dcp(Canonicalization):
@@ -92,7 +102,9 @@ class Dqcp2Dcp(Canonicalization):
         constraints = []
         for constr in problem.constraints:
             constraints += self._canonicalize_constraint(constr)
-        feas_problem = problems.problem.Problem(Minimize(0), constraints)
+        lazy, real = _get_lazy_and_real_constraints(constraints)
+        feas_problem = problems.problem.Problem(Minimize(0), real)
+        feas_problem._lazy_constraints = lazy
 
         objective = problem.objective.expr
         if objective.is_nonneg():
@@ -102,7 +114,10 @@ class Dqcp2Dcp(Canonicalization):
         else:
             t = Parameter()
         constraints += self._canonicalize_constraint(objective <= t)
-        param_problem = problems.problem.Problem(Minimize(0), constraints)
+
+        lazy, real = _get_lazy_and_real_constraints(constraints)
+        param_problem = problems.problem.Problem(Minimize(0), real)
+        param_problem._lazy_constraints = lazy
         param_problem._bisection_data = BisectionData(
             feas_problem, t, *tighten.tighten_fns(objective))
         return param_problem, InverseData(problem)
@@ -141,9 +156,10 @@ class Dqcp2Dcp(Canonicalization):
             rhs_val = np.array(rhs.value)
             if np.all(lhs_val == -np.inf) or np.all(rhs_val == np.inf):
                 # constraint is redundant
-                return [None]
+                return [True]
             elif np.any(lhs_val == np.inf) or np.any(rhs_val == -np.inf):
-                return [s.INFEASIBLE]
+                # constraint is infeasible
+                return [False]
 
         if constr.is_dcp():
             canon_constr, aux_constr = self.canonicalize_tree(constr)

--- a/cvxpy/reductions/dqcp2dcp/sets.py
+++ b/cvxpy/reductions/dqcp2dcp/sets.py
@@ -16,13 +16,12 @@ limitations under the License.
 from cvxpy import atoms
 from cvxpy.atoms.affine import binary_operators as bin_op
 from cvxpy.expressions.constants.parameter import Parameter
-import cvxpy.settings as s
 
 
 # Sublevel sets for quasiconvex atoms.
 #
-# In the below functions, s.INFEASIBLE is a placeholder for an infeasible
-# constraint (one that cannot be represented in a DCP way), and None
+# In the below functions, False is a placeholder for an infeasible
+# constraint (one that cannot be represented in a DCP way), and True
 # is a placeholder for the absence of a constraint
 def dist_ratio_sub(expr, t):
     x = expr.args[0]
@@ -31,7 +30,7 @@ def dist_ratio_sub(expr, t):
 
     def sublevel_set():
         if t.value > 1:
-            return s.INFEASIBLE
+            return False
         tsq = t.value**2
         return ((1-tsq**2)*atoms.sum_squares(x) -
                 atoms.matmul(2*(a-tsq*b), x) + atoms.sum_squares(a) -
@@ -84,9 +83,9 @@ def length_sub(expr, t):
     if isinstance(t, Parameter):
         def sublevel_set():
             if t.value < 0:
-                return s.INFEASIBLE
+                return False
             if t.value >= arg.size:
-                return None
+                return True
             return arg[int(atoms.floor(t).value):] == 0
         return [sublevel_set]
     else:
@@ -98,11 +97,11 @@ def sign_sup(expr, t):
 
     def superlevel_set():
         if t.value <= -1:
-            return None
+            return True
         elif t.value <= 1:
             return x >= 0
         else:
-            return s.INFEASIBLE
+            return False
     return [superlevel_set]
 
 
@@ -111,11 +110,11 @@ def sign_sub(expr, t):
 
     def sublevel_set():
         if t.value >= 1:
-            return None
+            return True
         elif t.value >= -1:
             return x <= 0
         else:
-            return s.INFEASIBLE
+            return False
     return [sublevel_set]
 
 

--- a/cvxpy/reductions/solvers/bisection.py
+++ b/cvxpy/reductions/solvers/bisection.py
@@ -25,17 +25,12 @@ from cvxpy.reductions.solution import failure_solution
 
 def _lower_problem(problem):
     """Evaluates lazy constraints."""
-    constrs = [c() if callable(c) else c for c in problem.constraints]
-    constrs = [c for c in constrs if c is not None]
-    if s.INFEASIBLE in constrs:
-        # Indicates that the problem is infeasible.
-        return None
-    return problems.problem.Problem(Minimize(0), constrs)
+    return problems.problem.Problem(
+            Minimize(0),
+            problem.constraints + [c() for c in problem._lazy_constraints])
 
 
 def _solve(problem, solver) -> None:
-    if problem is None:
-        return
     with warnings.catch_warnings():
         # TODO(akshayka): Try to emit DPP problems in Dqcp2Dcp
         warnings.filterwarnings('ignore', message=r'.*DPP.*')

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1799,6 +1799,14 @@ class TestProblem(BaseTest):
         prob.solve(solver=cp.ECOS)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
+    def test_invalid_constr(self) -> None:
+        """Test a problem with an invalid constraint.
+        """
+        x = cp.Variable()
+        with self.assertRaisesRegex(ValueError,
+                                    r"Problem has an invalid constraint.*"):
+            cp.Problem(cp.Minimize(x), [cp.sum(x)])
+
     def test_pos(self) -> None:
         """Test the pos and neg attributes.
         """


### PR DESCRIPTION
Problem canonicalization fails silently when an expression is included
in a problem's list of constraints.

This change modifies the Problem constructor to check that each
constraint is in fact a Constraint (or a bool)

Previously DQCP included lazily evaluated
constraints in the constraint list. This change modifies the DQCP
reduction to store the lazy constraints elsewhere.

Fixes #1462