### PR TITLE
Fixes for DQCP

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -946,6 +946,12 @@ class Problem(u.Canonical):
                 start = time.time()
                 if type(self.objective) == Maximize:
                     reductions = [FlipObjective()] + reductions
+                    # flip objective flips the sign of the objective
+                    low, high = kwargs.get("low"), kwargs.get("high")
+                    if high is not None:
+                        kwargs["low"] = high * -1
+                    if low is not None:
+                        kwargs["high"] = low * -1
                 chain = Chain(problem=self, reductions=reductions)
                 soln = bisection.bisect(
                     chain.reduce(), solver=solver, verbose=verbose, **kwargs)

--- a/cvxpy/reductions/solvers/bisection.py
+++ b/cvxpy/reductions/solvers/bisection.py
@@ -89,7 +89,9 @@ def _find_bisection_interval(problem, t, solver=None, low=None, high=None,
         if infeasible_low and feasible_high:
             return low, high
 
-    raise error.SolverError("Unable to find suitable interval for bisection.")
+    raise error.SolverError(
+            "Unable to find suitable interval for bisection; "
+            "your problem may be unbounded..")
 
 
 def _bisect(problem, solver, t, low, high, tighten_lower, tighten_higher,
@@ -102,7 +104,7 @@ def _bisect(problem, solver, t, low, high, tighten_lower, tighten_higher,
         assert low <= high
         if soln is not None and (high - low) <= eps:
             # the previous iteration might have been infeasible, but
-            # the tigthen* functions might have narrowed the interval
+            # the tighten* functions might have narrowed the interval
             # to the optimal value in the previous iteration (hence the
             # soln is not None check)
             return soln, low, high

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -538,6 +538,23 @@ class TestDqcp(base_test.BaseTest):
         self.assertAlmostEqual(x.value, 10, places=1)
         self.assertAlmostEqual(problem.value, -20, places=1)
 
+    def test_reciprocal(self) -> None:
+        x = cp.Variable(pos=True)
+        problem = cp.Problem(cp.Minimize(1/x))
+        problem.solve(SOLVER, qcp=True)
+        self.assertAlmostEqual(problem.value, 0, places=3)
+
+    def test_abs(self) -> None:
+        x = cp.Variable(pos=True)
+        problem = cp.Problem(cp.Minimize(cp.abs(1/x)))
+        problem.solve(SOLVER, qcp=True)
+        self.assertAlmostEqual(problem.value, 0, places=3)
+
+        x = cp.Variable(neg=True)
+        problem = cp.Problem(cp.Minimize(cp.abs(1/x)))
+        problem.solve(SOLVER, qcp=True)
+        self.assertAlmostEqual(problem.value, 0, places=3)
+
     def test_tutorial_example(self) -> None:
         x = cp.Variable()
         y = cp.Variable(pos=True)
@@ -604,3 +621,18 @@ class TestDqcp(base_test.BaseTest):
         t = cp.Variable(5, pos=True)
         expr = cp.sum(cp.square(t) / t)
         self.assertFalse(expr.is_dqcp())
+
+    def test_flip_bounds(self) -> None:
+        x = cp.Variable(pos=True)
+        problem = cp.Problem(cp.Maximize(cp.ceil(x)), [x <= 1])
+        problem.solve(SOLVER, qcp=True, low=0, high=0.5)
+        self.assertGreater(x.value, 0)
+        self.assertLessEqual(x.value, 1)
+
+        problem.solve(SOLVER, qcp=True, low=0, high=None)
+        self.assertGreater(x.value, 0)
+        self.assertLessEqual(x.value, 1)
+
+        problem.solve(SOLVER, qcp=True, low=None, high=0.5)
+        self.assertGreater(x.value, 0)
+        self.assertLessEqual(x.value, 1)


### PR DESCRIPTION
- Add inverse operator for (signed) abs, fix operator for ratio (fixes #1477)
- Flip user specified bisection limits when flip objective is used