### PR TITLE
[CI] Build cvxpy-base (Issue 1478)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,3 +101,77 @@ jobs:
         with:
           name: wheels
           path: ./wheelhouse
+
+  build_cvxpy-base:
+    needs: build
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-18.04, macos-10.15, windows-2019 ]
+        python-version: [ 3.6, 3.7, 3.9 ]
+        include:
+          - os: ubuntu-18.04
+            python-version: 3.8
+          - os: macos-10.15
+            python-version: 3.8
+            deploy_pypi_source: "True"
+          - os: windows-2019
+            python-version: 3.8
+
+    env:
+      PYTHON_VERSION: ${{ matrix.python-version }}
+      DEPLOY_PYPI_SOURCE: "${{ matrix.deploy_pypi_source == 'True' && 'True' || 'False' }}"
+      PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
+      PYPI_USER: ${{ secrets.PYPI_USER }}
+      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set Additional Envs
+        shell: bash
+        run: |
+          echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
+          echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
+
+      - name: Adapt setup.py
+        if: ${{env.DEPLOY == 'True'}}
+        shell: bash
+        run: |
+          # Mac has a different syntax for sed -i, this works across oses
+          sed -i.bak -e "s/name='cvxpy',/name='cvxpy-base',/g" setup.py
+          sed -i.bak '/osqp >= /d' setup.py
+          sed -i.bak '/ecos >= /d' setup.py
+          sed -i.bak '/scs >= /d' setup.py
+          rm -rf setup.py.bak
+
+      - name: Build wheels
+        if: ${{env.DEPLOY == 'True'}}
+        env:
+          CIBW_BUILD: "cp3${{env.PYTHON_SUBVERSION}}-*"
+          CIBW_SKIP: "*-win32 *-manylinux_i686"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
+        uses: joerick/cibuildwheel@v1.11.0
+
+      - name: Build source
+        if: ${{env.DEPLOY == 'True' && env.DEPLOY_PYPI_SOURCE == 'True'}}
+        run: |
+          python setup.py sdist --dist-dir=wheelhouse
+
+      - name: Release to pypi
+        if: ${{env.DEPLOY == 'True'}}
+        run: |
+          python -m pip install --upgrade twine
+          twine check wheelhouse/*
+          twine upload --repository-url $PYPI_SERVER wheelhouse/* -u $PYPI_USER -p $PYPI_PASSWORD
+
+      - name: Upload artifacts to github
+        if: ${{env.DEPLOY == 'True'}}
+        uses: actions/upload-artifact@v1
+        with:
+          name: wheels-base
+          path: ./wheelhouse

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -184,6 +184,27 @@ Install with SCIPY support
 CVXPY supports the SCIPY solver for LPs.
 This requires the `SciPy`_ package in Python which should already be installed as it is a requirement for CVXPY. `SciPy`_'s "interior-point" and "revised-simplex" implementations are written in python and are always available however the main advantage of this solver, is its ability to use the `HiGHS`_ LP solvers (which are written in C++) that comes bundled with `SciPy`_ version 1.6.1 and higher.
 
+Install without default solvers
+-------------------------
+
+CVXPY can also be installed without the default solver dependencies.
+This can be useful if the intention is to only use non-default solvers.
+
+The solver-less installation, ``cvxpy-base``, can currently be installed through pip and conda.
+
+Installing using pip:
+
+  ::
+
+      pip install cvxpy-base
+
+
+Installing using conda:
+
+  ::
+
+      conda install cvxpy-base
+
 
 .. _Anaconda: https://store.continuum.io/cshop/anaconda/
 .. _website: https://store.continuum.io/cshop/anaconda/

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     cmdclass={'build_ext': build_ext_cvxpy},
     ext_modules=[canon],
     packages=find_packages(exclude=["cvxpy.performance_tests"]),
-    url='http://github.com/cvxgrp/cvxpy/',
+    url='https://github.com/cvxpy/cvxpy',
     license='Apache License, Version 2.0',
     zip_safe=False,
     description='A domain-specific language for modeling convex optimization '

--- a/setup.py
+++ b/setup.py
@@ -91,10 +91,12 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
     python_requires='>=3.6',
-    install_requires=["osqp >= 0.4.1",
-                      "ecos >= 2",
-                      "scs >= 1.1.6",
-                      "numpy >= 1.15",
-                      "scipy >= 1.1.0"],
+    install_requires=[
+        "osqp >= 0.4.1",
+        "ecos >= 2",
+        "scs >= 1.1.6",
+        "numpy >= 1.15",
+        "scipy >= 1.1.0"
+    ],
     setup_requires=["numpy >= 1.15"],
 )


### PR DESCRIPTION
Discussion: #1478 

@SteveDiamond as discussed, this additional action publishes `cvxpy-base` on PyPi, i.e. without any solvers preinstalled.

I have done a test run on [TestPyPI](https://test.pypi.org/project/cvxpy-base/), which worked well.
It can be tried using:

```
# Dependency not available on TestPyPI
pip install scipy
pip install --index-url https://test.pypi.org/simple/ cvxpy-base
```

It would only run with the next tagged release, but one could upload the current 1.1.15 version by disabling the `${{env.DEPLOY == 'True'}}` checks for one commit.

I have added a small section to the docs as well.