### PR TITLE
Sort imports

### DIFF
--- a/cvxpy/__init__.py
+++ b/cvxpy/__init__.py
@@ -15,20 +15,22 @@ limitations under the License.
 """
 
 __version__ = "1.1.15"
+import cvxpy.interface.scipy_wrapper
 from cvxpy.atoms import *
-from cvxpy.constraints import NonPos, Zero, SOC, PSD
+from cvxpy.constraints import PSD, SOC, NonPos, Zero
+from cvxpy.error import (DCPError, DGPError, DPPError, SolverError,
+                         disable_warnings, enable_warnings, warnings_enabled,)
+from cvxpy.expressions.constants import CallbackParam, Constant, Parameter
 from cvxpy.expressions.expression import Expression
 from cvxpy.expressions.variable import Variable
-from cvxpy.expressions.constants import Parameter, CallbackParam, Constant
-from cvxpy.problems.problem import Problem
 from cvxpy.problems.objective import Maximize, Minimize
-import cvxpy.interface.scipy_wrapper
-from cvxpy.error import DCPError, DPPError, DGPError, SolverError, disable_warnings, enable_warnings, warnings_enabled
-from cvxpy.settings import (CVXOPT, GLPK, GLPK_MI, CBC, CPLEX, OSQP, NAG,
-                            ECOS, SCS, DIFFCP, GUROBI, MOSEK, XPRESS, SCIP, SCIPY, ECOS_BB,
-                            OPTIMAL, UNBOUNDED, INFEASIBLE, SOLVER_ERROR, ROBUST_KKTSOLVER,
-                            OPTIMAL_INACCURATE, UNBOUNDED_INACCURATE, INFEASIBLE_INACCURATE, USER_LIMIT)
-from cvxpy.settings import get_num_threads, set_num_threads
-from cvxpy.transforms import linearize, partial_optimize, suppfunc
+from cvxpy.problems.problem import Problem
 from cvxpy.reductions import *
 from cvxpy.reductions.solvers.defines import installed_solvers
+from cvxpy.settings import (CBC, CPLEX, CVXOPT, DIFFCP, ECOS, ECOS_BB, GLPK,
+                            GLPK_MI, GUROBI, INFEASIBLE, INFEASIBLE_INACCURATE,
+                            MOSEK, NAG, OPTIMAL, OPTIMAL_INACCURATE, OSQP,
+                            ROBUST_KKTSOLVER, SCIP, SCIPY, SCS, SOLVER_ERROR,
+                            UNBOUNDED, UNBOUNDED_INACCURATE, USER_LIMIT,
+                            XPRESS, get_num_threads, set_num_threads,)
+from cvxpy.transforms import linearize, partial_optimize, suppfunc

--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -14,46 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.cummax import cummax
-from cvxpy.atoms.dist_ratio import dist_ratio
-from cvxpy.atoms.eye_minus_inv import eye_minus_inv, resolvent
-from cvxpy.atoms.geo_mean import geo_mean
-from cvxpy.atoms.gen_lambda_max import gen_lambda_max
-from cvxpy.atoms.gmatmul import gmatmul
-from cvxpy.atoms.harmonic_mean import harmonic_mean
-from cvxpy.atoms.inv_prod import inv_prod
-from cvxpy.atoms.lambda_max import lambda_max
-from cvxpy.atoms.lambda_min import lambda_min
-from cvxpy.atoms.lambda_sum_largest import lambda_sum_largest
-from cvxpy.atoms.lambda_sum_smallest import lambda_sum_smallest
-from cvxpy.atoms.length import length
-from cvxpy.atoms.log_det import log_det
-from cvxpy.atoms.log_sum_exp import log_sum_exp
-from cvxpy.atoms.matrix_frac import matrix_frac
-from cvxpy.atoms.matrix_frac import MatrixFrac
-from cvxpy.atoms.max import max
-from cvxpy.atoms.min import min
-from cvxpy.atoms.norm import norm, norm2
-from cvxpy.atoms.norm1 import norm1
-from cvxpy.atoms.norm_inf import norm_inf
-from cvxpy.atoms.norm_nuc import normNuc
-from cvxpy.atoms.mixed_norm import mixed_norm
-from cvxpy.atoms.norm1 import norm1
-from cvxpy.atoms.norm_inf import norm_inf
-from cvxpy.atoms.one_minus_pos import one_minus_pos
-from cvxpy.atoms.one_minus_pos import diff_pos
-from cvxpy.atoms.pf_eigenvalue import pf_eigenvalue
-from cvxpy.atoms.pnorm import pnorm, Pnorm
-from cvxpy.atoms.prod import prod, Prod
-from cvxpy.atoms.quad_form import quad_form, QuadForm
-from cvxpy.atoms.quad_over_lin import quad_over_lin
-from cvxpy.atoms.sigma_max import sigma_max
-from cvxpy.atoms.sign import sign
-from cvxpy.atoms.sum_largest import sum_largest
-from cvxpy.atoms.sum_smallest import sum_smallest
-from cvxpy.atoms.sum_squares import sum_squares
-from cvxpy.atoms.total_variation import tv
-
+from cvxpy.atoms.affine.binary_operators import (matmul, multiply,
+                                                 scalar_product,)
 from cvxpy.atoms.affine.bmat import bmat
 from cvxpy.atoms.affine.conj import conj
 from cvxpy.atoms.affine.conv import conv
@@ -63,17 +25,17 @@ from cvxpy.atoms.affine.diff import diff
 from cvxpy.atoms.affine.hstack import hstack
 from cvxpy.atoms.affine.imag import imag
 from cvxpy.atoms.affine.kron import kron
-from cvxpy.atoms.affine.binary_operators import multiply, matmul, scalar_product
 from cvxpy.atoms.affine.promote import promote
 from cvxpy.atoms.affine.real import real
-from cvxpy.atoms.affine.reshape import reshape, deep_flatten
+from cvxpy.atoms.affine.reshape import deep_flatten, reshape
 from cvxpy.atoms.affine.sum import sum
 from cvxpy.atoms.affine.trace import trace
 from cvxpy.atoms.affine.transpose import transpose
 from cvxpy.atoms.affine.upper_tri import upper_tri
 from cvxpy.atoms.affine.vec import vec
 from cvxpy.atoms.affine.vstack import vstack
-
+from cvxpy.atoms.cummax import cummax
+from cvxpy.atoms.dist_ratio import dist_ratio
 from cvxpy.atoms.elementwise.abs import abs
 from cvxpy.atoms.elementwise.ceil import ceil, floor
 from cvxpy.atoms.elementwise.entr import entr
@@ -82,9 +44,9 @@ from cvxpy.atoms.elementwise.huber import huber
 from cvxpy.atoms.elementwise.inv_pos import inv_pos
 from cvxpy.atoms.elementwise.kl_div import kl_div
 from cvxpy.atoms.elementwise.log import log
-from cvxpy.atoms.elementwise.loggamma import loggamma
-from cvxpy.atoms.elementwise.log_normcdf import log_normcdf
 from cvxpy.atoms.elementwise.log1p import log1p
+from cvxpy.atoms.elementwise.log_normcdf import log_normcdf
+from cvxpy.atoms.elementwise.loggamma import loggamma
 from cvxpy.atoms.elementwise.logistic import logistic
 from cvxpy.atoms.elementwise.maximum import maximum
 from cvxpy.atoms.elementwise.minimum import minimum
@@ -95,6 +57,39 @@ from cvxpy.atoms.elementwise.rel_entr import rel_entr
 from cvxpy.atoms.elementwise.scalene import scalene
 from cvxpy.atoms.elementwise.sqrt import sqrt
 from cvxpy.atoms.elementwise.square import square
+from cvxpy.atoms.eye_minus_inv import eye_minus_inv, resolvent
+from cvxpy.atoms.gen_lambda_max import gen_lambda_max
+from cvxpy.atoms.geo_mean import geo_mean
+from cvxpy.atoms.gmatmul import gmatmul
+from cvxpy.atoms.harmonic_mean import harmonic_mean
+from cvxpy.atoms.inv_prod import inv_prod
+from cvxpy.atoms.lambda_max import lambda_max
+from cvxpy.atoms.lambda_min import lambda_min
+from cvxpy.atoms.lambda_sum_largest import lambda_sum_largest
+from cvxpy.atoms.lambda_sum_smallest import lambda_sum_smallest
+from cvxpy.atoms.length import length
+from cvxpy.atoms.log_det import log_det
+from cvxpy.atoms.log_sum_exp import log_sum_exp
+from cvxpy.atoms.matrix_frac import MatrixFrac, matrix_frac
+from cvxpy.atoms.max import max
+from cvxpy.atoms.min import min
+from cvxpy.atoms.mixed_norm import mixed_norm
+from cvxpy.atoms.norm import norm, norm2
+from cvxpy.atoms.norm1 import norm1
+from cvxpy.atoms.norm_inf import norm_inf
+from cvxpy.atoms.norm_nuc import normNuc
+from cvxpy.atoms.one_minus_pos import diff_pos, one_minus_pos
+from cvxpy.atoms.pf_eigenvalue import pf_eigenvalue
+from cvxpy.atoms.pnorm import Pnorm, pnorm
+from cvxpy.atoms.prod import Prod, prod
+from cvxpy.atoms.quad_form import QuadForm, quad_form
+from cvxpy.atoms.quad_over_lin import quad_over_lin
+from cvxpy.atoms.sigma_max import sigma_max
+from cvxpy.atoms.sign import sign
+from cvxpy.atoms.sum_largest import sum_largest
+from cvxpy.atoms.sum_smallest import sum_smallest
+from cvxpy.atoms.sum_squares import sum_squares
+from cvxpy.atoms.total_variation import tv
 
 # TODO(akshayka): Perhaps couple this information with the atom classes
 # themselves.

--- a/cvxpy/atoms/affine/add_expr.py
+++ b/cvxpy/atoms/affine/add_expr.py
@@ -13,13 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import operator as op
 from functools import reduce
 from typing import List, Tuple
 
-import cvxpy.utilities as u
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
-import operator as op
+import cvxpy.utilities as u
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
 

--- a/cvxpy/atoms/affine/affine_atom.py
+++ b/cvxpy/atoms/affine/affine_atom.py
@@ -16,15 +16,15 @@ limitations under the License.
 import abc
 from typing import Any, List, Tuple
 
-import cvxpy.utilities as u
+import scipy.sparse as sp
+
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
+import cvxpy.utilities as u
 from cvxpy.atoms.atom import Atom
 from cvxpy.cvxcore.python import canonInterface
 from cvxpy.expressions.constants import Constant
 from cvxpy.utilities import performance_utils as perf
-
-import scipy.sparse as sp
 
 
 class AffAtom(Atom):

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -15,24 +15,27 @@ limitations under the License.
 """
 
 from __future__ import division
+
+import operator as op
 from functools import reduce
 from typing import List, Tuple
 
+import numpy as np
+import scipy.sparse as sp
+
 import cvxpy.interface as intf
-from cvxpy.atoms.affine.affine_atom import AffAtom
-from cvxpy.atoms.affine.add_expr import AddExpression
-from cvxpy.atoms.affine.sum import sum as cvxpy_sum
-from cvxpy.atoms.affine.reshape import deep_flatten
-from cvxpy.atoms.affine.conj import conj
-from cvxpy.constraints.constraint import Constraint
-from cvxpy.expressions.constants.parameter import is_param_affine, is_param_free
-from cvxpy.error import DCPError
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
 import cvxpy.utilities as u
-import numpy as np
-import operator as op
-import scipy.sparse as sp
+from cvxpy.atoms.affine.add_expr import AddExpression
+from cvxpy.atoms.affine.affine_atom import AffAtom
+from cvxpy.atoms.affine.conj import conj
+from cvxpy.atoms.affine.reshape import deep_flatten
+from cvxpy.atoms.affine.sum import sum as cvxpy_sum
+from cvxpy.constraints.constraint import Constraint
+from cvxpy.error import DCPError
+from cvxpy.expressions.constants.parameter import (is_param_affine,
+                                                   is_param_free,)
 
 
 class BinaryOperator(AffAtom):

--- a/cvxpy/atoms/affine/bmat.py
+++ b/cvxpy/atoms/affine/bmat.py
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.affine.vstack import vstack
 from cvxpy.atoms.affine.hstack import hstack
+from cvxpy.atoms.affine.vstack import vstack
 
 
 def bmat(block_lists):

--- a/cvxpy/atoms/affine/conj.py
+++ b/cvxpy/atoms/affine/conj.py
@@ -16,10 +16,11 @@ limitations under the License.
 
 from typing import List, Tuple
 
+import numpy as np
+
 import cvxpy.lin_ops.lin_op as lo
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
-import numpy as np
 
 
 class conj(AffAtom):

--- a/cvxpy/atoms/affine/conv.py
+++ b/cvxpy/atoms/affine/conv.py
@@ -16,14 +16,14 @@ limitations under the License.
 
 from typing import List, Tuple
 
+import numpy as np
+
 import cvxpy.interface as intf
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
 import cvxpy.utilities as u
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
-
-import numpy as np
 
 
 class conv(AffAtom):

--- a/cvxpy/atoms/affine/cumsum.py
+++ b/cvxpy/atoms/affine/cumsum.py
@@ -13,18 +13,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from cvxpy.expressions.expression import Expression
 from typing import List, Tuple
 
-from cvxpy.atoms.axis_atom import AxisAtom
-from cvxpy.atoms.affine.affine_atom import AffAtom
-from cvxpy.atoms.affine.binary_operators import MulExpression
-from cvxpy.constraints.constraint import Constraint
-from cvxpy.expressions.variable import Variable
-import cvxpy.lin_ops.lin_op as lo
-import cvxpy.lin_ops.lin_utils as lu
 import numpy as np
 import scipy.sparse as sp
+
+import cvxpy.lin_ops.lin_op as lo
+import cvxpy.lin_ops.lin_utils as lu
+from cvxpy.atoms.affine.affine_atom import AffAtom
+from cvxpy.atoms.affine.binary_operators import MulExpression
+from cvxpy.atoms.axis_atom import AxisAtom
+from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions.expression import Expression
+from cvxpy.expressions.variable import Variable
 
 
 def get_diff_mat(dim: int, axis: int) -> sp.csc_matrix:

--- a/cvxpy/atoms/affine/diag.py
+++ b/cvxpy/atoms/affine/diag.py
@@ -13,15 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from cvxpy.constraints.constraint import Constraint
 from typing import List, Tuple, Union
+
+import numpy as np
 
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.atoms.affine.vec import vec
-
-import numpy as np
+from cvxpy.constraints.constraint import Constraint
 
 
 def diag(expr) -> Union["diag_mat", "diag_vec"]:

--- a/cvxpy/atoms/affine/hstack.py
+++ b/cvxpy/atoms/affine/hstack.py
@@ -15,11 +15,12 @@ limitations under the License.
 """
 from typing import List, Tuple
 
+import numpy as np
+
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
-import numpy as np
 
 
 def hstack(arg_list) -> "Hstack":

--- a/cvxpy/atoms/affine/imag.py
+++ b/cvxpy/atoms/affine/imag.py
@@ -15,8 +15,9 @@ limitations under the License.
 """
 from typing import Tuple
 
-from cvxpy.atoms.affine.affine_atom import AffAtom
 import numpy as np
+
+from cvxpy.atoms.affine.affine_atom import AffAtom
 
 
 class imag(AffAtom):

--- a/cvxpy/atoms/affine/index.py
+++ b/cvxpy/atoms/affine/index.py
@@ -13,18 +13,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from cvxpy.expressions.expression import Expression
 from typing import List, Tuple
 
-from cvxpy.atoms.affine.affine_atom import AffAtom
-from cvxpy.atoms.affine.vec import vec
-from cvxpy.atoms.affine.reshape import reshape
-from cvxpy.constraints.constraint import Constraint
-from cvxpy.utilities import key_utils as ku
+import numpy as np
+import scipy.sparse as sp
+
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
-import scipy.sparse as sp
-import numpy as np
+from cvxpy.atoms.affine.affine_atom import AffAtom
+from cvxpy.atoms.affine.reshape import reshape
+from cvxpy.atoms.affine.vec import vec
+from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions.expression import Expression
+from cvxpy.utilities import key_utils as ku
 
 
 class index(AffAtom):

--- a/cvxpy/atoms/affine/kron.py
+++ b/cvxpy/atoms/affine/kron.py
@@ -15,13 +15,13 @@ limitations under the License.
 """
 from typing import List, Tuple
 
+import numpy as np
+
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
 import cvxpy.utilities as u
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
-
-import numpy as np
 
 
 class kron(AffAtom):

--- a/cvxpy/atoms/affine/promote.py
+++ b/cvxpy/atoms/affine/promote.py
@@ -15,12 +15,13 @@ limitations under the License.
 """
 from typing import List, Tuple
 
+import numpy as np
+
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
-from cvxpy.constraints.constraint import Constraint
 from cvxpy.atoms.affine.affine_atom import AffAtom
+from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.expression import Expression
-import numpy as np
 
 
 def promote(expr: Expression, shape: Tuple[int, ...]):

--- a/cvxpy/atoms/affine/real.py
+++ b/cvxpy/atoms/affine/real.py
@@ -15,8 +15,9 @@ limitations under the License.
 """
 from typing import Tuple
 
-from cvxpy.atoms.affine.affine_atom import AffAtom
 import numpy as np
+
+from cvxpy.atoms.affine.affine_atom import AffAtom
 
 
 class real(AffAtom):

--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -13,17 +13,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import numbers
 from typing import List, Tuple
 
+import numpy as np
+
 import cvxpy.lin_ops.lin_op as lo
+import cvxpy.lin_ops.lin_utils as lu
+from cvxpy.atoms.affine.affine_atom import AffAtom
+from cvxpy.atoms.affine.hstack import hstack
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.expression import Expression
-from cvxpy.atoms.affine.hstack import hstack
-from cvxpy.atoms.affine.affine_atom import AffAtom
-
-import cvxpy.lin_ops.lin_utils as lu
-import numbers
-import numpy as np
 
 
 class reshape(AffAtom):

--- a/cvxpy/atoms/affine/sum.py
+++ b/cvxpy/atoms/affine/sum.py
@@ -16,13 +16,14 @@ limitations under the License.
 from functools import wraps
 from typing import List, Optional, Tuple
 
+import numpy as np
+
+import cvxpy.interface as intf
+import cvxpy.lin_ops.lin_op as lo
+import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.atoms.axis_atom import AxisAtom
 from cvxpy.constraints.constraint import Constraint
-import cvxpy.lin_ops.lin_op as lo
-import cvxpy.lin_ops.lin_utils as lu
-import cvxpy.interface as intf
-import numpy as np
 
 
 class Sum(AxisAtom, AffAtom):

--- a/cvxpy/atoms/affine/trace.py
+++ b/cvxpy/atoms/affine/trace.py
@@ -15,11 +15,12 @@ limitations under the License.
 """
 from typing import List, Tuple
 
-from cvxpy.atoms.affine.affine_atom import AffAtom
-from cvxpy.constraints.constraint import Constraint
+import numpy as np
+
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
-import numpy as np
+from cvxpy.atoms.affine.affine_atom import AffAtom
+from cvxpy.constraints.constraint import Constraint
 
 
 class trace(AffAtom):

--- a/cvxpy/atoms/affine/transpose.py
+++ b/cvxpy/atoms/affine/transpose.py
@@ -15,11 +15,12 @@ limitations under the License.
 """
 from typing import List, Tuple
 
-from cvxpy.atoms.affine.affine_atom import AffAtom
-from cvxpy.constraints.constraint import Constraint
+import numpy as np
+
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
-import numpy as np
+from cvxpy.atoms.affine.affine_atom import AffAtom
+from cvxpy.constraints.constraint import Constraint
 
 
 class transpose(AffAtom):

--- a/cvxpy/atoms/affine/unary_operators.py
+++ b/cvxpy/atoms/affine/unary_operators.py
@@ -13,13 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import operator as op
 from typing import List, Tuple
 
-from cvxpy.atoms.affine.affine_atom import AffAtom
-from cvxpy.constraints.constraint import Constraint
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
-import operator as op
+from cvxpy.atoms.affine.affine_atom import AffAtom
+from cvxpy.constraints.constraint import Constraint
 
 
 class UnaryOperator(AffAtom):

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -15,14 +15,15 @@ limitations under the License.
 """
 from typing import List, Tuple
 
-from cvxpy.constraints.constraint import Constraint
-from cvxpy.expressions.expression import Expression
-from cvxpy.atoms.affine.affine_atom import AffAtom
-from cvxpy.atoms.affine.reshape import reshape
-import cvxpy.lin_ops.lin_op as lo
-import cvxpy.lin_ops.lin_utils as lu
 import numpy as np
 from scipy.sparse import csc_matrix
+
+import cvxpy.lin_ops.lin_op as lo
+import cvxpy.lin_ops.lin_utils as lu
+from cvxpy.atoms.affine.affine_atom import AffAtom
+from cvxpy.atoms.affine.reshape import reshape
+from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions.expression import Expression
 
 
 class upper_tri(AffAtom):

--- a/cvxpy/atoms/affine/vec.py
+++ b/cvxpy/atoms/affine/vec.py
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.expressions.expression import Expression
 from cvxpy.atoms.affine.reshape import reshape
+from cvxpy.expressions.expression import Expression
 
 
 def vec(X):

--- a/cvxpy/atoms/affine/vstack.py
+++ b/cvxpy/atoms/affine/vstack.py
@@ -15,11 +15,12 @@ limitations under the License.
 """
 from typing import List, Tuple
 
+import numpy as np
+
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
-import numpy as np
 
 
 def vstack(arg_list) -> "Vstack":

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -14,11 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import abc
-from typing import List, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Tuple
 
 if TYPE_CHECKING:
     from cvxpy.constraints.constraint import Constraint
 
+import numpy as np
+
+import cvxpy.lin_ops.lin_op as lo
+import cvxpy.lin_ops.lin_utils as lu
 from cvxpy import interface as intf
 from cvxpy import utilities as u
 from cvxpy.expressions import cvxtypes
@@ -26,10 +30,6 @@ from cvxpy.expressions.constants import Constant
 from cvxpy.expressions.expression import Expression
 from cvxpy.utilities import performance_utils as perf
 from cvxpy.utilities.deterministic import unique_list
-import cvxpy.lin_ops.lin_op as lo
-import cvxpy.lin_ops.lin_utils as lu
-
-import numpy as np
 
 
 class Atom(Expression):
@@ -263,6 +263,7 @@ class Atom(Expression):
         """Is the expression quaisconvex?
         """
         from cvxpy.atoms.max import max as max_atom
+
         # Verifies the DQCP composition rule.
         if self.is_convex():
             return True
@@ -287,6 +288,7 @@ class Atom(Expression):
         """Is the expression quasiconcave?
         """
         from cvxpy.atoms.min import min as min_atom
+
         # Verifies the DQCP composition rule.
         if self.is_concave():
             return True

--- a/cvxpy/atoms/axis_atom.py
+++ b/cvxpy/atoms/axis_atom.py
@@ -17,9 +17,10 @@ limitations under the License.
 import abc
 from typing import List, Optional, Tuple
 
-from cvxpy.atoms.atom import Atom
 import numpy as np
 import scipy.sparse as sp
+
+from cvxpy.atoms.atom import Atom
 
 
 class AxisAtom(Atom):

--- a/cvxpy/atoms/cummax.py
+++ b/cvxpy/atoms/cummax.py
@@ -15,9 +15,10 @@ limitations under the License.
 """
 from typing import Tuple
 
+import numpy as np
+
 from cvxpy.atoms.atom import Atom
 from cvxpy.atoms.axis_atom import AxisAtom
-import numpy as np
 
 
 class cummax(AxisAtom):

--- a/cvxpy/atoms/dist_ratio.py
+++ b/cvxpy/atoms/dist_ratio.py
@@ -13,10 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from cvxpy.atoms.atom import Atom
 from typing import Tuple
 
 import numpy as np
+
+from cvxpy.atoms.atom import Atom
 
 
 class dist_ratio(Atom):

--- a/cvxpy/atoms/elementwise/abs.py
+++ b/cvxpy/atoms/elementwise/abs.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from .elementwise import Elementwise
 from typing import Tuple
 
 import numpy as np
+
+from .elementwise import Elementwise
 
 
 class abs(Elementwise):

--- a/cvxpy/atoms/elementwise/ceil.py
+++ b/cvxpy/atoms/elementwise/ceil.py
@@ -13,12 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import cvxpy.settings as s
-from cvxpy.atoms.elementwise.elementwise import Elementwise
 from typing import Tuple
 
 import numpy as np
 import scipy.sparse as sp
+
+import cvxpy.settings as s
+from cvxpy.atoms.elementwise.elementwise import Elementwise
 
 
 class ceil(Elementwise):

--- a/cvxpy/atoms/elementwise/elementwise.py
+++ b/cvxpy/atoms/elementwise/elementwise.py
@@ -17,11 +17,12 @@ limitations under the License.
 import abc
 from typing import Tuple
 
-from cvxpy.atoms.atom import Atom
-import cvxpy.utilities as u
-import cvxpy.lin_ops.lin_utils as lu
 import numpy as np
 import scipy.sparse as sp
+
+import cvxpy.lin_ops.lin_utils as lu
+import cvxpy.utilities as u
+from cvxpy.atoms.atom import Atom
 
 
 class Elementwise(Atom):

--- a/cvxpy/atoms/elementwise/entr.py
+++ b/cvxpy/atoms/elementwise/entr.py
@@ -15,10 +15,11 @@ limitations under the License.
 """
 from typing import List, Tuple
 
-from cvxpy.atoms.elementwise.elementwise import Elementwise
-from cvxpy.constraints.constraint import Constraint
 import numpy as np
 from scipy.special import xlogy
+
+from cvxpy.atoms.elementwise.elementwise import Elementwise
+from cvxpy.constraints.constraint import Constraint
 
 # TODO(akshayka): DGP support.
 

--- a/cvxpy/atoms/elementwise/exp.py
+++ b/cvxpy/atoms/elementwise/exp.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.elementwise.elementwise import Elementwise
 from typing import Tuple
 
 import numpy as np
+
+from cvxpy.atoms.elementwise.elementwise import Elementwise
 
 
 class exp(Elementwise):

--- a/cvxpy/atoms/elementwise/huber.py
+++ b/cvxpy/atoms/elementwise/huber.py
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.elementwise.elementwise import Elementwise
 from typing import Tuple
 
-import scipy.special
 import numpy as np
+import scipy.special
+
+from cvxpy.atoms.elementwise.elementwise import Elementwise
 
 # TODO(akshayka): DGP support.
 

--- a/cvxpy/atoms/elementwise/kl_div.py
+++ b/cvxpy/atoms/elementwise/kl_div.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 from __future__ import division
 
-from typing import List, Tuple, Optional
+from typing import List, Optional, Tuple
 
 import numpy as np
 from scipy.sparse import csc_matrix

--- a/cvxpy/atoms/elementwise/log.py
+++ b/cvxpy/atoms/elementwise/log.py
@@ -15,10 +15,10 @@ limitations under the License.
 """
 from typing import List, Tuple
 
+import numpy as np
+
 from cvxpy.atoms.elementwise.elementwise import Elementwise
 from cvxpy.constraints.constraint import Constraint
-
-import numpy as np
 
 
 class log(Elementwise):

--- a/cvxpy/atoms/elementwise/log1p.py
+++ b/cvxpy/atoms/elementwise/log1p.py
@@ -15,10 +15,11 @@ limitations under the License.
 """
 from typing import List, Tuple
 
+import numpy as np
+import scipy
+
 from cvxpy.atoms.elementwise.log import log
 from cvxpy.constraints.constraint import Constraint
-import scipy
-import numpy as np
 
 
 class log1p(log):

--- a/cvxpy/atoms/elementwise/log_normcdf.py
+++ b/cvxpy/atoms/elementwise/log_normcdf.py
@@ -11,13 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import scipy.sparse
 import numpy as np
+import scipy.sparse
 
-from cvxpy.expressions.expression import Expression
 from cvxpy.atoms.affine.reshape import reshape
 from cvxpy.atoms.affine.sum import sum as sum_
 from cvxpy.atoms.elementwise.maximum import maximum
+from cvxpy.expressions.expression import Expression
 
 
 def log_normcdf(x):

--- a/cvxpy/atoms/elementwise/logistic.py
+++ b/cvxpy/atoms/elementwise/logistic.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.elementwise.elementwise import Elementwise
 from typing import Tuple
 
 import numpy as np
+
+from cvxpy.atoms.elementwise.elementwise import Elementwise
 
 
 class logistic(Elementwise):

--- a/cvxpy/atoms/elementwise/maximum.py
+++ b/cvxpy/atoms/elementwise/maximum.py
@@ -15,10 +15,12 @@ limitations under the License.
 """
 
 import sys
-from cvxpy.atoms.elementwise.elementwise import Elementwise
 from typing import Any, List, Tuple
 
 import numpy as np
+
+from cvxpy.atoms.elementwise.elementwise import Elementwise
+
 if sys.version_info >= (3, 0):
     from functools import reduce
 

--- a/cvxpy/atoms/elementwise/minimum.py
+++ b/cvxpy/atoms/elementwise/minimum.py
@@ -14,10 +14,12 @@ limitations under the License.
 """
 
 import sys
-from cvxpy.atoms.elementwise.elementwise import Elementwise
 from typing import Any, List, Tuple
 
 import numpy as np
+
+from cvxpy.atoms.elementwise.elementwise import Elementwise
+
 if sys.version_info >= (3, 0):
     from functools import reduce
 

--- a/cvxpy/atoms/elementwise/power.py
+++ b/cvxpy/atoms/elementwise/power.py
@@ -12,16 +12,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from cvxpy.constraints.constraint import Constraint
 from typing import List, Tuple
 
-from cvxpy.atoms.elementwise.elementwise import Elementwise
-from cvxpy.expressions import cvxtypes
-from cvxpy.utilities.power_tools import (is_power2, pow_mid,
-                                         pow_high, pow_neg)
-import cvxpy.utilities as u
 import numpy as np
 import scipy.sparse as sp
+
+import cvxpy.utilities as u
+from cvxpy.atoms.elementwise.elementwise import Elementwise
+from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions import cvxtypes
+from cvxpy.utilities.power_tools import is_power2, pow_high, pow_mid, pow_neg
 
 
 def _is_const(p) -> bool:

--- a/cvxpy/atoms/elementwise/rel_entr.py
+++ b/cvxpy/atoms/elementwise/rel_entr.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 from __future__ import division
 
-from typing import List, Tuple, Optional
+from typing import List, Optional, Tuple
 
 import numpy as np
 from scipy.sparse import csc_matrix

--- a/cvxpy/atoms/elementwise/scalene.py
+++ b/cvxpy/atoms/elementwise/scalene.py
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.elementwise.pos import pos
 from cvxpy.atoms.elementwise.neg import neg
+from cvxpy.atoms.elementwise.pos import pos
 
 
 def scalene(x, alpha, beta):

--- a/cvxpy/atoms/elementwise/sqrt.py
+++ b/cvxpy/atoms/elementwise/sqrt.py
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.elementwise.power import power
 from fractions import Fraction
+
+from cvxpy.atoms.elementwise.power import power
 
 
 def sqrt(x):

--- a/cvxpy/atoms/eye_minus_inv.py
+++ b/cvxpy/atoms/eye_minus_inv.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.atom import Atom
 from typing import Tuple
 
 import numpy as np
+
+from cvxpy.atoms.atom import Atom
 
 
 def resolvent(X, s: float):

--- a/cvxpy/atoms/gen_lambda_max.py
+++ b/cvxpy/atoms/gen_lambda_max.py
@@ -15,9 +15,10 @@ limitations under the License.
 """
 from typing import List, Tuple
 
-from cvxpy.constraints.constraint import Constraint
-from cvxpy.atoms.atom import Atom
 from scipy import linalg as LA
+
+from cvxpy.atoms.atom import Atom
+from cvxpy.constraints.constraint import Constraint
 
 
 class gen_lambda_max(Atom):

--- a/cvxpy/atoms/geo_mean.py
+++ b/cvxpy/atoms/geo_mean.py
@@ -14,13 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.atom import Atom
-from cvxpy.constraints.constraint import Constraint
+from typing import List, Optional, Tuple
+
 import numpy as np
 import scipy.sparse as sp
-from cvxpy.utilities.power_tools import (fracify, decompose, approx_error, lower_bound,
-                                         over_bound, prettydict)
-from typing import List, Optional, Tuple
+
+from cvxpy.atoms.atom import Atom
+from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.power_tools import (approx_error, decompose, fracify,
+                                         lower_bound, over_bound, prettydict,)
 
 
 class geo_mean(Atom):

--- a/cvxpy/atoms/gmatmul.py
+++ b/cvxpy/atoms/gmatmul.py
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.atom import Atom
-from cvxpy.expressions import cvxtypes
 from typing import Tuple
 
-import cvxpy.utilities as u
 import numpy as np
+
+import cvxpy.utilities as u
+from cvxpy.atoms.atom import Atom
+from cvxpy.expressions import cvxtypes
 
 
 class gmatmul(Atom):

--- a/cvxpy/atoms/inv_prod.py
+++ b/cvxpy/atoms/inv_prod.py
@@ -13,9 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from cvxpy.atoms.geo_mean import geo_mean
-from cvxpy.atoms.elementwise.power import power
 from cvxpy.atoms.elementwise.inv_pos import inv_pos
+from cvxpy.atoms.elementwise.power import power
+from cvxpy.atoms.geo_mean import geo_mean
 
 
 def inv_prod(value):

--- a/cvxpy/atoms/lambda_max.py
+++ b/cvxpy/atoms/lambda_max.py
@@ -15,12 +15,12 @@ limitations under the License.
 """
 from typing import List, Tuple
 
-from cvxpy.atoms.atom import Atom
-from cvxpy.constraints.constraint import Constraint
-from scipy import linalg as LA
-
 import numpy as np
 import scipy.sparse as sp
+from scipy import linalg as LA
+
+from cvxpy.atoms.atom import Atom
+from cvxpy.constraints.constraint import Constraint
 
 
 class lambda_max(Atom):

--- a/cvxpy/atoms/lambda_min.py
+++ b/cvxpy/atoms/lambda_min.py
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.expressions.expression import Expression
 from cvxpy.atoms.lambda_max import lambda_max
+from cvxpy.expressions.expression import Expression
 
 
 def lambda_min(X):

--- a/cvxpy/atoms/lambda_sum_largest.py
+++ b/cvxpy/atoms/lambda_sum_largest.py
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from scipy import linalg as LA
 import numpy as np
+from scipy import linalg as LA
+
 from cvxpy.atoms.lambda_max import lambda_max
 from cvxpy.atoms.sum_largest import sum_largest
 

--- a/cvxpy/atoms/lambda_sum_smallest.py
+++ b/cvxpy/atoms/lambda_sum_smallest.py
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.expressions.expression import Expression
 from cvxpy.atoms.lambda_sum_largest import lambda_sum_largest
+from cvxpy.expressions.expression import Expression
 
 
 def lambda_sum_smallest(X, k):

--- a/cvxpy/atoms/length.py
+++ b/cvxpy/atoms/length.py
@@ -13,10 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from cvxpy.atoms.atom import Atom
 from typing import Tuple
 
 import numpy as np
+
+from cvxpy.atoms.atom import Atom
 
 
 class length(Atom):

--- a/cvxpy/atoms/log_det.py
+++ b/cvxpy/atoms/log_det.py
@@ -14,14 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy.settings as s
-from cvxpy.constraints.constraint import Constraint
-from cvxpy.atoms.atom import Atom
-import numpy as np
-from numpy import linalg as LA
 from typing import List, Tuple
 
+import numpy as np
 import scipy.sparse as sp
+from numpy import linalg as LA
+
+import cvxpy.settings as s
+from cvxpy.atoms.atom import Atom
+from cvxpy.constraints.constraint import Constraint
 
 
 class log_det(Atom):

--- a/cvxpy/atoms/log_sum_exp.py
+++ b/cvxpy/atoms/log_sum_exp.py
@@ -14,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.atom import Atom
-from cvxpy.atoms.axis_atom import AxisAtom
+from typing import Tuple
+
 import numpy as np
 from scipy.special import logsumexp
-from typing import Tuple
+
+from cvxpy.atoms.atom import Atom
+from cvxpy.atoms.axis_atom import AxisAtom
 
 
 class log_sum_exp(AxisAtom):

--- a/cvxpy/atoms/matrix_frac.py
+++ b/cvxpy/atoms/matrix_frac.py
@@ -15,13 +15,15 @@ limitations under the License.
 """
 
 from functools import wraps
-from cvxpy.atoms.atom import Atom
-from cvxpy.constraints.constraint import Constraint
-from numpy import linalg as LA
+from typing import List, Tuple
+
 import numpy as np
 import scipy.sparse as sp
+from numpy import linalg as LA
+
+from cvxpy.atoms.atom import Atom
 from cvxpy.atoms.quad_form import QuadForm
-from typing import List, Tuple
+from cvxpy.constraints.constraint import Constraint
 
 
 class MatrixFrac(Atom):

--- a/cvxpy/atoms/max.py
+++ b/cvxpy/atoms/max.py
@@ -15,9 +15,10 @@ limitations under the License.
 """
 from typing import Optional, Tuple
 
+import numpy as np
+
 from cvxpy.atoms.atom import Atom
 from cvxpy.atoms.axis_atom import AxisAtom
-import numpy as np
 
 
 class max(AxisAtom):

--- a/cvxpy/atoms/min.py
+++ b/cvxpy/atoms/min.py
@@ -15,9 +15,10 @@ limitations under the License.
 """
 from typing import Optional, Tuple
 
+import numpy as np
+
 from cvxpy.atoms.atom import Atom
 from cvxpy.atoms.axis_atom import AxisAtom
-import numpy as np
 
 
 class min(AxisAtom):

--- a/cvxpy/atoms/mixed_norm.py
+++ b/cvxpy/atoms/mixed_norm.py
@@ -16,8 +16,8 @@ limitations under the License.
 
 from typing import Union
 
-from cvxpy.expressions.expression import Expression
 from cvxpy.atoms.norm import norm
+from cvxpy.expressions.expression import Expression
 
 
 def mixed_norm(X, p: Union[int, str] = 2, q: Union[int, str] = 1):

--- a/cvxpy/atoms/norm.py
+++ b/cvxpy/atoms/norm.py
@@ -17,14 +17,15 @@ limitations under the License.
 from typing import Union
 
 import numpy as np
+
 import cvxpy
-from cvxpy.expressions.expression import Expression
-from cvxpy.atoms.norm_nuc import normNuc
-from cvxpy.atoms.sigma_max import sigma_max
-from cvxpy.atoms.pnorm import pnorm
+from cvxpy.atoms.affine.vec import vec
 from cvxpy.atoms.norm1 import norm1
 from cvxpy.atoms.norm_inf import norm_inf
-from cvxpy.atoms.affine.vec import vec
+from cvxpy.atoms.norm_nuc import normNuc
+from cvxpy.atoms.pnorm import pnorm
+from cvxpy.atoms.sigma_max import sigma_max
+from cvxpy.expressions.expression import Expression
 
 
 def norm(x, p: Union[int, str] = 2, axis=None):

--- a/cvxpy/atoms/norm1.py
+++ b/cvxpy/atoms/norm1.py
@@ -15,10 +15,11 @@ limitations under the License.
 """
 from typing import List, Tuple
 
-from cvxpy.atoms.axis_atom import AxisAtom
-from cvxpy.constraints.constraint import Constraint
 import numpy as np
 import scipy.sparse as sp
+
+from cvxpy.atoms.axis_atom import AxisAtom
+from cvxpy.constraints.constraint import Constraint
 
 
 class norm1(AxisAtom):

--- a/cvxpy/atoms/norm_inf.py
+++ b/cvxpy/atoms/norm_inf.py
@@ -15,11 +15,11 @@ limitations under the License.
 """
 from typing import List, Tuple
 
-from cvxpy.atoms.axis_atom import AxisAtom
-from cvxpy.constraints.constraint import Constraint
-
 import numpy as np
 import scipy.sparse as sp
+
+from cvxpy.atoms.axis_atom import AxisAtom
+from cvxpy.constraints.constraint import Constraint
 
 
 class norm_inf(AxisAtom):

--- a/cvxpy/atoms/norm_nuc.py
+++ b/cvxpy/atoms/norm_nuc.py
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.atom import Atom
 from typing import Tuple
 
 import numpy as np
 import scipy.sparse as sp
+
+from cvxpy.atoms.atom import Atom
 
 
 class normNuc(Atom):

--- a/cvxpy/atoms/one_minus_pos.py
+++ b/cvxpy/atoms/one_minus_pos.py
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.atom import Atom
-from cvxpy.atoms.affine.binary_operators import multiply
 from typing import Tuple
 
 import numpy as np
 import scipy.sparse as sp
+
+from cvxpy.atoms.affine.binary_operators import multiply
+from cvxpy.atoms.atom import Atom
 
 
 def diff_pos(x, y):

--- a/cvxpy/atoms/pf_eigenvalue.py
+++ b/cvxpy/atoms/pf_eigenvalue.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.atom import Atom
 from typing import Tuple
 
 import numpy as np
+
+from cvxpy.atoms.atom import Atom
 
 
 class pf_eigenvalue(Atom):

--- a/cvxpy/atoms/pnorm.py
+++ b/cvxpy/atoms/pnorm.py
@@ -15,12 +15,13 @@ limitations under the License.
 """
 from typing import List, Tuple, Union
 
+import numpy as np
+import scipy.sparse as sp
+
 from cvxpy.atoms.axis_atom import AxisAtom
 from cvxpy.atoms.norm1 import norm1
 from cvxpy.atoms.norm_inf import norm_inf
 from cvxpy.constraints.constraint import Constraint
-import numpy as np
-import scipy.sparse as sp
 from cvxpy.utilities.power_tools import pow_high, pow_mid, pow_neg
 
 

--- a/cvxpy/atoms/prod.py
+++ b/cvxpy/atoms/prod.py
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.affine.hstack import hstack
-from cvxpy.atoms.axis_atom import AxisAtom
 from typing import Tuple
 
-import cvxpy.interface as intf
 import numpy as np
+
+import cvxpy.interface as intf
+from cvxpy.atoms.affine.hstack import hstack
+from cvxpy.atoms.axis_atom import AxisAtom
 
 
 class Prod(AxisAtom):

--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -17,14 +17,15 @@ limitations under the License.
 from __future__ import division
 
 import warnings
+from typing import Tuple
 
 import numpy as np
+import scipy.sparse as sp
 from scipy import linalg as LA
+
 from cvxpy.atoms.atom import Atom
 from cvxpy.expressions.expression import Expression
 from cvxpy.interface.matrix_utilities import is_sparse
-import scipy.sparse as sp
-from typing import Tuple
 
 
 class CvxPyDomainError(Exception):

--- a/cvxpy/atoms/quad_over_lin.py
+++ b/cvxpy/atoms/quad_over_lin.py
@@ -16,12 +16,12 @@ limitations under the License.
 
 from typing import List, Tuple
 
+import numpy as np
+import scipy as scipy
+import scipy.sparse as sp
+
 from cvxpy.atoms.atom import Atom
 from cvxpy.constraints.constraint import Constraint
-
-import numpy as np
-import scipy.sparse as sp
-import scipy as scipy
 
 
 class quad_over_lin(Atom):

--- a/cvxpy/atoms/sigma_max.py
+++ b/cvxpy/atoms/sigma_max.py
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.atom import Atom
-import scipy.sparse as sp
-from numpy import linalg as LA
 from typing import Tuple
 
 import numpy as np
+import scipy.sparse as sp
+from numpy import linalg as LA
+
+from cvxpy.atoms.atom import Atom
 
 
 class sigma_max(Atom):

--- a/cvxpy/atoms/sum_largest.py
+++ b/cvxpy/atoms/sum_largest.py
@@ -16,10 +16,11 @@ limitations under the License.
 
 from typing import Tuple
 
-from cvxpy.atoms.atom import Atom
-import cvxpy.interface as intf
 import numpy as np
 import scipy.sparse as sp
+
+import cvxpy.interface as intf
+from cvxpy.atoms.atom import Atom
 
 
 class sum_largest(Atom):

--- a/cvxpy/atoms/sum_smallest.py
+++ b/cvxpy/atoms/sum_smallest.py
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.expressions.expression import Expression
 from cvxpy.atoms.sum_largest import sum_largest
+from cvxpy.expressions.expression import Expression
 
 
 def sum_smallest(x, k):

--- a/cvxpy/atoms/suppfunc.py
+++ b/cvxpy/atoms/suppfunc.py
@@ -1,11 +1,11 @@
 from typing import Tuple
 
+import numpy as np
+import scipy.sparse as sp
+
 import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.atom import Atom
 from cvxpy.expressions.variable import Variable
-
-import scipy.sparse as sp
-import numpy as np
 
 
 class SuppFuncAtom(Atom):
@@ -106,8 +106,8 @@ class SuppFuncAtom(Atom):
         return False
 
     def _value_impl(self):
-        from cvxpy.problems.problem import Problem
         from cvxpy.problems.objective import Maximize
+        from cvxpy.problems.problem import Problem
         y_val = self.args[0].value.round(decimals=9).ravel(order='F')
         x_flat = self._parent.x.flatten()
         cons = self._parent.constraints

--- a/cvxpy/atoms/total_variation.py
+++ b/cvxpy/atoms/total_variation.py
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.expressions.expression import Expression
-from cvxpy.atoms.norm import norm
-from cvxpy.atoms.affine.vstack import vstack
-from cvxpy.atoms.affine.sum import sum
 from cvxpy.atoms.affine.reshape import reshape
+from cvxpy.atoms.affine.sum import sum
+from cvxpy.atoms.affine.vstack import vstack
+from cvxpy.atoms.norm import norm
+from cvxpy.expressions.expression import Expression
 
 
 def tv(value, *args):

--- a/cvxpy/constraints/__init__.py
+++ b/cvxpy/constraints/__init__.py
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.constraints.zero import Equality, Zero
 from cvxpy.constraints.exponential import ExpCone
-from cvxpy.constraints.nonpos import Inequality, NonPos, NonNeg
+from cvxpy.constraints.nonpos import Inequality, NonNeg, NonPos
+from cvxpy.constraints.power import PowCone3D, PowConeND
 from cvxpy.constraints.psd import PSD
 from cvxpy.constraints.second_order import SOC
-from cvxpy.constraints.power import PowConeND, PowCone3D
+from cvxpy.constraints.zero import Equality, Zero

--- a/cvxpy/constraints/constraint.py
+++ b/cvxpy/constraints/constraint.py
@@ -14,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy.utilities as u
-import cvxpy.lin_ops.lin_utils as lu
-from cvxpy.expressions import cvxtypes
 import abc
+
 import numpy as np
+
+import cvxpy.lin_ops.lin_utils as lu
+import cvxpy.utilities as u
+from cvxpy.expressions import cvxtypes
 
 
 class Constraint(u.Canonical):

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -15,12 +15,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.constraints.constraint import Constraint
-from cvxpy.expressions import cvxtypes
-from cvxpy.utilities import scopes
 from typing import List, Tuple
 
 import numpy as np
+
+from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions import cvxtypes
+from cvxpy.utilities import scopes
 
 
 class ExpCone(Constraint):
@@ -69,7 +70,7 @@ class ExpCone(Constraint):
     @property
     def residual(self):
         # TODO(akshayka): The projection should be implemented directly.
-        from cvxpy import Problem, Minimize, Variable, norm2, hstack
+        from cvxpy import Minimize, Problem, Variable, hstack, norm2
         if self.x.value is None or self.y.value is None or self.z.value is None:
             return None
         x = Variable(self.x.shape)

--- a/cvxpy/constraints/nonpos.py
+++ b/cvxpy/constraints/nonpos.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+
 # Only need Variable from expressions, but that would create a circular import.
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.utilities import scopes
-import numpy as np
 
 
 class NonPos(Constraint):

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.constraints.constraint import Constraint
-from cvxpy.expressions import cvxtypes
-from cvxpy.utilities import scopes
 from typing import List, Tuple
 
 import numpy as np
+
+from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions import cvxtypes
+from cvxpy.utilities import scopes
 
 
 class PowCone3D(Constraint):
@@ -67,7 +68,7 @@ class PowCone3D(Constraint):
 
     def residual(self):
         # TODO: The projection should be implemented directly.
-        from cvxpy import Problem, Minimize, Variable, norm2, hstack
+        from cvxpy import Minimize, Problem, Variable, hstack, norm2
         if self.x.value is None or self.y.value is None or self.z.value is None:
             return None
         x = Variable(self.x.shape)
@@ -205,7 +206,7 @@ class PowConeND(Constraint):
     @property
     def residual(self):
         # TODO: The projection should be implemented directly.
-        from cvxpy import Problem, Minimize, Variable, norm2, hstack
+        from cvxpy import Minimize, Problem, Variable, hstack, norm2
         if self.W.value is None or self.z.value is None:
             return None
         W = Variable(self.W.shape)

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.constraints.constraint import Constraint
-from cvxpy.expressions import cvxtypes
-from cvxpy.utilities import scopes
 from typing import List
 
 import numpy as np
+
+from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions import cvxtypes
+from cvxpy.utilities import scopes
 
 
 class SOC(Constraint):

--- a/cvxpy/constraints/utilities.py
+++ b/cvxpy/constraints/utilities.py
@@ -15,10 +15,12 @@ limitations under the License.
 """
 from typing import Tuple
 
-# Utility functions for constraints.
+import scipy.sparse as sp
 
 import cvxpy.lin_ops.lin_utils as lu
-import scipy.sparse as sp
+
+# Utility functions for constraints.
+
 
 
 def format_axis(t, X, axis):

--- a/cvxpy/constraints/zero.py
+++ b/cvxpy/constraints/zero.py
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.utilities import scopes
-import numpy as np
 
 
 class Zero(Constraint):

--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -13,12 +13,14 @@ Copyright 2017 Steven Diamond
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-from cvxpy.lin_ops import lin_op as lo
-import cvxpy.cvxcore.python.cvxcore as cvxcore
-import cvxpy.settings as s
 import numbers
+
 import numpy as np
 import scipy.sparse
+
+import cvxpy.cvxcore.python.cvxcore as cvxcore
+import cvxpy.settings as s
+from cvxpy.lin_ops import lin_op as lo
 
 
 def get_parameter_vector(param_size,

--- a/cvxpy/cvxcore/python/cvxcore.py
+++ b/cvxpy/cvxcore/python/cvxcore.py
@@ -5,6 +5,7 @@
 # the SWIG interface file instead.
 
 from sys import version_info as _swig_python_version_info
+
 if _swig_python_version_info < (2, 7, 0):
     raise RuntimeError("Python 2.7 or later required")
 

--- a/cvxpy/expressions/constants/__init__.py
+++ b/cvxpy/expressions/constants/__init__.py
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from .constant import Constant
 from .callback_param import CallbackParam
+from .constant import Constant
 from .parameter import Parameter

--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -16,14 +16,15 @@ limitations under the License.
 
 from typing import List, Optional, Tuple
 
-import cvxpy.interface as intf
-import cvxpy.lin_ops.lin_utils as lu
 import numpy as np
 import scipy.sparse as sp
+from scipy.sparse.linalg import eigsh
+
+import cvxpy.interface as intf
+import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.expressions.leaf import Leaf
 from cvxpy.settings import EIGVAL_TOL
 from cvxpy.utilities import performance_utils as perf
-from scipy.sparse.linalg import eigsh
 
 
 class Constant(Leaf):

--- a/cvxpy/expressions/constants/parameter.py
+++ b/cvxpy/expressions/constants/parameter.py
@@ -15,9 +15,9 @@ limitations under the License.
 """
 from typing import List, Optional, Tuple
 
+import cvxpy.lin_ops.lin_utils as lu
 from cvxpy import settings as s
 from cvxpy.expressions.leaf import Leaf
-import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.utilities import scopes
 
 

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -14,20 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import abc
+import warnings
 from functools import wraps
 from typing import Tuple
-import warnings
 
-from cvxpy import error
-from cvxpy.constraints import Equality, Inequality, PSD
-from cvxpy.expressions import cvxtypes
-from cvxpy.utilities import scopes
-import cvxpy.utilities.performance_utils as perf
+import numpy as np
+
+import cvxpy.settings as s
 import cvxpy.utilities as u
 import cvxpy.utilities.key_utils as ku
-import cvxpy.settings as s
-import abc
-import numpy as np
+import cvxpy.utilities.performance_utils as perf
+from cvxpy import error
+from cvxpy.constraints import PSD, Equality, Inequality
+from cvxpy.expressions import cvxtypes
+from cvxpy.utilities import scopes
 
 
 def _cast_other(binary_op):

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -15,23 +15,23 @@ limitations under the License.
 """
 
 import abc
-from typing import List, Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Tuple, Union
 
 if TYPE_CHECKING:
     from cvxpy import Constant, Variable
     from cvxpy.atoms.atom import Atom
 
-from cvxpy.constraints.constraint import Constraint
-from cvxpy.expressions import expression
-from cvxpy.settings import (GENERAL_PROJECTION_TOL,
-                            PSD_NSD_PROJECTION_TOL,
-                            SPARSE_PROJECTION_TOL)
-
-import cvxpy.interface as intf
 import numbers
+
 import numpy as np
 import numpy.linalg as LA
 import scipy.sparse as sp
+
+import cvxpy.interface as intf
+from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions import expression
+from cvxpy.settings import (GENERAL_PROJECTION_TOL, PSD_NSD_PROJECTION_TOL,
+                            SPARSE_PROJECTION_TOL,)
 
 
 class Leaf(expression.Expression):

--- a/cvxpy/expressions/variable.py
+++ b/cvxpy/expressions/variable.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import scipy.sparse as sp
+
+import cvxpy.lin_ops.lin_utils as lu
 from cvxpy import settings as s
 from cvxpy.expressions.leaf import Leaf
-import cvxpy.lin_ops.lin_utils as lu
-import scipy.sparse as sp
 
 
 def upper_tri_to_full(n):

--- a/cvxpy/interface/base_matrix_interface.py
+++ b/cvxpy/interface/base_matrix_interface.py
@@ -16,8 +16,9 @@ limitations under the License.
 import abc
 from typing import Tuple
 
-import cvxpy.interface.matrix_utilities
 import numpy as np
+
+import cvxpy.interface.matrix_utilities
 
 
 class BaseMatrixInterface:

--- a/cvxpy/interface/matrix_utilities.py
+++ b/cvxpy/interface/matrix_utilities.py
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.interface import numpy_interface as np_intf
-import scipy.sparse as sp
 import numbers
+
 import numpy as np
+import scipy.sparse as sp
+
+from cvxpy.interface import numpy_interface as np_intf
 
 # A mapping of class to interface.
 INTERFACES = {np.ndarray: np_intf.NDArrayInterface(),

--- a/cvxpy/interface/numpy_interface/__init__.py
+++ b/cvxpy/interface/numpy_interface/__init__.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.interface.numpy_interface.ndarray_interface import NDArrayInterface
 from cvxpy.interface.numpy_interface.matrix_interface import MatrixInterface
-from cvxpy.interface.numpy_interface.sparse_matrix_interface import SparseMatrixInterface
+from cvxpy.interface.numpy_interface.ndarray_interface import NDArrayInterface
+from cvxpy.interface.numpy_interface.sparse_matrix_interface import (
+    SparseMatrixInterface,)

--- a/cvxpy/interface/numpy_interface/matrix_interface.py
+++ b/cvxpy/interface/numpy_interface/matrix_interface.py
@@ -15,9 +15,10 @@ limitations under the License.
 """
 from typing import Tuple
 
-from cvxpy.interface.numpy_interface.ndarray_interface import NDArrayInterface
-import scipy.sparse as sp
 import numpy as np
+import scipy.sparse as sp
+
+from cvxpy.interface.numpy_interface.ndarray_interface import NDArrayInterface
 
 
 class MatrixInterface(NDArrayInterface):

--- a/cvxpy/interface/numpy_interface/ndarray_interface.py
+++ b/cvxpy/interface/numpy_interface/ndarray_interface.py
@@ -15,11 +15,12 @@ limitations under the License.
 """
 
 
-from .. import base_matrix_interface as base
 from typing import Tuple
 
 import numpy
 import scipy.sparse
+
+from .. import base_matrix_interface as base
 
 
 class NDArrayInterface(base.BaseMatrixInterface):

--- a/cvxpy/interface/numpy_interface/sparse_matrix_interface.py
+++ b/cvxpy/interface/numpy_interface/sparse_matrix_interface.py
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.interface.numpy_interface.ndarray_interface import NDArrayInterface
-import scipy.sparse as sp
 import numpy as np
+import scipy.sparse as sp
+
+from cvxpy.interface.numpy_interface.ndarray_interface import NDArrayInterface
 
 
 class SparseMatrixInterface(NDArrayInterface):

--- a/cvxpy/interface/scipy_wrapper.py
+++ b/cvxpy/interface/scipy_wrapper.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from scipy.sparse.base import spmatrix
+
 from cvxpy.expressions import expression as exp
 
 BIN_OPS = ["__div__", "__mul__", "__add__", "__sub__",

--- a/cvxpy/lin_ops/__init__.py
+++ b/cvxpy/lin_ops/__init__.py
@@ -15,4 +15,4 @@ limitations under the License.
 """
 
 from cvxpy.lin_ops.lin_constraints import LinEqConstr, LinLeqConstr
-from cvxpy.lin_ops.lin_op import LinOp, CONSTANT_ID
+from cvxpy.lin_ops.lin_op import CONSTANT_ID, LinOp

--- a/cvxpy/lin_ops/lin_utils.py
+++ b/cvxpy/lin_ops/lin_utils.py
@@ -18,10 +18,11 @@ DO NOT CALL THESE FUNCTIONS IN YOUR CODE!
 """
 from typing import Tuple
 
-from cvxpy.lin_ops.lin_constraints import LinEqConstr, LinLeqConstr
+import numpy as np
+
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.utilities as u
-import numpy as np
+from cvxpy.lin_ops.lin_constraints import LinEqConstr, LinLeqConstr
 
 # Utility functions for dealing with LinOp.
 

--- a/cvxpy/lin_ops/tree_mat.py
+++ b/cvxpy/lin_ops/tree_mat.py
@@ -16,11 +16,13 @@ limitations under the License.
 THIS FILE IS DEPRECATED AND MAY BE REMOVED WITHOUT WARNING!
 DO NOT CALL THESE FUNCTIONS IN YOUR CODE!
 """
-import cvxpy.interface as intf
-import cvxpy.lin_ops.lin_op as lo
 import copy
+
 import numpy as np
 from scipy.signal import fftconvolve
+
+import cvxpy.interface as intf
+import cvxpy.lin_ops.lin_op as lo
 
 # Utility functions for treating an expression tree as a matrix
 # and multiplying by it and it's transpose.

--- a/cvxpy/performance_tests/test_param_cache.py
+++ b/cvxpy/performance_tests/test_param_cache.py
@@ -17,8 +17,9 @@ THIS FILE IS DEPRECATED AND MAY BE REMOVED WITHOUT WARNING!
 DO NOT CALL THESE FUNCTIONS IN YOUR CODE!
 """
 
-import unittest
 import time
+import unittest
+
 import cvxpy as cvx
 
 

--- a/cvxpy/performance_tests/test_robustness.py
+++ b/cvxpy/performance_tests/test_robustness.py
@@ -18,14 +18,16 @@ THIS FILE IS DEPRECATED AND MAY BE REMOVED WITHOUT WARNING!
 DO NOT CALL THESE FUNCTIONS IN YOUR CODE!
 """
 
-import cvxpy as cp
-import cvxpy.atoms as at
-from cvxpy.expressions.variable import Variable
-from cvxpy.problems.problem import Problem
-import cvxpy.interface.matrix_utilities as intf
+import unittest
+
 import numpy as np
 import scipy.sparse as sp
-import unittest
+
+import cvxpy as cp
+import cvxpy.atoms as at
+import cvxpy.interface.matrix_utilities as intf
+from cvxpy.expressions.variable import Variable
+from cvxpy.problems.problem import Problem
 
 
 class TestProblem(unittest.TestCase):

--- a/cvxpy/performance_tests/test_warmstart.py
+++ b/cvxpy/performance_tests/test_warmstart.py
@@ -19,8 +19,10 @@ DO NOT CALL THESE FUNCTIONS IN YOUR CODE!
 """
 
 from __future__ import print_function
-import unittest
+
 import time
+import unittest
+
 import cvxpy as cp
 
 

--- a/cvxpy/problems/iterative.py
+++ b/cvxpy/problems/iterative.py
@@ -20,8 +20,9 @@ DO NOT CALL THESE FUNCTIONS IN YOUR CODE!
 
 # Methods for SCS iterative solver.
 
-from cvxpy.lin_ops.tree_mat import mul, tmul, sum_dicts
 import numpy as np
+
+from cvxpy.lin_ops.tree_mat import mul, sum_dicts, tmul
 
 
 def get_mul_funcs(sym_data):

--- a/cvxpy/problems/objective.py
+++ b/cvxpy/problems/objective.py
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import cvxpy.lin_ops.lin_utils as lu
 import cvxpy.utilities as u
 from cvxpy.error import DCPError
 from cvxpy.expressions.expression import Expression
 from cvxpy.interface.matrix_utilities import scalar_value
-import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.utilities import scopes
 
 

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -19,17 +19,19 @@ import warnings
 from collections import namedtuple
 from typing import Dict, List, Optional, Union
 
+import numpy as np
+
 import cvxpy.utilities as u
 import cvxpy.utilities.performance_utils as perf
-from cvxpy import error
-from cvxpy import settings as s, Constant
+from cvxpy import Constant, error
+from cvxpy import settings as s
 from cvxpy.atoms.atom import Atom
-from cvxpy.constraints import Equality, Inequality, NonPos, Zero, NonNeg
+from cvxpy.constraints import Equality, Inequality, NonNeg, NonPos, Zero
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
 from cvxpy.expressions.variable import Variable
 from cvxpy.interface.matrix_utilities import scalar_value
-from cvxpy.problems.objective import Minimize, Maximize
+from cvxpy.problems.objective import Maximize, Minimize
 from cvxpy.reductions import InverseData
 from cvxpy.reductions.chain import Chain
 from cvxpy.reductions.dgp2dcp.dgp2dcp import Dgp2Dcp
@@ -39,15 +41,13 @@ from cvxpy.reductions.flip_objective import FlipObjective
 from cvxpy.reductions.solvers import bisection
 from cvxpy.reductions.solvers import defines as slv_def
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
-from cvxpy.reductions.solvers.defines import SOLVER_MAP_QP, SOLVER_MAP_CONIC
+from cvxpy.reductions.solvers.defines import SOLVER_MAP_CONIC, SOLVER_MAP_QP
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 from cvxpy.reductions.solvers.solver import Solver
-from cvxpy.reductions.solvers.solving_chain import construct_solving_chain, SolvingChain
+from cvxpy.reductions.solvers.solving_chain import (SolvingChain,
+                                                    construct_solving_chain,)
 from cvxpy.settings import SOLVERS
 from cvxpy.utilities.deterministic import unique_list
-
-import numpy as np
-
 
 SolveResult = namedtuple(
     'SolveResult',

--- a/cvxpy/problems/xpress_problem.py
+++ b/cvxpy/problems/xpress_problem.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from collections import namedtuple
+
 from cvxpy.problems.problem import Problem
 from cvxpy.utilities.deterministic import unique_list
 

--- a/cvxpy/reductions/__init__.py
+++ b/cvxpy/reductions/__init__.py
@@ -14,19 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.reductions.inverse_data import InverseData
-from cvxpy.reductions.reduction import Reduction
-from cvxpy.reductions.solution import Solution
-
 from cvxpy.reductions.chain import Chain
-from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
 from cvxpy.reductions.complex2real.complex2real import Complex2Real
 from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
+from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
 from cvxpy.reductions.dcp2cone.dcp2cone import Dcp2Cone
 from cvxpy.reductions.dgp2dcp.dgp2dcp import Dgp2Dcp
 from cvxpy.reductions.dqcp2dcp.dqcp2dcp import Dqcp2Dcp
 from cvxpy.reductions.eval_params import EvalParams
 from cvxpy.reductions.flip_objective import FlipObjective
-from cvxpy.reductions.qp2quad_form.qp_matrix_stuffing import QpMatrixStuffing
+from cvxpy.reductions.inverse_data import InverseData
 from cvxpy.reductions.qp2quad_form.qp2symbolic_qp import Qp2SymbolicQp
+from cvxpy.reductions.qp2quad_form.qp_matrix_stuffing import QpMatrixStuffing
+from cvxpy.reductions.reduction import Reduction
+from cvxpy.reductions.solution import Solution
 from cvxpy.reductions.solvers.solving_chain import SolvingChain

--- a/cvxpy/reductions/complex2real/atom_canonicalizers/__init__.py
+++ b/cvxpy/reductions/complex2real/atom_canonicalizers/__init__.py
@@ -14,48 +14,49 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms import (bmat, cumsum, kron, conv,
-                         abs, reshape, trace,
-                         upper_tri, conj, imag, real,
-                         norm1, norm_inf, Pnorm,
-                         sigma_max, lambda_max, lambda_sum_largest,
-                         log_det, QuadForm, MatrixFrac, quad_over_lin)
+from cvxpy.atoms import (MatrixFrac, Pnorm, QuadForm, abs, bmat, conj, conv,
+                         cumsum, imag, kron, lambda_max, lambda_sum_largest,
+                         log_det, norm1, norm_inf, quad_over_lin, real,
+                         reshape, sigma_max, trace, upper_tri,)
+from cvxpy.atoms.affine.add_expr import AddExpression
+from cvxpy.atoms.affine.binary_operators import (DivExpression, MulExpression,
+                                                 multiply,)
 from cvxpy.atoms.affine.diag import diag_mat, diag_vec
+from cvxpy.atoms.affine.hstack import Hstack
+from cvxpy.atoms.affine.index import index, special_index
 from cvxpy.atoms.affine.promote import Promote
 from cvxpy.atoms.affine.sum import Sum
-from cvxpy.atoms.affine.add_expr import AddExpression
-from cvxpy.atoms.affine.index import index, special_index
-from cvxpy.atoms.affine.unary_operators import NegExpression
 from cvxpy.atoms.affine.transpose import transpose
-from cvxpy.atoms.affine.hstack import Hstack
+from cvxpy.atoms.affine.unary_operators import NegExpression
 from cvxpy.atoms.affine.vstack import Vstack
 from cvxpy.atoms.norm_nuc import normNuc
-from cvxpy.atoms.affine.binary_operators import (MulExpression,
-                                                 multiply,
-                                                 DivExpression)
+from cvxpy.constraints import (PSD, SOC, Equality, Inequality, NonNeg, NonPos,
+                               Zero,)
 from cvxpy.expressions.constants import Constant, Parameter
 from cvxpy.expressions.variable import Variable
-from cvxpy.constraints import Equality, Inequality, NonPos, SOC, PSD, Zero, NonNeg
-from cvxpy.reductions.complex2real.atom_canonicalizers.abs_canon import abs_canon
-from cvxpy.reductions.complex2real.atom_canonicalizers.aff_canon import (separable_canon,
-                                                                         real_canon,
-                                                                         imag_canon,
-                                                                         conj_canon,
-                                                                         binary_canon)
-from cvxpy.reductions.complex2real.atom_canonicalizers.pnorm_canon import pnorm_canon
-from cvxpy.reductions.complex2real.atom_canonicalizers.matrix_canon import (
-    hermitian_canon, quad_canon, lambda_sum_largest_canon, norm_nuc_canon, matrix_frac_canon,
-    quad_over_lin_canon)
-from cvxpy.reductions.complex2real.atom_canonicalizers.inequality_canon import (
-    inequality_canon, nonpos_canon, nonneg_canon)
-from cvxpy.reductions.complex2real.atom_canonicalizers.psd_canon import psd_canon
-from cvxpy.reductions.complex2real.atom_canonicalizers.soc_canon import soc_canon
-from cvxpy.reductions.complex2real.atom_canonicalizers.variable_canon import variable_canon
-from cvxpy.reductions.complex2real.atom_canonicalizers.constant_canon import constant_canon
-from cvxpy.reductions.complex2real.atom_canonicalizers.param_canon import param_canon
+from cvxpy.reductions.complex2real.atom_canonicalizers.abs_canon import (
+    abs_canon,)
+from cvxpy.reductions.complex2real.atom_canonicalizers.aff_canon import (
+    binary_canon, conj_canon, imag_canon, real_canon, separable_canon,)
+from cvxpy.reductions.complex2real.atom_canonicalizers.constant_canon import (
+    constant_canon,)
 from cvxpy.reductions.complex2real.atom_canonicalizers.equality_canon import (
-    equality_canon, zero_canon)
-
+    equality_canon, zero_canon,)
+from cvxpy.reductions.complex2real.atom_canonicalizers.inequality_canon import (
+    inequality_canon, nonneg_canon, nonpos_canon,)
+from cvxpy.reductions.complex2real.atom_canonicalizers.matrix_canon import (
+    hermitian_canon, lambda_sum_largest_canon, matrix_frac_canon,
+    norm_nuc_canon, quad_canon, quad_over_lin_canon,)
+from cvxpy.reductions.complex2real.atom_canonicalizers.param_canon import (
+    param_canon,)
+from cvxpy.reductions.complex2real.atom_canonicalizers.pnorm_canon import (
+    pnorm_canon,)
+from cvxpy.reductions.complex2real.atom_canonicalizers.psd_canon import (
+    psd_canon,)
+from cvxpy.reductions.complex2real.atom_canonicalizers.soc_canon import (
+    soc_canon,)
+from cvxpy.reductions.complex2real.atom_canonicalizers.variable_canon import (
+    variable_canon,)
 
 CANON_METHODS = {
     AddExpression: separable_canon,

--- a/cvxpy/reductions/complex2real/atom_canonicalizers/abs_canon.py
+++ b/cvxpy/reductions/complex2real/atom_canonicalizers/abs_canon.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms import abs, vstack, pnorm, reshape
+from cvxpy.atoms import abs, pnorm, reshape, vstack
 
 
 def abs_canon(expr, real_args, imag_args, real2imag):

--- a/cvxpy/reductions/complex2real/atom_canonicalizers/aff_canon.py
+++ b/cvxpy/reductions/complex2real/atom_canonicalizers/aff_canon.py
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.expressions.constants import Constant
 import numpy as np
+
+from cvxpy.expressions.constants import Constant
 
 
 def separable_canon(expr, real_args, imag_args, real2imag):

--- a/cvxpy/reductions/complex2real/atom_canonicalizers/equality_canon.py
+++ b/cvxpy/reductions/complex2real/atom_canonicalizers/equality_canon.py
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.expressions.constants import Constant
-from cvxpy.constraints.zero import Equality, Zero
 import numpy as np
+
+from cvxpy.constraints.zero import Equality, Zero
+from cvxpy.expressions.constants import Constant
 
 
 def equality_canon(expr, real_args, imag_args, real2imag):

--- a/cvxpy/reductions/complex2real/atom_canonicalizers/inequality_canon.py
+++ b/cvxpy/reductions/complex2real/atom_canonicalizers/inequality_canon.py
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.expressions.constants import Constant
-from cvxpy.constraints import Inequality, NonPos, NonNeg
 import numpy as np
+
+from cvxpy.constraints import Inequality, NonNeg, NonPos
+from cvxpy.expressions.constants import Constant
 
 
 def inequality_canon(expr, real_args, imag_args, real2imag):

--- a/cvxpy/reductions/complex2real/atom_canonicalizers/matrix_canon.py
+++ b/cvxpy/reductions/complex2real/atom_canonicalizers/matrix_canon.py
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+
 from cvxpy.atoms import bmat, reshape, vstack
 from cvxpy.atoms.affine.wraps import psd_wrap
-import numpy as np
 
 # We expand the matrix A to B = [[Re(A), -Im(A)], [Im(A), Re(A)]]
 # B has the same eigenvalues as A (if A is Hermitian).

--- a/cvxpy/reductions/complex2real/atom_canonicalizers/pnorm_canon.py
+++ b/cvxpy/reductions/complex2real/atom_canonicalizers/pnorm_canon.py
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.reductions.complex2real.atom_canonicalizers.abs_canon import abs_canon
+from cvxpy.reductions.complex2real.atom_canonicalizers.abs_canon import (
+    abs_canon,)
 
 
 def pnorm_canon(expr, real_args, imag_args, real2imag):

--- a/cvxpy/reductions/complex2real/atom_canonicalizers/psd_canon.py
+++ b/cvxpy/reductions/complex2real/atom_canonicalizers/psd_canon.py
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms import bmat
 import numpy as np
+
+from cvxpy.atoms import bmat
 
 
 def psd_canon(expr, real_args, imag_args, real2imag):

--- a/cvxpy/reductions/complex2real/complex2real.py
+++ b/cvxpy/reductions/complex2real/complex2real.py
@@ -15,16 +15,15 @@ limitations under the License.
 """
 
 from cvxpy import problems
-from cvxpy.expressions import cvxtypes
-from cvxpy.reductions.reduction import Reduction
-from cvxpy.reductions import InverseData, Solution
-from cvxpy.constraints import (Equality, Inequality,
-                               Zero, NonNeg,
-                               PSD, SOC, NonPos)
-from cvxpy.reductions.complex2real.atom_canonicalizers import (
-    CANON_METHODS as elim_cplx_methods)
-from cvxpy.lin_ops import lin_utils as lu
 from cvxpy import settings as s
+from cvxpy.constraints import (PSD, SOC, Equality, Inequality, NonNeg, NonPos,
+                               Zero,)
+from cvxpy.expressions import cvxtypes
+from cvxpy.lin_ops import lin_utils as lu
+from cvxpy.reductions import InverseData, Solution
+from cvxpy.reductions.complex2real.atom_canonicalizers import (
+    CANON_METHODS as elim_cplx_methods,)
+from cvxpy.reductions.reduction import Reduction
 
 
 def accepts(problem) -> bool:

--- a/cvxpy/reductions/cone2cone/affine2direct.py
+++ b/cvxpy/reductions/cone2cone/affine2direct.py
@@ -13,17 +13,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from cvxpy import settings as s
-from cvxpy.reductions.solution import Solution
-from cvxpy.constraints.zero import Zero as Zero_obj
-from cvxpy.constraints.nonpos import NonNeg as NonNeg_obj
-from cvxpy.constraints.second_order import SOC as SOC_obj
-from cvxpy.constraints.exponential import ExpCone as ExpCone_obj
-from cvxpy.constraints.psd import PSD as PSD_obj
-from cvxpy.constraints.power import PowCone3D as PowCone_obj
 import numpy as np
 import scipy as sp
 
+from cvxpy import settings as s
+from cvxpy.constraints.exponential import ExpCone as ExpCone_obj
+from cvxpy.constraints.nonpos import NonNeg as NonNeg_obj
+from cvxpy.constraints.power import PowCone3D as PowCone_obj
+from cvxpy.constraints.psd import PSD as PSD_obj
+from cvxpy.constraints.second_order import SOC as SOC_obj
+from cvxpy.constraints.zero import Zero as Zero_obj
+from cvxpy.reductions.solution import Solution
 
 FREE = 'fr'
 ZERO = '0'

--- a/cvxpy/reductions/cone2cone/exotic2common.py
+++ b/cvxpy/reductions/cone2cone/exotic2common.py
@@ -15,11 +15,12 @@ limitations under the License.
 """
 
 import numpy as np
-from cvxpy.expressions.variable import Variable
+
 from cvxpy.atoms.affine.hstack import hstack
 from cvxpy.atoms.affine.reshape import reshape
-from cvxpy.reductions.canonicalization import Canonicalization
 from cvxpy.constraints.power import PowCone3D, PowConeND
+from cvxpy.expressions.variable import Variable
+from cvxpy.reductions.canonicalization import Canonicalization
 
 EXOTIC_CONES = {
     PowConeND: {PowCone3D}

--- a/cvxpy/reductions/cvx_attr2constr.py
+++ b/cvxpy/reductions/cvx_attr2constr.py
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms import diag, reshape
-from cvxpy.expressions.constants import Constant
-from cvxpy.expressions import cvxtypes
-from cvxpy.expressions.variable import Variable, upper_tri_to_full
-from cvxpy.reductions.reduction import Reduction
-from cvxpy.reductions.solution import Solution
 import numpy as np
 import scipy.sparse as sp
 
+from cvxpy.atoms import diag, reshape
+from cvxpy.expressions import cvxtypes
+from cvxpy.expressions.constants import Constant
+from cvxpy.expressions.variable import Variable, upper_tri_to_full
+from cvxpy.reductions.reduction import Reduction
+from cvxpy.reductions.solution import Solution
 
 # Convex attributes that generate constraints.
 CONVEX_ATTRIBUTES = [

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/__init__.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/__init__.py
@@ -15,40 +15,37 @@ limitations under the License.
 """
 
 from cvxpy.atoms import *
-from cvxpy.atoms.suppfunc import SuppFuncAtom
 from cvxpy.atoms.affine.binary_operators import MulExpression, multiply
 from cvxpy.atoms.affine.index import special_index
-from cvxpy.transforms.indicator import indicator
-from cvxpy.reductions.dcp2cone.atom_canonicalizers.exp_canon import *
+from cvxpy.atoms.suppfunc import SuppFuncAtom
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.entr_canon import *
+from cvxpy.reductions.dcp2cone.atom_canonicalizers.exp_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.geo_mean_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.huber_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.indicator_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.kl_div_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.lambda_max_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.lambda_sum_largest_canon import *
+from cvxpy.reductions.dcp2cone.atom_canonicalizers.log1p_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.log_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.log_det_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.log_sum_exp_canon import *
-from cvxpy.reductions.dcp2cone.atom_canonicalizers.log1p_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.logistic_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.matrix_frac_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.normNuc_canon import *
-from cvxpy.reductions.dcp2cone.atom_canonicalizers.power_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.pnorm_canon import *
-from cvxpy.reductions.dcp2cone.atom_canonicalizers.rel_entr_canon import *
-from cvxpy.reductions.dcp2cone.atom_canonicalizers.sigma_max_canon import *
+from cvxpy.reductions.dcp2cone.atom_canonicalizers.power_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.quad_form_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.quad_over_lin_canon import *
-from cvxpy.reductions.dcp2cone.atom_canonicalizers.suppfunc_canon import suppfunc_canon
-
-from cvxpy.reductions.utilities import special_index_canon
-
+from cvxpy.reductions.dcp2cone.atom_canonicalizers.rel_entr_canon import *
+from cvxpy.reductions.dcp2cone.atom_canonicalizers.sigma_max_canon import *
+from cvxpy.reductions.dcp2cone.atom_canonicalizers.suppfunc_canon import (
+    suppfunc_canon,)
 from cvxpy.reductions.eliminate_pwl.atom_canonicalizers import (
-    abs_canon, cummax_canon, cumsum_canon, maximum_canon,
-    max_canon, minimum_canon, min_canon, norm1_canon,
-    norm_inf_canon, sum_largest_canon
-)
+    abs_canon, cummax_canon, cumsum_canon, max_canon, maximum_canon, min_canon,
+    minimum_canon, norm1_canon, norm_inf_canon, sum_largest_canon,)
+from cvxpy.reductions.utilities import special_index_canon
+from cvxpy.transforms.indicator import indicator
 
 # TODO: remove pwl canonicalize methods, use EliminatePwl reduction instead
 CANON_METHODS = {

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/entr_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/entr_canon.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+
 from cvxpy.constraints.exponential import ExpCone
 from cvxpy.expressions.constants import Constant
 from cvxpy.expressions.variable import Variable
-import numpy as np
 
 
 def entr_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/exp_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/exp_canon.py
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+
 from cvxpy.atoms import promote
 from cvxpy.constraints.exponential import ExpCone
 from cvxpy.expressions.constants import Constant
 from cvxpy.expressions.variable import Variable
-import numpy as np
 
 
 def exp_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/huber_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/huber_canon.py
@@ -17,8 +17,10 @@ limitations under the License.
 from cvxpy.atoms.elementwise.abs import abs
 from cvxpy.atoms.elementwise.power import power
 from cvxpy.expressions.variable import Variable
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.abs_canon import abs_canon
-from cvxpy.reductions.dcp2cone.atom_canonicalizers.power_canon import power_canon
+from cvxpy.reductions.dcp2cone.atom_canonicalizers.power_canon import (
+    power_canon,)
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.abs_canon import (
+    abs_canon,)
 
 
 def huber_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/lambda_max_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/lambda_max_canon.py
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.affine.promote import promote
 from cvxpy.atoms.affine.diag import diag_vec
+from cvxpy.atoms.affine.promote import promote
 from cvxpy.atoms.affine.upper_tri import upper_tri
 from cvxpy.constraints.psd import PSD
 from cvxpy.expressions.variable import Variable

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/lambda_sum_largest_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/lambda_sum_largest_canon.py
@@ -16,7 +16,8 @@ limitations under the License.
 
 from cvxpy.atoms import trace
 from cvxpy.expressions.variable import Variable
-from cvxpy.reductions.dcp2cone.atom_canonicalizers.lambda_max_canon import lambda_max_canon
+from cvxpy.reductions.dcp2cone.atom_canonicalizers.lambda_max_canon import (
+    lambda_max_canon,)
 
 
 def lambda_sum_largest_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/log_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/log_canon.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+
 from cvxpy.constraints.exponential import ExpCone
 from cvxpy.expressions.constants import Constant
 from cvxpy.expressions.variable import Variable
-import numpy as np
 
 
 def log_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/log_det_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/log_det_canon.py
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from cvxpy.atoms.affine.bmat import bmat
 from cvxpy.atoms.affine.diag import diag_mat, diag_vec
 from cvxpy.atoms.affine.sum import sum
-from cvxpy.atoms.affine.bmat import bmat
 from cvxpy.atoms.affine.upper_tri import vec_to_upper_tri
 from cvxpy.atoms.elementwise.log import log
 from cvxpy.constraints.psd import PSD

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/log_sum_exp_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/log_sum_exp_canon.py
@@ -16,9 +16,7 @@ limitations under the License.
 
 import numpy as np
 
-from cvxpy.atoms import exp
-from cvxpy.atoms import promote, reshape
-from cvxpy.atoms import sum
+from cvxpy.atoms import exp, promote, reshape, sum
 from cvxpy.expressions.constants import Constant
 from cvxpy.expressions.variable import Variable
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.exp_canon import exp_canon

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/logistic_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/logistic_canon.py
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.reductions.dcp2cone.atom_canonicalizers.exp_canon import \
-    exp_canon
+import numpy as np
+
 from cvxpy.expressions.constants import Constant
 from cvxpy.expressions.variable import Variable
-import numpy as np
+from cvxpy.reductions.dcp2cone.atom_canonicalizers.exp_canon import exp_canon
 
 
 def logistic_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/matrix_frac_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/matrix_frac_canon.py
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms import reshape, trace, bmat, upper_tri
-from cvxpy.expressions.variable import Variable
+from cvxpy.atoms import bmat, reshape, trace, upper_tri
 from cvxpy.constraints.psd import PSD
+from cvxpy.expressions.variable import Variable
 
 
 def matrix_frac_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/normNuc_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/normNuc_canon.py
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from typing import List, Tuple
+
+from cvxpy.atoms.affine.bmat import bmat
 from cvxpy.atoms.affine.trace import trace
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.variable import Variable
-from cvxpy.atoms.affine.bmat import bmat
-from typing import List, Tuple
 
 
 def normNuc_canon(expr, args) -> Tuple[float, List[Constraint]]:

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/pnorm_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/pnorm_canon.py
@@ -14,16 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from fractions import Fraction
+
+import numpy as np
+
 from cvxpy.atoms.affine.sum import sum
 from cvxpy.atoms.affine.vec import vec
 from cvxpy.atoms.elementwise.abs import abs
 from cvxpy.constraints.second_order import SOC
 from cvxpy.expressions.constants import Constant
 from cvxpy.expressions.variable import Variable
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.abs_canon import abs_canon
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.abs_canon import (
+    abs_canon,)
 from cvxpy.utilities.power_tools import gm_constrs
-from fractions import Fraction
-import numpy as np
 
 
 def pnorm_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/power_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/power_canon.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+
 from cvxpy.expressions.constants import Constant
 from cvxpy.expressions.variable import Variable
 from cvxpy.utilities.power_tools import gm_constrs
-import numpy as np
 
 
 def power_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/quad_form_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/quad_form_canon.py
@@ -17,7 +17,8 @@ limitations under the License.
 from cvxpy.atoms import sum_squares
 from cvxpy.atoms.quad_form import decomp_quad
 from cvxpy.expressions.constants import Constant
-from cvxpy.reductions.dcp2cone.atom_canonicalizers.quad_over_lin_canon import quad_over_lin_canon
+from cvxpy.reductions.dcp2cone.atom_canonicalizers.quad_over_lin_canon import (
+    quad_over_lin_canon,)
 
 
 def quad_form_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/sigma_max_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/sigma_max_canon.py
@@ -13,11 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from cvxpy.expressions.variable import Variable
+import numpy as np
+import scipy.sparse as sp
+
 from cvxpy.atoms.affine.bmat import bmat
 from cvxpy.constraints.psd import PSD
-import scipy.sparse as sp
-import numpy as np
+from cvxpy.expressions.variable import Variable
 
 
 def sigma_max_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/suppfunc_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/suppfunc_canon.py
@@ -1,7 +1,9 @@
-from cvxpy import hstack, SOC, Variable
-from cvxpy.constraints.exponential import ExpCone
-from cvxpy.reductions.solvers.conic_solvers.scs_conif import scs_psdvec_to_psdmat
 import numpy as np
+
+from cvxpy import SOC, Variable, hstack
+from cvxpy.constraints.exponential import ExpCone
+from cvxpy.reductions.solvers.conic_solvers.scs_conif import (
+    scs_psdvec_to_psdmat,)
 
 
 def suppfunc_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -14,24 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+import scipy.sparse as sp
+
+import cvxpy.settings as s
+from cvxpy.constraints import (PSD, SOC, Equality, ExpCone, Inequality, NonNeg,
+                               NonPos, PowCone3D, Zero,)
 from cvxpy.cvxcore.python import canonInterface
-from cvxpy.constraints import (Equality, ExpCone, Inequality,
-                               SOC, Zero, NonNeg, NonPos,
-                               PSD, PowCone3D)
 from cvxpy.expressions.variable import Variable
 from cvxpy.problems.objective import Minimize
 from cvxpy.problems.param_prob import ParamProb
 from cvxpy.reductions import InverseData, Solution, cvx_attr2constr
-from cvxpy.reductions.matrix_stuffing import extract_mip_idx, MatrixStuffing
-from cvxpy.reductions.utilities import (are_args_affine,
-                                        group_constraints,
-                                        lower_equality,
-                                        lower_ineq_to_nonneg,
-                                        nonpos2nonneg)
-import cvxpy.settings as s
+from cvxpy.reductions.matrix_stuffing import MatrixStuffing, extract_mip_idx
+from cvxpy.reductions.utilities import (are_args_affine, group_constraints,
+                                        lower_equality, lower_ineq_to_nonneg,
+                                        nonpos2nonneg,)
 from cvxpy.utilities.coeff_extractor import CoeffExtractor
-import numpy as np
-import scipy.sparse as sp
 
 
 class ConeDims:

--- a/cvxpy/reductions/dcp2cone/dcp2cone.py
+++ b/cvxpy/reductions/dcp2cone/dcp2cone.py
@@ -15,8 +15,8 @@ limitations under the License.
 """
 from cvxpy.problems.objective import Minimize
 from cvxpy.reductions.canonicalization import Canonicalization
-from cvxpy.reductions.dcp2cone.atom_canonicalizers import (CANON_METHODS as
-                                                           cone_canon_methods)
+from cvxpy.reductions.dcp2cone.atom_canonicalizers import (
+    CANON_METHODS as cone_canon_methods,)
 
 
 class Dcp2Cone(Canonicalization):

--- a/cvxpy/reductions/dgp2dcp/atom_canonicalizers/__init__.py
+++ b/cvxpy/reductions/dgp2dcp/atom_canonicalizers/__init__.py
@@ -1,20 +1,23 @@
+import numpy as np
+
 from cvxpy.atoms.affine.add_expr import AddExpression
-from cvxpy.atoms.affine.binary_operators import MulExpression, DivExpression, multiply
+from cvxpy.atoms.affine.binary_operators import (DivExpression, MulExpression,
+                                                 multiply,)
 from cvxpy.atoms.affine.sum import Sum
 from cvxpy.atoms.affine.trace import trace
 from cvxpy.atoms.elementwise.exp import exp
 from cvxpy.atoms.elementwise.log import log
-from cvxpy.atoms.elementwise.power import power
 from cvxpy.atoms.elementwise.maximum import maximum
 from cvxpy.atoms.elementwise.minimum import minimum
+from cvxpy.atoms.elementwise.power import power
+from cvxpy.atoms.eye_minus_inv import eye_minus_inv
 from cvxpy.atoms.geo_mean import geo_mean
 from cvxpy.atoms.gmatmul import gmatmul
-from cvxpy.atoms.one_minus_pos import one_minus_pos
-from cvxpy.atoms.eye_minus_inv import eye_minus_inv
 from cvxpy.atoms.max import max
 from cvxpy.atoms.min import min
 from cvxpy.atoms.norm1 import norm1
 from cvxpy.atoms.norm_inf import norm_inf
+from cvxpy.atoms.one_minus_pos import one_minus_pos
 from cvxpy.atoms.pf_eigenvalue import pf_eigenvalue
 from cvxpy.atoms.pnorm import pnorm
 from cvxpy.atoms.prod import Prod
@@ -23,31 +26,43 @@ from cvxpy.atoms.quad_over_lin import quad_over_lin
 from cvxpy.expressions.constants.constant import Constant
 from cvxpy.expressions.constants.parameter import Parameter
 from cvxpy.expressions.variable import Variable
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers import CANON_METHODS as PWL_METHODS
 from cvxpy.reductions.dgp2dcp.atom_canonicalizers.add_canon import add_canon
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.constant_canon import constant_canon
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.constant_canon import (
+    constant_canon,)
 from cvxpy.reductions.dgp2dcp.atom_canonicalizers.div_canon import div_canon
 from cvxpy.reductions.dgp2dcp.atom_canonicalizers.exp_canon import exp_canon
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.eye_minus_inv_canon import eye_minus_inv_canon
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.geo_mean_canon import geo_mean_canon
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.gmatmul_canon import gmatmul_canon
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.eye_minus_inv_canon import (
+    eye_minus_inv_canon,)
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.geo_mean_canon import (
+    geo_mean_canon,)
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.gmatmul_canon import (
+    gmatmul_canon,)
 from cvxpy.reductions.dgp2dcp.atom_canonicalizers.log_canon import log_canon
 from cvxpy.reductions.dgp2dcp.atom_canonicalizers.mul_canon import mul_canon
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.mulexpression_canon import mulexpression_canon
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.norm1_canon import norm1_canon
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.norm_inf_canon import norm_inf_canon
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.one_minus_pos_canon import one_minus_pos_canon
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.pf_eigenvalue_canon import pf_eigenvalue_canon
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.pnorm_canon import pnorm_canon
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.power_canon import power_canon
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.mulexpression_canon import (
+    mulexpression_canon,)
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.norm1_canon import (
+    norm1_canon,)
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.norm_inf_canon import (
+    norm_inf_canon,)
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.one_minus_pos_canon import (
+    one_minus_pos_canon,)
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.pf_eigenvalue_canon import (
+    pf_eigenvalue_canon,)
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.pnorm_canon import (
+    pnorm_canon,)
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.power_canon import (
+    power_canon,)
 from cvxpy.reductions.dgp2dcp.atom_canonicalizers.prod_canon import prod_canon
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.quad_form_canon import quad_form_canon
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.quad_over_lin_canon import quad_over_lin_canon
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.quad_form_canon import (
+    quad_form_canon,)
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.quad_over_lin_canon import (
+    quad_over_lin_canon,)
 from cvxpy.reductions.dgp2dcp.atom_canonicalizers.sum_canon import sum_canon
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.trace_canon import trace_canon
-
-import numpy as np
-
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.trace_canon import (
+    trace_canon,)
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers import (
+    CANON_METHODS as PWL_METHODS,)
 
 CANON_METHODS = {
     AddExpression : add_canon,

--- a/cvxpy/reductions/dgp2dcp/atom_canonicalizers/add_canon.py
+++ b/cvxpy/reductions/dgp2dcp/atom_canonicalizers/add_canon.py
@@ -1,8 +1,8 @@
-from cvxpy.atoms.log_sum_exp import log_sum_exp
 from cvxpy.atoms.affine.bmat import bmat
 from cvxpy.atoms.affine.hstack import hstack
 from cvxpy.atoms.affine.promote import promote
 from cvxpy.atoms.affine.reshape import reshape
+from cvxpy.atoms.log_sum_exp import log_sum_exp
 
 
 def add_canon(expr, args):

--- a/cvxpy/reductions/dgp2dcp/atom_canonicalizers/constant_canon.py
+++ b/cvxpy/reductions/dgp2dcp/atom_canonicalizers/constant_canon.py
@@ -13,9 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from cvxpy.expressions.constants.constant import Constant
-
 import numpy as np
+
+from cvxpy.expressions.constants.constant import Constant
 
 
 def constant_canon(expr, args):

--- a/cvxpy/reductions/dgp2dcp/atom_canonicalizers/eye_minus_inv_canon.py
+++ b/cvxpy/reductions/dgp2dcp/atom_canonicalizers/eye_minus_inv_canon.py
@@ -2,8 +2,10 @@ from cvxpy.atoms.affine.binary_operators import matmul
 from cvxpy.atoms.affine.diag import diag
 from cvxpy.atoms.one_minus_pos import one_minus_pos
 from cvxpy.expressions.variable import Variable
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.one_minus_pos_canon import one_minus_pos_canon
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.mulexpression_canon import mulexpression_canon
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.mulexpression_canon import (
+    mulexpression_canon,)
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.one_minus_pos_canon import (
+    one_minus_pos_canon,)
 
 
 def eye_minus_inv_canon(expr, args):

--- a/cvxpy/reductions/dgp2dcp/atom_canonicalizers/mulexpression_canon.py
+++ b/cvxpy/reductions/dgp2dcp/atom_canonicalizers/mulexpression_canon.py
@@ -1,9 +1,9 @@
 """Canonicalization for matrix multiplication."""
 
-from cvxpy.atoms.log_sum_exp import log_sum_exp
 from cvxpy.atoms.affine.bmat import bmat
 from cvxpy.atoms.affine.hstack import hstack
 from cvxpy.atoms.affine.reshape import reshape
+from cvxpy.atoms.log_sum_exp import log_sum_exp
 from cvxpy.utilities.shape import mul_shapes_promote
 
 

--- a/cvxpy/reductions/dgp2dcp/atom_canonicalizers/norm_inf_canon.py
+++ b/cvxpy/reductions/dgp2dcp/atom_canonicalizers/norm_inf_canon.py
@@ -1,5 +1,6 @@
 from cvxpy.atoms.max import max
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.max_canon import max_canon
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.max_canon import (
+    max_canon,)
 
 
 def norm_inf_canon(expr, args):

--- a/cvxpy/reductions/dgp2dcp/atom_canonicalizers/one_minus_pos_canon.py
+++ b/cvxpy/reductions/dgp2dcp/atom_canonicalizers/one_minus_pos_canon.py
@@ -1,5 +1,5 @@
-from cvxpy.atoms.elementwise.log import log
 from cvxpy.atoms.elementwise.exp import exp
+from cvxpy.atoms.elementwise.log import log
 
 
 def one_minus_pos_canon(expr, args):

--- a/cvxpy/reductions/dgp2dcp/atom_canonicalizers/parameter_canon.py
+++ b/cvxpy/reductions/dgp2dcp/atom_canonicalizers/parameter_canon.py
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.expressions.constants.parameter import Parameter
-
 import numpy as np
+
+from cvxpy.expressions.constants.parameter import Parameter
 
 
 def parameter_canon(expr, args):

--- a/cvxpy/reductions/dgp2dcp/atom_canonicalizers/pf_eigenvalue_canon.py
+++ b/cvxpy/reductions/dgp2dcp/atom_canonicalizers/pf_eigenvalue_canon.py
@@ -1,7 +1,8 @@
 from cvxpy.atoms.affine.binary_operators import matmul
 from cvxpy.expressions.variable import Variable
-from cvxpy.reductions.dgp2dcp.atom_canonicalizers.mulexpression_canon import mulexpression_canon
 from cvxpy.reductions.dgp2dcp.atom_canonicalizers.mul_canon import mul_canon
+from cvxpy.reductions.dgp2dcp.atom_canonicalizers.mulexpression_canon import (
+    mulexpression_canon,)
 
 
 def pf_eigenvalue_canon(expr, args):

--- a/cvxpy/reductions/dgp2dcp/dgp2dcp.py
+++ b/cvxpy/reductions/dgp2dcp/dgp2dcp.py
@@ -13,11 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import numpy as np
+
+from cvxpy import settings
 from cvxpy.reductions.canonicalization import Canonicalization
 from cvxpy.reductions.dgp2dcp.atom_canonicalizers import DgpCanonMethods
-from cvxpy import settings
-
-import numpy as np
 
 
 class Dgp2Dcp(Canonicalization):

--- a/cvxpy/reductions/dqcp2dcp/dqcp2dcp.py
+++ b/cvxpy/reductions/dqcp2dcp/dqcp2dcp.py
@@ -13,28 +13,25 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from collections import namedtuple
+from typing import Any, List, Tuple
+
+import numpy as np
+
 from cvxpy import problems
-from cvxpy.atoms.max import max as max_atom
-from cvxpy.atoms.min import min as min_atom
 from cvxpy.atoms.elementwise.maximum import maximum
 from cvxpy.atoms.elementwise.minimum import minimum
+from cvxpy.atoms.max import max as max_atom
+from cvxpy.atoms.min import min as min_atom
 from cvxpy.constraints import Inequality
 from cvxpy.expressions.constants.parameter import Parameter
 from cvxpy.expressions.variable import Variable
 from cvxpy.problems.objective import Minimize
 from cvxpy.reductions.canonicalization import Canonicalization
 from cvxpy.reductions.dcp2cone.atom_canonicalizers import CANON_METHODS
-from cvxpy.reductions.dqcp2dcp import inverse
-from cvxpy.reductions.dqcp2dcp import tighten
-from cvxpy.reductions.dqcp2dcp import sets
+from cvxpy.reductions.dqcp2dcp import inverse, sets, tighten
 from cvxpy.reductions.inverse_data import InverseData
 from cvxpy.reductions.solution import Solution
-
-from collections import namedtuple
-from typing import Any, List, Tuple
-
-import numpy as np
-
 
 # A tuple (feas_problem, param, tighten_lower, tighten_upper), where
 #

--- a/cvxpy/reductions/dqcp2dcp/inverse.py
+++ b/cvxpy/reductions/dqcp2dcp/inverse.py
@@ -13,13 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import numpy as np
+
 from cvxpy import atoms
 from cvxpy.atoms.affine.add_expr import AddExpression
 from cvxpy.atoms.affine.binary_operators import DivExpression
-from cvxpy.atoms.affine.unary_operators import NegExpression
 from cvxpy.atoms.affine.sum import Sum
-import numpy as np
-
+from cvxpy.atoms.affine.unary_operators import NegExpression
 
 # these atoms are always invertible. others (like AddExpression, DivExpression,
 # Sum, and cumsum) are only invertible in special cases, checked in the

--- a/cvxpy/reductions/dqcp2dcp/tighten.py
+++ b/cvxpy/reductions/dqcp2dcp/tighten.py
@@ -13,9 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from cvxpy.atoms import ceil, floor, length
 import numpy as np
 
+from cvxpy.atoms import ceil, floor, length
 
 integer_valued_fns = set([ceil, floor, length])
 

--- a/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/__init__.py
+++ b/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/__init__.py
@@ -14,19 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms import (abs, cummax, cumsum, maximum, max, minimum,
-                         min, norm1, norm_inf, sum_largest)
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.abs_canon import abs_canon
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.cummax_canon import cummax_canon
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.cumsum_canon import cumsum_canon
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.maximum_canon import maximum_canon
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.minimum_canon import minimum_canon
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.max_canon import max_canon
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.min_canon import min_canon
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.norm1_canon import norm1_canon
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.norm_inf_canon import norm_inf_canon
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.sum_largest_canon import sum_largest_canon
-
+from cvxpy.atoms import (abs, cummax, cumsum, max, maximum, min, minimum,
+                         norm1, norm_inf, sum_largest,)
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.abs_canon import (
+    abs_canon,)
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.cummax_canon import (
+    cummax_canon,)
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.cumsum_canon import (
+    cumsum_canon,)
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.max_canon import (
+    max_canon,)
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.maximum_canon import (
+    maximum_canon,)
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.min_canon import (
+    min_canon,)
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.minimum_canon import (
+    minimum_canon,)
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.norm1_canon import (
+    norm1_canon,)
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.norm_inf_canon import (
+    norm_inf_canon,)
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.sum_largest_canon import (
+    sum_largest_canon,)
 
 CANON_METHODS = {
     abs: abs_canon,

--- a/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/max_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/max_canon.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+
 from cvxpy.atoms import promote, reshape
 from cvxpy.expressions.constants import Constant
 from cvxpy.expressions.variable import Variable
-import numpy as np
 
 
 def max_canon(expr, args):

--- a/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/min_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/min_canon.py
@@ -15,7 +15,8 @@ limitations under the License.
 """
 
 from cvxpy.atoms.max import max
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.max_canon import max_canon
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.max_canon import (
+    max_canon,)
 
 
 def min_canon(expr, args):

--- a/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/minimum_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/minimum_canon.py
@@ -15,7 +15,8 @@ limitations under the License.
 """
 
 from cvxpy.atoms.elementwise.maximum import maximum
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.maximum_canon import maximum_canon
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.maximum_canon import (
+    maximum_canon,)
 
 
 def minimum_canon(expr, args):

--- a/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/norm1_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/norm1_canon.py
@@ -16,7 +16,8 @@ limitations under the License.
 
 from cvxpy.atoms.affine.sum import sum
 from cvxpy.atoms.elementwise.abs import abs
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.abs_canon import abs_canon
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.abs_canon import (
+    abs_canon,)
 
 
 def norm1_canon(expr, args):

--- a/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/norm_inf_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/norm_inf_canon.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+
 from cvxpy.atoms import promote, reshape
 from cvxpy.expressions.constants import Constant
 from cvxpy.expressions.variable import Variable
-import numpy as np
 
 
 def norm_inf_canon(expr, args):

--- a/cvxpy/reductions/eliminate_pwl/eliminate_pwl.py
+++ b/cvxpy/reductions/eliminate_pwl/eliminate_pwl.py
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms import abs, maximum, sum_largest, max, norm1, norm_inf
+from cvxpy.atoms import abs, max, maximum, norm1, norm_inf, sum_largest
 from cvxpy.reductions.canonicalization import Canonicalization
 from cvxpy.reductions.eliminate_pwl.atom_canonicalizers import (
-    CANON_METHODS as elim_pwl_methods)
+    CANON_METHODS as elim_pwl_methods,)
 
 
 class EliminatePwl(Canonicalization):

--- a/cvxpy/reductions/eval_params.py
+++ b/cvxpy/reductions/eval_params.py
@@ -1,7 +1,7 @@
+from cvxpy import problems
 from cvxpy.error import ParameterError
 from cvxpy.expressions.constants.constant import Constant
 from cvxpy.expressions.constants.parameter import Parameter
-from cvxpy import problems
 from cvxpy.reductions.reduction import Reduction
 
 

--- a/cvxpy/reductions/matrix_stuffing.py
+++ b/cvxpy/reductions/matrix_stuffing.py
@@ -16,11 +16,11 @@ limitations under the License.
 
 
 import abc
-
-from cvxpy.reductions.reduction import Reduction
 from typing import List, Tuple
 
 import numpy as np
+
+from cvxpy.reductions.reduction import Reduction
 
 
 def extract_mip_idx(variables) -> Tuple[List[int], List[int]]:

--- a/cvxpy/reductions/qp2quad_form/atom_canonicalizers/__init__.py
+++ b/cvxpy/reductions/qp2quad_form/atom_canonicalizers/__init__.py
@@ -16,12 +16,13 @@ limitations under the License.
 
 from cvxpy.atoms import *
 from cvxpy.atoms.affine.index import special_index
-from cvxpy.transforms.indicator import indicator
-from cvxpy.reductions.dcp2cone.atom_canonicalizers import CANON_METHODS as CONE_METHODS
-from cvxpy.reductions.qp2quad_form.atom_canonicalizers.quad_over_lin_canon import *
+from cvxpy.reductions.dcp2cone.atom_canonicalizers import (
+    CANON_METHODS as CONE_METHODS,)
+from cvxpy.reductions.qp2quad_form.atom_canonicalizers.huber_canon import *
 from cvxpy.reductions.qp2quad_form.atom_canonicalizers.power_canon import *
 from cvxpy.reductions.qp2quad_form.atom_canonicalizers.quad_form_canon import *
-from cvxpy.reductions.qp2quad_form.atom_canonicalizers.huber_canon import *
+from cvxpy.reductions.qp2quad_form.atom_canonicalizers.quad_over_lin_canon import *
+from cvxpy.transforms.indicator import indicator
 
 CANON_METHODS = {}
 

--- a/cvxpy/reductions/qp2quad_form/atom_canonicalizers/huber_canon.py
+++ b/cvxpy/reductions/qp2quad_form/atom_canonicalizers/huber_canon.py
@@ -17,8 +17,10 @@ limitations under the License.
 from cvxpy.atoms.elementwise.abs import abs
 from cvxpy.atoms.elementwise.power import power
 from cvxpy.expressions.variable import Variable
-from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.abs_canon import abs_canon
-from cvxpy.reductions.qp2quad_form.atom_canonicalizers.power_canon import power_canon
+from cvxpy.reductions.eliminate_pwl.atom_canonicalizers.abs_canon import (
+    abs_canon,)
+from cvxpy.reductions.qp2quad_form.atom_canonicalizers.power_canon import (
+    power_canon,)
 
 
 def huber_canon(expr, args):

--- a/cvxpy/reductions/qp2quad_form/atom_canonicalizers/quad_over_lin_canon.py
+++ b/cvxpy/reductions/qp2quad_form/atom_canonicalizers/quad_over_lin_canon.py
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.expressions.variable import Variable
-from cvxpy.atoms.quad_form import SymbolicQuadForm
 from scipy.sparse import eye
+
+from cvxpy.atoms.quad_form import SymbolicQuadForm
+from cvxpy.expressions.variable import Variable
 
 
 def quad_over_lin_canon(expr, args):

--- a/cvxpy/reductions/qp2quad_form/qp2symbolic_qp.py
+++ b/cvxpy/reductions/qp2quad_form/qp2symbolic_qp.py
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.constraints import Equality, Inequality, NonPos, NonNeg, Zero
+from cvxpy.constraints import Equality, Inequality, NonNeg, NonPos, Zero
 from cvxpy.reductions.canonicalization import Canonicalization
 from cvxpy.reductions.cvx_attr2constr import convex_attributes
 from cvxpy.reductions.qp2quad_form.atom_canonicalizers import (
-    CANON_METHODS as qp_canon_methods)
+    CANON_METHODS as qp_canon_methods,)
 from cvxpy.reductions.utilities import are_args_affine
 
 

--- a/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
+++ b/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
@@ -14,22 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+
+import cvxpy.settings as s
+from cvxpy.constraints import (PSD, SOC, Equality, ExpCone, Inequality, NonPos,
+                               Zero,)
 from cvxpy.cvxcore.python import canonInterface
-from cvxpy.constraints import (Equality, ExpCone, Inequality,
-                               SOC, Zero, NonPos, PSD)
 from cvxpy.expressions.variable import Variable
 from cvxpy.problems.objective import Minimize
 from cvxpy.problems.param_prob import ParamProb
-from cvxpy.reductions import Solution, InverseData
+from cvxpy.reductions import InverseData, Solution
 from cvxpy.reductions.cvx_attr2constr import convex_attributes
-from cvxpy.reductions.matrix_stuffing import extract_mip_idx, MatrixStuffing
-from cvxpy.reductions.utilities import (are_args_affine,
-                                        lower_equality,
-                                        lower_ineq_to_nonpos,
-                                        group_constraints)
-import cvxpy.settings as s
+from cvxpy.reductions.matrix_stuffing import MatrixStuffing, extract_mip_idx
+from cvxpy.reductions.utilities import (are_args_affine, group_constraints,
+                                        lower_equality, lower_ineq_to_nonpos,)
 from cvxpy.utilities.coeff_extractor import CoeffExtractor
-import numpy as np
 
 
 class ConeDims:

--- a/cvxpy/reductions/solvers/bisection.py
+++ b/cvxpy/reductions/solvers/bisection.py
@@ -15,10 +15,9 @@ limitations under the License.
 """
 import warnings
 
-
-import cvxpy.settings as s
 import cvxpy.error as error
 import cvxpy.problems as problems
+import cvxpy.settings as s
 from cvxpy.problems.objective import Minimize
 from cvxpy.reductions.solution import failure_solution
 

--- a/cvxpy/reductions/solvers/compr_matrix.py
+++ b/cvxpy/reductions/solvers/compr_matrix.py
@@ -16,8 +16,8 @@ limitations under the License.
 THIS FILE IS DEPRECATED AND MAY BE REMOVED WITHOUT WARNING!
 DO NOT CALL THESE FUNCTIONS IN YOUR CODE!
 """
-import scipy.sparse as sp
 import numpy as np
+import scipy.sparse as sp
 
 
 def get_row_nnz(mat, row):

--- a/cvxpy/reductions/solvers/conic_solvers/__init__.py
+++ b/cvxpy/reductions/solvers/conic_solvers/__init__.py
@@ -23,8 +23,8 @@ from .glpk_conif import GLPK
 from .glpk_mi_conif import GLPK_MI
 from .gurobi_conif import GUROBI
 from .mosek_conif import MOSEK
+from .nag_conif import NAG
 from .scip_conif import SCIP
 from .scipy_conif import SCIPY
 from .scs_conif import SCS
 from .xpress_conif import XPRESS
-from .nag_conif import NAG

--- a/cvxpy/reductions/solvers/conic_solvers/cbc_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cbc_conif.py
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy.settings as s
-from cvxpy.reductions.solvers.conic_solvers.scs_conif import (SCS,
-                                                              dims_to_solver_dict)
-from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
-from cvxpy.reductions.solution import Solution, failure_solution
 import numpy as np
+
+import cvxpy.settings as s
+from cvxpy.reductions.solution import Solution, failure_solution
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from cvxpy.reductions.solvers.conic_solvers.scs_conif import (
+    SCS, dims_to_solver_dict,)
 
 
 class CBC(SCS):
@@ -103,7 +104,7 @@ class CBC(SCS):
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
         # Import basic modelling tools of cylp
         from cylp.cy import CyClpSimplex
-        from cylp.py.modeling.CyLPModel import CyLPModel, CyLPArray
+        from cylp.py.modeling.CyLPModel import CyLPArray, CyLPModel
 
         c = data[s.C]
         b = data[s.B]

--- a/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
+++ b/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
@@ -15,16 +15,16 @@ limitations under the License.
 """
 from typing import Tuple
 
-import cvxpy.settings as s
-from cvxpy.constraints import SOC, ExpCone, PSD, Zero, NonNeg, PowCone3D
-from cvxpy.reductions.cvx_attr2constr import convex_attributes
-from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ParamConeProg
-from cvxpy.reductions.solution import Solution, failure_solution
-from cvxpy.reductions.solvers.solver import Solver
-from cvxpy.reductions.solvers import utilities
 import numpy as np
 import scipy.sparse as sp
 
+import cvxpy.settings as s
+from cvxpy.constraints import PSD, SOC, ExpCone, NonNeg, PowCone3D, Zero
+from cvxpy.reductions.cvx_attr2constr import convex_attributes
+from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ParamConeProg
+from cvxpy.reductions.solution import Solution, failure_solution
+from cvxpy.reductions.solvers import utilities
+from cvxpy.reductions.solvers.solver import Solver
 
 # NOTE(akshayka): Small changes to this file can lead to drastic
 # performance regressions. If you are making a change to this file,

--- a/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
@@ -14,16 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from collections import namedtuple
+
+import numpy as np
+from scipy.sparse import dok_matrix
+
 import cvxpy.settings as s
 from cvxpy.constraints import SOC
-from cvxpy.reductions.solvers.conic_solvers.scs_conif import (SCS,
-                                                              dims_to_solver_dict)
-from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
-from collections import namedtuple
-from scipy.sparse import dok_matrix
-import numpy as np
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from cvxpy.reductions.solvers.conic_solvers.scs_conif import (
+    SCS, dims_to_solver_dict,)
 
 # Values used to distinguish between linear and quadratic constraints.
 _LIN, _QUAD = 0, 1
@@ -442,6 +444,7 @@ class CPLEX(SCS):
             supporting variable indices).
         """
         import cplex
+
         # Assume first expression (i.e. t) is nonzero.
         lin_expr_list, soc_vars, lin_rhs = [], [], []
         csr = mat.tocsr()

--- a/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
@@ -14,21 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy.interface as intf
-import cvxpy.settings as s
-from cvxpy.constraints import Zero, NonNeg, SOC, PSD
-from cvxpy.reductions.solution import failure_solution, Solution
-from cvxpy.reductions.solvers import utilities
-from cvxpy.reductions.solvers.conic_solvers.ecos_conif import ECOS
-from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
-from cvxpy.reductions.solvers.compr_matrix import compress_matrix
-from cvxpy.reductions.solvers.kktsolver import setup_ldl_factor
-from scipy.sparse.linalg import eigsh
 from typing import Dict, List, Union
 
-import scipy.sparse as sp
-import scipy
 import numpy as np
+import scipy
+import scipy.sparse as sp
+from scipy.sparse.linalg import eigsh
+
+import cvxpy.interface as intf
+import cvxpy.settings as s
+from cvxpy.constraints import PSD, SOC, NonNeg, Zero
+from cvxpy.reductions.solution import Solution, failure_solution
+from cvxpy.reductions.solvers import utilities
+from cvxpy.reductions.solvers.compr_matrix import compress_matrix
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from cvxpy.reductions.solvers.conic_solvers.ecos_conif import ECOS
+from cvxpy.reductions.solvers.kktsolver import setup_ldl_factor
 
 
 # Utility method for formatting a ConeDims instance into a dictionary
@@ -154,6 +155,7 @@ class CVXOPT(ECOS):
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
         import cvxopt.solvers
+
         # Save original cvxopt solver options.
         old_options = cvxopt.solvers.options.copy()
         # Save old data in case need to use robust solver.

--- a/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
@@ -15,12 +15,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.reductions.solvers.conic_solvers import scs_conif
-from cvxpy.reductions.solution import failure_solution, Solution
-from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
-from cvxpy.reductions.solvers import utilities
-import cvxpy.settings as s
 import time
+
+import cvxpy.settings as s
+from cvxpy.reductions.solution import Solution, failure_solution
+from cvxpy.reductions.solvers import utilities
+from cvxpy.reductions.solvers.conic_solvers import scs_conif
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 
 
 class DIFFCP(scs_conif.SCS):

--- a/cvxpy/reductions/solvers/conic_solvers/ecos_bb_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/ecos_bb_conif.py
@@ -18,11 +18,11 @@ limitations under the License.
 import cvxpy.interface as intf
 import cvxpy.settings as s
 from cvxpy.constraints import ExpCone
+from cvxpy.reductions.solution import Solution, failure_solution
+from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.conic_solvers.ecos_conif import (
-                                                    dims_to_solver_dict, ECOS)
-from cvxpy.reductions.solution import failure_solution, Solution
-from cvxpy.reductions.solvers import utilities
+    ECOS, dims_to_solver_dict,)
 
 
 class ECOS_BB(ECOS):

--- a/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy.settings as s
-from cvxpy.constraints import NonNeg, SOC, ExpCone, Zero
-import cvxpy.interface as intf
-from cvxpy.reductions.solution import failure_solution, Solution
-from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
-from cvxpy.reductions.solvers import utilities
 import numpy as np
+
+import cvxpy.interface as intf
+import cvxpy.settings as s
+from cvxpy.constraints import SOC, ExpCone, NonNeg, Zero
+from cvxpy.reductions.solution import Solution, failure_solution
+from cvxpy.reductions.solvers import utilities
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 
 
 # Utility method for formatting a ConeDims instance into a dictionary

--- a/cvxpy/reductions/solvers/conic_solvers/glpk_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glpk_conif.py
@@ -16,10 +16,10 @@ limitations under the License.
 
 import cvxpy.interface as intf
 import cvxpy.settings as s
-from cvxpy.reductions.solvers.conic_solvers.cvxopt_conif import CVXOPT
-from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from cvxpy.reductions.solvers.conic_solvers.cvxopt_conif import CVXOPT
 
 
 class GLPK(CVXOPT):
@@ -88,6 +88,7 @@ class GLPK(CVXOPT):
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
         import cvxopt.solvers
+
         # Save original cvxopt solver options.
         old_options = cvxopt.solvers.options.copy()
         # Silence cvxopt if verbose is False.

--- a/cvxpy/reductions/solvers/conic_solvers/glpk_mi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glpk_mi_conif.py
@@ -16,9 +16,9 @@ limitations under the License.
 
 import cvxpy.interface as intf
 import cvxpy.settings as s
+from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.conic_solvers import GLPK
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
-from cvxpy.reductions.solution import Solution, failure_solution
 
 
 class GLPK_MI(GLPK):
@@ -51,6 +51,7 @@ class GLPK_MI(GLPK):
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
         import cvxopt
         import cvxopt.solvers
+
         # Save original cvxopt solver options.
         old_options = cvxopt.glpk.options.copy()
         # Silence cvxopt if verbose is False.

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -15,15 +15,15 @@ limitations under the License.
 """
 
 import numpy as np
+import scipy.sparse as sp
 
 import cvxpy.settings as s
 from cvxpy.constraints import SOC
-from cvxpy.reductions.solvers.conic_solvers.scs_conif import (SCS,
-                                                              dims_to_solver_dict)
-from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
-import scipy.sparse as sp
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from cvxpy.reductions.solvers.conic_solvers.scs_conif import (
+    SCS, dims_to_solver_dict,)
 
 
 class GUROBI(SCS):

--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -14,16 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from collections import defaultdict
+
 import numpy as np
 import scipy as sp
-from cvxpy.reductions.solvers.utilities import expcone_permutor
+
 import cvxpy.settings as s
 from cvxpy.constraints import PSD, SOC, ExpCone, PowCone3D
-from cvxpy.reductions.solution import Solution
-from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.cone2cone import affine2direct as a2d
 from cvxpy.reductions.cone2cone.affine2direct import Dualize, Slacks
-from collections import defaultdict
+from cvxpy.reductions.solution import Solution
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from cvxpy.reductions.solvers.utilities import expcone_permutor
 
 
 def vectorized_lower_tri_to_mat(v, dim):
@@ -261,6 +263,7 @@ class MOSEK(ConicSolver):
         "A @ x + A_bar(X_bars) == b".
         """
         import mosek
+
         # problem data
         c, A, b, K = data[s.C], data[s.A], data[s.B], data['K_dir']
         n, m = A.shape

--- a/cvxpy/reductions/solvers/conic_solvers/nag_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/nag_conif.py
@@ -14,13 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import warnings
+
+import numpy as np
+import scipy as sp
+
 import cvxpy.settings as s
 from cvxpy.constraints import SOC, NonNeg, Zero
-from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
-import scipy as sp
-import numpy as np
-import warnings
 from cvxpy.reductions.solution import Solution
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 
 
 class NAG(ConicSolver):
@@ -187,8 +189,8 @@ class NAG(ConicSolver):
         return Solution(status, opt_val, primal_vars, dual_vars, attr)
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
-        from naginterfaces.library import opt
         from naginterfaces.base import utils
+        from naginterfaces.library import opt
 
         bigbnd = 1.0e20
         c = data[s.C]

--- a/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
@@ -22,12 +22,13 @@ from scipy.sparse import dok_matrix
 
 import cvxpy.settings as s
 from cvxpy import Zero
-from cvxpy.constraints import ExpCone, NonNeg, SOC
+from cvxpy.constraints import SOC, ExpCone, NonNeg
 from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ParamConeProg
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
-from cvxpy.reductions.solvers.conic_solvers.scs_conif import dims_to_solver_dict
+from cvxpy.reductions.solvers.conic_solvers.scs_conif import (
+    dims_to_solver_dict,)
 
 log = logging.getLogger(__name__)
 

--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -15,14 +15,16 @@ limitations under the License.
 """
 
 
+import warnings
+from distutils.version import StrictVersion
+
+import scipy  # For version checks
+
 import cvxpy.settings as s
 from cvxpy.constraints import NonNeg, Zero
-from cvxpy.reductions.solution import failure_solution, Solution
-from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
-from distutils.version import StrictVersion
-import scipy  # For version checks
-import warnings
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 
 
 class SCIPY(ConicSolver):

--- a/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
@@ -16,14 +16,15 @@ limitations under the License.
 """
 from distutils.version import StrictVersion
 
-import cvxpy.settings as s
-from cvxpy.constraints import Zero, NonNeg, PSD, SOC, ExpCone, PowCone3D
-from cvxpy.expressions.expression import Expression
-from cvxpy.reductions.solution import failure_solution, Solution
-from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
-from cvxpy.reductions.solvers import utilities
 import numpy as np
 import scipy.sparse as sp
+
+import cvxpy.settings as s
+from cvxpy.constraints import PSD, SOC, ExpCone, NonNeg, PowCone3D, Zero
+from cvxpy.expressions.expression import Expression
+from cvxpy.reductions.solution import Solution, failure_solution
+from cvxpy.reductions.solvers import utilities
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 
 
 # Utility method for formatting a ConeDims instance into a dictionary

--- a/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
@@ -14,14 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+
 import cvxpy.settings as s
 from cvxpy.constraints import SOC
-from cvxpy.reductions.solvers.conic_solvers.scs_conif import (SCS,
-                                                              dims_to_solver_dict)
-from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solution import Solution
 from cvxpy.reductions.solvers import utilities
-import numpy as np
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from cvxpy.reductions.solvers.conic_solvers.scs_conif import (
+    SCS, dims_to_solver_dict,)
 
 
 def makeMstart(A, n, ifCol: int = 1):

--- a/cvxpy/reductions/solvers/constant_solver.py
+++ b/cvxpy/reductions/solvers/constant_solver.py
@@ -1,6 +1,6 @@
+import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution
 from cvxpy.reductions.solvers.solver import Solver
-import cvxpy.settings as s
 
 
 class ConstantSolver(Solver):

--- a/cvxpy/reductions/solvers/defines.py
+++ b/cvxpy/reductions/solvers/defines.py
@@ -14,45 +14,38 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy.settings as s
 import numpy as np
 
+import cvxpy.settings as s
+from cvxpy.reductions.solvers.conic_solvers.cbc_conif import CBC as CBC_con
+from cvxpy.reductions.solvers.conic_solvers.cplex_conif import (
+    CPLEX as CPLEX_con,)
+from cvxpy.reductions.solvers.conic_solvers.cvxopt_conif import (
+    CVXOPT as CVXOPT_con,)
 # Conic interfaces
-from cvxpy.reductions.solvers.conic_solvers.diffcp_conif \
-    import DIFFCP as DIFFCP_con
-from cvxpy.reductions.solvers.conic_solvers.ecos_conif \
-    import ECOS as ECOS_con
-from cvxpy.reductions.solvers.conic_solvers.ecos_bb_conif \
-    import ECOS_BB as ECOS_BB_con
-from cvxpy.reductions.solvers.conic_solvers.cvxopt_conif \
-    import CVXOPT as CVXOPT_con
-from cvxpy.reductions.solvers.conic_solvers.glpk_conif \
-    import GLPK as GLPK_con
-from cvxpy.reductions.solvers.conic_solvers.glpk_mi_conif \
-    import GLPK_MI as GLPK_MI_con
-from cvxpy.reductions.solvers.conic_solvers.cbc_conif \
-    import CBC as CBC_con
-from cvxpy.reductions.solvers.conic_solvers.scs_conif \
-    import SCS as SCS_con
-from cvxpy.reductions.solvers.conic_solvers.gurobi_conif \
-    import GUROBI as GUROBI_con
-from cvxpy.reductions.solvers.conic_solvers.xpress_conif \
-    import XPRESS as XPRESS_con
-from cvxpy.reductions.solvers.conic_solvers.mosek_conif \
-    import MOSEK as MOSEK_con
-from cvxpy.reductions.solvers.conic_solvers.cplex_conif \
-    import CPLEX as CPLEX_con
-from cvxpy.reductions.solvers.conic_solvers.nag_conif \
-    import NAG as NAG_con
-from cvxpy.reductions.solvers.conic_solvers.scip_conif \
-    import SCIP as SCIP_con
-from cvxpy.reductions.solvers.conic_solvers.scipy_conif \
-    import SCIPY as SCIPY_con
-
+from cvxpy.reductions.solvers.conic_solvers.diffcp_conif import (
+    DIFFCP as DIFFCP_con,)
+from cvxpy.reductions.solvers.conic_solvers.ecos_bb_conif import (
+    ECOS_BB as ECOS_BB_con,)
+from cvxpy.reductions.solvers.conic_solvers.ecos_conif import ECOS as ECOS_con
+from cvxpy.reductions.solvers.conic_solvers.glpk_conif import GLPK as GLPK_con
+from cvxpy.reductions.solvers.conic_solvers.glpk_mi_conif import (
+    GLPK_MI as GLPK_MI_con,)
+from cvxpy.reductions.solvers.conic_solvers.gurobi_conif import (
+    GUROBI as GUROBI_con,)
+from cvxpy.reductions.solvers.conic_solvers.mosek_conif import (
+    MOSEK as MOSEK_con,)
+from cvxpy.reductions.solvers.conic_solvers.nag_conif import NAG as NAG_con
+from cvxpy.reductions.solvers.conic_solvers.scip_conif import SCIP as SCIP_con
+from cvxpy.reductions.solvers.conic_solvers.scipy_conif import (
+    SCIPY as SCIPY_con,)
+from cvxpy.reductions.solvers.conic_solvers.scs_conif import SCS as SCS_con
+from cvxpy.reductions.solvers.conic_solvers.xpress_conif import (
+    XPRESS as XPRESS_con,)
+from cvxpy.reductions.solvers.qp_solvers.cplex_qpif import CPLEX as CPLEX_qp
+from cvxpy.reductions.solvers.qp_solvers.gurobi_qpif import GUROBI as GUROBI_qp
 # QP interfaces
 from cvxpy.reductions.solvers.qp_solvers.osqp_qpif import OSQP as OSQP_qp
-from cvxpy.reductions.solvers.qp_solvers.gurobi_qpif import GUROBI as GUROBI_qp
-from cvxpy.reductions.solvers.qp_solvers.cplex_qpif import CPLEX as CPLEX_qp
 from cvxpy.reductions.solvers.qp_solvers.xpress_qpif import XPRESS as XPRESS_qp
 
 solver_conic_intf = [DIFFCP_con(), ECOS_con(),

--- a/cvxpy/reductions/solvers/intermediate_chain.py
+++ b/cvxpy/reductions/solvers/intermediate_chain.py
@@ -14,13 +14,13 @@ limitations under the License.
 from cvxpy.error import DCPError, DGPError, SolverError
 from cvxpy.problems.objective import Maximize
 from cvxpy.reductions.chain import Chain
-from cvxpy.reductions.dcp2cone.dcp2cone import Dcp2Cone
-from cvxpy.reductions.flip_objective import FlipObjective
-from cvxpy.reductions.dgp2dcp.dgp2dcp import Dgp2Dcp
-from cvxpy.reductions.qp2quad_form.qp2symbolic_qp import Qp2SymbolicQp
-from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
 from cvxpy.reductions.complex2real import complex2real
+from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
+from cvxpy.reductions.dcp2cone.dcp2cone import Dcp2Cone
+from cvxpy.reductions.dgp2dcp.dgp2dcp import Dgp2Dcp
+from cvxpy.reductions.flip_objective import FlipObjective
 from cvxpy.reductions.qp2quad_form import qp2symbolic_qp
+from cvxpy.reductions.qp2quad_form.qp2symbolic_qp import Qp2SymbolicQp
 from cvxpy.utilities.debug_tools import build_non_disciplined_error_msg
 
 

--- a/cvxpy/reductions/solvers/kktsolver.py
+++ b/cvxpy/reductions/solvers/kktsolver.py
@@ -73,7 +73,7 @@ def kkt_ldl(G, dims, A):
     """
     from cvxopt import blas, lapack
     from cvxopt.base import matrix
-    from cvxopt.misc import scale, pack, unpack
+    from cvxopt.misc import pack, scale, unpack
 
     p, n = A.size
     ldK = n + p + dims['l'] + sum(dims['q']) + sum([int(k*(k+1)/2)

--- a/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
@@ -1,13 +1,11 @@
-import cvxpy.settings as s
-import cvxpy.interface as intf
-from cvxpy.reductions import Solution
-from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
-from cvxpy.reductions.solvers.conic_solvers.cplex_conif import (
-    get_status,
-    hide_solver_output,
-    set_parameters
-)
 import numpy as np
+
+import cvxpy.interface as intf
+import cvxpy.settings as s
+from cvxpy.reductions import Solution
+from cvxpy.reductions.solvers.conic_solvers.cplex_conif import (
+    get_status, hide_solver_output, set_parameters,)
+from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 
 
 def constrain_cplex_infty(v) -> None:

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -1,8 +1,9 @@
-import cvxpy.settings as s
+import numpy as np
+
 import cvxpy.interface as intf
+import cvxpy.settings as s
 from cvxpy.reductions import Solution
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
-import numpy as np
 
 
 def constrain_gurobi_infty(v) -> None:
@@ -104,6 +105,7 @@ class GUROBI(QpSolver):
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
         import gurobipy as grb
+
         # N.B. Here we assume that the matrices in data are in csc format
         P = data[s.P]
         q = data[s.Q]

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -1,9 +1,10 @@
-import cvxpy.settings as s
-import cvxpy.interface as intf
-from cvxpy.reductions import Solution
-from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 import numpy as np
 import scipy.sparse as sp
+
+import cvxpy.interface as intf
+import cvxpy.settings as s
+from cvxpy.reductions import Solution
+from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 
 
 class OSQP(QpSolver):

--- a/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
+++ b/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
@@ -14,14 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.reductions.cvx_attr2constr import convex_attributes
-from cvxpy.constraints import NonPos, Zero
-from cvxpy.reductions.solvers.solver import Solver
-from cvxpy.reductions.utilities import group_constraints
-from cvxpy.reductions.qp2quad_form.qp_matrix_stuffing import ParamQuadProg, ConeDims
-import cvxpy.settings as s
 import numpy as np
 import scipy.sparse as sp
+
+import cvxpy.settings as s
+from cvxpy.constraints import NonPos, Zero
+from cvxpy.reductions.cvx_attr2constr import convex_attributes
+from cvxpy.reductions.qp2quad_form.qp_matrix_stuffing import (ConeDims,
+                                                              ParamQuadProg,)
+from cvxpy.reductions.solvers.solver import Solver
+from cvxpy.reductions.utilities import group_constraints
 
 
 class QpSolver(Solver):

--- a/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
@@ -1,13 +1,11 @@
-import cvxpy.settings as s
-import cvxpy.interface as intf
-from cvxpy.reductions import Solution
-from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
-from cvxpy.reductions.solvers.conic_solvers.xpress_conif import (
-    makeMstart,
-    get_status_maps
-)
-
 import numpy as np
+
+import cvxpy.interface as intf
+import cvxpy.settings as s
+from cvxpy.reductions import Solution
+from cvxpy.reductions.solvers.conic_solvers.xpress_conif import (
+    get_status_maps, makeMstart,)
+from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 
 
 class XPRESS(QpSolver):

--- a/cvxpy/reductions/solvers/solver.py
+++ b/cvxpy/reductions/solvers/solver.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import abc
+
 from cvxpy.reductions.reduction import Reduction
 
 

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -1,27 +1,27 @@
 import warnings
+from typing import Any, List
 
-
-from cvxpy.atoms import EXP_ATOMS, PSD_ATOMS, SOC_ATOMS, NONPOS_ATOMS
-from cvxpy.constraints import ExpCone, PSD, SOC, NonNeg, \
-                              NonPos, Inequality, Equality, Zero, PowCone3D
+from cvxpy.atoms import EXP_ATOMS, NONPOS_ATOMS, PSD_ATOMS, SOC_ATOMS
+from cvxpy.constraints import (PSD, SOC, Equality, ExpCone, Inequality, NonNeg,
+                               NonPos, PowCone3D, Zero,)
 from cvxpy.error import DCPError, DGPError, DPPError, SolverError
 from cvxpy.problems.objective import Maximize
 from cvxpy.reductions.chain import Chain
 from cvxpy.reductions.complex2real import complex2real
+from cvxpy.reductions.cone2cone.exotic2common import (EXOTIC_CONES,
+                                                      Exotic2Common,)
 from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
 from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
 from cvxpy.reductions.dcp2cone.dcp2cone import Dcp2Cone
-from cvxpy.reductions.cone2cone.exotic2common import EXOTIC_CONES, Exotic2Common
 from cvxpy.reductions.dgp2dcp.dgp2dcp import Dgp2Dcp
 from cvxpy.reductions.eval_params import EvalParams
 from cvxpy.reductions.flip_objective import FlipObjective
 from cvxpy.reductions.qp2quad_form import qp2symbolic_qp
 from cvxpy.reductions.qp2quad_form.qp_matrix_stuffing import QpMatrixStuffing
+from cvxpy.reductions.solvers import defines as slv_def
 from cvxpy.reductions.solvers.constant_solver import ConstantSolver
 from cvxpy.reductions.solvers.solver import Solver
-from cvxpy.reductions.solvers import defines as slv_def
 from cvxpy.utilities.debug_tools import build_non_disciplined_error_msg
-from typing import Any, List
 
 
 def _is_lp(self):

--- a/cvxpy/reductions/solvers/utilities.py
+++ b/cvxpy/reductions/solvers/utilities.py
@@ -16,8 +16,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy.interface as intf
 import numpy as np
+
+import cvxpy.interface as intf
 
 
 def expcone_permutor(n_cones, exp_cone_order) -> np.ndarray:

--- a/cvxpy/reductions/utilities.py
+++ b/cvxpy/reductions/utilities.py
@@ -14,13 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.affine.reshape import reshape
-from cvxpy.atoms.affine.vec import vec
-from cvxpy.constraints.zero import Zero
-from cvxpy.constraints.nonpos import NonPos, NonNeg
 from collections import defaultdict
+
 import numpy as np
 import scipy.sparse as sp
+
+from cvxpy.atoms.affine.reshape import reshape
+from cvxpy.atoms.affine.vec import vec
+from cvxpy.constraints.nonpos import NonNeg, NonPos
+from cvxpy.constraints.zero import Zero
 
 
 def lower_ineq_to_nonpos(inequality):

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -16,7 +16,6 @@ limitations under the License.
 import logging
 import sys
 
-
 LOGGER = logging.getLogger("__cvxpy__")
 LOGGER.propagate = False
 LOGGER.setLevel(logging.INFO)

--- a/cvxpy/tests/base_test.py
+++ b/cvxpy/tests/base_test.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 # Base class for unit tests.
 import unittest
+
 import numpy as np
 
 

--- a/cvxpy/tests/ram_limited.py
+++ b/cvxpy/tests/ram_limited.py
@@ -16,8 +16,10 @@ limitations under the License.
 
 import sys
 import unittest
-import cvxpy as cp
+
 import numpy as np
+
+import cvxpy as cp
 
 """
 This file contains tests which require massive amounts of RAM.

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -14,19 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy as cp
-import cvxpy.settings as s
-from cvxpy.transforms.partial_optimize import partial_optimize
-from cvxpy.expressions.variable import Variable
-from cvxpy.expressions.constants import Parameter, Constant
-from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS
-import numpy as np
-from cvxpy import Problem, Minimize
-from cvxpy.tests.base_test import BaseTest
 import unittest
+
+import numpy as np
 import scipy
 import scipy.sparse as sp
 import scipy.stats
+
+import cvxpy as cp
+import cvxpy.settings as s
+from cvxpy import Minimize, Problem
+from cvxpy.expressions.constants import Constant, Parameter
+from cvxpy.expressions.variable import Variable
+from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS
+from cvxpy.tests.base_test import BaseTest
+from cvxpy.transforms.partial_optimize import partial_optimize
 
 
 class TestAtoms(BaseTest):

--- a/cvxpy/tests/test_benchmarks.py
+++ b/cvxpy/tests/test_benchmarks.py
@@ -1,11 +1,12 @@
+import os
+import time
+
+import numpy as np
+import pytest
+
 import cvxpy as cp
 from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
 from cvxpy.tests.base_test import BaseTest
-import pytest
-import numpy as np
-
-import os
-import time
 
 
 def benchmark(func, iters: int = 1, name=None) -> None:

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -14,15 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy as cvx
-from cvxpy.expressions.variable import Variable
-from cvxpy.expressions.constants import Constant
-from cvxpy.expressions.constants import Parameter
-from cvxpy import Problem, Minimize
-from cvxpy.tests.base_test import BaseTest
+import sys
+
 import numpy as np
 import scipy.sparse as sp
-import sys
+
+import cvxpy as cvx
+from cvxpy import Minimize, Problem
+from cvxpy.expressions.constants import Constant, Parameter
+from cvxpy.expressions.variable import Variable
+from cvxpy.tests.base_test import BaseTest
+
 PY35 = sys.version_info >= (3, 5)
 
 

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -14,24 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import unittest
-import pytest
+
 import numpy as np
-import cvxpy as cp
+import pytest
 import scipy as sp
-from cvxpy.tests.base_test import BaseTest
-from cvxpy.tests import solver_test_helpers as STH
-from cvxpy.reductions.cone2cone import affine2direct as a2d
+
+import cvxpy as cp
 from cvxpy import settings as s
-from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS as INSTALLED_MI
-from cvxpy.reductions.solvers.defines import MI_SOCP_SOLVERS as MI_SOCP
-from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from cvxpy.constraints.exponential import ExpCone
+from cvxpy.constraints.power import PowCone3D, PowConeND
+from cvxpy.constraints.second_order import SOC
 from cvxpy.reductions.chain import Chain
-from cvxpy.reductions.dcp2cone.dcp2cone import Dcp2Cone
+from cvxpy.reductions.cone2cone import affine2direct as a2d
 from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
 from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
-from cvxpy.constraints.second_order import SOC
-from cvxpy.constraints.exponential import ExpCone
-from cvxpy.constraints.power import PowConeND, PowCone3D
+from cvxpy.reductions.dcp2cone.dcp2cone import Dcp2Cone
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from cvxpy.reductions.solvers.defines import (
+    INSTALLED_MI_SOLVERS as INSTALLED_MI,)
+from cvxpy.reductions.solvers.defines import MI_SOCP_SOLVERS as MI_SOCP
+from cvxpy.tests import solver_test_helpers as STH
+from cvxpy.tests.base_test import BaseTest
 
 
 class TestDualize(BaseTest):

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -16,23 +16,21 @@ limitations under the License.
 
 import math
 import unittest
+from distutils.version import StrictVersion
 
 import numpy as np
-import scipy.linalg as la
 import pytest
+import scipy.linalg as la
 
 import cvxpy as cp
-from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS, INSTALLED_SOLVERS
+from cvxpy.reductions.solvers.defines import (INSTALLED_MI_SOLVERS,
+                                              INSTALLED_SOLVERS,)
 from cvxpy.tests.base_test import BaseTest
-from cvxpy.tests.solver_test_helpers import (
-    StandardTestECPs,
-    StandardTestLPs,
-    StandardTestMixedCPs,
-    StandardTestSDPs,
-    StandardTestSOCPs,
-    StandardTestPCPs
-)
-from distutils.version import StrictVersion
+from cvxpy.tests.solver_test_helpers import (StandardTestECPs, StandardTestLPs,
+                                             StandardTestMixedCPs,
+                                             StandardTestPCPs,
+                                             StandardTestSDPs,
+                                             StandardTestSOCPs,)
 
 
 class TestECOS(BaseTest):
@@ -1347,8 +1345,9 @@ class TestAllSolvers(BaseTest):
     def test_installed_solvers(self) -> None:
         """Test the list of installed solvers.
         """
-        from cvxpy.reductions.solvers.defines import (SOLVER_MAP_CONIC, SOLVER_MAP_QP,
-                                                      INSTALLED_SOLVERS)
+        from cvxpy.reductions.solvers.defines import (INSTALLED_SOLVERS,
+                                                      SOLVER_MAP_CONIC,
+                                                      SOLVER_MAP_QP,)
         prob = cp.Problem(cp.Minimize(cp.norm(self.x, 1) + 1.0), [self.x == 0])
         for solver in SOLVER_MAP_CONIC.keys():
             if solver in INSTALLED_SOLVERS:

--- a/cvxpy/tests/test_constant_atoms.py
+++ b/cvxpy/tests/test_constant_atoms.py
@@ -14,21 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-# Tests atoms by calling them with a constant value.
-import cvxpy as cp
-from cvxpy.settings import (SCS, OSQP, ECOS, CVXOPT,
-                            ROBUST_KKTSOLVER, MOSEK)
-from cvxpy.problems.problem import Problem
-from cvxpy.expressions.variable import Variable
-from cvxpy.expressions.constants import Constant, Parameter
-from cvxpy.error import SolverError
-import cvxpy.interface as intf
-from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS
+import itertools
+import math
+
 import numpy as np
 import numpy.linalg as LA
-import math
-import itertools
 import pytest
+
+# Tests atoms by calling them with a constant value.
+import cvxpy as cp
+import cvxpy.interface as intf
+from cvxpy.error import SolverError
+from cvxpy.expressions.constants import Constant, Parameter
+from cvxpy.expressions.variable import Variable
+from cvxpy.problems.problem import Problem
+from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS
+from cvxpy.settings import CVXOPT, ECOS, MOSEK, OSQP, ROBUST_KKTSOLVER, SCS
 
 ROBUST_CVXOPT = "robust_cvxopt"
 SOLVER_TO_TOL = {SCS: 1e-2,

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.expressions.variable import Variable
-from cvxpy.atoms.affine.reshape import reshape as reshape_atom
-from cvxpy.constraints.second_order import SOC
-from cvxpy.constraints.power import PowCone3D, PowConeND
-from cvxpy.tests.base_test import BaseTest
-import cvxpy as cp
 import numpy as np
+
+import cvxpy as cp
+from cvxpy.atoms.affine.reshape import reshape as reshape_atom
+from cvxpy.constraints.power import PowCone3D, PowConeND
+from cvxpy.constraints.second_order import SOC
+from cvxpy.expressions.variable import Variable
+from cvxpy.tests.base_test import BaseTest
 
 
 class TestConstraints(BaseTest):

--- a/cvxpy/tests/test_convolution.py
+++ b/cvxpy/tests/test_convolution.py
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+
 import cvxpy as cvx
+import cvxpy.problems.iterative as iterative
 import cvxpy.settings as s
 from cvxpy.lin_ops.tree_mat import prune_constants
-import cvxpy.problems.iterative as iterative
 from cvxpy.tests.base_test import BaseTest
-import numpy as np
 
 
 class TestConvolution(BaseTest):

--- a/cvxpy/tests/test_curvature.py
+++ b/cvxpy/tests/test_curvature.py
@@ -15,9 +15,9 @@ limitations under the License.
 """
 
 import unittest
-from cvxpy import log
-from cvxpy import Constant, Variable
-from cvxpy.settings import UNKNOWN, QUASILINEAR
+
+from cvxpy import Constant, Variable, log
+from cvxpy.settings import QUASILINEAR, UNKNOWN
 
 
 class TestCurvature(unittest.TestCase):

--- a/cvxpy/tests/test_custom_solver.py
+++ b/cvxpy/tests/test_custom_solver.py
@@ -1,8 +1,8 @@
 import unittest
 
 import cvxpy as cp
-from cvxpy.reductions.solvers.qp_solvers.osqp_qpif import OSQP
 from cvxpy.reductions.solvers.conic_solvers.scs_conif import SCS
+from cvxpy.reductions.solvers.qp_solvers.osqp_qpif import OSQP
 
 
 class CustomQPSolverCalled(Exception):

--- a/cvxpy/tests/test_derivative.py
+++ b/cvxpy/tests/test_derivative.py
@@ -1,9 +1,11 @@
+import warnings
+
+import numpy as np
+
 import cvxpy as cp
 import cvxpy.settings as s
 from cvxpy.tests.base_test import BaseTest
 
-import numpy as np
-import warnings
 warnings.filterwarnings("ignore")
 
 SOLVE_METHODS = [s.SCS, s.ECOS]

--- a/cvxpy/tests/test_dgp.py
+++ b/cvxpy/tests/test_dgp.py
@@ -1,7 +1,8 @@
-import cvxpy
-from cvxpy.tests.base_test import BaseTest
 import numpy as np
 import scipy.sparse as sp
+
+import cvxpy
+from cvxpy.tests.base_test import BaseTest
 
 
 class TestDgp(BaseTest):

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -1,13 +1,12 @@
+import numpy as np
+
 import cvxpy
-from cvxpy.atoms.affine.add_expr import AddExpression
 import cvxpy.error as error
 import cvxpy.reductions.dgp2dcp.atom_canonicalizers as dgp_atom_canon
+from cvxpy.atoms.affine.add_expr import AddExpression
 from cvxpy.reductions import solution
 from cvxpy.settings import SOLVER_ERROR
 from cvxpy.tests.base_test import BaseTest
-
-import numpy as np
-
 
 SOLVER = cvxpy.ECOS
 

--- a/cvxpy/tests/test_domain.py
+++ b/cvxpy/tests/test_domain.py
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy as cp
-from cvxpy.transforms.partial_optimize import partial_optimize
-from cvxpy.expressions.variable import Variable
 import numpy as np
-from cvxpy import Problem, Minimize, Maximize
+
+import cvxpy as cp
+from cvxpy import Maximize, Minimize, Problem
+from cvxpy.expressions.variable import Variable
 from cvxpy.tests.base_test import BaseTest
+from cvxpy.transforms.partial_optimize import partial_optimize
 
 
 class TestDomain(BaseTest):

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -1,11 +1,10 @@
 import warnings
 
+import numpy as np
+
 import cvxpy as cp
 import cvxpy.error as error
 from cvxpy.tests.base_test import BaseTest
-
-import numpy as np
-
 
 SOLVER = cp.ECOS
 

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -13,13 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import cvxpy as cp
-from cvxpy.reductions.solvers import bisection
-import cvxpy.settings as s
-from cvxpy.tests import base_test
-
 import numpy as np
 
+import cvxpy as cp
+import cvxpy.settings as s
+from cvxpy.reductions.solvers import bisection
+from cvxpy.tests import base_test
 
 SOLVER = cp.ECOS
 

--- a/cvxpy/tests/test_examples.py
+++ b/cvxpy/tests/test_examples.py
@@ -15,12 +15,15 @@ limitations under the License.
 """
 
 from __future__ import print_function
+
+import unittest
+
+import numpy as np
+
 import cvxpy as cvx
 import cvxpy.interface as intf
-from cvxpy.tests.base_test import BaseTest
 from cvxpy.reductions.solvers.conic_solvers import ecos_conif
-import numpy as np
-import unittest
+from cvxpy.tests.base_test import BaseTest
 
 
 class TestExamples(BaseTest):
@@ -624,6 +627,7 @@ class TestExamples(BaseTest):
         data, chain, inverse = prob.get_problem_data(cvx.SCS)
 
         import ecos
+
         # Get ECOS arguments.
         data, chain, inverse = prob.get_problem_data(cvx.ECOS)
         # Call ECOS solver.

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -14,18 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy as cp
-from cvxpy.atoms.affine.add_expr import AddExpression
-from cvxpy.expressions.variable import Variable
-from cvxpy.expressions.constants import Constant
-from cvxpy.expressions.constants import Parameter
-from cvxpy import Problem, Minimize
-import cvxpy.interface.matrix_utilities as intf
-import cvxpy.settings as s
-from cvxpy.tests.base_test import BaseTest
+import warnings
+
 import numpy as np
 import scipy.sparse as sp
-import warnings
+
+import cvxpy as cp
+import cvxpy.interface.matrix_utilities as intf
+import cvxpy.settings as s
+from cvxpy import Minimize, Problem
+from cvxpy.atoms.affine.add_expr import AddExpression
+from cvxpy.expressions.constants import Constant, Parameter
+from cvxpy.expressions.variable import Variable
+from cvxpy.tests.base_test import BaseTest
 
 
 class TestExpressions(BaseTest):

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -15,13 +15,15 @@ limitations under the License.
 """
 
 from __future__ import division
-import cvxpy as cp
-from cvxpy.transforms.partial_optimize import partial_optimize
-from cvxpy.expressions.variable import Variable
-from cvxpy.transforms import linearize
+
 import numpy as np
-from cvxpy import Problem, Minimize, Maximize
+
+import cvxpy as cp
+from cvxpy import Maximize, Minimize, Problem
+from cvxpy.expressions.variable import Variable
 from cvxpy.tests.base_test import BaseTest
+from cvxpy.transforms import linearize
+from cvxpy.transforms.partial_optimize import partial_optimize
 
 
 class TestGrad(BaseTest):

--- a/cvxpy/tests/test_interfaces.py
+++ b/cvxpy/tests/test_interfaces.py
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy.interface as intf
 import numpy as np
 import scipy.sparse as sp
+
+import cvxpy.interface as intf
 from cvxpy.tests.base_test import BaseTest
 
 

--- a/cvxpy/tests/test_lin_ops.py
+++ b/cvxpy/tests/test_lin_ops.py
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.lin_ops.lin_utils import (create_var, create_param, sum_expr,
-                                     sum_entries, get_expr_vars, neg_expr,
-                                     create_const, create_eq, create_leq)
-from cvxpy.lin_ops.lin_op import (VARIABLE, PARAM, SCALAR_CONST, NEG,
-                                  DENSE_CONST, SPARSE_CONST, SUM_ENTRIES)
 import numpy as np
 import scipy.sparse as sp
+
+from cvxpy.lin_ops.lin_op import (DENSE_CONST, NEG, PARAM, SCALAR_CONST,
+                                  SPARSE_CONST, SUM_ENTRIES, VARIABLE,)
+from cvxpy.lin_ops.lin_utils import (create_const, create_eq, create_leq,
+                                     create_param, create_var, get_expr_vars,
+                                     neg_expr, sum_entries, sum_expr,)
 from cvxpy.tests.base_test import BaseTest
 
 

--- a/cvxpy/tests/test_linear_cone.py
+++ b/cvxpy/tests/test_linear_cone.py
@@ -17,7 +17,7 @@ limitations under the License.
 import numpy as np
 
 from cvxpy import Maximize, Minimize, Problem
-from cvxpy.atoms import exp, diag, pnorm, hstack
+from cvxpy.atoms import diag, exp, hstack, pnorm
 from cvxpy.constraints import SOC, ExpCone, NonNeg
 from cvxpy.error import SolverError
 from cvxpy.expressions.constants import Constant

--- a/cvxpy/tests/test_matrices.py
+++ b/cvxpy/tests/test_matrices.py
@@ -13,16 +13,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import unittest
 import sys
+import unittest
 from typing import Tuple
 
-from cvxpy.expressions.expression import Expression
-from cvxpy.constraints.constraint import Constraint
-from cvxpy.expressions.variable import Variable
-import cvxpy.interface.matrix_utilities as intf
 import numpy
 import scipy.sparse as sp
+
+import cvxpy.interface.matrix_utilities as intf
+from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions.expression import Expression
+from cvxpy.expressions.variable import Variable
 
 PY35 = sys.version_info >= (3, 5)
 

--- a/cvxpy/tests/test_mip_vars.py
+++ b/cvxpy/tests/test_mip_vars.py
@@ -14,11 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import unittest
-import cvxpy as cp
+
 import numpy as np
+
+import cvxpy as cp
 import cvxpy.settings as s
+from cvxpy.reductions.solvers.defines import (
+    INSTALLED_MI_SOLVERS as MIP_SOLVERS,)
 from cvxpy.tests.base_test import BaseTest
-from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS as MIP_SOLVERS
 
 
 @unittest.skipUnless(len(MIP_SOLVERS) > 0, 'No mixed-integer solver is installed.')

--- a/cvxpy/tests/test_nonlinear_atoms.py
+++ b/cvxpy/tests/test_nonlinear_atoms.py
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import math
+
+import numpy as np
+
 import cvxpy as cvx
 from cvxpy.tests.base_test import BaseTest
-import math
-import numpy as np
 
 
 class TestNonlinearAtoms(BaseTest):

--- a/cvxpy/tests/test_objectives.py
+++ b/cvxpy/tests/test_objectives.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy as cp
-from cvxpy.expressions.variable import Variable
-from cvxpy.error import DCPError
 import unittest
+
+import cvxpy as cp
+from cvxpy.error import DCPError
+from cvxpy.expressions.variable import Variable
 
 
 class TestObjectives(unittest.TestCase):

--- a/cvxpy/tests/test_param_cone_prog.py
+++ b/cvxpy/tests/test_param_cone_prog.py
@@ -15,11 +15,11 @@ limitations under the License.
 """
 import math
 
+import numpy as np
+
 import cvxpy as cp
 from cvxpy.reductions.solvers.conic_solvers.scs_conif import SCS
 from cvxpy.tests.base_test import BaseTest
-
-import numpy as np
 
 
 class TestParamConeProg(BaseTest):

--- a/cvxpy/tests/test_param_quad_prog.py
+++ b/cvxpy/tests/test_param_quad_prog.py
@@ -13,11 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import cvxpy as cp
-from cvxpy.reductions.solvers.defines import QP_SOLVERS, INSTALLED_SOLVERS
-from cvxpy.tests.base_test import BaseTest
-
 import numpy as np
+
+import cvxpy as cp
+from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS, QP_SOLVERS
+from cvxpy.tests.base_test import BaseTest
 
 
 class TestParamQuadProg(BaseTest):

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -14,31 +14,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import builtins
+import pickle
+import sys
+import warnings
 from fractions import Fraction
-import cvxpy.settings as s
+from io import StringIO
+
+import ecos
+import numpy
+import numpy as np
+import scipy.sparse as sp
+# Solvers.
+import scs
+from numpy import linalg as LA
+
 import cvxpy as cp
-from cvxpy.constraints import NonPos, Zero, ExpCone, PSD
+import cvxpy.interface as intf
+import cvxpy.settings as s
+from cvxpy.constraints import PSD, ExpCone, NonPos, Zero
 from cvxpy.error import DCPError, ParameterError, SolverError
 from cvxpy.expressions.constants import Constant, Parameter
 from cvxpy.expressions.variable import Variable
 from cvxpy.problems.problem import Problem
-from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.conic_solvers import ecos_conif, scs_conif
-from cvxpy.reductions.solvers.defines import SOLVER_MAP_CONIC, INSTALLED_SOLVERS
-import cvxpy.interface as intf
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from cvxpy.reductions.solvers.defines import (INSTALLED_SOLVERS,
+                                              SOLVER_MAP_CONIC,)
 from cvxpy.tests.base_test import BaseTest
-from numpy import linalg as LA
-import numpy
-import numpy as np
-import scipy.sparse as sp
-import builtins
-import sys
-import pickle
-# Solvers.
-import scs
-import ecos
-import warnings
-from io import StringIO
 
 
 class TestProblem(BaseTest):

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -19,18 +19,13 @@ import numpy as np
 import scipy.sparse as sp
 from scipy.linalg import lstsq
 
-from cvxpy import Minimize, Problem, Parameter, Maximize
-from cvxpy.atoms import (QuadForm, abs, power,
-                         quad_over_lin, sum, sum_squares,
-                         norm,
-                         huber,
-                         matrix_frac)
-from cvxpy.reductions.solvers.defines import QP_SOLVERS, INSTALLED_SOLVERS
+from cvxpy import Maximize, Minimize, Parameter, Problem
+from cvxpy.atoms import (QuadForm, abs, huber, matrix_frac, norm, power,
+                         quad_over_lin, sum, sum_squares,)
 from cvxpy.expressions.variable import Variable
+from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS, QP_SOLVERS
 from cvxpy.tests.base_test import BaseTest
-from cvxpy.tests.solver_test_helpers import (
-    StandardTestLPs,
-)
+from cvxpy.tests.solver_test_helpers import StandardTestLPs
 
 
 class TestQp(BaseTest):

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -14,15 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import division, print_function, absolute_import
+from __future__ import absolute_import, division, print_function
 
-import numpy as np
-from numpy.testing import assert_allclose, assert_equal
-import scipy.sparse as sp
-import cvxpy
-from cvxpy.settings import EIGVAL_TOL
 import warnings
 
+import numpy as np
+import scipy.sparse as sp
+from numpy.testing import assert_allclose, assert_equal
+
+import cvxpy
+from cvxpy.settings import EIGVAL_TOL
 from cvxpy.tests.base_test import BaseTest
 
 

--- a/cvxpy/tests/test_quadratic.py
+++ b/cvxpy/tests/test_quadratic.py
@@ -14,13 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import warnings
+
+import numpy as np
+
 import cvxpy as cp
 from cvxpy.atoms.affine.vstack import vstack
 from cvxpy.atoms.elementwise.power import power
 from cvxpy.expressions.variable import Variable
 from cvxpy.tests.base_test import BaseTest
-import numpy as np
-import warnings
 
 
 class TestExpressions(BaseTest):

--- a/cvxpy/tests/test_semidefinite_vars.py
+++ b/cvxpy/tests/test_semidefinite_vars.py
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+
 import cvxpy as cvx
 from cvxpy.expressions.variable import Variable
-import numpy as np
 from cvxpy.tests.base_test import BaseTest
 
 

--- a/cvxpy/tests/test_shape.py
+++ b/cvxpy/tests/test_shape.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import unittest
+
 from cvxpy.atoms.affine.reshape import reshape
 from cvxpy.expressions.variable import Variable
 from cvxpy.utilities import shape
-import unittest
 
 
 class TestShape(unittest.TestCase):

--- a/cvxpy/tests/test_suppfunc.py
+++ b/cvxpy/tests/test_suppfunc.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy as cp
 import numpy as np
-from cvxpy.tests.base_test import BaseTest
+
+import cvxpy as cp
 from cvxpy.error import SolverError
+from cvxpy.tests.base_test import BaseTest
 
 
 class TestSupportFunctions(BaseTest):

--- a/cvxpy/transforms/__init__.py
+++ b/cvxpy/transforms/__init__.py
@@ -14,11 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from cvxpy.transforms.indicator import indicator
 # from cvxpy.transforms.partial_optimize import partial_optimize
 # from cvxpy.transforms.separable_problems import get_separable_problems
 from cvxpy.transforms.linearize import linearize
-from cvxpy.transforms.indicator import indicator
-from cvxpy.transforms.scalarize import (weighted_sum,
-                                        targets_and_priorities,
-                                        max, log_sum_exp)
+from cvxpy.transforms.scalarize import (log_sum_exp, max,
+                                        targets_and_priorities, weighted_sum,)
 from cvxpy.transforms.suppfunc import SuppFunc as suppfunc

--- a/cvxpy/transforms/indicator.py
+++ b/cvxpy/transforms/indicator.py
@@ -16,10 +16,11 @@ limitations under the License.
 
 from typing import List, Tuple
 
+import numpy as np
+
+import cvxpy.utilities.performance_utils as perf
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.expression import Expression
-import cvxpy.utilities.performance_utils as perf
-import numpy as np
 
 
 class indicator(Expression):

--- a/cvxpy/transforms/partial_optimize.py
+++ b/cvxpy/transforms/partial_optimize.py
@@ -14,16 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.expressions.constants.constant import Constant
 from typing import List, Optional, Tuple
 
 import cvxpy.settings as s
 import cvxpy.utilities as u
-from cvxpy.problems.objective import Minimize, Maximize
-from cvxpy.problems.problem import Problem
-from cvxpy.expressions.variable import Variable
+from cvxpy.atoms import sum, trace
+from cvxpy.expressions.constants.constant import Constant
 from cvxpy.expressions.expression import Expression
-from cvxpy.atoms import trace, sum
+from cvxpy.expressions.variable import Variable
+from cvxpy.problems.objective import Maximize, Minimize
+from cvxpy.problems.problem import Problem
 
 
 def partial_optimize(

--- a/cvxpy/transforms/scalarize.py
+++ b/cvxpy/transforms/scalarize.py
@@ -17,7 +17,7 @@ from typing import List, Union
 
 import cvxpy.atoms as atoms
 from cvxpy import Constant
-from cvxpy.problems.objective import Minimize, Maximize
+from cvxpy.problems.objective import Maximize, Minimize
 from cvxpy.transforms import indicator
 
 

--- a/cvxpy/transforms/suppfunc.py
+++ b/cvxpy/transforms/suppfunc.py
@@ -1,8 +1,9 @@
-from cvxpy.expressions.variable import Variable
-from cvxpy.atoms.suppfunc import SuppFuncAtom
-from cvxpy.reductions.cvx_attr2constr import CONVEX_ATTRIBUTES
 import numpy as np
 from scipy import sparse
+
+from cvxpy.atoms.suppfunc import SuppFuncAtom
+from cvxpy.expressions.variable import Variable
+from cvxpy.reductions.cvx_attr2constr import CONVEX_ATTRIBUTES
 
 
 def scs_coniclift(x, constraints):
@@ -23,9 +24,9 @@ def scs_coniclift(x, constraints):
     This function DOES NOT work when ``x`` has attributes, like ``PSD=True``,
     ``diag=True``, ``symmetric=True``, etc...
     """
-    from cvxpy.problems.problem import Problem
-    from cvxpy.problems.objective import Minimize
     from cvxpy.atoms.affine.sum import sum
+    from cvxpy.problems.objective import Minimize
+    from cvxpy.problems.problem import Problem
     prob = Problem(Minimize(sum(x)), constraints)
     # ^ The objective value is only used to make sure that "x"
     # participates in the problem. So, if constraints is an

--- a/cvxpy/utilities/__init__.py
+++ b/cvxpy/utilities/__init__.py
@@ -14,7 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from . import grad, shape, sign
 from .canonical import Canonical
-from . import grad
-from . import shape
-from . import sign

--- a/cvxpy/utilities/canonical.py
+++ b/cvxpy/utilities/canonical.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import abc
+
 from cvxpy.utilities import performance_utils as pu
 from cvxpy.utilities.deterministic import unique_list
 

--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -23,10 +23,10 @@ import numpy as np
 import scipy.sparse as sp
 
 from cvxpy.cvxcore.python import canonInterface
+from cvxpy.lin_ops.lin_op import NO_OP, LinOp
 from cvxpy.reductions.inverse_data import InverseData
 from cvxpy.utilities.replace_quad_forms import (replace_quad_forms,
-                                                restore_quad_forms)
-from cvxpy.lin_ops.lin_op import LinOp, NO_OP
+                                                restore_quad_forms,)
 
 
 # TODO find best format for sparse matrices: csr, csc, dok, lil, ...

--- a/cvxpy/utilities/key_utils.py
+++ b/cvxpy/utilities/key_utils.py
@@ -17,10 +17,11 @@ limitations under the License.
 # Utility functions to handle indexing/slicing into an expression.
 
 from __future__ import division
+
+import numbers
 from typing import Optional, Tuple
 
 import numpy as np
-import numbers
 
 
 # TODO(akshayka): This module needs to be updated in order to handle

--- a/cvxpy/utilities/power_tools.py
+++ b/cvxpy/utilities/power_tools.py
@@ -14,14 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numbers
+from collections import defaultdict
 from fractions import Fraction
+
+import numpy as np
+
 from cvxpy.atoms.affine.reshape import reshape
 from cvxpy.atoms.affine.vstack import vstack
 from cvxpy.constraints.second_order import SOC
 from cvxpy.expressions.variable import Variable
-import numpy as np
-from collections import defaultdict
-import numbers
 
 
 def gm(t, x, y):

--- a/cvxpy/utilities/replace_quad_forms.py
+++ b/cvxpy/utilities/replace_quad_forms.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.quad_form import SymbolicQuadForm, QuadForm
+from cvxpy.atoms.quad_form import QuadForm, SymbolicQuadForm
 from cvxpy.expressions.variable import Variable
 
 

--- a/cvxpy/utilities/scopes.py
+++ b/cvxpy/utilities/scopes.py
@@ -17,7 +17,6 @@ limitations under the License.
 """
 import contextlib
 
-
 _dpp_scope_active = False
 
 

--- a/cvxpy/utilities/sign.py
+++ b/cvxpy/utilities/sign.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Tuple
 
 if TYPE_CHECKING:
     from cvxpy.expressions.expression import Expression

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -11,7 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/doc/sphinxext/docscrape.py
+++ b/doc/sphinxext/docscrape.py
@@ -19,11 +19,13 @@ limitations under the License.
 """
 
 import inspect
-import textwrap
-import re
 import pydoc
-from StringIO import StringIO
+import re
+import textwrap
 from warnings import warn
+
+from StringIO import StringIO
+
 
 class Reader:
     """A line-based string reader.

--- a/doc/sphinxext/docscrape_sphinx.py
+++ b/doc/sphinxext/docscrape_sphinx.py
@@ -14,9 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import re, inspect, textwrap, pydoc
+import inspect
+import pydoc
+import re
+import textwrap
+
 import sphinx
-from docscrape import NumpyDocString, FunctionDoc, ClassDoc
+from docscrape import ClassDoc, FunctionDoc, NumpyDocString
+
 
 class SphinxDocString(NumpyDocString):
     def __init__(self, docstring, config={}):

--- a/doc/sphinxext/numpydoc.py
+++ b/doc/sphinxext/numpydoc.py
@@ -37,10 +37,14 @@ import sphinx
 if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")
 
-import os, re, pydoc
-from docscrape_sphinx import get_doc_object, SphinxDocString
-from sphinx.util.compat import Directive
 import inspect
+import os
+import pydoc
+import re
+
+from docscrape_sphinx import SphinxDocString, get_doc_object
+from sphinx.util.compat import Directive
+
 
 def mangle_docstrings(app, what, name, obj, options, lines,
                       reference_offset=[0]):
@@ -127,6 +131,7 @@ def setup(app, get_doc_object_=get_doc_object):
 from docutils.statemachine import ViewList
 from sphinx.domains.c import CDomain
 from sphinx.domains.python import PythonDomain
+
 
 class ManglingDomainBase:
     directive_mangling_map = {}

--- a/examples/admm_example.py
+++ b/examples/admm_example.py
@@ -16,7 +16,9 @@ limitations under the License.
 from multiprocessing import Pool
 
 import numpy as np
-from cvxpy import norm, Minimize, Problem, square, Variable
+
+from cvxpy import Minimize, Problem, Variable, norm, square
+
 
 def solveX(data):
 	a = data[0:3]

--- a/examples/admm_lasso.py
+++ b/examples/admm_lasso.py
@@ -17,7 +17,8 @@ limitations under the License.
 from multiprocessing import Pool
 
 import numpy as np
-from cvxpy import norm, Minimize, Problem, sum_squares, Variable
+
+from cvxpy import Minimize, Problem, Variable, norm, sum_squares
 
 # Problem data.
 m = 100

--- a/examples/admm_svm_pool.py
+++ b/examples/admm_svm_pool.py
@@ -18,7 +18,8 @@ limitations under the License.
 from multiprocessing import Pool
 
 import numpy as np
-from cvxpy import norm, Minimize, pos, Problem, sum_squares, Variable
+
+from cvxpy import Minimize, Problem, Variable, norm, pos, sum_squares
 
 # Divide the data into NUM_PROCS segments,
 # using NUM_PROCS processes.

--- a/examples/admm_svm_procs.py
+++ b/examples/admm_svm_procs.py
@@ -15,10 +15,12 @@ limitations under the License.
 """
 
 # A SVM example with CVXPY.
-from multiprocessing import Process, Pipe
+from multiprocessing import Pipe, Process
 
 import numpy as np
-from cvxpy import norm, Minimize, Parameter, pos, Problem, sum_squares, Variable
+
+from cvxpy import (Minimize, Parameter, Problem, Variable, norm, pos,
+                   sum_squares,)
 
 # Divide the data into NUM_PROCS segments,
 # using NUM_PROCS processes.

--- a/examples/advanced/acent.py
+++ b/examples/advanced/acent.py
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy import Variable, Problem, Minimize, log
 import cvxopt
+
+from cvxpy import Minimize, Problem, Variable, log
 
 cvxopt.solvers.options['show_progress'] = False
 

--- a/examples/advanced/cheshire_tomography.py
+++ b/examples/advanced/cheshire_tomography.py
@@ -14,9 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy as cp
-from ..extensions.mixed_integer.boolean import Boolean
 import ncvx
+
+import cvxpy as cp
+
+from ..extensions.mixed_integer.boolean import Boolean
 
 bv = [] # Boolean variables.
 for i in range(26):

--- a/examples/advanced/circuits.py
+++ b/examples/advanced/circuits.py
@@ -14,9 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import abc
+
 # An object oriented model of a circuit.
 import cvxpy as cp
-import abc
+
 
 class Node:
     """ A node connecting devices. """

--- a/examples/advanced/image_processing.py
+++ b/examples/advanced/image_processing.py
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy import Minimize, Problem, Variable, square
+import math
+
 import cvxopt
 import pylab
-import math
+
+from cvxpy import Minimize, Problem, Variable, square
 
 # create simple image
 n = 32

--- a/examples/advanced/numpy_test.py
+++ b/examples/advanced/numpy_test.py
@@ -14,8 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import numpy
 import abc
+
+import numpy
+
+
 class Meta:
     def __subclasscheck__(self, subclass):
         print("hello")

--- a/examples/advanced/optimal_control.py
+++ b/examples/advanced/optimal_control.py
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy import Minimize, Problem, Variable, square
 import cvxopt
+
+from cvxpy import Minimize, Problem, Variable, square
 
 # Problem data
 T = 10

--- a/examples/advanced/stock_tradeoff.py
+++ b/examples/advanced/stock_tradeoff.py
@@ -14,12 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import math
+from multiprocessing import Pool
+
 import cvxopt
 import numpy
-from cvxpy import Maximize, Parameter, Problem, Variable, norm2, square
-from multiprocessing import Pool
 from pylab import figure, show
-import math
+
+from cvxpy import Maximize, Parameter, Problem, Variable, norm2, square
 
 num_assets = 100
 num_factors = 20

--- a/examples/advanced/test.py
+++ b/examples/advanced/test.py
@@ -70,6 +70,7 @@ class Exp:
     __array_priority__ = 100
 
 import numpy as np
+
 a = np.random.random((2,2))
 
 

--- a/examples/advanced/xpress_example.py
+++ b/examples/advanced/xpress_example.py
@@ -8,16 +8,17 @@
 # more or less the same as with the CVXPY interface and does not
 # require any specialization for Xpress.
 
+import numpy
+
 from cvxpy import Minimize, Variable, sum_squares
+from cvxpy.problems.xpress_problem import XpressProblem
 
 #
 # First (minor) difference: we must import the XpressProblem class
 # from xpress_problem.py in the problems/ directory.
 #
 
-from cvxpy.problems.xpress_problem import XpressProblem
 
-import numpy
 
 # Problem data.
 n = 2

--- a/examples/branch_and_bound.py
+++ b/examples/branch_and_bound.py
@@ -23,7 +23,8 @@ subject to x in {0, 1}^n
 from queue import PriorityQueue
 
 import numpy
-from cvxpy import Minimize, Parameter, Problem, sum_squares, Variable
+
+from cvxpy import Minimize, Parameter, Problem, Variable, sum_squares
 
 # Problem data.
 m = 25

--- a/examples/chebyshev.py
+++ b/examples/chebyshev.py
@@ -18,8 +18,9 @@ from __future__ import division
 
 import cvxopt
 import numpy as np
-from cvxpy import Maximize, Problem, Variable
 from pylab import axis, plot, show, title, xlabel, ylabel
+
+from cvxpy import Maximize, Problem, Variable
 
 # Taken from CVX website http://cvxr.com/cvx/examples/
 # Example: Compute and display the Chebyshev center of a 2D polyhedron

--- a/examples/communications/Channel_capacity_BV4.57.py
+++ b/examples/communications/Channel_capacity_BV4.57.py
@@ -18,8 +18,9 @@ limitations under the License.
 # @author: R. Gowers, S. Al-Izzi, T. Pollington, R. Hill & K. Briggs
 # Boyd and Vandenberghe, Convex Optimization, exercise 4.57 page 207
 
-import cvxpy as cvx
 import numpy as np
+
+import cvxpy as cvx
 
 '''
 Input parameters

--- a/examples/communications/maximise_minimum_SINR_BV4.20.py
+++ b/examples/communications/maximise_minimum_SINR_BV4.20.py
@@ -18,8 +18,9 @@ limitations under the License.
 # @author: R. Gowers, S. Al-Izzi, T. Pollington, R. Hill & K. Briggs
 # Boyd and Vandenberghe, Convex Optimization, exercise 4.20 page 196
 
-import cvxpy as cvx
 import numpy as np
+
+import cvxpy as cvx
 
 '''
 Input parameters

--- a/examples/communications/optimal_power_Gaussian_channel_BV4.62.py
+++ b/examples/communications/optimal_power_Gaussian_channel_BV4.62.py
@@ -19,6 +19,7 @@ limitations under the License.
 # Boyd and Vandenberghe, Convex Optimization, exercise 4.62 page 210
 
 import numpy as np
+
 import cvxpy as cvx
 
 '''

--- a/examples/communications/water_filling_BVex5.2.py
+++ b/examples/communications/water_filling_BVex5.2.py
@@ -19,6 +19,7 @@ limitations under the License.
 # Boyd and Vandenberghe, Convex Optimization, example 5.2 page 145
 
 import numpy as np
+
 import cvxpy as cvx
 
 '''

--- a/examples/consensus_admm.py
+++ b/examples/consensus_admm.py
@@ -16,7 +16,8 @@ limitations under the License.
 from multiprocessing import Pool
 
 import numpy as np
-from cvxpy import norm, Minimize, Problem, sum_squares, Variable
+
+from cvxpy import Minimize, Problem, Variable, norm, sum_squares
 
 # Problem data.
 m = 100

--- a/examples/deadzone.py
+++ b/examples/deadzone.py
@@ -17,7 +17,8 @@ limitations under the License.
 from __future__ import division
 
 import cvxopt
-from cvxpy import maximum, Minimize, Problem, Variable
+
+from cvxpy import Minimize, Problem, Variable, maximum
 
 # Taken from CVX website http://cvxr.com/cvx/examples/
 # Section 6.1.2: Residual minimization with deadzone penalty

--- a/examples/ex_4_3.py
+++ b/examples/ex_4_3.py
@@ -18,7 +18,8 @@ limitations under the License.
 from __future__ import division
 
 import cvxopt
-from cvxpy import Minimize, Problem, quad_form, Variable
+
+from cvxpy import Minimize, Problem, Variable, quad_form
 
 # Taken from CVX website http://cvxr.com/cvx/examples/
 # Example: CVX Textbook exercise 4.3: Solve a simple QP with inequality constraints

--- a/examples/ex_5_1.py
+++ b/examples/ex_5_1.py
@@ -15,12 +15,13 @@ limitations under the License.
 """
 
 from __future__ import division
+
 from multiprocessing import Pool
 
 import numpy as np
-from cvxpy import Minimize, Parameter, Problem, quad_form, Variable
 from pylab import axis, plot, show, title, xlabel, ylabel
 
+from cvxpy import Minimize, Parameter, Problem, Variable, quad_form
 
 # Taken from CVX website http://cvxr.com/cvx/examples/
 # Exercise 5.1d: Sensitivity analysis for a simple QCQP

--- a/examples/ex_5_33.py
+++ b/examples/ex_5_33.py
@@ -15,12 +15,14 @@ limitations under the License.
 """
 
 from __future__ import division
+
 from multiprocessing import Pool
 
 import cvxopt
 import numpy as np
-from cvxpy import norm, Minimize, Parameter, Problem, Variable
 from pylab import plot, show, title, xlabel, ylabel
+
+from cvxpy import Minimize, Parameter, Problem, Variable, norm
 
 # Taken from CVX website http://cvxr.com/cvx/examples/
 # Exercise 5.33: Parametrized l1-norm approximation

--- a/examples/expr_trees/1D_convolution.py
+++ b/examples/expr_trees/1D_convolution.py
@@ -16,11 +16,13 @@ limitations under the License.
 
 #!/usr/bin/env python
 
-from cvxpy import Minimize, Parameter, Problem, SCS, Variable, conv, norm
-import numpy as np
 import random
+from math import exp, pi, sqrt
 
-from math import pi, sqrt, exp
+import numpy as np
+
+from cvxpy import SCS, Minimize, Parameter, Problem, Variable, conv, norm
+
 
 def gauss(n: float = 11, sigma: float = 1):
     r = range(-int(n/2),int(n/2)+1)
@@ -65,6 +67,7 @@ data, dims = prob.get_problem_data(solver=SCS)
 
 # Plot result and fit.
 import matplotlib.pyplot as plt
+
 plt.plot(range(n), signal, label="true signal")
 plt.plot(range(n), np.asarray(noisy_signal.value[:n, 0]), label="noisy convolution")
 plt.plot(range(n), np.asarray(x.value[:,0]), label="recovered signal")

--- a/examples/expr_trees/helloworld.py
+++ b/examples/expr_trees/helloworld.py
@@ -16,11 +16,13 @@ limitations under the License.
 
 #!/usr/bin/env python
 
-from cvxpy import Minimize, Problem, SCS, Variable, conv, norm
-import numpy as np
 import random
+from math import exp, pi, sqrt
 
-from math import pi, sqrt, exp
+import numpy as np
+
+from cvxpy import SCS, Minimize, Problem, Variable, conv, norm
+
 
 def gauss(n: float = 11,sigma: float = 1):
     r = range(-int(n/2),int(n/2)+1)

--- a/examples/expr_trees/inpainting.py
+++ b/examples/expr_trees/inpainting.py
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from scipy import misc
 import matplotlib.pyplot as plt
 import numpy as np
+from scipy import misc
 
 l = misc.ascent()
 l = l.astype(np.float64, copy=False)
@@ -57,6 +57,7 @@ idx2pair = np.array(idx2pair) #convert back to numpy array
 
 import scipy.sparse as sp
 from cvxopt import spmatrix
+
 
 def involvedpairs(pairs):
     ''' Get all the pixel pairs whose gradient involves an unknown pixel.
@@ -120,6 +121,7 @@ def formCOO(pair2idx, img):
 
 Gx, Gy, bx, by = formCOO(pair2idx, r)
 import cvxpy as cp
+
 m, n = Gx.size
 x = cp.Variable(n)
 
@@ -132,6 +134,7 @@ constraints = [z[:, 0] == x.__rmul__(Gx) + bx,
 objective = cp.Minimize(sum([cp.norm(z[i,:]) for i in range(m)]))
 p = cp.Problem(objective, constraints)
 import cProfile
+
 cProfile.run("""
 result = p.solve(solver=cp.ECOS, verbose=True)
 """)

--- a/examples/expr_trees/performance.py
+++ b/examples/expr_trees/performance.py
@@ -15,8 +15,10 @@ limitations under the License.
 """
 
 from collections import namedtuple
-from cvxpy import Minimize, Problem, Variable, exp
+
 import scipy.sparse as sp
+
+from cvxpy import Minimize, Problem, Variable, exp
 
 n = 100
 x = Variable(n*n)

--- a/examples/expr_trees/portfolio.py
+++ b/examples/expr_trees/portfolio.py
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-# simple_portfolio_data
-from cvxpy import CVXOPT, ECOS, Minimize, Problem, SCS, Variable, quad_form
 import numpy as np
+
+# simple_portfolio_data
+from cvxpy import CVXOPT, ECOS, SCS, Minimize, Problem, Variable, quad_form
 
 np.random.seed(5)
 n = 8000
@@ -40,6 +41,7 @@ constraints_longonly = [sum(x) == 1, x >= 0]
 prob = Problem(objective, constraints_longonly)
 #constraints_totalshort = [sum(x) == 1, one.T * max(-x, 0) <= 0.5]
 import time
+
 print("starting problems")
 
 start = time.clock()

--- a/examples/expr_trees/portfolio_profiler.py
+++ b/examples/expr_trees/portfolio_profiler.py
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-# simple_portfolio_data
-from cvxpy import (
-    CVXOPT, ECOS, Minimize, Problem, SCS, Variable, norm, quad_form, square
-)
 import numpy as np
 import scipy.sparse as sp
+
+# simple_portfolio_data
+from cvxpy import (CVXOPT, ECOS, SCS, Minimize, Problem, Variable, norm,
+                   quad_form, square,)
 
 np.random.seed(5)
 n = 10000
@@ -54,6 +54,7 @@ constraints_longonly = [sum(x) == 1, x >= 0]
 prob = Problem(objective, constraints_longonly)
 #constraints_totalshort = [sum(x) == 1, one.T * max(-x, 0) <= 0.5]
 import time
+
 print("starting problems")
 
 start = time.clock()

--- a/examples/extensions/feature_selection.py
+++ b/examples/extensions/feature_selection.py
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy import Card, norm, Minimize, Parameter, pos, Problem, Variable
-from mixed_integer import *
 import numpy as np
+from mixed_integer import *
+
+from cvxpy import Card, Minimize, Parameter, Problem, Variable, norm, pos
 
 # Feature selection on a linear kernel SVM classifier.
 # Uses the Alternating Direction Method of Multipliers

--- a/examples/extensions/integer_ls.py
+++ b/examples/extensions/integer_ls.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy import Minimize, Problem, sum_squares
-from ncvx.boolean import Boolean
-import ncvx.branch_and_bound
 import cvxopt
+import ncvx.branch_and_bound
+from ncvx.boolean import Boolean
+
+from cvxpy import Minimize, Problem, sum_squares
 
 x = Boolean(3, name='x')
 A = cvxopt.matrix([1,2,3,4,5,6,7,8,9], (3, 3), tc='d')

--- a/examples/extensions/kmeans.py
+++ b/examples/extensions/kmeans.py
@@ -14,15 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy as cvx
 import mixed_integer as mi
+
+import cvxpy as cvx
 
 print(__doc__)
 
 from time import time
-import numpy as np
-import matplotlib.pyplot as plt
 
+import matplotlib.pyplot as plt
+import numpy as np
 from sklearn import metrics
 from sklearn.cluster import KMeans
 from sklearn.datasets import load_digits

--- a/examples/extensions/mixed_integer/__init__.py
+++ b/examples/extensions/mixed_integer/__init__.py
@@ -15,8 +15,8 @@ limitations under the License.
 """
 
 import admm_problem
+from assign import Assign
 from boolean import Boolean
 from card import Card
 from choose import Choose
 from integer import Integer
-from assign import Assign

--- a/examples/extensions/mixed_integer/admm_problem.py
+++ b/examples/extensions/mixed_integer/admm_problem.py
@@ -14,10 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from .noncvx_variable import NonCvxVariable
+import numpy as np
+
 import cvxpy as cvx
 from cvxpy import settings as s
-import numpy as np
+
+from .noncvx_variable import NonCvxVariable
+
 
 # Use ADMM to attempt non-convex problem.
 def admm(self, rho: float = 0.5, iterations: int = 5, *args, **kwargs):

--- a/examples/extensions/mixed_integer/assign.py
+++ b/examples/extensions/mixed_integer/assign.py
@@ -14,10 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from .boolean import Boolean
-import cvxpy.lin_ops.lin_utils as lu
-from munkres import Munkres
 import numpy as np
+from munkres import Munkres
+
+import cvxpy.lin_ops.lin_utils as lu
+
+from .boolean import Boolean
+
 
 class Assign(Boolean):
     """ An assignment matrix. """

--- a/examples/extensions/mixed_integer/boolean.py
+++ b/examples/extensions/mixed_integer/boolean.py
@@ -14,9 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from .noncvx_variable import NonCvxVariable
-import cvxpy.lin_ops.lin_utils as lu
 import numpy as np
+
+import cvxpy.lin_ops.lin_utils as lu
+
+from .noncvx_variable import NonCvxVariable
+
 
 class Boolean(NonCvxVariable):
     """ A boolean variable. """

--- a/examples/extensions/mixed_integer/card.py
+++ b/examples/extensions/mixed_integer/card.py
@@ -14,9 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from .noncvx_variable import NonCvxVariable
-import cvxpy.interface.matrix_utilities as intf
 from itertools import product
+
+import cvxpy.interface.matrix_utilities as intf
+
+from .noncvx_variable import NonCvxVariable
+
 
 class Card(NonCvxVariable):
     """ A variable with constrained cardinality. """

--- a/examples/extensions/mixed_integer/choose.py
+++ b/examples/extensions/mixed_integer/choose.py
@@ -14,10 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from .boolean import Boolean
+from itertools import product
+
 import cvxopt
 import numpy as np
-from itertools import product
+
+from .boolean import Boolean
+
 
 class Choose(Boolean):
     """ A variable with k 1's and all other entries 0. """

--- a/examples/extensions/mixed_integer/integer.py
+++ b/examples/extensions/mixed_integer/integer.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 from .noncvx_variable import NonCvxVariable
 
+
 class Integer(NonCvxVariable):
     """ An integer variable. """
     # All values set rounded to the nearest integer.

--- a/examples/extensions/mixed_integer/noncvx_variable.py
+++ b/examples/extensions/mixed_integer/noncvx_variable.py
@@ -15,9 +15,12 @@ limitations under the License.
 """
 
 import abc
+
+import cvxopt
+
 import cvxpy
 import cvxpy.interface as intf
-import cvxopt
+
 
 class NonCvxVariable(cvxpy.Variable):
     __metaclass__ = abc.ABCMeta

--- a/examples/extensions/mixed_integer/tests/test_vars.py
+++ b/examples/extensions/mixed_integer/tests/test_vars.py
@@ -14,11 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy import CVXOPT, Maximize, Minimize, Problem, Variable
-from mixed_integer import Assign, Boolean, Card, Choose
+import unittest
+
 import cvxopt
 import numpy as np
-import unittest
+from mixed_integer import Assign, Boolean, Card, Choose
+
+from cvxpy import CVXOPT, Maximize, Minimize, Problem, Variable
+
 
 class TestVars(unittest.TestCase):
     """ Unit tests for the variable types. """

--- a/examples/extensions/ncvx/boolean.py
+++ b/examples/extensions/ncvx/boolean.py
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.expressions.variable import Variable
-from cvxpy.expressions.constants import Parameter
 import cvxopt
 import numpy as np
+
+from cvxpy.expressions.constants import Parameter
+from cvxpy.expressions.variable import Variable
+
 
 class Boolean(Variable):
     def __init__(self, rows: int = 1, cols: int = 1, *args, **kwargs) -> None:

--- a/examples/extensions/ncvx/branch_and_bound.py
+++ b/examples/extensions/ncvx/branch_and_bound.py
@@ -15,9 +15,11 @@ limitations under the License.
 """
 
 import cvxopt
+from boolean import Boolean
+
 import cvxpy.problems.problem as problem
 import cvxpy.settings as s
-from boolean import Boolean
+
 
 def branch(booleans):
     bool_vals = (b for b in booleans if not b.fix_values)

--- a/examples/extensions/sudoku.py
+++ b/examples/extensions/sudoku.py
@@ -14,11 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy import Minimize, Problem, square
-from ncvx.boolean import Boolean
+import cProfile
+import pstats
+
 import cvxopt
-import cProfile, pstats
 import numpy as np
+from ncvx.boolean import Boolean
+
+from cvxpy import Minimize, Problem, square
 
 n = 9
 # 9x9 sudoku grid

--- a/examples/extensions/sudoku_admm.py
+++ b/examples/extensions/sudoku_admm.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy import Assign, Minimize, Problem, vstack
-from mixed_integer import *
 import cvxopt
 import numpy as np
+from mixed_integer import *
+
+from cvxpy import Assign, Minimize, Problem, vstack
 
 n = 9
 # 9x9 sudoku grid

--- a/examples/extensions/three_sat.py
+++ b/examples/extensions/three_sat.py
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy import Boolean, ECOS, Minimize, Problem
-from mixed_integer import *
 import random
+
 import numpy as np
+from mixed_integer import *
+
+from cvxpy import ECOS, Boolean, Minimize, Problem
 
 # TODO this is wrong because Boolean.u and Boolean.z aren't reset
 # between iterations.

--- a/examples/extensions/tsp.py
+++ b/examples/extensions/tsp.py
@@ -1,8 +1,10 @@
 from __future__ import division
-from cvxpy import Assign, ECOS, GUROBI, norm, Minimize, Problem, vstack
+
+import numpy as np
 from mixed_integer import *
 from ncvx import Boolean
-import numpy as np
+
+from cvxpy import ECOS, GUROBI, Assign, Minimize, Problem, norm, vstack
 
 # Traveling salesman problem.
 n = 10

--- a/examples/fig6_9.py
+++ b/examples/fig6_9.py
@@ -16,15 +16,14 @@ limitations under the License.
 
 from __future__ import division
 
-import numpy as np
 from multiprocessing import Pool
 
 import cvxopt
-from cvxpy import norm, Minimize, Parameter, Problem, Variable
-from scipy import sparse
+import numpy as np
 from pylab import plot, show, title, xlabel, ylabel
+from scipy import sparse
 
-
+from cvxpy import Minimize, Parameter, Problem, Variable, norm
 
 # Taken from CVX website http://cvxr.com/cvx/examples/
 # Figure 6.9: An optimal tradeoff curve

--- a/examples/floor_packing.py
+++ b/examples/floor_packing.py
@@ -16,7 +16,9 @@ limitations under the License.
 import math
 
 import pylab
-from cvxpy import geo_mean, Minimize, Problem, Variable, vstack
+
+from cvxpy import Minimize, Problem, Variable, geo_mean, vstack
+
 
 # Based on http://cvxopt.org/examples/book/floorplan.html
 class Box:

--- a/examples/flows/commodity_flow.py
+++ b/examples/flows/commodity_flow.py
@@ -18,9 +18,9 @@ import random as r
 
 import create_graph as g
 import cvxopt
-from cvxpy import Maximize, Problem, Variable
 from max_flow import Edge, Node
 
+from cvxpy import Maximize, Problem, Variable
 
 # Multi-commodity flow.
 COMMODITIES = 5 # Number of commodities.

--- a/examples/flows/create_graph.py
+++ b/examples/flows/create_graph.py
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import pickle
 # Construct a random connected graph and stores it as tuples of
 # (start node #, end node #, capacity).
-from random import sample, random
-import pickle
+from random import random, sample
 
 # Constants
 FILE = "graph_data"

--- a/examples/flows/incidence_matrix.py
+++ b/examples/flows/incidence_matrix.py
@@ -19,6 +19,7 @@ import pickle
 
 import create_graph as g
 import cvxopt
+
 from cvxpy import Maximize, Problem, Variable, vstack
 
 # Read a graph from a file.

--- a/examples/flows/leaky_edges.py
+++ b/examples/flows/leaky_edges.py
@@ -17,8 +17,10 @@ limitations under the License.
 import pickle
 
 from cvxpy import Maximize, Problem, Variable
-from .create_graph import FILE, NODE_COUNT_KEY, EDGES_KEY
-from .max_flow import Node, Edge
+
+from .create_graph import EDGES_KEY, FILE, NODE_COUNT_KEY
+from .max_flow import Edge, Node
+
 
 # Max-flow with different kinds of edges.
 class Directed(Edge):

--- a/examples/flows/max_flow.py
+++ b/examples/flows/max_flow.py
@@ -17,7 +17,9 @@ limitations under the License.
 import pickle
 
 from cvxpy import Maximize, Problem, Variable
-from .create_graph import FILE, NODE_COUNT_KEY, EDGES_KEY
+
+from .create_graph import EDGES_KEY, FILE, NODE_COUNT_KEY
+
 
 # An object oriented max-flow problem.
 class Edge:

--- a/examples/fmmc.py
+++ b/examples/fmmc.py
@@ -20,7 +20,9 @@ limitations under the License.
 # Boyd, Diaconis, and Xiao SIAM Rev. 46 (2004) 667-689 at p.672
 
 import numpy as np
+
 import cvxpy
+
 
 def antiadjacency(g):
   # form the complementary graph

--- a/examples/lasso.py
+++ b/examples/lasso.py
@@ -15,9 +15,10 @@ limitations under the License.
 """
 from multiprocessing import Pool
 
-import numpy as np
 import cvxopt
-from cvxpy import norm, Minimize, Parameter, Problem, sum_squares, Variable
+import numpy as np
+
+from cvxpy import Minimize, Parameter, Problem, Variable, norm, sum_squares
 
 # Problem data.
 n = 10

--- a/examples/machine_learning/lasso_regression.py
+++ b/examples/machine_learning/lasso_regression.py
@@ -1,6 +1,7 @@
-import cvxpy as cp
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
+import cvxpy as cp
 
 
 def loss_fn(X, Y, beta):

--- a/examples/machine_learning/ridge_regression.py
+++ b/examples/machine_learning/ridge_regression.py
@@ -1,6 +1,7 @@
-import cvxpy as cp
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
+import cvxpy as cp
 
 
 def loss_fn(X, Y, beta):

--- a/examples/matrix_games_LP.py
+++ b/examples/matrix_games_LP.py
@@ -18,6 +18,7 @@ limitations under the License.
 from __future__ import division
 
 import cvxopt
+
 from cvxpy import Maximize, Minimize, Problem, Variable
 
 # Taken from CVX website http://cvxr.com/cvx/examples/

--- a/examples/mpi_consensus_admm.py
+++ b/examples/mpi_consensus_admm.py
@@ -20,14 +20,15 @@ limitations under the License.
 # xi = argmin [f(xi) + (rho/2)norm(xi - xbar + ui)]
 # ui = ui + xi - xbar
 
+import operator as op
 from functools import reduce
 from multiprocessing import Pool
 
 import dill
 import numpy as np
-import operator as op
-from cvxpy import norm, Minimize, Parameter, Problem, sum_squares, Variable
 from numpy.random import randn
+
+from cvxpy import Minimize, Parameter, Problem, Variable, norm, sum_squares
 
 # Initialize the problem.
 n = 1000

--- a/examples/norm_approx.py
+++ b/examples/norm_approx.py
@@ -15,12 +15,13 @@ limitations under the License.
 """
 
 from __future__ import division
+
 import math
 
 import cvxopt
 import numpy as np
-from cvxpy import norm, Maximize, Minimize, Problem, square, Variable
 
+from cvxpy import Maximize, Minimize, Problem, Variable, norm, square
 
 # Taken from CVX website http://cvxr.com/cvx/examples/
 # Examples 5.6,5.8: An l_p norm approximation problem

--- a/examples/notebooks/simple_portfolio_data.py
+++ b/examples/notebooks/simple_portfolio_data.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 # simple_portfolio_data
 import numpy as np
+
 np.random.seed(5)
 n = 20
 pbar = (np.ones((n, 1)) * .03 +

--- a/examples/penalty_comp_cvx.py
+++ b/examples/penalty_comp_cvx.py
@@ -18,8 +18,9 @@ from __future__ import division
 
 import cvxopt
 import numpy as np
-from cvxpy import norm, Minimize, pos, Problem, Variable
 from pylab import hist, plot, show, subplot, title, ylabel
+
+from cvxpy import Minimize, Problem, Variable, norm, pos
 
 # Taken from CVX website http://cvxr.com/cvx/examples/
 # Figure 6.2: Penalty function approximation

--- a/examples/qcqp.py
+++ b/examples/qcqp.py
@@ -16,10 +16,12 @@ limitations under the License.
 
 # for decimal division
 from __future__ import division
+
 import sys
 
 import cvxopt
-from cvxpy import Minimize, OPTIMAL, Problem, quad_form, Variable
+
+from cvxpy import OPTIMAL, Minimize, Problem, Variable, quad_form
 
 # Taken from CVX website http://cvxr.com/cvx/examples/
 # Derived from Example: Finding the fastest mixing Markov chain on a graph

--- a/examples/relax_and_round.py
+++ b/examples/relax_and_round.py
@@ -18,7 +18,8 @@ limitations under the License.
 from __future__ import division
 
 import numpy
-from cvxpy import Minimize, Parameter, Problem, sum_squares, Variable
+
+from cvxpy import Minimize, Parameter, Problem, Variable, sum_squares
 
 # def bool_vars(prob):
 #     return [var for var in prob.variables() if var.boolean]
@@ -125,6 +126,7 @@ def example(n, get_vals: bool = False):
 
 # Plot relaxation z_star.
 import matplotlib.pyplot as plt
+
 n = 20
 vals = range(1, n+1)
 relaxed, rounded, truth = map(numpy.asarray, example(n, True))
@@ -137,6 +139,7 @@ plt.show()
 
 # Plot optimal values.
 import matplotlib.pyplot as plt
+
 relaxed = []
 rounded = []
 truth = []

--- a/examples/sdp.py
+++ b/examples/sdp.py
@@ -38,8 +38,9 @@ required to be PSD (instead of also Toeplitz)
 # prob = cvx.Problem(objective, constr)
 # prob.solve()
 
-import cvxpy as cp
 import numpy as np
+
+import cvxpy as cp
 
 # create data P
 P = cp.Parameter((3,3))

--- a/examples/tsp_mip.py
+++ b/examples/tsp_mip.py
@@ -15,7 +15,8 @@ limitations under the License.
 """
 
 import numpy as np
-from cvxpy import Minimize, multiply, Problem, Variable
+
+from cvxpy import Minimize, Problem, Variable, multiply
 
 # Based on formulation described
 #    @ https://en.wikipedia.org/wiki/Travelling_salesman_problem (February 2016)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import platform
 import sys
 
-from setuptools import setup, Extension, find_packages
+from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 
 


### PR DESCRIPTION
This is replicating #1436 to handle merge conflicts. Imports are sorted by applying ``isort --up --tc .`` to the project root.