### PR TITLE
WIP - backwards compatible support for SCS 3

### DIFF
--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -110,7 +110,7 @@ EQ, LEQ, SOC, SOC_EW, PSD, EXP, BOOL, INT = range(8)
 #   Riley follow-up on this: cone dims are now defined in matrix
 #   stuffing modules (e.g. cone_matrix_stuffing.py), rather than
 #   the solver module.
-EQ_DIM = "f"
+EQ_DIM = "z"
 LEQ_DIM = "l"
 SOC_DIM = "q"
 PSD_DIM = "s"


### PR DESCRIPTION
This is a work-in-progress. Many of the tests are failing due to accuracy, since the old SCS termination criteria is not the same as the new one.

This is an update to the cvxpy interface for SCS that should work in a backwards compatible way for all SCS versions.

This does *not* add support for any of the new SCS features, like the quadratic objective or the box cone.