### PR TITLE
[CI] Fix Windows deploy for cvxpy-base

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,6 +180,7 @@ jobs:
           python setup.py sdist --dist-dir=wheelhouse
 
       - name: Release to pypi
+        shell: bash
         if: ${{env.DEPLOY == 'True'}}
         run: |
           python -m pip install --upgrade twine


### PR DESCRIPTION
@SteveDiamond The default shell for Windows is `pwsh`, so `$PYPI_USER` is not recognized, leading to the error `twine upload: error: argument -u/--username: expected one argument`.