### PR TITLE
User-facing "infeasible or unbounded" status

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -38,6 +38,7 @@ from cvxpy.reductions.dgp2dcp.dgp2dcp import Dgp2Dcp
 from cvxpy.reductions.dqcp2dcp import dqcp2dcp
 from cvxpy.reductions.eval_params import EvalParams
 from cvxpy.reductions.flip_objective import FlipObjective
+from cvxpy.reductions.solution import INF_OR_UNB_MESSAGE
 from cvxpy.reductions.solvers import bisection
 from cvxpy.reductions.solvers import defines as slv_def
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
@@ -1297,6 +1298,8 @@ class Problem(u.Canonical):
                 "adjusting the solver settings, or solve with "
                 "verbose=True for more information."
             )
+        if solution.status == s.INFEASIBLE_OR_UNBOUNDED:
+            warnings.warn(INF_OR_UNB_MESSAGE)
         if solution.status in s.ERROR:
             raise error.SolverError(
                     "Solver '%s' failed. " % chain.solver.name() +

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -979,7 +979,8 @@ class Problem(u.Canonical):
         if verbose:
             print(_FOOTER)
             s.LOGGER.info('Problem status: %s', self.status)
-            s.LOGGER.info('Optimal value: %.3e', self.value)
+            val = self.value if self.value is not None else np.NaN
+            s.LOGGER.info('Optimal value: %.3e', val)
             s.LOGGER.info('Compilation took %.3e seconds', self._compilation_time)
             s.LOGGER.info(
                     'Solver (including time spent in interface) took '

--- a/cvxpy/reductions/solution.py
+++ b/cvxpy/reductions/solution.py
@@ -39,7 +39,7 @@ def failure_solution(status, attr=None) -> "Solution":
         opt_val = None
     if attr is None:
         attr = {}
-    if status == s.UNBOUNDED_INACCURATE:
+    if status == s.INFEASIBLE_OR_UNBOUNDED:
         attr['message'] = """
         The problem is either infeasible or unbounded, but the solver
         cannot tell which. Disable any solver-specific presolve methods

--- a/cvxpy/reductions/solution.py
+++ b/cvxpy/reductions/solution.py
@@ -17,6 +17,15 @@ import numpy as np
 
 import cvxpy.settings as s
 
+INF_OR_UNB_MESSAGE = """
+    The problem is either infeasible or unbounded, but the solver
+    cannot tell which. Disable any solver-specific presolve methods
+    and re-solve to determine the precise problem status.
+
+    For GUROBI and CPLEX you can automatically perform this re-solve
+    with the keyword argument prob.solve(reoptimize=True, ...).
+    """
+
 
 def failure_solution(status, attr=None) -> "Solution":
     """Factory function for infeasible or unbounded solutions.
@@ -40,14 +49,7 @@ def failure_solution(status, attr=None) -> "Solution":
     if attr is None:
         attr = {}
     if status == s.INFEASIBLE_OR_UNBOUNDED:
-        attr['message'] = """
-        The problem is either infeasible or unbounded, but the solver
-        cannot tell which. Disable any solver-specific presolve methods
-        and re-solve to determine the precise problem status.
-
-        For GUROBI and CPLEX you can automatically perform this re-solve
-        with the keyword argument prob.solve(reoptimize=True, ...).
-        """
+        attr['message'] = INF_OR_UNB_MESSAGE
     return Solution(status, opt_val, {}, {}, attr)
 
 

--- a/cvxpy/reductions/solution.py
+++ b/cvxpy/reductions/solution.py
@@ -39,6 +39,12 @@ def failure_solution(status, attr=None) -> "Solution":
         opt_val = None
     if attr is None:
         attr = {}
+    if status == s.UNBOUNDED_INACCURATE:
+        attr['message'] = """
+        The problem is either infeasible or unbounded, but the solver
+        cannot tell which. Disable any solver-specific presolve methods
+        and re-solve to determine the precise problem status.
+        """
     return Solution(status, opt_val, {}, {}, attr)
 
 

--- a/cvxpy/reductions/solution.py
+++ b/cvxpy/reductions/solution.py
@@ -44,6 +44,9 @@ def failure_solution(status, attr=None) -> "Solution":
         The problem is either infeasible or unbounded, but the solver
         cannot tell which. Disable any solver-specific presolve methods
         and re-solve to determine the precise problem status.
+
+        For GUROBI and CPLEX you can automatically perform this re-solve
+        with the keyword argument prob.solve(reoptimize=True, ...).
         """
     return Solution(status, opt_val, {}, {}, attr)
 

--- a/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
@@ -193,9 +193,10 @@ def get_status(model):
                      status.feasible_relaxed_inf,
                      status.feasible_relaxed_sum):
         return s.SOLVER_ERROR
-    elif solstat in (status.unbounded,
-                     status.infeasible_or_unbounded):
+    elif solstat == status.unbounded:
         return s.UNBOUNDED
+    elif solstat == status.infeasible_or_unbounded:
+        return s.INFEASIBLE_OR_UNBOUNDED
     else:
         return s.SOLVER_ERROR
 
@@ -358,6 +359,7 @@ class CPLEX(ConicSolver):
             model.parameters.preprocessing.qcpduals.values.force)
 
         # Set parameters
+        reoptimize = solver_opts.pop('reoptimize', True)
         set_parameters(model, solver_opts)
 
         # Solve problem
@@ -366,6 +368,14 @@ class CPLEX(ConicSolver):
             start_time = model.get_time()
             model.solve()
             solution[s.SOLVE_TIME] = model.get_time() - start_time
+
+            ambiguous_status = get_status(model) == s.INFEASIBLE_OR_UNBOUNDED
+            if ambiguous_status and reoptimize:
+                model.parameters.preprocessing.presolve.set(0)
+                start_time = model.get_time()
+                model.solve()
+                solution[s.SOLVE_TIME] += model.get_time() - start_time
+
         except Exception:
             pass
 

--- a/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
@@ -359,7 +359,7 @@ class CPLEX(ConicSolver):
             model.parameters.preprocessing.qcpduals.values.force)
 
         # Set parameters
-        reoptimize = solver_opts.pop('reoptimize', True)
+        reoptimize = solver_opts.pop('reoptimize', False)
         set_parameters(model, solver_opts)
 
         # Solve problem

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -37,7 +37,7 @@ class GUROBI(ConicSolver):
     # Map of Gurobi status to CVXPY status.
     STATUS_MAP = {2: s.OPTIMAL,
                   3: s.INFEASIBLE,
-                  4: s.SOLVER_ERROR,  # Triggers reoptimize.
+                  4: s.INFEASIBLE_OR_UNBOUNDED,  # Triggers reoptimize.
                   5: s.UNBOUNDED,
                   6: s.SOLVER_ERROR,
                   7: s.SOLVER_ERROR,
@@ -221,8 +221,10 @@ class GUROBI(ConicSolver):
         solution = {}
         try:
             model.optimize()
-            # Reoptimize if INF_OR_UNBD, to get definitive answer.
-            if model.Status == 4:
+            if model.Status == 4 and solver_opts.get('reoptimize', True):
+                # INF_OR_UNBD. The user hasn't specifically said
+                # reoptimize=False, so we solve again to get a definitive
+                # answer.
                 model.setParam("DualReductions", 0)
                 model.optimize()
             solution["value"] = model.ObjVal

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -221,10 +221,8 @@ class GUROBI(ConicSolver):
         solution = {}
         try:
             model.optimize()
-            if model.Status == 4 and solver_opts.get('reoptimize', True):
-                # INF_OR_UNBD. The user hasn't specifically said
-                # reoptimize=False, so we solve again to get a definitive
-                # answer.
+            if model.Status == 4 and solver_opts.get('reoptimize', False):
+                # INF_OR_UNBD. Solve again to get a definitive answer.
                 model.setParam("DualReductions", 0)
                 model.optimize()
             solution["value"] = model.ObjVal

--- a/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
@@ -49,7 +49,7 @@ STATUS_MAP = {
     # INF_OR_UNB
     "infeasible": s.INFEASIBLE,
     "unbounded": s.UNBOUNDED,
-    "inforunbd": s.UNBOUNDED_INACCURATE,
+    "inforunbd": s.INFEASIBLE_OR_UNBOUNDED,
     # ERROR
     "userinterrupt": s.SOLVER_ERROR,
     "memlimit": s.SOLVER_ERROR,

--- a/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
@@ -67,7 +67,7 @@ class CPLEX(QpSolver):
 
             sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            sol = failure_solution(status, dict())
+            sol = failure_solution(status, attr)
         return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):

--- a/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import cvxpy.interface as intf
 import cvxpy.settings as s
-from cvxpy.reductions import Solution
+from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.conic_solvers.cplex_conif import (
     get_status, hide_solver_output, set_parameters,)
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
@@ -65,14 +65,10 @@ class CPLEX(QpSolver):
                 y = -np.array(model.solution.get_dual_values())
                 dual_vars = {CPLEX.DUAL_VAR_ID: y}
 
+            sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            primal_vars = None
-            dual_vars = None
-            opt_val = np.inf
-            if status == s.UNBOUNDED:
-                opt_val = -np.inf
-
-        return Solution(status, opt_val, primal_vars, dual_vars, attr)
+            sol = failure_solution(status, dict())
+        return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
         import cplex as cpx
@@ -149,6 +145,7 @@ class CPLEX(QpSolver):
             hide_solver_output(model)
 
         # Set parameters
+        reoptimize = solver_opts.pop('reoptimize', True)
         set_parameters(model, solver_opts)
 
         # Solve problem
@@ -158,6 +155,14 @@ class CPLEX(QpSolver):
             model.solve()
             end = model.get_time()
             results_dict["cputime"] = end - start
+
+            ambiguous_status = get_status(model) == s.INFEASIBLE_OR_UNBOUNDED
+            if ambiguous_status and reoptimize:
+                model.parameters.preprocessing.presolve.set(0)
+                start_time = model.get_time()
+                model.solve()
+                results_dict["cputime"] += model.get_time() - start_time
+
         except Exception:  # Error in the solution
             results_dict["status"] = s.SOLVER_ERROR
 

--- a/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
@@ -145,7 +145,7 @@ class CPLEX(QpSolver):
             hide_solver_output(model)
 
         # Set parameters
-        reoptimize = solver_opts.pop('reoptimize', True)
+        reoptimize = solver_opts.pop('reoptimize', False)
         set_parameters(model, solver_opts)
 
         # Solve problem

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -234,10 +234,8 @@ class GUROBI(QpSolver):
         try:
             # Solve
             model.optimize()
-            if model.Status == 4 and solver_opts.get('reoptimize', True):
-                # INF_OR_UNBD. The user hasn't specifically said
-                # reoptimize=False, so we solve again to get a definitive
-                # answer.
+            if model.Status == 4 and solver_opts.get('reoptimize', False):
+                # INF_OR_UNBD. Solve again to get a definitive answer.
                 model.setParam("DualReductions", 0)
                 model.optimize()
         except Exception:  # Error in the solution

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import cvxpy.interface as intf
 import cvxpy.settings as s
-from cvxpy.reductions import Solution
+from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 
 
@@ -30,7 +30,7 @@ class GUROBI(QpSolver):
     STATUS_MAP = {2: s.OPTIMAL,
                   3: s.INFEASIBLE,
                   5: s.UNBOUNDED,
-                  4: s.INFEASIBLE_INACCURATE,
+                  4: s.INFEASIBLE_OR_UNBOUNDED,
                   6: s.INFEASIBLE,
                   7: s.SOLVER_ERROR,
                   8: s.SOLVER_ERROR,
@@ -94,14 +94,10 @@ class GUROBI(QpSolver):
                 y = -np.array([constraints_grb[i].Pi for i in range(m)])
                 dual_vars = {GUROBI.DUAL_VAR_ID: y}
 
+            sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            primal_vars = None
-            dual_vars = None
-            opt_val = np.inf
-            if status == s.UNBOUNDED:
-                opt_val = -np.inf
-
-        return Solution(status, opt_val, primal_vars, dual_vars, attr)
+            sol = failure_solution(status, dict())
+        return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
         import gurobipy as grb
@@ -238,6 +234,12 @@ class GUROBI(QpSolver):
         try:
             # Solve
             model.optimize()
+            if model.Status == 4 and solver_opts.get('reoptimize', True):
+                # INF_OR_UNBD. The user hasn't specifically said
+                # reoptimize=False, so we solve again to get a definitive
+                # answer.
+                model.setParam("DualReductions", 0)
+                model.optimize()
         except Exception:  # Error in the solution
             results_dict["status"] = s.SOLVER_ERROR
 

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -96,7 +96,7 @@ class GUROBI(QpSolver):
 
             sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            sol = failure_solution(status, dict())
+            sol = failure_solution(status, attr)
         return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -3,7 +3,7 @@ import scipy.sparse as sp
 
 import cvxpy.interface as intf
 import cvxpy.settings as s
-from cvxpy.reductions import Solution
+from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 
 
@@ -44,14 +44,10 @@ class OSQP(QpSolver):
             }
             dual_vars = {OSQP.DUAL_VAR_ID: solution.y}
             attr[s.NUM_ITERS] = solution.info.iter
+            sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            primal_vars = None
-            dual_vars = None
-            opt_val = np.inf
-            if status == s.UNBOUNDED:
-                opt_val = -np.inf
-
-        return Solution(status, opt_val, primal_vars, dual_vars, attr)
+            sol = failure_solution(status, dict())
+        return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts,
                        solver_cache=None):

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -46,7 +46,7 @@ class OSQP(QpSolver):
             attr[s.NUM_ITERS] = solution.info.iter
             sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            sol = failure_solution(status, dict())
+            sol = failure_solution(status, attr)
         return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts,

--- a/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
@@ -82,7 +82,7 @@ class XPRESS(QpSolver):
 
             sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            sol = failure_solution(status, dict())
+            sol = failure_solution(status, attr)
         return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):

--- a/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import cvxpy.interface as intf
 import cvxpy.settings as s
-from cvxpy.reductions import Solution
+from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.conic_solvers.xpress_conif import (
     get_status_maps, makeMstart,)
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
@@ -80,14 +80,10 @@ class XPRESS(QpSolver):
                 y = -np.array(results['getDual'])
                 dual_vars = {XPRESS.DUAL_VAR_ID: y}
 
+            sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            primal_vars = None
-            dual_vars = None
-            opt_val = np.inf
-            if status == s.UNBOUNDED:
-                opt_val = -np.inf
-
-        return Solution(status, opt_val, primal_vars, dual_vars, attr)
+            sol = failure_solution(status, dict())
+        return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
 

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -52,13 +52,15 @@ INFEASIBLE = "infeasible"
 INFEASIBLE_INACCURATE = "infeasible_inaccurate"
 UNBOUNDED = "unbounded"
 UNBOUNDED_INACCURATE = "unbounded_inaccurate"
+INFEASIBLE_OR_UNBOUNDED = "infeasible_or_unbounded"
 USER_LIMIT = "user_limit"
 SOLVER_ERROR = "solver_error"
 # Statuses that indicate a solution was found.
 SOLUTION_PRESENT = [OPTIMAL, OPTIMAL_INACCURATE, USER_LIMIT]
 # Statuses that indicate the problem is infeasible or unbounded.
 INF_OR_UNB = [INFEASIBLE, INFEASIBLE_INACCURATE,
-              UNBOUNDED, UNBOUNDED_INACCURATE]
+              UNBOUNDED, UNBOUNDED_INACCURATE,
+              INFEASIBLE_OR_UNBOUNDED]
 # Statuses that indicate an inaccurate solution.
 INACCURATE = [OPTIMAL_INACCURATE, INFEASIBLE_INACCURATE,
               UNBOUNDED_INACCURATE, USER_LIMIT]

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -800,8 +800,9 @@ class TestCPLEX(BaseTest):
     def test_cplex_lp_3(self) -> None:
         # CPLEX initially produces an INFEASIBLE_OR_UNBOUNDED status
         sth = sths.lp_3()
-        sth.prob.solve(solver='CPLEX')
-        self.assertEqual(sth.prob.status, cp.settings.INFEASIBLE_OR_UNBOUNDED)
+        with self.assertWarns(Warning):
+            sth.prob.solve(solver='CPLEX')
+            self.assertEqual(sth.prob.status, cp.settings.INFEASIBLE_OR_UNBOUNDED)
         # Determine the precise status with reoptimize=True.
         StandardTestLPs.test_lp_3(solver='CPLEX', reoptimize=True)
 
@@ -1021,15 +1022,16 @@ class TestGUROBI(BaseTest):
     def test_gurobi_lp_3(self) -> None:
         # GUROBI initially produces an INFEASIBLE_OR_UNBOUNDED status
         sth = sths.lp_3()
-        sth.prob.solve(solver='GUROBI')
-        self.assertEqual(sth.prob.status, cp.settings.INFEASIBLE_OR_UNBOUNDED)
+        with self.assertWarns(Warning):
+            sth.prob.solve(solver='GUROBI')
+            self.assertEqual(sth.prob.status, cp.settings.INFEASIBLE_OR_UNBOUNDED)
         # The user disables presolve and so makes reoptimization unnecessary
         StandardTestLPs.test_lp_3(solver='GUROBI', InfUnbdInfo=1)
         # The user determines the precise status with reoptimize=True
         StandardTestLPs.test_lp_3(solver='GUROBI', reoptimize=True)
 
     def test_gurobi_lp_4(self) -> None:
-        StandardTestLPs.test_lp_4(solver='GUROBI')
+        StandardTestLPs.test_lp_4(solver='GUROBI', reoptimize=True)
 
     def test_gurobi_lp_5(self) -> None:
         StandardTestLPs.test_lp_5(solver='GUROBI')

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -798,13 +798,12 @@ class TestCPLEX(BaseTest):
         StandardTestLPs.test_lp_2(solver='CPLEX')
 
     def test_cplex_lp_3(self) -> None:
-        # CPLEX initially produces an INFEASIBLE_OR_UNBOUNDED status,
-        # and the user will encounter that if they set reoptimize=False.
+        # CPLEX initially produces an INFEASIBLE_OR_UNBOUNDED status
         sth = sths.lp_3()
-        sth.prob.solve(solver='CPLEX', reoptimize=False)
+        sth.prob.solve(solver='CPLEX')
         self.assertEqual(sth.prob.status, cp.settings.INFEASIBLE_OR_UNBOUNDED)
-        # The user does nothing, and CPLEX silently reoptimizes.
-        StandardTestLPs.test_lp_3(solver='CPLEX')
+        # Determine the precise status with reoptimize=True.
+        StandardTestLPs.test_lp_3(solver='CPLEX', reoptimize=True)
 
     def test_cplex_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver='CPLEX')
@@ -1020,15 +1019,14 @@ class TestGUROBI(BaseTest):
         StandardTestLPs.test_lp_2(solver='GUROBI')
 
     def test_gurobi_lp_3(self) -> None:
-        # GUROBI initially produces an INFEASIBLE_OR_UNBOUNDED status,
-        # and the user will encounter that if they set reoptimize=False.
+        # GUROBI initially produces an INFEASIBLE_OR_UNBOUNDED status
         sth = sths.lp_3()
-        sth.prob.solve(solver='GUROBI', reoptimize=False)
+        sth.prob.solve(solver='GUROBI')
         self.assertEqual(sth.prob.status, cp.settings.INFEASIBLE_OR_UNBOUNDED)
         # The user disables presolve and so makes reoptimization unnecessary
-        StandardTestLPs.test_lp_3(solver='GUROBI', InfUnbdInfo=1, reoptimize=False)
-        # The user does nothing, and GUROBI silently reoptimizes.
-        StandardTestLPs.test_lp_3(solver='GUROBI')
+        StandardTestLPs.test_lp_3(solver='GUROBI', InfUnbdInfo=1)
+        # The user determines the precise status with reoptimize=True
+        StandardTestLPs.test_lp_3(solver='GUROBI', reoptimize=True)
 
     def test_gurobi_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver='GUROBI')

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -865,6 +865,12 @@ The following cut-generators are available:
 ``'cplex_filename'``
     a string specifying the filename to which the problem will be written. For example, use "model.lp", "model.sav", or "model.mps" to export to the LP, SAV, and MPS formats, respectively.
 
+``reoptimize``
+    A boolean. This is only relevant for problems where CPLEX initially produces an "infeasible or unbounded" status.
+    Its default value is True, which means that if CPLEX produces an "infeasible or unbounded" status, then its algorithm
+    parameters are automatically changed and the problem is re-solved in order to determine its precise status.
+
+
 `NAG`_ options:
 
 ``'nag_params'``
@@ -888,6 +894,11 @@ In addition to Gurobi's parameters, the following options are available:
 
 ``'env'``
     Allows for the passage of a Gurobi Environment, which specifies parameters and license information.  Keyword arguments will override any settings in this environment.
+
+``reoptimize``
+    A boolean. This is only relevant for problems where GUROBI initially produces an "infeasible or unbounded" status.
+    Its default value is True, which means that if GUROBI produces an "infeasible or unbounded" status, then its algorithm
+    parameters are automatically changed and the problem is re-solved in order to determine its precise status.
 
 Getting the standard form
 -------------------------

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -867,7 +867,7 @@ The following cut-generators are available:
 
 ``reoptimize``
     A boolean. This is only relevant for problems where CPLEX initially produces an "infeasible or unbounded" status.
-    Its default value is True, which means that if CPLEX produces an "infeasible or unbounded" status, then its algorithm
+    Its default value is False. If set to True, then if CPLEX produces an "infeasible or unbounded" status, its algorithm
     parameters are automatically changed and the problem is re-solved in order to determine its precise status.
 
 
@@ -897,7 +897,7 @@ In addition to Gurobi's parameters, the following options are available:
 
 ``reoptimize``
     A boolean. This is only relevant for problems where GUROBI initially produces an "infeasible or unbounded" status.
-    Its default value is True, which means that if GUROBI produces an "infeasible or unbounded" status, then its algorithm
+    Its default value is False. If set to True, then if GUROBI produces an "infeasible or unbounded" status, its algorithm
     parameters are automatically changed and the problem is re-solved in order to determine its precise status.
 
 Getting the standard form

--- a/doc/source/tutorial/intro/index.rst
+++ b/doc/source/tutorial/intro/index.rst
@@ -137,12 +137,21 @@ CVXPY provides the following constants as aliases for the different status strin
 *  ``OPTIMAL_INACCURATE``
 * ``INFEASIBLE_INACCURATE``
 * ``UNBOUNDED_INACCURATE``
+* ``INFEASIBLE_OR_UNBOUNDED``
 
-For example, to test if a problem was solved successfully, you would use
+To test if a problem was solved successfully, you would use
 
 .. code:: python
 
     prob.status == OPTIMAL
+
+The status ``INFEASIBLE_OR_UNBOUNDED`` is rare. It's used when a solver was able to
+determine that the problem was either infeasible or unbounded, but could not tell which.
+You can determine the precise status by re-solving the problem where you where you
+set the objective function to a constant (e.g., ``objective = cp.Minimize(0)``).
+If the new problem is solved with status code ``INFEASIBLE_OR_UNBOUNDED`` then the
+original problem was infeasible. If the new problem is solved with status ``OPTIMAL``
+then the original problem was unbounded.
 
 Vectors and matrices
 --------------------

--- a/doc/source/tutorial/intro/index.rst
+++ b/doc/source/tutorial/intro/index.rst
@@ -147,7 +147,7 @@ To test if a problem was solved successfully, you would use
 
 The status ``INFEASIBLE_OR_UNBOUNDED`` is rare. It's used when a solver was able to
 determine that the problem was either infeasible or unbounded, but could not tell which.
-You can determine the precise status by re-solving the problem where you where you
+You can determine the precise status by re-solving the problem where you
 set the objective function to a constant (e.g., ``objective = cp.Minimize(0)``).
 If the new problem is solved with status code ``INFEASIBLE_OR_UNBOUNDED`` then the
 original problem was infeasible. If the new problem is solved with status ``OPTIMAL``


### PR DESCRIPTION
This resolves #1071.  I added a user-facing ``INFEASIBLE_OR_UNBOUNDED`` status. I also changed GUROBI and CPLEX interfaces (conic and QP) to automatically re-solve when they encounter such a status. The documentation has been updated so that users can set ``reoptimize=False`` when using these solvers and get the ``INFEASIBLE_OR_UNBOUNDED`` status directly. I'm open to discussion on what the default behavior here should actually be.
