### PR TITLE
Specify tests paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,11 @@ extend_skip = [
     "cvxpy/reductions/dcp2cone/atom_canonicalizers/__init__.py"
 ]
 
+[tool.pytest.ini_options]
+testpaths = [
+    "cvxpy/tests/"
+]
+
 [build-system]
 requires = [
     "numpy>=1.15,<1.16; python_version=='3.6'",


### PR DESCRIPTION
Adding this config, one can call
```
pytest
```
instead of 
```
pytest cvxpy/tests
```

The former also so far added tests from `cvxpy/examples/extensions/mixed_integer/tests/test_vars.py`, which fail (at least in my case).
Additionally, the tests from the examples folder could be moved to `cvxpy/tests`, if they are still relevant.