### PR TITLE
Have complex2real handle absence of dual variables

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -38,6 +38,7 @@ from cvxpy.reductions.dgp2dcp.dgp2dcp import Dgp2Dcp
 from cvxpy.reductions.dqcp2dcp import dqcp2dcp
 from cvxpy.reductions.eval_params import EvalParams
 from cvxpy.reductions.flip_objective import FlipObjective
+from cvxpy.reductions.solution import INF_OR_UNB_MESSAGE
 from cvxpy.reductions.solvers import bisection
 from cvxpy.reductions.solvers import defines as slv_def
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
@@ -1297,6 +1298,8 @@ class Problem(u.Canonical):
                 "adjusting the solver settings, or solve with "
                 "verbose=True for more information."
             )
+        if solution.status == s.INFEASIBLE_OR_UNBOUNDED:
+            warnings.warn(INF_OR_UNB_MESSAGE)
         if solution.status in s.ERROR:
             raise error.SolverError(
                     "Solver '%s' failed. " % chain.solver.name() +

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -979,7 +979,8 @@ class Problem(u.Canonical):
         if verbose:
             print(_FOOTER)
             s.LOGGER.info('Problem status: %s', self.status)
-            s.LOGGER.info('Optimal value: %.3e', self.value)
+            val = self.value if self.value is not None else np.NaN
+            s.LOGGER.info('Optimal value: %.3e', val)
             s.LOGGER.info('Compilation took %.3e seconds', self._compilation_time)
             s.LOGGER.info(
                     'Solver (including time spent in interface) took '

--- a/cvxpy/reductions/complex2real/complex2real.py
+++ b/cvxpy/reductions/complex2real/complex2real.py
@@ -93,33 +93,34 @@ class Complex2Real(Reduction):
                             1j*solution.primal_vars[imag_id]
                     else:
                         pvars[vid] = solution.primal_vars[vid]
-            for cid, cons in inverse_data.id2cons.items():
-                if cons.is_real():
-                    dvars[cid] = solution.dual_vars[cid]
-                elif cons.is_imag():
-                    imag_id = inverse_data.real2imag[cid]
-                    dvars[cid] = 1j*solution.dual_vars[imag_id]
-                # For equality and inequality constraints.
-                elif isinstance(cons,
-                                (Equality, Zero, Inequality,
-                                 NonNeg, NonPos)
-                                ) and cons.is_complex():
-                    imag_id = inverse_data.real2imag[cid]
-                    if imag_id in solution.dual_vars:
-                        dvars[cid] = solution.dual_vars[cid] + \
-                            1j*solution.dual_vars[imag_id]
-                    else:
+            if solution.dual_vars:
+                for cid, cons in inverse_data.id2cons.items():
+                    if cons.is_real():
                         dvars[cid] = solution.dual_vars[cid]
-                elif isinstance(cons, SOC) and cons.is_complex():
-                    # TODO add dual variables for complex SOC.
-                    pass
-                # For PSD constraints.
-                elif isinstance(cons, PSD) and cons.is_complex():
-                    n = cons.args[0].shape[0]
-                    dual = solution.dual_vars[cid]
-                    dvars[cid] = dual[:n, :n] + 1j*dual[n:, :n]
-                else:
-                    raise Exception("Unknown constraint type.")
+                    elif cons.is_imag():
+                        imag_id = inverse_data.real2imag[cid]
+                        dvars[cid] = 1j*solution.dual_vars[imag_id]
+                    # For equality and inequality constraints.
+                    elif isinstance(cons,
+                                    (Equality, Zero, Inequality,
+                                     NonNeg, NonPos)
+                                    ) and cons.is_complex():
+                        imag_id = inverse_data.real2imag[cid]
+                        if imag_id in solution.dual_vars:
+                            dvars[cid] = solution.dual_vars[cid] + \
+                                1j*solution.dual_vars[imag_id]
+                        else:
+                            dvars[cid] = solution.dual_vars[cid]
+                    elif isinstance(cons, SOC) and cons.is_complex():
+                        # TODO add dual variables for complex SOC.
+                        pass
+                    # For PSD constraints.
+                    elif isinstance(cons, PSD) and cons.is_complex():
+                        n = cons.args[0].shape[0]
+                        dual = solution.dual_vars[cid]
+                        dvars[cid] = dual[:n, :n] + 1j*dual[n:, :n]
+                    else:
+                        raise Exception("Unknown constraint type.")
 
         return Solution(solution.status, solution.opt_val, pvars, dvars,
                         solution.attr)

--- a/cvxpy/reductions/solution.py
+++ b/cvxpy/reductions/solution.py
@@ -39,7 +39,7 @@ def failure_solution(status, attr=None) -> "Solution":
         opt_val = None
     if attr is None:
         attr = {}
-    if status == s.UNBOUNDED_INACCURATE:
+    if status == s.INFEASIBLE_OR_UNBOUNDED:
         attr['message'] = """
         The problem is either infeasible or unbounded, but the solver
         cannot tell which. Disable any solver-specific presolve methods

--- a/cvxpy/reductions/solution.py
+++ b/cvxpy/reductions/solution.py
@@ -17,6 +17,15 @@ import numpy as np
 
 import cvxpy.settings as s
 
+INF_OR_UNB_MESSAGE = """
+    The problem is either infeasible or unbounded, but the solver
+    cannot tell which. Disable any solver-specific presolve methods
+    and re-solve to determine the precise problem status.
+
+    For GUROBI and CPLEX you can automatically perform this re-solve
+    with the keyword argument prob.solve(reoptimize=True, ...).
+    """
+
 
 def failure_solution(status, attr=None) -> "Solution":
     """Factory function for infeasible or unbounded solutions.
@@ -40,14 +49,7 @@ def failure_solution(status, attr=None) -> "Solution":
     if attr is None:
         attr = {}
     if status == s.INFEASIBLE_OR_UNBOUNDED:
-        attr['message'] = """
-        The problem is either infeasible or unbounded, but the solver
-        cannot tell which. Disable any solver-specific presolve methods
-        and re-solve to determine the precise problem status.
-
-        For GUROBI and CPLEX you can automatically perform this re-solve
-        with the keyword argument prob.solve(reoptimize=True, ...).
-        """
+        attr['message'] = INF_OR_UNB_MESSAGE
     return Solution(status, opt_val, {}, {}, attr)
 
 

--- a/cvxpy/reductions/solution.py
+++ b/cvxpy/reductions/solution.py
@@ -39,6 +39,12 @@ def failure_solution(status, attr=None) -> "Solution":
         opt_val = None
     if attr is None:
         attr = {}
+    if status == s.UNBOUNDED_INACCURATE:
+        attr['message'] = """
+        The problem is either infeasible or unbounded, but the solver
+        cannot tell which. Disable any solver-specific presolve methods
+        and re-solve to determine the precise problem status.
+        """
     return Solution(status, opt_val, {}, {}, attr)
 
 

--- a/cvxpy/reductions/solution.py
+++ b/cvxpy/reductions/solution.py
@@ -44,6 +44,9 @@ def failure_solution(status, attr=None) -> "Solution":
         The problem is either infeasible or unbounded, but the solver
         cannot tell which. Disable any solver-specific presolve methods
         and re-solve to determine the precise problem status.
+
+        For GUROBI and CPLEX you can automatically perform this re-solve
+        with the keyword argument prob.solve(reoptimize=True, ...).
         """
     return Solution(status, opt_val, {}, {}, attr)
 

--- a/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
@@ -193,9 +193,10 @@ def get_status(model):
                      status.feasible_relaxed_inf,
                      status.feasible_relaxed_sum):
         return s.SOLVER_ERROR
-    elif solstat in (status.unbounded,
-                     status.infeasible_or_unbounded):
+    elif solstat == status.unbounded:
         return s.UNBOUNDED
+    elif solstat == status.infeasible_or_unbounded:
+        return s.INFEASIBLE_OR_UNBOUNDED
     else:
         return s.SOLVER_ERROR
 
@@ -358,6 +359,7 @@ class CPLEX(ConicSolver):
             model.parameters.preprocessing.qcpduals.values.force)
 
         # Set parameters
+        reoptimize = solver_opts.pop('reoptimize', True)
         set_parameters(model, solver_opts)
 
         # Solve problem
@@ -366,6 +368,14 @@ class CPLEX(ConicSolver):
             start_time = model.get_time()
             model.solve()
             solution[s.SOLVE_TIME] = model.get_time() - start_time
+
+            ambiguous_status = get_status(model) == s.INFEASIBLE_OR_UNBOUNDED
+            if ambiguous_status and reoptimize:
+                model.parameters.preprocessing.presolve.set(0)
+                start_time = model.get_time()
+                model.solve()
+                solution[s.SOLVE_TIME] += model.get_time() - start_time
+
         except Exception:
             pass
 

--- a/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
@@ -359,7 +359,7 @@ class CPLEX(ConicSolver):
             model.parameters.preprocessing.qcpduals.values.force)
 
         # Set parameters
-        reoptimize = solver_opts.pop('reoptimize', True)
+        reoptimize = solver_opts.pop('reoptimize', False)
         set_parameters(model, solver_opts)
 
         # Solve problem

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -37,7 +37,7 @@ class GUROBI(ConicSolver):
     # Map of Gurobi status to CVXPY status.
     STATUS_MAP = {2: s.OPTIMAL,
                   3: s.INFEASIBLE,
-                  4: s.SOLVER_ERROR,  # Triggers reoptimize.
+                  4: s.INFEASIBLE_OR_UNBOUNDED,  # Triggers reoptimize.
                   5: s.UNBOUNDED,
                   6: s.SOLVER_ERROR,
                   7: s.SOLVER_ERROR,
@@ -221,8 +221,10 @@ class GUROBI(ConicSolver):
         solution = {}
         try:
             model.optimize()
-            # Reoptimize if INF_OR_UNBD, to get definitive answer.
-            if model.Status == 4:
+            if model.Status == 4 and solver_opts.get('reoptimize', True):
+                # INF_OR_UNBD. The user hasn't specifically said
+                # reoptimize=False, so we solve again to get a definitive
+                # answer.
                 model.setParam("DualReductions", 0)
                 model.optimize()
             solution["value"] = model.ObjVal

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -221,10 +221,8 @@ class GUROBI(ConicSolver):
         solution = {}
         try:
             model.optimize()
-            if model.Status == 4 and solver_opts.get('reoptimize', True):
-                # INF_OR_UNBD. The user hasn't specifically said
-                # reoptimize=False, so we solve again to get a definitive
-                # answer.
+            if model.Status == 4 and solver_opts.get('reoptimize', False):
+                # INF_OR_UNBD. Solve again to get a definitive answer.
                 model.setParam("DualReductions", 0)
                 model.optimize()
             solution["value"] = model.ObjVal

--- a/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
@@ -49,7 +49,7 @@ STATUS_MAP = {
     # INF_OR_UNB
     "infeasible": s.INFEASIBLE,
     "unbounded": s.UNBOUNDED,
-    "inforunbd": s.UNBOUNDED_INACCURATE,
+    "inforunbd": s.INFEASIBLE_OR_UNBOUNDED,
     # ERROR
     "userinterrupt": s.SOLVER_ERROR,
     "memlimit": s.SOLVER_ERROR,

--- a/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
@@ -67,7 +67,7 @@ class CPLEX(QpSolver):
 
             sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            sol = failure_solution(status, dict())
+            sol = failure_solution(status, attr)
         return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):

--- a/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import cvxpy.interface as intf
 import cvxpy.settings as s
-from cvxpy.reductions import Solution
+from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.conic_solvers.cplex_conif import (
     get_status, hide_solver_output, set_parameters,)
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
@@ -65,14 +65,10 @@ class CPLEX(QpSolver):
                 y = -np.array(model.solution.get_dual_values())
                 dual_vars = {CPLEX.DUAL_VAR_ID: y}
 
+            sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            primal_vars = None
-            dual_vars = None
-            opt_val = np.inf
-            if status == s.UNBOUNDED:
-                opt_val = -np.inf
-
-        return Solution(status, opt_val, primal_vars, dual_vars, attr)
+            sol = failure_solution(status, dict())
+        return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
         import cplex as cpx
@@ -149,6 +145,7 @@ class CPLEX(QpSolver):
             hide_solver_output(model)
 
         # Set parameters
+        reoptimize = solver_opts.pop('reoptimize', True)
         set_parameters(model, solver_opts)
 
         # Solve problem
@@ -158,6 +155,14 @@ class CPLEX(QpSolver):
             model.solve()
             end = model.get_time()
             results_dict["cputime"] = end - start
+
+            ambiguous_status = get_status(model) == s.INFEASIBLE_OR_UNBOUNDED
+            if ambiguous_status and reoptimize:
+                model.parameters.preprocessing.presolve.set(0)
+                start_time = model.get_time()
+                model.solve()
+                results_dict["cputime"] += model.get_time() - start_time
+
         except Exception:  # Error in the solution
             results_dict["status"] = s.SOLVER_ERROR
 

--- a/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
@@ -145,7 +145,7 @@ class CPLEX(QpSolver):
             hide_solver_output(model)
 
         # Set parameters
-        reoptimize = solver_opts.pop('reoptimize', True)
+        reoptimize = solver_opts.pop('reoptimize', False)
         set_parameters(model, solver_opts)
 
         # Solve problem

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -234,10 +234,8 @@ class GUROBI(QpSolver):
         try:
             # Solve
             model.optimize()
-            if model.Status == 4 and solver_opts.get('reoptimize', True):
-                # INF_OR_UNBD. The user hasn't specifically said
-                # reoptimize=False, so we solve again to get a definitive
-                # answer.
+            if model.Status == 4 and solver_opts.get('reoptimize', False):
+                # INF_OR_UNBD. Solve again to get a definitive answer.
                 model.setParam("DualReductions", 0)
                 model.optimize()
         except Exception:  # Error in the solution

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import cvxpy.interface as intf
 import cvxpy.settings as s
-from cvxpy.reductions import Solution
+from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 
 
@@ -30,7 +30,7 @@ class GUROBI(QpSolver):
     STATUS_MAP = {2: s.OPTIMAL,
                   3: s.INFEASIBLE,
                   5: s.UNBOUNDED,
-                  4: s.INFEASIBLE_INACCURATE,
+                  4: s.INFEASIBLE_OR_UNBOUNDED,
                   6: s.INFEASIBLE,
                   7: s.SOLVER_ERROR,
                   8: s.SOLVER_ERROR,
@@ -94,14 +94,10 @@ class GUROBI(QpSolver):
                 y = -np.array([constraints_grb[i].Pi for i in range(m)])
                 dual_vars = {GUROBI.DUAL_VAR_ID: y}
 
+            sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            primal_vars = None
-            dual_vars = None
-            opt_val = np.inf
-            if status == s.UNBOUNDED:
-                opt_val = -np.inf
-
-        return Solution(status, opt_val, primal_vars, dual_vars, attr)
+            sol = failure_solution(status, dict())
+        return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
         import gurobipy as grb
@@ -238,6 +234,12 @@ class GUROBI(QpSolver):
         try:
             # Solve
             model.optimize()
+            if model.Status == 4 and solver_opts.get('reoptimize', True):
+                # INF_OR_UNBD. The user hasn't specifically said
+                # reoptimize=False, so we solve again to get a definitive
+                # answer.
+                model.setParam("DualReductions", 0)
+                model.optimize()
         except Exception:  # Error in the solution
             results_dict["status"] = s.SOLVER_ERROR
 

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -96,7 +96,7 @@ class GUROBI(QpSolver):
 
             sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            sol = failure_solution(status, dict())
+            sol = failure_solution(status, attr)
         return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -3,7 +3,7 @@ import scipy.sparse as sp
 
 import cvxpy.interface as intf
 import cvxpy.settings as s
-from cvxpy.reductions import Solution
+from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 
 
@@ -44,14 +44,10 @@ class OSQP(QpSolver):
             }
             dual_vars = {OSQP.DUAL_VAR_ID: solution.y}
             attr[s.NUM_ITERS] = solution.info.iter
+            sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            primal_vars = None
-            dual_vars = None
-            opt_val = np.inf
-            if status == s.UNBOUNDED:
-                opt_val = -np.inf
-
-        return Solution(status, opt_val, primal_vars, dual_vars, attr)
+            sol = failure_solution(status, dict())
+        return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts,
                        solver_cache=None):

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -46,7 +46,7 @@ class OSQP(QpSolver):
             attr[s.NUM_ITERS] = solution.info.iter
             sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            sol = failure_solution(status, dict())
+            sol = failure_solution(status, attr)
         return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts,

--- a/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
@@ -82,7 +82,7 @@ class XPRESS(QpSolver):
 
             sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            sol = failure_solution(status, dict())
+            sol = failure_solution(status, attr)
         return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):

--- a/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import cvxpy.interface as intf
 import cvxpy.settings as s
-from cvxpy.reductions import Solution
+from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.conic_solvers.xpress_conif import (
     get_status_maps, makeMstart,)
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
@@ -80,14 +80,10 @@ class XPRESS(QpSolver):
                 y = -np.array(results['getDual'])
                 dual_vars = {XPRESS.DUAL_VAR_ID: y}
 
+            sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            primal_vars = None
-            dual_vars = None
-            opt_val = np.inf
-            if status == s.UNBOUNDED:
-                opt_val = -np.inf
-
-        return Solution(status, opt_val, primal_vars, dual_vars, attr)
+            sol = failure_solution(status, dict())
+        return sol
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
 

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -52,13 +52,15 @@ INFEASIBLE = "infeasible"
 INFEASIBLE_INACCURATE = "infeasible_inaccurate"
 UNBOUNDED = "unbounded"
 UNBOUNDED_INACCURATE = "unbounded_inaccurate"
+INFEASIBLE_OR_UNBOUNDED = "infeasible_or_unbounded"
 USER_LIMIT = "user_limit"
 SOLVER_ERROR = "solver_error"
 # Statuses that indicate a solution was found.
 SOLUTION_PRESENT = [OPTIMAL, OPTIMAL_INACCURATE, USER_LIMIT]
 # Statuses that indicate the problem is infeasible or unbounded.
 INF_OR_UNB = [INFEASIBLE, INFEASIBLE_INACCURATE,
-              UNBOUNDED, UNBOUNDED_INACCURATE]
+              UNBOUNDED, UNBOUNDED_INACCURATE,
+              INFEASIBLE_OR_UNBOUNDED]
 # Statuses that indicate an inaccurate solution.
 INACCURATE = [OPTIMAL_INACCURATE, INFEASIBLE_INACCURATE,
               UNBOUNDED_INACCURATE, USER_LIMIT]

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -14,18 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sys
-
 import numpy as np
 import scipy.sparse as sp
 
-import cvxpy as cvx
+import cvxpy as cp
 from cvxpy import Minimize, Problem
 from cvxpy.expressions.constants import Constant, Parameter
 from cvxpy.expressions.variable import Variable
 from cvxpy.tests.base_test import BaseTest
-
-PY35 = sys.version_info >= (3, 5)
 
 
 class TestComplex(BaseTest):
@@ -104,7 +100,7 @@ class TestComplex(BaseTest):
         self.assertEqual(str(cm.exception), "The 'minimize' objective must be real valued.")
 
         with self.assertRaises(Exception) as cm:
-            cvx.Maximize(x)
+            cp.Maximize(x)
         self.assertEqual(str(cm.exception), "The 'maximize' objective must be real valued.")
 
     def test_arithmetic(self) -> None:
@@ -148,14 +144,14 @@ class TestComplex(BaseTest):
         """
         A = np.ones((2, 2))
         expr = Constant(A) + 1j*Constant(A)
-        expr = cvx.real(expr)
+        expr = cp.real(expr)
         assert expr.is_real()
         assert not expr.is_complex()
         assert not expr.is_imag()
         self.assertItemsAlmostEqual(expr.value, A)
 
         x = Variable(complex=True)
-        expr = cvx.imag(x) + cvx.real(x)
+        expr = cp.imag(x) + cp.real(x)
         assert expr.is_real()
 
     def test_imag(self) -> None:
@@ -163,7 +159,7 @@ class TestComplex(BaseTest):
         """
         A = np.ones((2, 2))
         expr = Constant(A) + 2j*Constant(A)
-        expr = cvx.imag(expr)
+        expr = cp.imag(expr)
         assert expr.is_real()
         assert not expr.is_complex()
         assert not expr.is_imag()
@@ -174,7 +170,7 @@ class TestComplex(BaseTest):
         """
         A = np.ones((2, 2))
         expr = Constant(A) + 1j*Constant(A)
-        expr = cvx.conj(expr)
+        expr = cp.conj(expr)
         assert not expr.is_real()
         assert expr.is_complex()
         assert not expr.is_imag()
@@ -185,7 +181,7 @@ class TestComplex(BaseTest):
         """
         # Scalar.
         x = Variable()
-        expr = cvx.imag(x + 1j*x)
+        expr = cp.imag(x + 1j*x)
         prob = Problem(Minimize(expr), [x >= 0])
         result = prob.solve(solver="SCS", eps=1e-6)
         self.assertAlmostEqual(result, 0)
@@ -193,29 +189,29 @@ class TestComplex(BaseTest):
 
         x = Variable(imag=True)
         expr = 1j*x
-        prob = Problem(Minimize(expr), [cvx.imag(x) <= 1])
+        prob = Problem(Minimize(expr), [cp.imag(x) <= 1])
         result = prob.solve(solver="SCS", eps=1e-6)
         self.assertAlmostEqual(result, -1)
         self.assertAlmostEqual(x.value, 1j)
 
         x = Variable(2)
         expr = x*1j
-        prob = Problem(Minimize(expr[0]*1j + expr[1]*1j), [cvx.real(x + 1j) >= 1])
+        prob = Problem(Minimize(expr[0]*1j + expr[1]*1j), [cp.real(x + 1j) >= 1])
         result = prob.solve(solver="SCS", eps=1e-6)
         self.assertAlmostEqual(result, -np.inf)
-        prob = Problem(Minimize(expr[0]*1j + expr[1]*1j), [cvx.real(x + 1j) <= 1])
+        prob = Problem(Minimize(expr[0]*1j + expr[1]*1j), [cp.real(x + 1j) <= 1])
         result = prob.solve(solver="SCS", eps=1e-6)
         self.assertAlmostEqual(result, -2)
         self.assertItemsAlmostEqual(x.value, [1, 1])
-        prob = Problem(Minimize(expr[0]*1j + expr[1]*1j), [cvx.real(x + 1j) >= 1, cvx.conj(x) <= 0])
+        prob = Problem(Minimize(expr[0]*1j + expr[1]*1j), [cp.real(x + 1j) >= 1, cp.conj(x) <= 0])
         result = prob.solve(solver="SCS", eps=1e-6)
         self.assertAlmostEqual(result, np.inf)
 
         x = Variable((2, 2))
         y = Variable((3, 2), complex=True)
-        expr = cvx.vstack([x, y])
-        prob = Problem(Minimize(cvx.sum(cvx.imag(cvx.conj(expr)))),
-                       [x == 0, cvx.real(y) == 0, cvx.imag(y) <= 1])
+        expr = cp.vstack([x, y])
+        prob = Problem(Minimize(cp.sum(cp.imag(cp.conj(expr)))),
+                       [x == 0, cp.real(y) == 0, cp.imag(y) <= 1])
         result = prob.solve(solver="SCS", eps=1e-6)
         self.assertAlmostEqual(result, -6)
         self.assertItemsAlmostEqual(y.value, 1j*np.ones((3, 2)))
@@ -223,9 +219,9 @@ class TestComplex(BaseTest):
 
         x = Variable((2, 2))
         y = Variable((3, 2), complex=True)
-        expr = cvx.vstack([x, y])
-        prob = Problem(Minimize(cvx.sum(cvx.imag(expr.H))),
-                       [x == 0, cvx.real(y) == 0, cvx.imag(y) <= 1])
+        expr = cp.vstack([x, y])
+        prob = Problem(Minimize(cp.sum(cp.imag(expr.H))),
+                       [x == 0, cp.real(y) == 0, cp.imag(y) <= 1])
         result = prob.solve(solver="SCS", eps=1e-6)
         self.assertAlmostEqual(result, -6)
         self.assertItemsAlmostEqual(y.value, 1j*np.ones((3, 2)))
@@ -234,9 +230,9 @@ class TestComplex(BaseTest):
     def test_params(self) -> None:
         """Test with parameters.
         """
-        p = cvx.Parameter(imag=True, value=1j)
+        p = cp.Parameter(imag=True, value=1j)
         x = Variable(2, complex=True)
-        prob = Problem(cvx.Maximize(cvx.sum(cvx.imag(x) + cvx.real(x))), [cvx.abs(p*x) <= 2])
+        prob = Problem(cp.Maximize(cp.sum(cp.imag(x) + cp.real(x))), [cp.abs(p*x) <= 2])
         result = prob.solve(solver="SCS", eps=1e-6)
         self.assertAlmostEqual(result, 4*np.sqrt(2))
         val = np.ones(2)*np.sqrt(2)
@@ -246,14 +242,14 @@ class TestComplex(BaseTest):
         """Test problems where imaginary is missing.
         """
         Z = Variable((2, 2), hermitian=True)
-        constraints = [cvx.trace(cvx.real(Z)) == 1]
-        obj = cvx.Minimize(0)
-        prob = cvx.Problem(obj, constraints)
+        constraints = [cp.trace(cp.real(Z)) == 1]
+        obj = cp.Minimize(0)
+        prob = cp.Problem(obj, constraints)
         prob.solve(solver="SCS")
 
         Z = Variable((2, 2), imag=True)
-        obj = cvx.Minimize(cvx.trace(cvx.real(Z)))
-        prob = cvx.Problem(obj, constraints)
+        obj = cp.Minimize(cp.trace(cp.real(Z)))
+        prob = cp.Problem(obj, constraints)
         result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, 0)
 
@@ -261,7 +257,7 @@ class TestComplex(BaseTest):
         """Test with absolute value.
         """
         x = Variable(2, complex=True)
-        prob = Problem(cvx.Maximize(cvx.sum(cvx.imag(x) + cvx.real(x))), [cvx.abs(x) <= 2])
+        prob = Problem(cp.Maximize(cp.sum(cp.imag(x) + cp.real(x))), [cp.abs(x) <= 2])
         result = prob.solve(solver="SCS", eps=1e-6)
         self.assertAlmostEqual(result, 4*np.sqrt(2))
         val = np.ones(2)*np.sqrt(2)
@@ -272,7 +268,7 @@ class TestComplex(BaseTest):
         """
         x = Variable(2, complex=True)
         t = Variable()
-        prob = Problem(cvx.Minimize(t), [cvx.SOC(t, x), x == 2j])
+        prob = Problem(cp.Minimize(t), [cp.SOC(t, x), x == 2j])
         result = prob.solve(solver="SCS", eps=1e-6)
         self.assertAlmostEqual(result, 2*np.sqrt(2))
         self.assertItemsAlmostEqual(x.value, [2j, 2j])
@@ -281,15 +277,15 @@ class TestComplex(BaseTest):
         """Test complex with pnorm.
         """
         x = Variable((1, 2), complex=True)
-        prob = Problem(cvx.Maximize(cvx.sum(cvx.imag(x) + cvx.real(x))), [cvx.norm1(x) <= 2])
+        prob = Problem(cp.Maximize(cp.sum(cp.imag(x) + cp.real(x))), [cp.norm1(x) <= 2])
         result = prob.solve(solver="ECOS")
         self.assertAlmostEqual(result, 2*np.sqrt(2))
         val = np.ones(2)*np.sqrt(2)/2
         # self.assertItemsAlmostEqual(x.value, val + 1j*val)
 
         x = Variable((2, 2), complex=True)
-        prob = Problem(cvx.Maximize(cvx.sum(cvx.imag(x) + cvx.real(x))),
-                       [cvx.pnorm(x, p=2) <= np.sqrt(8)])
+        prob = Problem(cp.Maximize(cp.sum(cp.imag(x) + cp.real(x))),
+                       [cp.pnorm(x, p=2) <= np.sqrt(8)])
         result = prob.solve(solver="ECOS")
         self.assertAlmostEqual(result, 8)
         val = np.ones((2, 2))
@@ -302,14 +298,14 @@ class TestComplex(BaseTest):
         P = np.reshape(P, (2, 4))
         sigma_max = np.linalg.norm(P, 2)
         X = Variable((2, 4), complex=True)
-        prob = Problem(Minimize(cvx.norm(X, 2)), [X == P])
+        prob = Problem(Minimize(cp.norm(X, 2)), [X == P])
         result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, sigma_max, places=1)
 
         norm_nuc = np.linalg.norm(P, 'nuc')
         X = Variable((2, 4), complex=True)
-        prob = Problem(Minimize(cvx.norm(X, 'nuc')), [X == P])
-        result = prob.solve(solver=cvx.SCS, eps=1e-4)
+        prob = Problem(Minimize(cp.norm(X, 'nuc')), [X == P])
+        result = prob.solve(solver=cp.SCS, eps=1e-4)
         self.assertAlmostEqual(result, norm_nuc, places=1)
 
     def test_log_det(self) -> None:
@@ -318,10 +314,10 @@ class TestComplex(BaseTest):
         P = np.arange(9) - 2j*np.arange(9)
         P = np.reshape(P, (3, 3))
         P = np.conj(P.T).dot(P)/100 + np.eye(3)*.1
-        value = cvx.log_det(P).value
+        value = cp.log_det(P).value
         X = Variable((3, 3), complex=True)
-        prob = Problem(cvx.Maximize(cvx.log_det(X)), [X == P])
-        result = prob.solve(solver=cvx.SCS, eps=1e-6)
+        prob = Problem(cp.Maximize(cp.log_det(X)), [X == P])
+        result = prob.solve(solver=cp.SCS, eps=1e-6)
         self.assertAlmostEqual(result, value, places=2)
 
     def test_eigval_atoms(self) -> None:
@@ -332,24 +328,24 @@ class TestComplex(BaseTest):
         P1 = np.conj(P.T).dot(P)/10 + np.eye(3)*.1
         P2 = np.array([[10, 1j, 0], [-1j, 10, 0], [0, 0, 1]])
         for P in [P1, P2]:
-            value = cvx.lambda_max(P).value
+            value = cp.lambda_max(P).value
             X = Variable(P.shape, complex=True)
-            prob = Problem(cvx.Minimize(cvx.lambda_max(X)), [X == P])
-            result = prob.solve(solver=cvx.SCS, eps=1e-6)
+            prob = Problem(cp.Minimize(cp.lambda_max(X)), [X == P])
+            result = prob.solve(solver=cp.SCS, eps=1e-6)
             self.assertAlmostEqual(result, value, places=2)
 
             eigs = np.linalg.eigvals(P).real
-            value = cvx.sum_largest(eigs, 2).value
+            value = cp.sum_largest(eigs, 2).value
             X = Variable(P.shape, complex=True)
-            prob = Problem(cvx.Minimize(cvx.lambda_sum_largest(X, 2)), [X == P])
-            result = prob.solve(solver=cvx.SCS, eps=1e-8)
+            prob = Problem(cp.Minimize(cp.lambda_sum_largest(X, 2)), [X == P])
+            result = prob.solve(solver=cp.SCS, eps=1e-8)
             self.assertAlmostEqual(result, value, places=3)
             self.assertItemsAlmostEqual(X.value, P, places=3)
 
-            value = cvx.sum_smallest(eigs, 2).value
+            value = cp.sum_smallest(eigs, 2).value
             X = Variable(P.shape, complex=True)
-            prob = Problem(cvx.Maximize(cvx.lambda_sum_smallest(X, 2)), [X == P])
-            result = prob.solve(solver=cvx.SCS, eps=1e-6)
+            prob = Problem(cp.Maximize(cp.lambda_sum_smallest(X, 2)), [X == P])
+            result = prob.solve(solver=cp.SCS, eps=1e-6)
             self.assertAlmostEqual(result, value, places=3)
 
     def test_quad_form(self) -> None:
@@ -363,16 +359,16 @@ class TestComplex(BaseTest):
         # Solve a problem with real variable
         b = np.arange(3)
         x = Variable(3, complex=False)
-        value = cvx.quad_form(b, P).value
-        prob = Problem(cvx.Minimize(cvx.quad_form(x, P)), [x == b])
+        value = cp.quad_form(b, P).value
+        prob = Problem(cp.Minimize(cp.quad_form(x, P)), [x == b])
         result = prob.solve(solver="ECOS")
         self.assertAlmostEqual(result, value)
 
         # Solve a problem with complex variable
         b = np.arange(3) + 3j*(np.arange(3) + 10)
         x = Variable(3, complex=True)
-        value = cvx.quad_form(b, P).value
-        prob = Problem(cvx.Minimize(cvx.quad_form(x, P)), [x == b])
+        value = cp.quad_form(b, P).value
+        prob = Problem(cp.Minimize(cp.quad_form(x, P)), [x == b])
         result = prob.solve(solver="ECOS")
         normalization = max(abs(result), abs(value))
         self.assertAlmostEqual(result / normalization, value / normalization, places=5)
@@ -380,9 +376,9 @@ class TestComplex(BaseTest):
         # Solve a problem with an imaginary variable
         b = 3j*(np.arange(3) + 10)
         x = Variable(3, imag=True)
-        value = cvx.quad_form(b, P).value
-        expr = cvx.quad_form(x, P)
-        prob = Problem(cvx.Minimize(expr), [x == b])
+        value = cp.quad_form(b, P).value
+        expr = cp.quad_form(x, P)
+        prob = Problem(cp.Minimize(expr), [x == b])
         result = prob.solve(solver="ECOS")
         normalization = max(abs(result), abs(value))
         self.assertAlmostEqual(result / normalization, value / normalization)
@@ -394,26 +390,26 @@ class TestComplex(BaseTest):
         Y = Variable((2, 2), complex=True)
         b = np.arange(2)
         x = Variable(2, complex=False)
-        value = cvx.matrix_frac(b, P).value
-        expr = cvx.matrix_frac(x, Y)
-        prob = Problem(cvx.Minimize(expr), [x == b, Y == P])
-        result = prob.solve(solver=cvx.SCS, eps=1e-6, max_iters=7500, verbose=True)
+        value = cp.matrix_frac(b, P).value
+        expr = cp.matrix_frac(x, Y)
+        prob = Problem(cp.Minimize(expr), [x == b, Y == P])
+        result = prob.solve(solver=cp.SCS, eps=1e-6, max_iters=7500, verbose=True)
         self.assertAlmostEqual(result, value, places=3)
 
         b = (np.arange(2) + 3j*(np.arange(2) + 10))
         x = Variable(2, complex=True)
-        value = cvx.matrix_frac(b, P).value
-        expr = cvx.matrix_frac(x, Y)
-        prob = Problem(cvx.Minimize(expr), [x == b, Y == P])
-        result = prob.solve(solver=cvx.SCS, eps=1e-6)
+        value = cp.matrix_frac(b, P).value
+        expr = cp.matrix_frac(x, Y)
+        prob = Problem(cp.Minimize(expr), [x == b, Y == P])
+        result = prob.solve(solver=cp.SCS, eps=1e-6)
         self.assertAlmostEqual(result, value, places=3)
 
         b = (np.arange(2) + 10)/10j
         x = Variable(2, imag=True)
-        value = cvx.matrix_frac(b, P).value
-        expr = cvx.matrix_frac(x, Y)
-        prob = Problem(cvx.Minimize(expr), [x == b, Y == P])
-        result = prob.solve(solver=cvx.SCS, eps=1e-5, max_iters=7500)
+        value = cp.matrix_frac(b, P).value
+        expr = cp.matrix_frac(x, Y)
+        prob = Problem(cp.Minimize(expr), [x == b, Y == P])
+        result = prob.solve(solver=cp.SCS, eps=1e-5, max_iters=7500)
         self.assertAlmostEqual(result, value, places=3)
 
     def test_quad_over_lin(self) -> None:
@@ -424,15 +420,15 @@ class TestComplex(BaseTest):
         b = 1
         y = Variable(complex=False)
 
-        value = cvx.quad_over_lin(P, b).value
-        expr = cvx.quad_over_lin(X, y)
-        prob = Problem(cvx.Minimize(expr), [X == P, y == b])
-        result = prob.solve(solver=cvx.SCS, eps=1e-6, max_iters=7500, verbose=True)
+        value = cp.quad_over_lin(P, b).value
+        expr = cp.quad_over_lin(X, y)
+        prob = Problem(cp.Minimize(expr), [X == P, y == b])
+        result = prob.solve(solver=cp.SCS, eps=1e-6, max_iters=7500, verbose=True)
         self.assertAlmostEqual(result, value, places=3)
 
-        expr = cvx.quad_over_lin(X - P, y)
-        prob = Problem(cvx.Minimize(expr), [y == b])
-        result = prob.solve(solver=cvx.SCS, eps=1e-6, max_iters=7500, verbose=True)
+        expr = cp.quad_over_lin(X - P, y)
+        prob = Problem(cp.Minimize(expr), [y == b])
+        result = prob.solve(solver=cp.SCS, eps=1e-6, max_iters=7500, verbose=True)
         self.assertAlmostEqual(result, 0, places=3)
         self.assertItemsAlmostEqual(X.value, P, places=3)
 
@@ -440,7 +436,7 @@ class TestComplex(BaseTest):
         """Test Hermitian variables.
         """
         X = Variable((2, 2), hermitian=True)
-        prob = Problem(cvx.Minimize(cvx.imag(X[1, 0])),
+        prob = Problem(cp.Minimize(cp.imag(X[1, 0])),
                        [X[0, 0] == 2, X[1, 1] == 3, X[0, 1] == 1+1j])
         prob.solve(solver="SCS")
         self.assertItemsAlmostEqual(X.value, [2, 1-1j, 1+1j, 3])
@@ -449,18 +445,18 @@ class TestComplex(BaseTest):
         """Test Hermitian variables.
         """
         X = Variable((2, 2), hermitian=True)
-        prob = Problem(cvx.Minimize(cvx.imag(X[1, 0])),
+        prob = Problem(cp.Minimize(cp.imag(X[1, 0])),
                        [X >> 0, X[0, 0] == -1])
         prob.solve(solver="SCS")
-        assert prob.status is cvx.INFEASIBLE
+        assert prob.status is cp.INFEASIBLE
 
     def test_promote(self) -> None:
         """Test promotion of complex variables.
         """
         v = Variable(complex=True)
-        obj = cvx.Maximize(cvx.real(cvx.sum(v * np.ones((2, 2)))))
-        con = [cvx.norm(v) <= 1]
-        prob = cvx.Problem(obj, con)
+        obj = cp.Maximize(cp.real(cp.sum(v * np.ones((2, 2)))))
+        con = [cp.norm(v) <= 1]
+        prob = cp.Problem(obj, con)
         result = prob.solve(solver="ECOS")
         self.assertAlmostEqual(result, 4.0)
 
@@ -474,21 +470,21 @@ class TestComplex(BaseTest):
         A = sp.csr_matrix((data, (row, col)), shape=(2, 2))
 
         # Feasibility with sparse matrix
-        rho = cvx.Variable((2, 2), complex=True)
+        rho = cp.Variable((2, 2), complex=True)
         Id = np.identity(2)
-        obj = cvx.Maximize(0)
+        obj = cp.Maximize(0)
         cons = [A @ rho == Id]
-        prob = cvx.Problem(obj, cons)
+        prob = cp.Problem(obj, cons)
         prob.solve(solver="SCS")
         rho_sparse = rho.value
         # infeasible here, which is wrong!
 
         # Feasibility with numpy array: just replace A with A.toarray()
-        rho = cvx.Variable((2, 2), complex=True)
+        rho = cp.Variable((2, 2), complex=True)
         Id = np.identity(2)
-        obj = cvx.Maximize(0)
+        obj = cp.Maximize(0)
         cons = [A.toarray() @ rho == Id]
-        prob = cvx.Problem(obj, cons)
+        prob = cp.Problem(obj, cons)
         prob.solve(solver="SCS")
         self.assertItemsAlmostEqual(rho.value, rho_sparse)
 
@@ -498,16 +494,16 @@ class TestComplex(BaseTest):
         c = [0, 1]
         n = len(c)
         # Create optimization variables.
-        f = cvx.Variable((n, n), hermitian=True)
+        f = cp.Variable((n, n), hermitian=True)
         # Create constraints.
         constraints = [f >> 0]
         for k in range(1, n):
             indices = [(i * n) + i - (n - k) for i in range(n - k, n)]
-            constraints += [cvx.sum(cvx.vec(f)[indices]) == c[n - k]]
+            constraints += [cp.sum(cp.vec(f)[indices]) == c[n - k]]
         # Form objective.
-        obj = cvx.Maximize(c[0] - cvx.real(cvx.trace(f)))
+        obj = cp.Maximize(c[0] - cp.real(cp.trace(f)))
         # Form and solve problem.
-        prob = cvx.Problem(obj, constraints)
+        prob = cp.Problem(obj, constraints)
         prob.solve(solver="SCS")
 
     def test_validation(self) -> None:
@@ -519,18 +515,18 @@ class TestComplex(BaseTest):
         self.assertEqual(str(cm.exception), "Inequality constraints cannot be complex.")
 
         with self.assertRaises(Exception) as cm:
-            cvx.quad_over_lin(x, x)
+            cp.quad_over_lin(x, x)
         self.assertEqual(str(cm.exception),
                          "The second argument to quad_over_lin cannot be complex.")
 
         with self.assertRaises(Exception) as cm:
-            cvx.sum_largest(x, 2)
+            cp.sum_largest(x, 2)
         self.assertEqual(str(cm.exception), "Arguments to sum_largest cannot be complex.")
 
         x = Variable(2, complex=True)
-        for atom in [cvx.geo_mean, cvx.log_sum_exp, cvx.max,
-                     cvx.entr, cvx.exp, cvx.huber,
-                     cvx.log, cvx.log1p, cvx.logistic]:
+        for atom in [cp.geo_mean, cp.log_sum_exp, cp.max,
+                     cp.entr, cp.exp, cp.huber,
+                     cp.log, cp.log1p, cp.logistic]:
             name = atom.__name__
             with self.assertRaises(Exception) as cm:
                 print(name)
@@ -538,7 +534,7 @@ class TestComplex(BaseTest):
             self.assertEqual(str(cm.exception), "Arguments to %s cannot be complex." % name)
 
         x = Variable(2, complex=True)
-        for atom in [cvx.maximum, cvx.kl_div]:
+        for atom in [cp.maximum, cp.kl_div]:
             name = atom.__name__
             with self.assertRaises(Exception) as cm:
                 print(name)
@@ -546,13 +542,13 @@ class TestComplex(BaseTest):
             self.assertEqual(str(cm.exception), "Arguments to %s cannot be complex." % name)
 
         x = Variable(2, complex=True)
-        for atom in [cvx.inv_pos, cvx.sqrt, lambda x: cvx.power(x, .2)]:
+        for atom in [cp.inv_pos, cp.sqrt, lambda x: cp.power(x, .2)]:
             with self.assertRaises(Exception) as cm:
                 atom(x)
             self.assertEqual(str(cm.exception), "Arguments to power cannot be complex.")
 
         x = Variable(2, complex=True)
-        for atom in [cvx.harmonic_mean, lambda x: cvx.pnorm(x, .2)]:
+        for atom in [cp.harmonic_mean, lambda x: cp.pnorm(x, .2)]:
             with self.assertRaises(Exception) as cm:
                 atom(x)
             self.assertEqual(str(cm.exception), "pnorm(x, p) cannot have x complex for p < 1.")
@@ -560,18 +556,18 @@ class TestComplex(BaseTest):
     def test_diag(self) -> None:
         """Test diag of mat, and of vector.
         """
-        X = cvx.Variable((2, 2), complex=True)
-        obj = cvx.Maximize(cvx.trace(cvx.real(X)))
-        cons = [cvx.diag(X) == 1]
-        prob = cvx.Problem(obj, cons)
+        X = cp.Variable((2, 2), complex=True)
+        obj = cp.Maximize(cp.trace(cp.real(X)))
+        cons = [cp.diag(X) == 1]
+        prob = cp.Problem(obj, cons)
         result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, 2)
 
-        x = cvx.Variable(2, complex=True)
-        X = cvx.diag(x)
-        obj = cvx.Maximize(cvx.trace(cvx.real(X)))
-        cons = [cvx.diag(X) == 1]
-        prob = cvx.Problem(obj, cons)
+        x = cp.Variable(2, complex=True)
+        X = cp.diag(x)
+        obj = cp.Maximize(cp.trace(cp.real(X)))
+        cons = [cp.diag(X) == 1]
+        prob = cp.Problem(obj, cons)
         result = prob.solve(solver="SCS")
         self.assertAlmostEqual(result, 2)
 
@@ -580,28 +576,44 @@ class TestComplex(BaseTest):
         """
         A0 = np.array([0+1j, 2-1j])
         A1 = np.array([[2, -1+1j], [4-3j, -3+2j]])
-        Z = cvx.Variable(complex=True)
-        X = cvx.Variable(2)
+        Z = cp.Variable(complex=True)
+        X = cp.Variable(2)
         B = np.array([2+1j, -2j])
 
-        objective = cvx.Minimize(cvx.sum_squares(A0*Z + A1@X - B))
-        prob = cvx.Problem(objective)
+        objective = cp.Minimize(cp.sum_squares(A0*Z + A1@X - B))
+        prob = cp.Problem(objective)
         prob.solve(solver="SCS")
-        self.assertEqual(prob.status, cvx.OPTIMAL)
+        self.assertEqual(prob.status, cp.OPTIMAL)
 
         constraints = [X >= 0]
-        prob = cvx.Problem(objective, constraints)
+        prob = cp.Problem(objective, constraints)
         prob.solve(solver="SCS")
-        self.assertEqual(prob.status, cvx.OPTIMAL)
+        self.assertEqual(prob.status, cp.OPTIMAL)
         assert constraints[0].dual_value is not None
 
     def test_quad_psd(self) -> None:
         """Test PSD checking from #1491.
         """
-        x = cvx.Variable(2, complex=True)
+        x = cp.Variable(2, complex=True)
         P1 = np.eye(2)
         P2 = np.array([[1+0j, 0+0j],
                        [0-0j, 1+0j]])
-        print("P1 is real:", cvx.quad_form(x, P1).curvature)
-        print("P2 is complex:", cvx.quad_form(x, P2).curvature)
-        assert cvx.quad_form(x, P2).is_dcp()
+        print("P1 is real:", cp.quad_form(x, P1).curvature)
+        print("P2 is complex:", cp.quad_form(x, P2).curvature)
+        assert cp.quad_form(x, P2).is_dcp()
+
+    def test_bool(self) -> None:
+        # The purpose of this test is to make sure
+        # that we don't try to recover dual variables
+        # unless they're actually present.
+        bool_var = cp.Variable(boolean=True)
+        complex_var = cp.Variable(complex=True)
+
+        constraints = [
+            cp.real(complex_var) <= bool_var,
+        ]
+
+        obj = cp.Maximize(cp.real(complex_var))
+        prob = cp.Problem(obj, constraints)
+        prob.solve(solver='ECOS_BB')
+        self.assertAlmostEqual(prob.value, 1, places=4)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -800,8 +800,9 @@ class TestCPLEX(BaseTest):
     def test_cplex_lp_3(self) -> None:
         # CPLEX initially produces an INFEASIBLE_OR_UNBOUNDED status
         sth = sths.lp_3()
-        sth.prob.solve(solver='CPLEX')
-        self.assertEqual(sth.prob.status, cp.settings.INFEASIBLE_OR_UNBOUNDED)
+        with self.assertWarns(Warning):
+            sth.prob.solve(solver='CPLEX')
+            self.assertEqual(sth.prob.status, cp.settings.INFEASIBLE_OR_UNBOUNDED)
         # Determine the precise status with reoptimize=True.
         StandardTestLPs.test_lp_3(solver='CPLEX', reoptimize=True)
 
@@ -1021,15 +1022,16 @@ class TestGUROBI(BaseTest):
     def test_gurobi_lp_3(self) -> None:
         # GUROBI initially produces an INFEASIBLE_OR_UNBOUNDED status
         sth = sths.lp_3()
-        sth.prob.solve(solver='GUROBI')
-        self.assertEqual(sth.prob.status, cp.settings.INFEASIBLE_OR_UNBOUNDED)
+        with self.assertWarns(Warning):
+            sth.prob.solve(solver='GUROBI')
+            self.assertEqual(sth.prob.status, cp.settings.INFEASIBLE_OR_UNBOUNDED)
         # The user disables presolve and so makes reoptimization unnecessary
         StandardTestLPs.test_lp_3(solver='GUROBI', InfUnbdInfo=1)
         # The user determines the precise status with reoptimize=True
         StandardTestLPs.test_lp_3(solver='GUROBI', reoptimize=True)
 
     def test_gurobi_lp_4(self) -> None:
-        StandardTestLPs.test_lp_4(solver='GUROBI')
+        StandardTestLPs.test_lp_4(solver='GUROBI', reoptimize=True)
 
     def test_gurobi_lp_5(self) -> None:
         StandardTestLPs.test_lp_5(solver='GUROBI')

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -798,13 +798,12 @@ class TestCPLEX(BaseTest):
         StandardTestLPs.test_lp_2(solver='CPLEX')
 
     def test_cplex_lp_3(self) -> None:
-        # CPLEX initially produces an INFEASIBLE_OR_UNBOUNDED status,
-        # and the user will encounter that if they set reoptimize=False.
+        # CPLEX initially produces an INFEASIBLE_OR_UNBOUNDED status
         sth = sths.lp_3()
-        sth.prob.solve(solver='CPLEX', reoptimize=False)
+        sth.prob.solve(solver='CPLEX')
         self.assertEqual(sth.prob.status, cp.settings.INFEASIBLE_OR_UNBOUNDED)
-        # The user does nothing, and CPLEX silently reoptimizes.
-        StandardTestLPs.test_lp_3(solver='CPLEX')
+        # Determine the precise status with reoptimize=True.
+        StandardTestLPs.test_lp_3(solver='CPLEX', reoptimize=True)
 
     def test_cplex_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver='CPLEX')
@@ -1020,15 +1019,14 @@ class TestGUROBI(BaseTest):
         StandardTestLPs.test_lp_2(solver='GUROBI')
 
     def test_gurobi_lp_3(self) -> None:
-        # GUROBI initially produces an INFEASIBLE_OR_UNBOUNDED status,
-        # and the user will encounter that if they set reoptimize=False.
+        # GUROBI initially produces an INFEASIBLE_OR_UNBOUNDED status
         sth = sths.lp_3()
-        sth.prob.solve(solver='GUROBI', reoptimize=False)
+        sth.prob.solve(solver='GUROBI')
         self.assertEqual(sth.prob.status, cp.settings.INFEASIBLE_OR_UNBOUNDED)
         # The user disables presolve and so makes reoptimization unnecessary
-        StandardTestLPs.test_lp_3(solver='GUROBI', InfUnbdInfo=1, reoptimize=False)
-        # The user does nothing, and GUROBI silently reoptimizes.
-        StandardTestLPs.test_lp_3(solver='GUROBI')
+        StandardTestLPs.test_lp_3(solver='GUROBI', InfUnbdInfo=1)
+        # The user determines the precise status with reoptimize=True
+        StandardTestLPs.test_lp_3(solver='GUROBI', reoptimize=True)
 
     def test_gurobi_lp_4(self) -> None:
         StandardTestLPs.test_lp_4(solver='GUROBI')

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -865,6 +865,12 @@ The following cut-generators are available:
 ``'cplex_filename'``
     a string specifying the filename to which the problem will be written. For example, use "model.lp", "model.sav", or "model.mps" to export to the LP, SAV, and MPS formats, respectively.
 
+``reoptimize``
+    A boolean. This is only relevant for problems where CPLEX initially produces an "infeasible or unbounded" status.
+    Its default value is True, which means that if CPLEX produces an "infeasible or unbounded" status, then its algorithm
+    parameters are automatically changed and the problem is re-solved in order to determine its precise status.
+
+
 `NAG`_ options:
 
 ``'nag_params'``
@@ -888,6 +894,11 @@ In addition to Gurobi's parameters, the following options are available:
 
 ``'env'``
     Allows for the passage of a Gurobi Environment, which specifies parameters and license information.  Keyword arguments will override any settings in this environment.
+
+``reoptimize``
+    A boolean. This is only relevant for problems where GUROBI initially produces an "infeasible or unbounded" status.
+    Its default value is True, which means that if GUROBI produces an "infeasible or unbounded" status, then its algorithm
+    parameters are automatically changed and the problem is re-solved in order to determine its precise status.
 
 Getting the standard form
 -------------------------

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -867,7 +867,7 @@ The following cut-generators are available:
 
 ``reoptimize``
     A boolean. This is only relevant for problems where CPLEX initially produces an "infeasible or unbounded" status.
-    Its default value is True, which means that if CPLEX produces an "infeasible or unbounded" status, then its algorithm
+    Its default value is False. If set to True, then if CPLEX produces an "infeasible or unbounded" status, its algorithm
     parameters are automatically changed and the problem is re-solved in order to determine its precise status.
 
 
@@ -897,7 +897,7 @@ In addition to Gurobi's parameters, the following options are available:
 
 ``reoptimize``
     A boolean. This is only relevant for problems where GUROBI initially produces an "infeasible or unbounded" status.
-    Its default value is True, which means that if GUROBI produces an "infeasible or unbounded" status, then its algorithm
+    Its default value is False. If set to True, then if GUROBI produces an "infeasible or unbounded" status, its algorithm
     parameters are automatically changed and the problem is re-solved in order to determine its precise status.
 
 Getting the standard form

--- a/doc/source/tutorial/intro/index.rst
+++ b/doc/source/tutorial/intro/index.rst
@@ -137,12 +137,21 @@ CVXPY provides the following constants as aliases for the different status strin
 *  ``OPTIMAL_INACCURATE``
 * ``INFEASIBLE_INACCURATE``
 * ``UNBOUNDED_INACCURATE``
+* ``INFEASIBLE_OR_UNBOUNDED``
 
-For example, to test if a problem was solved successfully, you would use
+To test if a problem was solved successfully, you would use
 
 .. code:: python
 
     prob.status == OPTIMAL
+
+The status ``INFEASIBLE_OR_UNBOUNDED`` is rare. It's used when a solver was able to
+determine that the problem was either infeasible or unbounded, but could not tell which.
+You can determine the precise status by re-solving the problem where you where you
+set the objective function to a constant (e.g., ``objective = cp.Minimize(0)``).
+If the new problem is solved with status code ``INFEASIBLE_OR_UNBOUNDED`` then the
+original problem was infeasible. If the new problem is solved with status ``OPTIMAL``
+then the original problem was unbounded.
 
 Vectors and matrices
 --------------------

--- a/doc/source/tutorial/intro/index.rst
+++ b/doc/source/tutorial/intro/index.rst
@@ -147,7 +147,7 @@ To test if a problem was solved successfully, you would use
 
 The status ``INFEASIBLE_OR_UNBOUNDED`` is rare. It's used when a solver was able to
 determine that the problem was either infeasible or unbounded, but could not tell which.
-You can determine the precise status by re-solving the problem where you where you
+You can determine the precise status by re-solving the problem where you
 set the objective function to a constant (e.g., ``objective = cp.Minimize(0)``).
 If the new problem is solved with status code ``INFEASIBLE_OR_UNBOUNDED`` then the
 original problem was infeasible. If the new problem is solved with status ``OPTIMAL``


### PR DESCRIPTION
EDIT: *Hold off on merging this until we merge the PR on infeasible_or_unbounded status. I accidentally made these changes by building off that branch instead of branching from master.*

Fixes #1133. Right now the complex2real reduction fails when a solver returns no dual variables (as happens with mixed-integer programs). The solution was just to check if dual variables were present before trying to parse them.

I also did a find-and-replace to replace "cvx" with "cp" in ``test_complex.py``.

EDIT: This also fixes #1090!