### PR TITLE
Fix #1555

### DIFF
--- a/cvxpy/lin_ops/lin_op.py
+++ b/cvxpy/lin_ops/lin_op.py
@@ -28,6 +28,9 @@ class LinOp:
         self.args = args
         self.data = data
 
+    def __repr__(self) -> str:
+        return f"LinOp({self.type}, {self.shape})"
+
 
 # The types of linear operators.
 

--- a/cvxpy/lin_ops/lin_utils.py
+++ b/cvxpy/lin_ops/lin_utils.py
@@ -290,7 +290,8 @@ def multiply(lh_op, rh_op):
     LinOp
         A linear operator representing the product.
     """
-    return lo.LinOp(lo.MUL_ELEM, lh_op.shape, [rh_op], lh_op)
+    shape = max(lh_op.shape, rh_op.shape)
+    return lo.LinOp(lo.MUL_ELEM, shape, [rh_op], lh_op)
 
 
 def kron(lh_op, rh_op, shape: Tuple[int, ...]):

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1972,3 +1972,18 @@ class TestProblem(BaseTest):
         prob = cp.Problem(cp.Minimize(cp.sum(cp.huber(A @ x - b))))
 
         prob.solve(solver=cp.SCS)
+
+    def test_rmul_param(self) -> None:
+        """Test a complex rmul expression with a parameter.
+           See issue #1555.
+        """
+        b = cp.Variable((1,))
+        param = cp.Parameter(1)
+
+        constraints = []
+        objective = cp.Minimize((2 * b) @ param)
+        prob = cp.Problem(objective, constraints)
+
+        param.value = np.array([1])
+        prob.solve()
+        assert prob.value == -np.inf


### PR DESCRIPTION
The issue was incorrect dimensions for the multiply LinOp, specifically arising when the arguments have shapes () and (1,).

I also added pretty print for LinOps, to help with debugging.