### PR TITLE
Don’t install a top-level ‘examples’ package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,9 @@ setup(
                  'echu508@stanford.edu, boyd@stanford.edu',
     cmdclass={'build_ext': build_ext_cvxpy},
     ext_modules=[canon],
-    packages=find_packages(exclude=["cvxpy.performance_tests"]),
+    packages=find_packages(
+        include=["cvxpy", "cvxpy.*"], exclude=["cvxpy.performance_tests"]
+    ),
     url='https://github.com/cvxpy/cvxpy',
     license='Apache License, Version 2.0',
     zip_safe=False,


### PR DESCRIPTION
Currently `pip install cvxpy` also installs a top-level module named `examples`. Fix `setup.py` to only install modules under `cvxpy`.