### PR TITLE
[CI] Adding Sonar

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,9 +1,0 @@
-[run]
-source = cvxpy
-omit =
-    */python2.7/*
-    */lib-python/2.7/*.py
-    */lib_pypy/_*.py
-    */site-packages/ordereddict.py
-    */site-packages/nose/*
-    */unittest2/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source = cvxpy
+relative_files = True

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,14 +47,14 @@ jobs:
             python-version: 3.8
           - os: macos-10.15
             python-version: 3.8
-            deploy_pypi_source: "True"
+            single_action_config: "True"
           - os: windows-2019
             python-version: 3.8
 
     env:
       RUNNER_OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}
-      DEPLOY_PYPI_SOURCE: "${{ matrix.deploy_pypi_source == 'True' && 'True' || 'False' }}"
+      SINGLE_ACTION_CONFIG: "${{ matrix.single_action_config == 'True' && 'True' || 'False' }}"
       USE_OPENMP: "${{ matrix.openmp == 'True' && 'True' || 'False' }}"
       PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
       PYPI_USER: ${{ secrets.PYPI_USER }}
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload coverage file
         uses: actions/upload-artifact@v2
-        if: ${{env.DEPLOY_PYPI_SOURCE == 'True'}}
+        if: ${{env.SINGLE_ACTION_CONFIG == 'True'}}
         with:
           name: coverage
           path: coverage.xml
@@ -99,7 +99,7 @@ jobs:
         uses: joerick/cibuildwheel@v1.11.0
 
       - name: Build source
-        if: ${{env.DEPLOY == 'True' && env.DEPLOY_PYPI_SOURCE == 'True'}}
+        if: ${{env.DEPLOY == 'True' && env.SINGLE_ACTION_CONFIG == 'True'}}
         run: |
           python setup.py sdist --dist-dir=wheelhouse
 
@@ -131,13 +131,13 @@ jobs:
             python-version: 3.8
           - os: macos-10.15
             python-version: 3.8
-            deploy_pypi_source: "True"
+            single_action_config: "True"
           - os: windows-2019
             python-version: 3.8
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
-      DEPLOY_PYPI_SOURCE: "${{ matrix.deploy_pypi_source == 'True' && 'True' || 'False' }}"
+      SINGLE_ACTION_CONFIG: "${{ matrix.single_action_config == 'True' && 'True' || 'False' }}"
       PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
       PYPI_USER: ${{ secrets.PYPI_USER }}
       PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
@@ -164,7 +164,7 @@ jobs:
           rm -rf setup.py.bak
 
       - name: Run some tests on one OS just to check imports are working
-        if: ${{env.DEPLOY_PYPI_SOURCE == 'True'}}
+        if: ${{env.SINGLE_ACTION_CONFIG == 'True'}}
         run: |
           pip install . pytest cplex
           pytest cvxpy/tests/test_conic_solvers.py -k 'TestCPLEX'
@@ -178,7 +178,7 @@ jobs:
         uses: joerick/cibuildwheel@v1.11.0
 
       - name: Build source
-        if: ${{env.DEPLOY == 'True' && env.DEPLOY_PYPI_SOURCE == 'True'}}
+        if: ${{env.DEPLOY == 'True' && env.SINGLE_ACTION_CONFIG == 'True'}}
         run: |
           python setup.py sdist --dist-dir=wheelhouse
 
@@ -201,6 +201,8 @@ jobs:
     needs: build
     name: SonarCloud
     runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -208,7 +210,11 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: coverage
+      - name: Check if environment variable exists
+        run: |
+          echo "RUN_SONAR=$( [[ -n "$SONAR_TOKEN" ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
       - name: SonarCloud Scan
+        if: ${{env.RUN_SONAR == 'True'}}
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,6 @@ jobs:
     env:
       RUNNER_OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}
-      COVERAGE: "False"
       DEPLOY_PYPI_SOURCE: "${{ matrix.deploy_pypi_source == 'True' && 'True' || 'False' }}"
       USE_OPENMP: "${{ matrix.openmp == 'True' && 'True' || 'False' }}"
       PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
@@ -84,8 +83,12 @@ jobs:
         run: |
           source continuous_integration/test_script.sh
 
-      - name: Coverage
-        run: if [[ "$COVERAGE" == "True" ]]; then coveralls; fi
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v2
+        if: ${{env.DEPLOY_PYPI_SOURCE == 'True'}}
+        with:
+          name: coverage
+          path: .coverage
 
       - name: Build wheels
         if: ${{env.DEPLOY == 'True' && env.USE_OPENMP != 'True'}}
@@ -195,12 +198,21 @@ jobs:
           path: ./wheelhouse
 
   sonarcloud:
+    needs: build
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - uses: actions/download-artifact@v2
+        with:
+          name: coverage
+      - name: Fix coverage paths
+        run: |
+          # Fix paths in coverage file https://stackoverflow.com/a/43895011
+          pip install coverage
+          coverage xml -i
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,3 +193,16 @@ jobs:
         with:
           name: wheels-base
           path: ./wheelhouse
+
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
         if: ${{env.DEPLOY_PYPI_SOURCE == 'True'}}
         with:
           name: coverage
-          path: .coverage
+          path: coverage.xml
 
       - name: Build wheels
         if: ${{env.DEPLOY == 'True' && env.USE_OPENMP != 'True'}}
@@ -208,11 +208,6 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: coverage
-      - name: Fix coverage paths
-        run: |
-          # Fix paths in coverage file https://stackoverflow.com/a/43895011
-          pip install coverage
-          coverage xml -i
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -11,7 +11,7 @@ conda config --set remote_backoff_factor 2
 conda config --set remote_read_timeout_secs 120.0
 
 if [[ "$PYTHON_VERSION" == "3.6" ]] || [[ "$PYTHON_VERSION" == "3.7" ]] || [[ "$PYTHON_VERSION" == "3.8" ]]; then
-  conda install scipy=1.3 numpy=1.16 mkl pip pytest lapack ecos scs osqp cvxopt
+  conda install scipy=1.3 numpy=1.16 mkl pip pytest pytest-cov lapack ecos scs osqp cvxopt
   python -m pip install cplex  # CPLEX is not available yet on 3.9
 elif [[ "$PYTHON_VERSION" == "3.9" ]]; then
   # The earliest version of numpy that works is 1.19.
@@ -42,8 +42,4 @@ fi
 
 if [[ "$USE_OPENMP" == "True" ]]; then
   conda install -c conda-forge openmp
-fi
-
-if [[ "$COVERAGE" == "True" ]]; then
-  python -m pip install coverage coveralls
 fi

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -19,7 +19,7 @@ fi
 python -c "import cvxpy; print(cvxpy.installed_solvers())"
 
 if [[ "$DEPLOY_PYPI_SOURCE" == "True" ]]; then
-    pytest cvxpy/tests --cov=cvxpy
+    pytest cvxpy/tests --cov=cvxpy --cov-report xml:coverage.xml
 else
     pytest cvxpy/tests
 fi

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -18,7 +18,7 @@ fi
 
 python -c "import cvxpy; print(cvxpy.installed_solvers())"
 
-if [[ "$DEPLOY_PYPI_SOURCE" == "True" ]]; then
+if [[ "$SINGLE_ACTION_CONFIG" == "True" ]]; then
     pytest cvxpy/tests --cov=cvxpy --cov-report xml:coverage.xml
 else
     pytest cvxpy/tests

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -18,11 +18,10 @@ fi
 
 python -c "import cvxpy; print(cvxpy.installed_solvers())"
 
-if [[ "$COVERAGE" == "True" ]]; then
-    export WITH_COVERAGE="--with-coverage"
+if [[ "$DEPLOY_PYPI_SOURCE" == "True" ]]; then
+    pytest cvxpy/tests --cov=cvxpy
 else
-    export WITH_COVERAGE=""
+    pytest cvxpy/tests
 fi
 
-pytest $WITH_COVERAGE cvxpy/tests
-pytest $WITH_COVERAGE cvxpy/performance_tests
+pytest cvxpy/performance_tests

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,5 +9,5 @@ sonar.c.file.suffixes=-
 sonar.cpp.file.suffixes=-
 sonar.objc.file.suffixes=-
 
-# Encoding of the source code. Default is default system encoding
-#sonar.sourceEncoding=UTF-8
+# Coverage
+sonar.python.coverage.reportPaths=coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,7 @@ sonar.organization=cvxpy-sonar
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=cvxpy
 sonar.language=py
+sonar.python.version=3.6, 3.7, 3.8, 3.9
 sonar.c.file.suffixes=-
 sonar.cpp.file.suffixes=-
 sonar.objc.file.suffixes=-

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.projectKey=cvxpy-sonar
+sonar.organization=cvxpy-sonar
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=cvxpy
+sonar.language=py
+sonar.c.file.suffixes=-
+sonar.cpp.file.suffixes=-
+sonar.objc.file.suffixes=-
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=cvxpy-sonar
-sonar.organization=cvxpy-sonar
+sonar.projectKey=cvxpy
+sonar.organization=cvxpy
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=cvxpy


### PR DESCRIPTION
Adding back coverage has been on the backlog for quite some time. This PR brings back coverage and also introduces static code analysis by adding [SonarCloud](https://sonarcloud.io/).

### What
SonarCloud is a tool to track code quality, and it is free for open-source projects.
I have included it in my fork, as seeing a live version is the best way to describe it.
The dashboard can be found [here](https://sonarcloud.io/project/overview?id=cvxpy-sonar).

### How
SonarCloud is linked via their provided GitHub action, and thus should be easy to maintain. 
Setup should be as simple as connecting the tool to the GitHub organization and adding the `SONAR_TOKEN` secret. Retriggering the CI on this PR should yield first results.
Smaller adjustments can then be made through the UI (e.g. set the definition of "New Code", which quality standards to apply, ...).

### Initial results
Some of the bugs and code smells are definitely false positives, many are triggered by the exception tests. These can be marked as such and will be ignored going forward. On the other hand, there are also a few findings where it makes sense to take a closer look. After an initial cleanup of the false positives, it could be worthwhile to link to the dashboard in the "Contribution" section, as it provides actionable tasks (coverage or code smells) that usually are well encapsulated. 

### Intrusiveness 
The tool can be set up on different levels of "intrusiveness". From running completely in the background just to track coverage, to commenting on every PR and even blocking PRs if certain criteria are not met.
I have prepared an [example PR](https://github.com/phschiele/cvxpy/pull/26) which includes code smells and missing coverage. The corresponding analysis can be found [here](https://sonarcloud.io/summary/new_code?id=cvxpy-sonar&pullRequest=26) (the same information would be shown in the bot comment).

### Implementation details:
- `DEPLOY_PYPI_SOURCE` was renamed to `SINGLE_ACTION_CONFIG` as this variable is not only used to decide which config uploads to PyPI, but also which config is used for the `cvxpy-base` tests and coverage
- It would theoretically be possible to run coverage on all configs and combine the outputs for the most accurate results. There are small differences as not all solvers are available for all platforms. I have not done this yet to keep this initial proposal as simple as possible.
- I have added a check to see if the `SONAR_TOKEN` variable exists. This will make sure the action does not fail on forks, which do not have the variable set.
- One can create a coverage badge directly from the SonarCloud UI, if desired
- I'll remove the test dashboard I have created if this PR is merged
- The action runs in parallel to the `cvxpy-base` tests, so the overall time of the CI is not increased. 