### PR TITLE
Change logging in MOSEK

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -545,8 +545,6 @@ class MOSEK(ConicSolver):
             print('\n')
             env.set_Stream(mosek.streamtype.log, streamprinter)
             task.set_Stream(mosek.streamtype.log, streamprinter)
-            task.putintparam(mosek.iparam.infeas_report_auto, mosek.onoffkey.on)
-            task.putintparam(mosek.iparam.log_presolve, 0)
 
         # Parse all user-specified parameters (override default logging
         # parameters if applicable).


### PR DESCRIPTION
I propose two changes in the MOSEK log output.

1. Remove automatic printing of infeasibility report/certificate. Since cvxpy does not pass names to MOSEK, this was not very useful in the first place (one has to know the mapping from cvxpy variables to the ``x`` variable in MOSEK to understand the report). Now that CVXPY dualizes continuous problems it is simply impossible even for a fairly expert user to immediately relate that report to the original problem. And that report can have lots of rows, obscuring the interesting part of the optimization log.
2. If we go verbose and log is enabled at all I see no reason why presolve log should be specifically disabled. It is just a few lines and sometimes can actually be informative.