### PR TITLE
Fix bugs in the example of Channel Capacity

### DIFF
--- a/examples/notebooks/WWW/Channel_capacity_BV4.57.ipynb
+++ b/examples/notebooks/WWW/Channel_capacity_BV4.57.ipynb
@@ -48,7 +48,8 @@
     "# @author: R. Gowers, S. Al-Izzi, T. Pollington, R. Hill & K. Briggs\n",
     "\n",
     "import cvxpy as cp\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "import math"
    ]
   },
   {
@@ -65,7 +66,7 @@
     "    We consider a communication channel, with input X(t)∈{1,..,n} and\n",
     "    output Y(t)∈{1,...,m}, for t=1,2,... .The relation between the\n",
     "    input and output is given statistically:\n",
-    "    p_(i,j) = ℙ(Y(t)=i|X(t)=j), i=1,..,m  j=1,...,m\n",
+    "    p_(i,j) = ℙ(Y(t)=i|X(t)=j), i=1,..,m  j=1,...,n\n",
     "    \n",
     "    The matrix P ∈ ℝ^(m*n) is called the channel transition matrix, and\n",
     "    the channel is called a discrete memoryless channel. Assuming X has a\n",
@@ -92,11 +93,11 @@
     "    \n",
     "    # y is the probability distribution of the output signal Y(t)\n",
     "    # P is the channel transition matrix\n",
-    "    y = P*x\n",
+    "    y = P@x\n",
     "    \n",
     "    # I is the mutual information between x and y\n",
-    "    c = np.sum(P*np.log2(P),axis=0)\n",
-    "    I = c*x + cp.sum(cp.entr(y))\n",
+    "    c = np.sum(np.array((xlogy(P, P) / math.log(2))), axis=0)\n",
+    "    I = c@x + cp.sum(cp.entr(y) / math.log(2))\n",
     "\n",
     "    # Channel capacity maximised by maximising the mutual information\n",
     "    obj = cp.Minimize(-I)\n",
@@ -122,7 +123,7 @@
     "\n",
     "$P = \\pmatrix{0.75,0.25\\\\0.25,0.75}$\n",
     "\n",
-    "Note that the rows of $P$ must sum to 1 and all elements of $P$ must be positive."
+    "Note that the columns of $P$ must sum to 1 and all elements of $P$ must be positive."
    ]
   },
   {


### PR DESCRIPTION
This PR aims to fix the bugs mentioned in https://github.com/cvxpy/cvxpy/issues/1578
Also, it uses `@` instead of the deprecated `*` for matrix-matrix multiplication

Note that `xlogy(P, P)` is actually `e-based`, and `cp.entr(y)` is also `e-based`. I think base-2 makes more sense (considering the fact that the original code has already used `P*np.log2(P)`, which is `2-based`).