### PR TITLE
[CI] Remove Gurobi for Python 3.6

### DIFF
--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -39,6 +39,8 @@ fi
 
 if [[ "$PYTHON_VERSION" == "3.10" ]]; then
   python -m pip install diffcp gurobipy
+elif [[ "$PYTHON_VERSION" == "3.6" ]]; then
+  python -m pip install diffcp xpress
 else
   python -m pip install diffcp gurobipy xpress
 fi


### PR DESCRIPTION
## Description
The free Gurobi license has expired for Python 3.6, leading to unrelated test failures in #1606.
> gurobipy.GurobiError: License expired 2022-01-13

Issue link (if applicable): NA

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)