### PR TITLE
Fix: GLPK with no constraints

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/glpk_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glpk_conif.py
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+
 import cvxpy.interface as intf
 import cvxpy.settings as s
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.conic_solvers.cvxopt_conif import CVXOPT
-import numpy as np
 
 
 class GLPK(CVXOPT):

--- a/cvxpy/reductions/solvers/conic_solvers/glpk_mi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glpk_mi_conif.py
@@ -19,6 +19,7 @@ import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.conic_solvers import GLPK
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+import numpy as np
 
 
 class GLPK_MI(GLPK):
@@ -51,6 +52,15 @@ class GLPK_MI(GLPK):
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
         import cvxopt
         import cvxopt.solvers
+
+        # handle missing constraints
+        var_length = data[s.C].size[0]
+        if data[s.A] is None:
+            data[s.A] = intf.sparse2cvxopt(np.zeros((1, var_length)))
+            data[s.B] = intf.dense2cvxopt(np.zeros((1, 1)))
+        if data[s.G] is None:
+            data[s.G] = intf.sparse2cvxopt(np.zeros((1, var_length)))
+            data[s.H] = intf.dense2cvxopt(np.zeros((1, 1)))
 
         # Save original cvxopt solver options.
         old_options = cvxopt.glpk.options.copy()

--- a/cvxpy/reductions/solvers/conic_solvers/glpk_mi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glpk_mi_conif.py
@@ -60,7 +60,7 @@ class GLPK_MI(GLPK):
         else:
             cvxopt.glpk.options["msg_lev"] = "GLP_MSG_OFF"
 
-        data = self._handle_missing_constraints(data)
+        data = self._prepare_cvxopt_matrices(data)
 
         # Apply any user-specific options.
         # Rename max_iters to maxiters.

--- a/cvxpy/reductions/solvers/conic_solvers/glpk_mi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glpk_mi_conif.py
@@ -19,7 +19,6 @@ import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.conic_solvers import GLPK
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
-import numpy as np
 
 
 class GLPK_MI(GLPK):
@@ -53,15 +52,6 @@ class GLPK_MI(GLPK):
         import cvxopt
         import cvxopt.solvers
 
-        # handle missing constraints
-        var_length = data[s.C].size[0]
-        if data[s.A] is None:
-            data[s.A] = intf.sparse2cvxopt(np.zeros((1, var_length)))
-            data[s.B] = intf.dense2cvxopt(np.zeros((1, 1)))
-        if data[s.G] is None:
-            data[s.G] = intf.sparse2cvxopt(np.zeros((1, var_length)))
-            data[s.H] = intf.dense2cvxopt(np.zeros((1, 1)))
-
         # Save original cvxopt solver options.
         old_options = cvxopt.glpk.options.copy()
         # Silence cvxopt if verbose is False.
@@ -69,6 +59,8 @@ class GLPK_MI(GLPK):
             cvxopt.glpk.options["msg_lev"] = "GLP_MSG_ON"
         else:
             cvxopt.glpk.options["msg_lev"] = "GLP_MSG_OFF"
+
+        data = self._handle_missing_constraints(data)
 
         # Apply any user-specific options.
         # Rename max_iters to maxiters.

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -245,6 +245,17 @@ def lp_5() -> SolverTestHelper:
     return sth
 
 
+def lp_6() -> SolverTestHelper:
+    """Test LP with no constraints"""
+    x = cp.Variable()
+    from cvxpy.expressions.constants import Constant
+    objective = cp.Maximize(Constant(0.23) * x)
+    obj_pair = (objective, np.inf)
+    var_pairs = [(x, None)]
+    sth = SolverTestHelper(obj_pair, var_pairs, [])
+    return sth
+
+
 def socp_0() -> SolverTestHelper:
     x = cp.Variable(shape=(2,))
     obj_pair = (cp.Minimize(cp.norm(x, 2) + 1), 1)
@@ -832,6 +843,17 @@ class StandardTestLPs:
     @staticmethod
     def test_lp_5(solver, places: int = 4, duals: bool = True,  **kwargs) -> SolverTestHelper:
         sth = lp_5()
+        sth.solve(solver, **kwargs)
+        sth.verify_objective(places)
+        sth.check_primal_feasibility(places)
+        if duals:
+            sth.check_complementarity(places)
+            sth.check_dual_domains(places)
+        return sth
+
+    @staticmethod
+    def test_lp_6(solver, places: int = 4, duals: bool = True, **kwargs) -> SolverTestHelper:
+        sth = lp_6()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.check_primal_feasibility(places)

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -693,6 +693,17 @@ def mi_lp_3() -> SolverTestHelper:
     return sth
 
 
+def mi_lp_4() -> SolverTestHelper:
+    """Test MI without constraints"""
+    x = cp.Variable(boolean=True)
+    from cvxpy.expressions.constants import Constant
+    objective = cp.Maximize(Constant(0.23) * x)
+    obj_pair = (objective, 0.23)
+    var_pairs = [(x, 1)]
+    sth = SolverTestHelper(obj_pair, var_pairs, [])
+    return sth
+
+
 def mi_socp_1() -> SolverTestHelper:
     """
     Formulate the following mixed-integer SOCP with cvxpy
@@ -861,6 +872,13 @@ class StandardTestLPs:
         sth.verify_primal_values(places)
         return sth
 
+    @staticmethod
+    def test_mi_lp_4(solver, places: int = 4, **kwargs) -> SolverTestHelper:
+        sth = mi_lp_4()
+        sth.solve(solver, **kwargs)
+        sth.verify_objective(places)
+        sth.verify_primal_values(places)
+        return sth
 
 class StandardTestSOCPs:
 

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -902,6 +902,7 @@ class StandardTestLPs:
         sth.verify_primal_values(places)
         return sth
 
+
 class StandardTestSOCPs:
 
     @staticmethod

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -671,6 +671,9 @@ class TestGLPK(unittest.TestCase):
     def test_glpk_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='GLPK_MI')
 
+    def test_glpk_mi_lp_4(self) -> None:
+        StandardTestLPs.test_mi_lp_4(solver='GLPK_MI')
+
 
 @unittest.skipUnless('CPLEX' in INSTALLED_SOLVERS, 'CPLEX is not installed.')
 class TestCPLEX(BaseTest):

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -659,6 +659,9 @@ class TestGLPK(unittest.TestCase):
     def test_glpk_lk_5(self) -> None:
         StandardTestLPs.test_lp_5(solver='GLPK')
 
+    def test_glpk_lp_6(self) -> None:
+        StandardTestLPs.test_lp_6(solver='GLPK')
+
     def test_glpk_mi_lp_0(self) -> None:
         StandardTestLPs.test_mi_lp_0(solver='GLPK_MI')
 


### PR DESCRIPTION
## Description
When no constraints are specified, the GLPK_MI and GLPK solvers would previously fail. Here we convert missing constraint matrices from `None` into trivial matrices that are valid for use by `cvxopt.glpk`.
Issue link (if applicable): https://github.com/cvxpy/cvxpy/issues/1614

### Benchmark before this change:
```
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.8.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/allen/work/community/cvxpy, configfile: pyproject.toml
collected 11 items                                                                                                                                                         

cvxpy/tests/test_benchmarks.py cone_matrix_stuffing_with_many_constraints: avg=8.369e-01 s , std=0.000e+00 s (1 iterations)
.diffcp_sdp: avg=3.681e+00 s , std=0.000e+00 s (1 iterations)
.least_squares: avg=4.734e-03 s , std=0.000e+00 s (1 iterations)
.sConic canonicalization
(ECOS) solver time:  0.038715335
cvxpy time:  0.41344025505737303
Quadratic canonicalization
(OSQP) solver time:  0.017661457
cvxpy time:  0.5075722885749512
.qp: avg=9.489e-03 s , std=0.000e+00 s (1 iterations)
.small_cone_matrix_stuffing: avg=3.803e-02 s , std=1.218e-02 s (10 iterations)
.small_lp: avg=1.310e-02 s , std=0.000e+00 s (1 iterations)
small_lp_second_time: avg=1.061e-03 s , std=0.000e+00 s (1 iterations)
.sstv_inpainting: avg=1.717e+00 s , std=0.000e+00 s (1 iterations)
.
```

### Benchmark after this change:  (updated to latest commit)
```
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.8.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/allen/work/community/cvxpy, configfile: pyproject.toml
collected 11 items                                                                                                                                                         

cvxpy/tests/test_benchmarks.py cone_matrix_stuffing_with_many_constraints: avg=8.326e-01 s , std=0.000e+00 s (1 iterations)
.diffcp_sdp: avg=3.606e+00 s , std=0.000e+00 s (1 iterations)
.least_squares: avg=4.615e-03 s , std=0.000e+00 s (1 iterations)
.sConic canonicalization
(ECOS) solver time:  0.038927703
cvxpy time:  0.40401014795214846
Quadratic canonicalization
(OSQP) solver time:  0.01777715
cvxpy time:  0.5073912688842773
.qp: avg=9.249e-03 s , std=0.000e+00 s (1 iterations)
.small_cone_matrix_stuffing: avg=3.758e-02 s , std=1.457e-02 s (10 iterations)
.small_lp: avg=1.250e-02 s , std=0.000e+00 s (1 iterations)
small_lp_second_time: avg=1.085e-03 s , std=0.000e+00 s (1 iterations)
.sstv_inpainting: avg=1.740e+00 s , std=0.000e+00 s (1 iterations)
.
```

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.