### PR TITLE
[doc] Multi-version documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,57 @@
+name: doc_deploy
+
+on:
+    workflow_dispatch:
+
+jobs:
+  doc_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+      - name: Set already deployed versions
+        run: |
+          python -m pip install packaging
+          echo LATEST_DEPLOYED_VERSION=$(python -c "import os;from packaging import version;print(sorted([version.parse(i) for i in os.listdir('version')])[-1])") >> $GITHUB_ENV
+          echo ALL_DEPLOYED_VERSIONS=$(python -c "import os;from packaging import version;print(os.listdir('version'))") >> $GITHUB_ENV
+
+        # Checkout master
+      - uses: actions/checkout@v2
+      - name: Install
+        run: |
+          python -m pip install -e .
+          python -m pip install sphinx
+          cd doc
+          make html
+
+      - name: Set current version
+        run: |
+          export CURRENT_VERSION=$(python -c "import cvxpy;__version__ = cvxpy.__version__;print('.'.join(__version__.split('.')[:2]))")
+          echo CURRENT_VERSION=$CURRENT_VERSION >> $GITHUB_ENV
+          echo VERSION_PATH=/version/$CURRENT_VERSION >> $GITHUB_ENV
+          echo DEPLOY_LATEST=$(python continuous_integration/doc_is_latest.py --c "$CURRENT_VERSION" --l "$LATEST_DEPLOYED_VERSION") >> $GITHUB_ENV
+
+      - name: Deploy this version
+        uses: JamesIves/github-pages-deploy-action@v4.2.2
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: doc/build/html # The folder the action should deploy.
+          target-folder: ${{ env.VERSION_PATH }}
+
+      - name: Create version json
+        run: |
+          python continuous_integration/doc_write_versions.py
+          mv versions.json doc/build/html
+
+      - name: Deploy to root if latest version
+        if: ${{env.DEPLOY_LATEST == 'True'}}
+        uses: JamesIves/github-pages-deploy-action@v4.2.2
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: doc/build/html # The folder the action should deploy.
+          clean-exclude: |
+            version/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,4 +11,4 @@ repos:
     hooks:
       - id: flake8
         args: ['--config=setup.cfg']
-        files: cvxpy/
+        files: ^(cvxpy|continuous_integration)/

--- a/PROCEDURES.md
+++ b/PROCEDURES.md
@@ -109,3 +109,11 @@ If this file has changed between versions, the old patch will fail to apply and 
 
 
 ## Deploying updated documentation to gh-pages
+
+The webdocs are built and deployed using a GitHub action that can be found can be found [here](https://github.com/cvxpy/cvxpy/blob/master/.github/workflows/docs.yml).
+
+To deploy the docs for a specific version, navigate to the [actions tab](https://github.com/cvxpy/cvxpy/actions) and select the `docs` workflow.
+Under `Use workflow from`, select the **Tags** tab and choose the version you want to deploy the docs for.
+This builds the docs and commits them to the `gh-pages` branch. This in turn triggers the deployment through the `github-pages bot`, which can also be monitored in the [actions tab](https://github.com/cvxpy/cvxpy/actions).
+
+After thie deployment, make sure that the docs are accessible through the browser and the version selector displays all expected versions.

--- a/PROCEDURES.md
+++ b/PROCEDURES.md
@@ -110,10 +110,10 @@ If this file has changed between versions, the old patch will fail to apply and 
 
 ## Deploying updated documentation to gh-pages
 
-The webdocs are built and deployed using a GitHub action that can be found can be found [here](https://github.com/cvxpy/cvxpy/blob/master/.github/workflows/docs.yml).
+The web documentation is built and deployed using a GitHub action that can be found [here](https://github.com/cvxpy/cvxpy/blob/master/.github/workflows/docs.yml).
 
 To deploy the docs for a specific version, navigate to the [actions tab](https://github.com/cvxpy/cvxpy/actions) and select the `docs` workflow.
 Under `Use workflow from`, select the **Tags** tab and choose the version you want to deploy the docs for.
 This builds the docs and commits them to the `gh-pages` branch. This in turn triggers the deployment through the `github-pages bot`, which can also be monitored in the [actions tab](https://github.com/cvxpy/cvxpy/actions).
 
-After thie deployment, make sure that the docs are accessible through the browser and the version selector displays all expected versions.
+After the deployment, make sure that the docs are accessible through the browser, and the version selector displays all expected versions.

--- a/continuous_integration/doc_is_latest.py
+++ b/continuous_integration/doc_is_latest.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-# This is a helper file to determine if the doc version that is currently deployed is the latest version
+# This is a helper to determine if the doc version that is currently deployed is the latest version
 
 import argparse
 

--- a/continuous_integration/doc_is_latest.py
+++ b/continuous_integration/doc_is_latest.py
@@ -1,0 +1,27 @@
+"""
+Copyright 2022 the CVXPY developers
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# This is a helper file to determine if the doc version that is currently deployed is the latest version
+
+import argparse
+
+from packaging import version
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--c', type=str, help='current version')
+parser.add_argument('--l', type=str, help='latest deployed version')
+args = parser.parse_args()
+if not args.l:
+    print(True)
+else:
+    print(version.parse(args.c) >= version.parse(args.l))

--- a/continuous_integration/doc_write_versions.py
+++ b/continuous_integration/doc_write_versions.py
@@ -1,0 +1,34 @@
+"""
+Copyright 2022 the CVXPY developers
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import ast
+import json
+import os
+
+from packaging import version
+
+# This script creates a "versions.json" file listing all currently deployed version of the documentation
+
+if os.environ["ALL_DEPLOYED_VERSIONS"]:
+    deployed_versions = [version.parse(v) for v in ast.literal_eval(os.environ["ALL_DEPLOYED_VERSIONS"])]
+else:
+    deployed_versions = []
+this_version = version.parse(os.environ["CURRENT_VERSION"])
+
+all_versions = {this_version} | set(deployed_versions)
+
+versions = reversed(sorted(all_versions))
+version_str = [str(v) for v in versions]
+
+with open("versions.json", "w") as f:
+    json.dump(version_str, f)

--- a/continuous_integration/doc_write_versions.py
+++ b/continuous_integration/doc_write_versions.py
@@ -18,6 +18,8 @@ import os
 from packaging import version
 
 # This script creates a "versions.json" file listing all deployed version of the documentation
+# The file is versioned on the gh-pages branch: https://github.com/cvxpy/cvxpy/commits/gh-pages/versions.json
+# (Link to discussion in PR: https://github.com/cvxpy/cvxpy/pull/1624#discussion_r795327821 )
 
 if os.environ["ALL_DEPLOYED_VERSIONS"]:
     deployed_versions = [

--- a/continuous_integration/doc_write_versions.py
+++ b/continuous_integration/doc_write_versions.py
@@ -17,10 +17,12 @@ import os
 
 from packaging import version
 
-# This script creates a "versions.json" file listing all currently deployed version of the documentation
+# This script creates a "versions.json" file listing all deployed version of the documentation
 
 if os.environ["ALL_DEPLOYED_VERSIONS"]:
-    deployed_versions = [version.parse(v) for v in ast.literal_eval(os.environ["ALL_DEPLOYED_VERSIONS"])]
+    deployed_versions = [
+        version.parse(v) for v in ast.literal_eval(os.environ["ALL_DEPLOYED_VERSIONS"])
+    ]
 else:
     deployed_versions = []
 this_version = version.parse(os.environ["CURRENT_VERSION"])

--- a/continuous_integration/doc_write_versions.py
+++ b/continuous_integration/doc_write_versions.py
@@ -18,7 +18,8 @@ import os
 from packaging import version
 
 # This script creates a "versions.json" file listing all deployed version of the documentation
-# The file is versioned on the gh-pages branch: https://github.com/cvxpy/cvxpy/commits/gh-pages/versions.json
+# The file is versioned on the gh-pages branch:
+# https://github.com/cvxpy/cvxpy/commits/gh-pages/versions.json
 # (Link to discussion in PR: https://github.com/cvxpy/cvxpy/pull/1624#discussion_r795327821 )
 
 if os.environ["ALL_DEPLOYED_VERSIONS"]:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -137,7 +137,7 @@ extensions += ['alabaster']
 html_theme = 'cvxpy_alabaster'
 html_sidebars = {
    '**': [
-       'about.html', 'navigation.html', 'searchbox.html',
+       'about.html', 'navigation.html', 'searchbox.html', 'version_selector.html',
    ]
 }
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -135,6 +135,8 @@ table_styling_embed_css = False
 html_theme_path = [alabaster.get_path(), "../themes"]
 extensions += ['alabaster']
 html_theme = 'cvxpy_alabaster'
+# Note: the version selector could be omitted for local builds.
+# See https://github.com/cvxpy/cvxpy/pull/1624#discussion_r795207339 for a discussion on the topic
 html_sidebars = {
    '**': [
        'about.html', 'navigation.html', 'searchbox.html', 'version_selector.html',

--- a/doc/themes/version_selector.html
+++ b/doc/themes/version_selector.html
@@ -1,0 +1,19 @@
+<div>
+    <h3>
+        Version selector
+    </h3>
+    <select id="dynamic_selector" name="versions" onchange="if (this.value) window.location.href=this.value">
+    </select>
+    <script>
+        obj = $.getJSON("https://raw.githubusercontent.com/cvxpy/cvxpy/gh-pages/versions.json")
+            .done(function (data) {
+                const base_url = "https://www.cvxpy.org/"
+                let html = "<option value='' selected>Choose version here</option>";
+                html += "<option value=" + base_url + ">latest" + ""
+                for (let i = 0; i < data.length; i++) {
+                    html += "<option value=" + base_url + "version/"  + data[i] + ">" + data[i] + ""
+                }
+                document.getElementById("dynamic_selector").innerHTML = html;
+            });
+    </script>
+</div>


### PR DESCRIPTION
## Description
This PR enables deploying multiple versions of the web documentation as a second follow-up to #1598.

### Details
Whenever the action is triggered:
1. The docs are built
2. The docs are deployed into a `version/MAJOR.MINOR` folder (overwriting if already exists) on the `gh-pages` branch
3. If the version of the current build is greater or equal to the highest previously deployed version, the docs are also deployed to the root of the `gh-pages` branch.
4. A file called `versions.json` in the root of the `gh-branch` is created or updated, which lists all currently deployed version
5. A dynamic version selector will reflect the changes in 4., such that one can always switch between all deployed versions

### Tests on my fork
I have experimented with the setup in my fork, see [here](https://phschiele.github.io/cvxpy/) (I'll remove this as soon as this PR is merged).

Here are the test cases I ran. Each commit has a `This is test X` on the landing page.
1. Deploy version `1.1.0` -> Deploys to root and `version/1.1`
2. Deploy version `1.2.1` -> Deploys to root and `version/1.2`
3. Deploy version `1.1.1` -> No deploy to root, only overwrites `version/1.1`
4. Deploy version `1.3.0` -> Deploys to root and `version/1.3`

Version dropdown shows:
- latest (1.3)
- 1.3
- 1.2
- 1.1

Note:
Tests for 3.6 are failing as during the conda install `ModuleNotFoundError: No module named 'dataclasses'` is raised. This seems unrelated to the changes in this PR. Looks similar to the failures observed in #1575 .

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.