### PR TITLE
Build failures: Python 3.6, and SCIP

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           ref: gh-pages
       - name: Set latest deployed version
-        run:
+        run: |
           python -m pip install packaging
           echo LATEST_DEPLOYED_VERSION=$(python -c "import os;from packaging import version;print(sorted([version.parse(i) for i in os.listdir('version')])[-1])") >> $GITHUB_ENV
 
@@ -29,7 +29,7 @@ jobs:
           make html
 
       - name: Set current version
-        run:
+        run: |
           export CURRENT_VERSION=$(python -c "import cvxpy;__version__ = cvxpy.__version__;print('.'.join(__version__.split('.')[:2]))")
           echo CURRENT_VERSION=$CURRENT_VERSION >> $GITHUB_ENV
           echo VERSION_PATH=/version/$CURRENT_VERSION

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           clean-exclude: '["version"]'
 
       - name: Deploy latest version
-        if: ${{env.VERSION == env.}}
+        if: ${{env.VERSION == env.LATEST_VERSION}}
         uses: JamesIves/github-pages-deploy-action@v4.2.2
         with:
           branch: gh-pages # The branch the action should deploy to.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           export CURRENT_VERSION=$(python -c "import cvxpy;__version__ = cvxpy.__version__;print('.'.join(__version__.split('.')[:2]))")
           echo CURRENT_VERSION=$CURRENT_VERSION >> $GITHUB_ENV
-          echo VERSION_PATH=/version/$CURRENT_VERSION
-          echo DEPLOY_LATEST=$(python -c "import os;from packaging import version;print(version.parse(os.environ["CURRENT_VERSION"])>=version.parse(os.environ["LATEST_DEPLOYED_VERSION"]))")
+          echo VERSION_PATH=/version/$CURRENT_VERSION >> $GITHUB_ENV
+          echo DEPLOY_LATEST=$(python continuous_integration/doc_deploy.py --c "CURRENT_VERSION" --l "$LATEST_DEPLOYED_VERSION") >> $GITHUB_ENV
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.2.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,23 +4,16 @@ on:
     workflow_dispatch:
 
 jobs:
-  cleanup-runs:
+  webdocs:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/setup-python@v2
         with:
-          auto-update-conda: true
           python-version: 3.8
-          channels: conda-forge,anaconda
       - name: Install
-        env:
-          PYTHON_VERSION: "3.8"
         run: |
-          source continuous_integration/install_dependencies.sh
+          python -m pip install -e .
           python -m pip install sphinx
           cd doc
           make html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install
         run: |
-          python -m pip install -e .
+          # python -m pip install -e .
           python -m pip install sphinx
           cd doc
           make html
@@ -41,7 +41,6 @@ jobs:
           branch: gh-pages # The branch the action should deploy to.
           folder: doc/build/html # The folder the action should deploy.
           target-folder: ${{ env.VERSION_PATH }}
-          clean: true # Automatically remove deleted files from the deploy branch
 
       - name: Deploy latest version
         if: ${{env.DEPLOY_LATEST == 'True'}}
@@ -49,5 +48,4 @@ jobs:
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: doc/build/html # The folder the action should deploy.
-          clean: true # Automatically remove deleted files from the deploy branch
           clean-exclude: '["version"]'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           ref: gh-pages
       - name: Set latest version
-        run: echo LATEST_VERSION=$(python -c "sorted([float(i) for i in os.listdir("version")])[-1]") >> $GITHUB_ENV
+        run: echo LATEST_VERSION=$(python -c "import os;sorted([float(i) for i in os.listdir("version")])[-1]") >> $GITHUB_ENV
 
         # Checkout master
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,9 @@ jobs:
         with:
           ref: gh-pages
       - name: Set latest deployed version
-        run: echo LATEST_DEPLOYED_VERSION=$(python -c "import os;from packaging import version;print(sorted([version.parse(i) for i in os.listdir('version')])[-1])") >> $GITHUB_ENV
+        run: |
+        python -m pip install packaging
+        echo LATEST_DEPLOYED_VERSION=$(python -c "import os;from packaging import version;print(sorted([version.parse(i) for i in os.listdir('version')])[-1])") >> $GITHUB_ENV
 
         # Checkout master
       - uses: actions/checkout@v2
@@ -28,7 +30,8 @@ jobs:
 
       - name: Set current version
         run:
-          echo CURRENT_VERSION=$(python -c "import cvxpy;__version__ = cvxpy.__version__;print('.'.join(__version__.split('.')[:2]))") >> $GITHUB_ENV
+          export CURRENT_VERSION=$(python -c "import cvxpy;__version__ = cvxpy.__version__;print('.'.join(__version__.split('.')[:2]))")
+          echo CURRENT_VERSION=$CURRENT_VERSION >> $GITHUB_ENV
           echo VERSION_PATH=/version/$CURRENT_VERSION
           echo DEPLOY_LATEST=$(python -c "import os;from packaging import version;print(version.parse(os.environ["CURRENT_VERSION"])>=version.parse(os.environ["LATEST_DEPLOYED_VERSION"]))")
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           ref: gh-pages
       - name: Set latest version
-        run: echo LATEST_VERSION=$(python -c "import os;sorted([float(i) for i in os.listdir("version")])[-1]") >> $GITHUB_ENV
+        run: echo LATEST_VERSION=$(python -c "import os;sorted([float(i) for i in os.listdir('version')])[-1]") >> $GITHUB_ENV
 
         # Checkout master
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,6 @@ jobs:
         run:
           echo CURRENT_VERSION=$(python -c "import cvxpy;__version__ = cvxpy.__version__;print('.'.join(__version__.split('.')[:2]))") >> $GITHUB_ENV
           echo VERSION_PATH=/version/$CURRENT_VERSION
-          # Deploy to the root if this version >= the latest deployed version
           echo DEPLOY_LATEST=$(python -c "import os;from packaging import version;print(version.parse(os.environ["CURRENT_VERSION"])>=version.parse(os.environ["LATEST_DEPLOYED_VERSION"]))")
 
       - name: Deploy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,18 @@ jobs:
   webdocs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+      - name: Set latest version
+        run: echo LATEST_VERSION=$(python -c "sorted([float(i) for i in os.listdir("version")])[-1]") >> $GITHUB_ENV
+
+        # Checkout master
+      - uses: actions/checkout@v2
+
       - name: Install
         run: |
           python -m pip install -e .
@@ -18,8 +26,8 @@ jobs:
           cd doc
           make html
 
-      - name: Set version
-        run:  echo VERSION=/version/$(python -c "import cvxpy;__version__ = cvxpy.__version__;print('.'.join(__version__.split('.')[:2]))") >> $GITHUB_ENV
+      - name: Set current version
+        run: echo VERSION=/version/$(python -c "import cvxpy;__version__ = cvxpy.__version__;print('.'.join(__version__.split('.')[:2]))") >> $GITHUB_ENV
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.2.2
@@ -29,4 +37,13 @@ jobs:
           target-folder: ${{ env.VERSION }}
           clean: true # Automatically remove deleted files from the deploy branch
           clean-exclude: '["version"]'
-          
+
+      - name: Deploy latest version
+        if: ${{env.VERSION == env.}}
+        uses: JamesIves/github-pages-deploy-action@v4.2.2
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: doc/build/html # The folder the action should deploy.
+          target-folder: ${{ env.LATEST_VERSION }}
+          clean: true # Automatically remove deleted files from the deploy branch
+          clean-exclude: '["version"]'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           export CURRENT_VERSION=$(python -c "import cvxpy;__version__ = cvxpy.__version__;print('.'.join(__version__.split('.')[:2]))")
           echo CURRENT_VERSION=$CURRENT_VERSION >> $GITHUB_ENV
           echo VERSION_PATH=/version/$CURRENT_VERSION >> $GITHUB_ENV
-          echo DEPLOY_LATEST=$(python continuous_integration/doc_deploy.py --c "CURRENT_VERSION" --l "$LATEST_DEPLOYED_VERSION") >> $GITHUB_ENV
+          echo DEPLOY_LATEST=$(python continuous_integration/doc_deploy.py --c "$CURRENT_VERSION" --l "$LATEST_DEPLOYED_VERSION") >> $GITHUB_ENV
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.2.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install
         run: |
-          # python -m pip install -e .
+          python -m pip install -e .
           python -m pip install sphinx
           cd doc
           make html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           ref: gh-pages
       - name: Set latest version
-        run: echo LATEST_VERSION=$(python -c "import os;sorted([float(i) for i in os.listdir('version')])[-1]") >> $GITHUB_ENV
+        run: echo LATEST_VERSION=$(python -c "import os;print(sorted([float(i) for i in os.listdir('version')])[-1])") >> $GITHUB_ENV
 
         # Checkout master
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,15 @@ jobs:
           cd doc
           make html
 
-      - name: deploy
+      - name: Set version
+        run:  echo VERSION=/version/$(python -c "import cvxpy;__version__ = cvxpy.__version__;print('.'.join(__version__.split('.')[:2]))") >> $GITHUB_ENV
+
+      - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.2.2
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: doc/build/html # The folder the action should deploy.
+          target_folder: ${{ env.VERSION }}
+          clean: true # Automatically remove deleted files from the deploy branch
+          clean_exclude: '["version"]'
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
         with:
           ref: gh-pages
       - name: Set latest deployed version
-        run: |
-        python -m pip install packaging
-        echo LATEST_DEPLOYED_VERSION=$(python -c "import os;from packaging import version;print(sorted([version.parse(i) for i in os.listdir('version')])[-1])") >> $GITHUB_ENV
+        run:
+          python -m pip install packaging
+          echo LATEST_DEPLOYED_VERSION=$(python -c "import os;from packaging import version;print(sorted([version.parse(i) for i in os.listdir('version')])[-1])") >> $GITHUB_ENV
 
         # Checkout master
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: gh-pages
-      - name: Set latest version
-        run: echo LATEST_VERSION=/version/$(python -c "import os;print(sorted([float(i) for i in os.listdir('version')])[-1])") >> $GITHUB_ENV
+      - name: Set latest deployed version
+        run: echo LATEST_DEPLOYED_VERSION=$(python -c "import os;from packaging import version;print(sorted([version.parse(i) for i in os.listdir('version')])[-1])") >> $GITHUB_ENV
 
         # Checkout master
       - uses: actions/checkout@v2
@@ -27,22 +27,25 @@ jobs:
           make html
 
       - name: Set current version
-        run: echo VERSION=/version/$(python -c "import cvxpy;__version__ = cvxpy.__version__;print('.'.join(__version__.split('.')[:2]))") >> $GITHUB_ENV
+        run:
+          echo CURRENT_VERSION=$(python -c "import cvxpy;__version__ = cvxpy.__version__;print('.'.join(__version__.split('.')[:2]))") >> $GITHUB_ENV
+          echo VERSION_PATH=/version/$CURRENT_VERSION
+          # Deploy to the root if this version >= the latest deployed version
+          echo DEPLOY_LATEST=$(python -c "import os;from packaging import version;print(version.parse(os.environ["CURRENT_VERSION"])>=version.parse(os.environ["LATEST_DEPLOYED_VERSION"]))")
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.2.2
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: doc/build/html # The folder the action should deploy.
-          target-folder: ${{ env.VERSION }}
+          target-folder: ${{ env.VERSION_PATH }}
           clean: true # Automatically remove deleted files from the deploy branch
 
       - name: Deploy latest version
-        if: ${{env.VERSION == env.LATEST_VERSION}}
+        if: ${{env.DEPLOY_LATEST == 'True'}}
         uses: JamesIves/github-pages-deploy-action@v4.2.2
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: doc/build/html # The folder the action should deploy.
-          target-folder: ${{ env.LATEST_VERSION }}
           clean: true # Automatically remove deleted files from the deploy branch
           clean-exclude: '["version"]'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,10 @@ jobs:
           folder: doc/build/html # The folder the action should deploy.
           target-folder: ${{ env.VERSION_PATH }}
 
-      - name: Deploy latest version
-        if: ${{env.DEPLOY_LATEST == 'True'}}
-        uses: JamesIves/github-pages-deploy-action@v4.2.2
-        with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: doc/build/html # The folder the action should deploy.
-          clean-exclude: '["version"]'
+#      - name: Deploy latest version
+#        if: ${{env.DEPLOY_LATEST == 'True'}}
+#        uses: JamesIves/github-pages-deploy-action@v4.2.2
+#        with:
+#          branch: gh-pages # The branch the action should deploy to.
+#          folder: doc/build/html # The folder the action should deploy.
+#          clean-exclude: '["version"]'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           python -m pip install packaging
           echo LATEST_DEPLOYED_VERSION=$(python -c "import os;from packaging import version;print(sorted([version.parse(i) for i in os.listdir('version')])[-1])") >> $GITHUB_ENV
+          echo ALL_DEPLOYED_VERSIONS=$(python -c "import os;from packaging import version;print(os.listdir('version'))") >> $GITHUB_ENV
 
         # Checkout master
       - uses: actions/checkout@v2
@@ -41,6 +42,11 @@ jobs:
           branch: gh-pages # The branch the action should deploy to.
           folder: doc/build/html # The folder the action should deploy.
           target-folder: ${{ env.VERSION_PATH }}
+
+      - name: Create version json
+        run: |
+          python continuous_integration/doc_write_versions.py
+          mv versions.json doc/build/html
 
       - name: Deploy latest version
         if: ${{env.DEPLOY_LATEST == 'True'}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: doc/build/html # The folder the action should deploy.
-          target_folder: ${{ env.VERSION }}
+          target-folder: ${{ env.VERSION }}
           clean: true # Automatically remove deleted files from the deploy branch
-          clean_exclude: '["version"]'
+          clean-exclude: '["version"]'
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,257 +1,33 @@
 name: build
 
 on:
-    pull_request:
-    push:
-        branches:
-            - master
-        tags:
-          - '*'
+    workflow_dispatch:
 
 jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
-    steps:
-    - uses: rokroskar/workflow-run-cleanup-action@master
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
-
-  linters:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: isort
-        uses: jamescurtin/isort-action@master
-      - name: flake8
-        uses: py-actions/flake8@v1
-
-  build:
-    runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -l {0}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-18.04, macos-10.15, windows-2019 ]
-        python-version: [ 3.6, 3.7, 3.9, "3.10" ]
-        include:
-          - os: ubuntu-18.04
-            python-version: 3.8
-            openmp: "True"
-          - os: ubuntu-18.04
-            python-version: 3.8
-          - os: macos-10.15
-            python-version: 3.8
-            single_action_config: "True"
-          - os: windows-2019
-            python-version: 3.8
-
-    env:
-      RUNNER_OS: ${{ matrix.os }}
-      PYTHON_VERSION: ${{ matrix.python-version }}
-      SINGLE_ACTION_CONFIG: "${{ matrix.single_action_config == 'True' && 'True' || 'False' }}"
-      USE_OPENMP: "${{ matrix.openmp == 'True' && 'True' || 'False' }}"
-      MOSEK_CI_BASE64: ${{ secrets.MOSEK_CI_BASE64 }}
-
     steps:
       - uses: actions/checkout@v2
-      - name: Set Additional Envs
-        run: |
-          echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
-          echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
-          echo $MOSEK_CI_BASE64 | base64 -d > mosek.lic
-          echo "MOSEKLM_LICENSE_FILE=$( [[ $RUNNER_OS == 'macOS' ]] && echo $(pwd)/mosek.lic || echo $(realpath mosek.lic) )" >> $GITHUB_ENV
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.8
           channels: conda-forge,anaconda
-
       - name: Install
+        env:
+          PYTHON_VERSION: "3.8"
         run: |
           source continuous_integration/install_dependencies.sh
+          python -m pip install sphinx
+          cd doc
+          make html
 
-      - name: Test
-        run: |
-          source continuous_integration/test_script.sh
-
-      - name: Upload coverage file
-        uses: actions/upload-artifact@v2
-        if: ${{env.SINGLE_ACTION_CONFIG == 'True'}}
+      - name: deploy
+        uses: JamesIves/github-pages-deploy-action@v4.2.2
         with:
-          name: coverage
-          path: coverage.xml
-
-  build_wheels:
-    needs: build
-
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-18.04, macos-10.15, windows-2019 ]
-        python-version: [ 3.6, 3.7, 3.9, "3.10" ]
-        include:
-          - os: ubuntu-18.04
-            python-version: 3.8
-          - os: macos-10.15
-            python-version: 3.8
-            single_action_config: "True"
-          - os: windows-2019
-            python-version: 3.8
-
-    env:
-      RUNNER_OS: ${{ matrix.os }}
-      PYTHON_VERSION: ${{ matrix.python-version }}
-      SINGLE_ACTION_CONFIG: "${{ matrix.single_action_config == 'True' }}"
-      PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
-      PYPI_USER: ${{ secrets.PYPI_USER }}
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Set Additional Envs
-        shell: bash
-        run: |
-          echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
-          echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
-
-      - name: Build wheels
-        if: ${{env.DEPLOY == 'True' && env.USE_OPENMP != 'True'}}
-        env:
-          CIBW_BUILD: "cp3${{env.PYTHON_SUBVERSION}}-*"
-          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
-        uses: joerick/cibuildwheel@v2.3.1
-
-      - name: Build source
-        if: ${{env.DEPLOY == 'True' && env.SINGLE_ACTION_CONFIG == 'True'}}
-        run: |
-          python setup.py sdist --dist-dir=wheelhouse
-
-      - name: Release to pypi
-        if: ${{env.DEPLOY == 'True' &&  env.USE_OPENMP != 'True'}}
-        shell: bash
-        run: |
-          python -m pip install --upgrade twine
-          twine check wheelhouse/*
-          twine upload --repository-url $PYPI_SERVER wheelhouse/* -u $PYPI_USER -p $PYPI_PASSWORD
-
-      - name: Upload artifacts to github
-        if: ${{env.DEPLOY == 'True' && env.USE_OPENMP != 'True'}}
-        uses: actions/upload-artifact@v1
-        with:
-          name: wheels
-          path: ./wheelhouse
-
-  build_cvxpy-base:
-    needs: build
-
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-18.04, macos-10.15, windows-2019 ]
-        python-version: [ 3.6, 3.7, 3.9, "3.10" ]
-        include:
-          - os: ubuntu-18.04
-            python-version: 3.8
-          - os: macos-10.15
-            python-version: 3.8
-            single_action_config: "True"
-          - os: windows-2019
-            python-version: 3.8
-
-    env:
-      PYTHON_VERSION: ${{ matrix.python-version }}
-      SINGLE_ACTION_CONFIG: "${{ matrix.single_action_config == 'True' }}"
-      PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
-      PYPI_USER: ${{ secrets.PYPI_USER }}
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Set Additional Envs
-        shell: bash
-        run: |
-          echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
-          echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
-
-      - name: Adapt setup.py
-        shell: bash
-        run: |
-          # Mac has a different syntax for sed -i, this works across oses
-          sed -i.bak -e "s/name='cvxpy',/name='cvxpy-base',/g" setup.py
-          sed -i.bak '/osqp >= /d' setup.py
-          sed -i.bak '/ecos >= /d' setup.py
-          sed -i.bak '/scs >= /d' setup.py
-          rm -rf setup.py.bak
-
-      - name: Run some tests on one OS just to check imports are working
-        if: ${{env.SINGLE_ACTION_CONFIG == 'True'}}
-        run: |
-          pip install . pytest cplex
-          pytest cvxpy/tests/test_conic_solvers.py -k 'TestCPLEX'
-
-      - name: Build wheels
-        if: ${{env.DEPLOY == 'True'}}
-        env:
-          CIBW_BUILD: "cp3${{env.PYTHON_SUBVERSION}}-*"
-          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
-        uses: joerick/cibuildwheel@v2.3.1
-
-      - name: Build source
-        if: ${{env.DEPLOY == 'True' && env.SINGLE_ACTION_CONFIG == 'True'}}
-        run: |
-          python setup.py sdist --dist-dir=wheelhouse
-
-      - name: Release to pypi
-        shell: bash
-        if: ${{env.DEPLOY == 'True'}}
-        run: |
-          python -m pip install --upgrade twine
-          twine check wheelhouse/*
-          twine upload --repository-url $PYPI_SERVER wheelhouse/* -u $PYPI_USER -p $PYPI_PASSWORD
-
-      - name: Upload artifacts to github
-        if: ${{env.DEPLOY == 'True'}}
-        uses: actions/upload-artifact@v1
-        with:
-          name: wheels-base
-          path: ./wheelhouse
-
-  sonarcloud:
-    needs: build
-    name: SonarCloud
-    runs-on: ubuntu-latest
-    env:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - uses: actions/download-artifact@v2
-        with:
-          name: coverage
-      - name: Check if environment variable exists
-        run: |
-          echo "RUN_SONAR=$( [[ -n "$SONAR_TOKEN" ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
-      - name: SonarCloud Scan
-        if: ${{env.RUN_SONAR == 'True'}}
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          branch: gh-pages # The branch the action should deploy to.
+          folder: doc/build # The folder the action should deploy.
+          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,5 +22,5 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.2.2
         with:
           branch: gh-pages # The branch the action should deploy to.
-          folder: doc/build # The folder the action should deploy.
+          folder: doc/build/html # The folder the action should deploy.
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,11 @@ jobs:
           folder: doc/build/html # The folder the action should deploy.
           target-folder: ${{ env.VERSION_PATH }}
 
-#      - name: Deploy latest version
-#        if: ${{env.DEPLOY_LATEST == 'True'}}
-#        uses: JamesIves/github-pages-deploy-action@v4.2.2
-#        with:
-#          branch: gh-pages # The branch the action should deploy to.
-#          folder: doc/build/html # The folder the action should deploy.
-#          clean-exclude: '["version"]'
+      - name: Deploy latest version
+        if: ${{env.DEPLOY_LATEST == 'True'}}
+        uses: JamesIves/github-pages-deploy-action@v4.2.2
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: doc/build/html # The folder the action should deploy.
+          clean-exclude: |
+            version/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           ref: gh-pages
       - name: Set latest version
-        run: echo LATEST_VERSION=$(python -c "import os;print(sorted([float(i) for i in os.listdir('version')])[-1])") >> $GITHUB_ENV
+        run: echo LATEST_VERSION=/version/$(python -c "import os;print(sorted([float(i) for i in os.listdir('version')])[-1])") >> $GITHUB_ENV
 
         # Checkout master
       - uses: actions/checkout@v2
@@ -36,7 +36,6 @@ jobs:
           folder: doc/build/html # The folder the action should deploy.
           target-folder: ${{ env.VERSION }}
           clean: true # Automatically remove deleted files from the deploy branch
-          clean-exclude: '["version"]'
 
       - name: Deploy latest version
         if: ${{env.VERSION == env.LATEST_VERSION}}

--- a/continuous_integration/doc_deploy.py
+++ b/continuous_integration/doc_deploy.py
@@ -1,0 +1,11 @@
+from packaging import version
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--c', type=str, help='current version')
+parser.add_argument('--l', type=str, help='latest deployed version')
+args = parser.parse_args()
+if not args.l:
+    print(True)
+else:
+    print(version.parse(args.c) >= version.parse(args.l))

--- a/continuous_integration/doc_write_versions.py
+++ b/continuous_integration/doc_write_versions.py
@@ -3,7 +3,15 @@ import ast
 import json
 import os
 
-versions = reversed(sorted(version.parse(v) for v in ast.literal_eval(os.environ["ALL_DEPLOYED_VERSIONS"])))
+if os.environ["ALL_DEPLOYED_VERSIONS"]:
+    deployed_versions = [version.parse(v) for v in ast.literal_eval(os.environ["ALL_DEPLOYED_VERSIONS"])]
+else:
+    deployed_versions = []
+this_version = version.parse(os.environ["CURRENT_VERSION"])
+
+all_versions = {this_version} | set(deployed_versions)
+
+versions = reversed(sorted(all_versions))
 version_str = [str(v) for v in versions]
 
 with open("versions.json", "w") as f:

--- a/continuous_integration/doc_write_versions.py
+++ b/continuous_integration/doc_write_versions.py
@@ -1,0 +1,10 @@
+from packaging import version
+import ast
+import json
+import os
+
+versions = reversed(sorted(version.parse(v) for v in ast.literal_eval(os.environ["ALL_DEPLOYED_VERSIONS"])))
+version_str = [str(v) for v in versions]
+
+with open("versions.json", "w") as f:
+    json.dump(version_str, f)

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -10,6 +10,10 @@ conda config --set remote_max_retries 10
 conda config --set remote_backoff_factor 2
 conda config --set remote_read_timeout_secs 120.0
 
+if [[ "$PYTHON_VERSION" == "3.6" ]]; then
+  conda install dataclasses
+fi
+
 if [[ "$PYTHON_VERSION" == "3.6" ]] || [[ "$PYTHON_VERSION" == "3.7" ]] || [[ "$PYTHON_VERSION" == "3.8" ]]; then
   conda install scipy=1.3 numpy=1.16 mkl pip pytest pytest-cov lapack ecos scs osqp cvxopt
   python -m pip install cplex  # CPLEX is not available yet on 3.9
@@ -34,7 +38,7 @@ fi
 
 # SCIP only works with scipy >= 1.5 due to dependency conflicts when installing on Linux/macOS
 if [[ "$PYTHON_VERSION" == "3.9" ]] || [[ "$RUNNER_OS" == "Windows" ]]; then
-  conda install pyscipopt
+  conda install pyscipopt<4.0.0
 fi
 
 if [[ "$PYTHON_VERSION" == "3.10" ]]; then

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -137,7 +137,7 @@ extensions += ['alabaster']
 html_theme = 'cvxpy_alabaster'
 html_sidebars = {
    '**': [
-       'about.html', 'navigation.html', 'searchbox.html',
+       'about.html', 'navigation.html', 'searchbox.html', 'version_selector.html'
    ]
 }
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,7 +13,7 @@ Welcome to CVXPY
 
 **Convex optimization, for everyone.**
 
-This is test 2
+This is test 3
 
 *We are building a CVXPY community* `on Discord <https://discord.gg/4urRQeGBCr>`_. *Join the conversation!*
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,7 +13,7 @@ Welcome to CVXPY
 
 **Convex optimization, for everyone.**
 
-This is test 1
+This is test 2
 
 *We are building a CVXPY community* `on Discord <https://discord.gg/4urRQeGBCr>`_. *Join the conversation!*
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,7 +13,7 @@ Welcome to CVXPY
 
 **Convex optimization, for everyone.**
 
-This is test 5
+This is test 1
 
 *We are building a CVXPY community* `on Discord <https://discord.gg/4urRQeGBCr>`_. *Join the conversation!*
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,7 +13,7 @@ Welcome to CVXPY
 
 **Convex optimization, for everyone.**
 
-This is test 4
+This is test 5
 
 *We are building a CVXPY community* `on Discord <https://discord.gg/4urRQeGBCr>`_. *Join the conversation!*
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,6 +13,8 @@ Welcome to CVXPY
 
 **Convex optimization, for everyone.**
 
+This is test 1
+
 *We are building a CVXPY community* `on Discord <https://discord.gg/4urRQeGBCr>`_. *Join the conversation!*
 
 CVXPY is an open source Python-embedded modeling language for convex

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,7 +13,7 @@ Welcome to CVXPY
 
 **Convex optimization, for everyone.**
 
-This is test 3
+This is test 4
 
 *We are building a CVXPY community* `on Discord <https://discord.gg/4urRQeGBCr>`_. *Join the conversation!*
 

--- a/doc/themes/version_selector.html
+++ b/doc/themes/version_selector.html
@@ -2,7 +2,7 @@
     <h3>
         Version selector
     </h3>
-    <select id="dynamic_selector" name="nationality" onchange="if (this.value) window.location.href=this.value">
+    <select id="dynamic_selector" name="versions" onchange="if (this.value) window.location.href=this.value">
     </select>
     <script>
         obj = $.getJSON("https://raw.githubusercontent.com/phschiele/cvxpy/gh-pages/versions.json")

--- a/doc/themes/version_selector.html
+++ b/doc/themes/version_selector.html
@@ -1,0 +1,19 @@
+<div>
+    <h3>
+        Version selector
+    </h3>
+    <select id="dynamic_selector" name="nationality" onchange="if (this.value) window.location.href=this.value">
+    </select>
+    <script>
+        obj = $.getJSON("https://raw.githubusercontent.com/phschiele/cvxpy/gh-pages/versions.json")
+            .done(function (data) {
+                const base_url = "https://phschiele.github.io/cvxpy/"
+                let html = "<option value='' selected>Choose version here</option>";
+                html += "<option value=" + base_url + ">latest" + ""
+                for (let i = 0; i < data.length; i++) {
+                    html += "<option value=" + base_url + "version/"  + data[i] + ">" + data[i] + ""
+                }
+                document.getElementById("dynamic_selector").innerHTML = html;
+            });
+    </script>
+</div>

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ from setuptools.command.build_ext import build_ext
 #
 
 MAJOR = 1
-MINOR = 1
-MICRO = 0
+MINOR = 2
+MICRO = 1
 IS_RELEASED = True
 IS_RELEASE_BRANCH = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools.command.build_ext import build_ext
 #
 
 MAJOR = 1
-MINOR = 2
+MINOR = 3
 MICRO = 0
 IS_RELEASED = True
 IS_RELEASE_BRANCH = True

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ from setuptools.command.build_ext import build_ext
 #
 
 MAJOR = 1
-MINOR = 1
-MICRO = 1
+MINOR = 3
+MICRO = 0
 IS_RELEASED = True
 IS_RELEASE_BRANCH = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools.command.build_ext import build_ext
 #
 
 MAJOR = 1
-MINOR = 3
+MINOR = 4
 MICRO = 0
 IS_RELEASED = True
 IS_RELEASE_BRANCH = True

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools.command.build_ext import build_ext
 #
 
 MAJOR = 1
-MINOR = 2
+MINOR = 1
 MICRO = 1
 IS_RELEASED = True
 IS_RELEASE_BRANCH = True

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ from setuptools.command.build_ext import build_ext
 MAJOR = 1
 MINOR = 2
 MICRO = 0
-IS_RELEASED = False
-IS_RELEASE_BRANCH = False
+IS_RELEASED = True
+IS_RELEASE_BRANCH = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools.command.build_ext import build_ext
 #
 
 MAJOR = 1
-MINOR = 4
+MINOR = 1
 MICRO = 0
 IS_RELEASED = True
 IS_RELEASE_BRANCH = True


### PR DESCRIPTION
## Description
This PR tries to fix recent test failures outlined in the issue below.
Issue link (if applicable): #1626 

Python 3.6:
The `dataclasses` module seems to be no longer available. This feature was introduced in Python 3.7, but a backport to 3.6 is available.

pyscipopt:
A new version was released yesterday: https://anaconda.org/conda-forge/pyscipopt/files
Limiting the version to get the tests passing again until the interface has been fixed. 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.