### PR TITLE
WIP: Build failures: Python 3.6, and SCIP

### DIFF
--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -10,6 +10,10 @@ conda config --set remote_max_retries 10
 conda config --set remote_backoff_factor 2
 conda config --set remote_read_timeout_secs 120.0
 
+if [[ "$PYTHON_VERSION" == "3.6" ]]; then
+  conda install dataclasses
+fi
+
 if [[ "$PYTHON_VERSION" == "3.6" ]] || [[ "$PYTHON_VERSION" == "3.7" ]] || [[ "$PYTHON_VERSION" == "3.8" ]]; then
   conda install scipy=1.3 numpy=1.16 mkl pip pytest pytest-cov lapack ecos scs osqp cvxopt
   python -m pip install cplex  # CPLEX is not available yet on 3.9
@@ -34,7 +38,7 @@ fi
 
 # SCIP only works with scipy >= 1.5 due to dependency conflicts when installing on Linux/macOS
 if [[ "$PYTHON_VERSION" == "3.9" ]] || [[ "$RUNNER_OS" == "Windows" ]]; then
-  conda install pyscipopt
+  conda install pyscipopt<4.0.0
 fi
 
 if [[ "$PYTHON_VERSION" == "3.10" ]]; then

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -11,16 +11,16 @@ conda config --set remote_backoff_factor 2
 conda config --set remote_read_timeout_secs 120.0
 
 if [[ "$PYTHON_VERSION" == "3.6" ]]; then
-  conda install dataclasses
-fi
-
-if [[ "$PYTHON_VERSION" == "3.6" ]] || [[ "$PYTHON_VERSION" == "3.7" ]] || [[ "$PYTHON_VERSION" == "3.8" ]]; then
+  conda install scipy=1.3 numpy=1.16 mkl pip=21.3.1 pytest pytest-cov lapack ecos scs osqp cvxopt
+  python -m pip install cplex  # CPLEX is not available yet on 3.10
+elif [[ "$PYTHON_VERSION" == "3.7" ]] || [[ "$PYTHON_VERSION" == "3.8" ]]; then
   conda install scipy=1.3 numpy=1.16 mkl pip pytest pytest-cov lapack ecos scs osqp cvxopt
-  python -m pip install cplex  # CPLEX is not available yet on 3.9
+  python -m pip install cplex  # CPLEX is not available yet on 3.10
 elif [[ "$PYTHON_VERSION" == "3.9" ]]; then
   # The earliest version of numpy that works is 1.19.
   # Given numpy 1.19, the earliest version of scipy we can use is 1.5.
   conda install scipy=1.5 numpy=1.19 mkl pip pytest lapack ecos scs osqp cvxopt
+  python -m pip install cplex  # CPLEX is not available yet on 3.10
 elif [[ "$PYTHON_VERSION" == "3.10" ]]; then
     # The earliest version of numpy that works is 1.21.
     # Given numpy 1.21, the earliest version of scipy we can use is 1.7.
@@ -38,7 +38,7 @@ fi
 
 # SCIP only works with scipy >= 1.5 due to dependency conflicts when installing on Linux/macOS
 if [[ "$PYTHON_VERSION" == "3.9" ]] || [[ "$RUNNER_OS" == "Windows" ]]; then
-  conda install pyscipopt<4.0.0
+  conda install pyscipopt"<4.0"  # TODO: update interface https://github.com/cvxpy/cvxpy/pull/1628
 fi
 
 if [[ "$PYTHON_VERSION" == "3.10" ]]; then


### PR DESCRIPTION
## Description
This PR tries to fix recent test failures outlined in the issue below 
(second PR as the first branch was not based on the current master).
Issue link (if applicable): #1626 

Python 3.6:
The `dataclasses` module seems to be no longer available. This feature was introduced in Python 3.7, but a backport to 3.6 is available.

pyscipopt:
A new version was released yesterday: https://anaconda.org/conda-forge/pyscipopt/files
Limiting the version to get the tests passing again until the interface has been fixed. 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.