### PR TITLE
Fix scipy deprecation warning

### DIFF
--- a/cvxpy/interface/scipy_wrapper.py
+++ b/cvxpy/interface/scipy_wrapper.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from scipy.sparse.base import spmatrix
+from scipy.sparse import spmatrix
 
 from cvxpy.expressions import expression as exp
 


### PR DESCRIPTION
## Description
Please include a short summary of the change.
Issue link (if applicable):
I fixed a scipy deprication warning which is reported in #1654

> cvxpy\cvxpy\interface\scipy_wrapper.py:17: DeprecationWarning: Please use `spmatrix` from the `scipy.sparse` namespace, the `scipy.sparse.base` namespace is deprecated.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.