### PR TITLE
WIP: Fix M1 wheels, drop Python 3.6, lots of documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,15 +165,19 @@ jobs:
         include:
           - os: ubuntu-18.04
             python-version: 3.8
+            pip_intall: "True"
           - os: macos-10.15
             python-version: 3.8
+            pip_install: "True"
             single_action_config: "True"
           - os: windows-2019
             python-version: 3.8
+            pip_install: "True"
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
       SINGLE_ACTION_CONFIG: "${{ matrix.single_action_config == 'True' }}"
+      PIP_INSTALL: "${{ matrix.pip_install == 'True' }}"
       PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
       PYPI_USER: ${{ secrets.PYPI_USER }}
       PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
@@ -199,8 +203,8 @@ jobs:
           sed -i.bak '/scs >= /d' setup.py
           rm -rf setup.py.bak
 
-      - name: Run some tests on one OS just to check imports are working
-        if: ${{env.SINGLE_ACTION_CONFIG == 'True'}}
+      - name: Verify that we can build by pip-install on each OS.
+        if: ${{env.PIP_INSTALL == 'True'}}
         run: |
           pip install . pytest cplex
           pytest cvxpy/tests/test_conic_solvers.py -k 'TestCPLEX'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-18.04, macos-10.15, windows-2019 ]
-        python-version: [ 3.6, 3.7, 3.9, "3.10" ]
+        python-version: [ 3.7, 3.9, "3.10" ]
         include:
           - os: ubuntu-18.04
             python-version: 3.8
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-18.04, macos-10.15, windows-2019 ]
-        python-version: [ 3.6, 3.7, 3.9, "3.10" ]
+        python-version: [ 3.7, 3.9, "3.10" ]
         include:
           - os: ubuntu-18.04
             python-version: 3.8
@@ -161,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-18.04, macos-10.15, windows-2019 ]
-        python-version: [ 3.6, 3.7, 3.9, "3.10" ]
+        python-version: [ 3.7, 3.9, "3.10" ]
         include:
           - os: ubuntu-18.04
             python-version: 3.8

--- a/cvxpy/atoms/affine/partial_trace.py
+++ b/cvxpy/atoms/affine/partial_trace.py
@@ -54,14 +54,17 @@ def _term(expr, j: int, dims: Tuple[int], axis: Optional[int] = 0):
     return a @ expr @ b
 
 
+# flake8: noqa: E501
 def partial_trace(expr, dims: Tuple[int], axis: Optional[int] = 0):
-    """Partial trace of a matrix.
+    """
+    Assumes :math:`\\texttt{expr} = X_1 \\otimes \\cdots \\otimes X_n` is a 2D Kronecker
+    product composed of :math:`n = \\texttt{len(dims)}` implicit subsystems.
+    Letting :math:`k = \\texttt{axis}`, the returned expression represents
+    the *partial trace* of :math:`\\texttt{expr}` along its :math:`k^{\\text{th}}` implicit subsystem:
 
-    Assumes :math:`expr = X1 \\odots ... \\odots Xn` is a 2D tensor product
-    composed implicitly of n subsystems. Here :math:`\\odots` denotes the Kronecker product,
-    and axis=k is the index of the subsystem to be traced out
-    from the tensor product that defines expr.
-    Returns :math:`tr(Xk) (X1 \\odots ... \\odots Xk-1 \\odots Xk+1 \\odots ... \\odots Xn)`
+    .. math::
+
+        \\text{tr}(X_k) (X_1 \\otimes \\cdots \\otimes X_{k-1} \\otimes X_{k+1} \\otimes \\cdots \\otimes X_n).
 
     Parameters
     ----------

--- a/cvxpy/atoms/affine/partial_transpose.py
+++ b/cvxpy/atoms/affine/partial_transpose.py
@@ -57,13 +57,15 @@ def _term(expr, i: int, j: int, dims: Tuple[int], axis: Optional[int] = 0):
 
 
 def partial_transpose(expr, dims: Tuple[int], axis: Optional[int] = 0):
-    """Partial transpose of a matrix.
+    """
+    Assumes :math:`\\texttt{expr} = X_1 \\otimes ... \\otimes X_n` is a 2D Kronecker
+    product composed of :math:`n = \\texttt{len(dims)}` implicit subsystems.
+    Letting :math:`k = \\texttt{axis}`, the returned expression is a
+    *partial transpose* of :math:`\\texttt{expr}`, with the transpose applied to its
+    :math:`k^{\\text{th}}` implicit subsystem:
 
-    Assumes :math:`expr = X1 \\odots ... \\odots Xn` is a 2D tensor product
-    composed implicitly of n subsystems. Here :math:`\\odots` denotes the Kronecker product,
-    and axis=k is the index of the subsystem to be transposed
-    from the tensor product that defines expr.
-    Returns :math:`X1 \\odots ... \\odots Xk^T \\odots ... \\odots Xn`
+    .. math::
+        X_1 \\otimes ... \\otimes X_k^T \\otimes ... \\otimes X_n.
 
     Parameters
     ----------

--- a/cvxpy/atoms/elementwise/log_normcdf.py
+++ b/cvxpy/atoms/elementwise/log_normcdf.py
@@ -20,10 +20,18 @@ from cvxpy.atoms.elementwise.maximum import maximum
 from cvxpy.expressions.expression import Expression
 
 
-def log_normcdf(x):
+# flake8: noqa: E501
+def log_normcdf(x):  # noqa: E501
     """Elementwise log of the cumulative distribution function of a standard normal random variable.
 
-    Implementation is a quadratic approximation with modest accuracy over [-4, 4].
+    The implementation is a quadratic approximation with modest accuracy over [-4, 4].
+    For details on the nature of the approximation, refer to
+    `CVXPY GitHub PR #1224 <https://github.com/cvxpy/cvxpy/pull/1224#issue-793221374>`_.
+
+    .. note::
+
+        SciPy's analog of ``log_normcdf`` is called `log_ndtr <https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.log_ndtr.html>`_.
+        We opted not to use that name because its meaning would not be obvious to the casual user.
     """
     A = scipy.sparse.diags(
         np.sqrt(

--- a/cvxpy/atoms/elementwise/loggamma.py
+++ b/cvxpy/atoms/elementwise/loggamma.py
@@ -16,11 +16,13 @@ from cvxpy.atoms.elementwise.log import log
 from cvxpy.atoms.elementwise.maximum import maximum
 
 
+# flake8: noqa: E501
 def loggamma(x):
     """Elementwise log of the gamma function.
 
     Implementation has modest accuracy over the full range, approaching perfect
-    accuracy as x goes to infinity.
+    accuracy as x goes to infinity. For details on the nature of the approximation,
+    refer to `CVXPY GitHub Issue #228 <https://github.com/cvxpy/cvxpy/issues/228#issuecomment-544281906>`_.
     """
 
     return maximum(

--- a/cvxpy/atoms/elementwise/power.py
+++ b/cvxpy/atoms/elementwise/power.py
@@ -66,7 +66,7 @@ class power(Elementwise):
         is usually *exact*. No such approximation
         is used for DGP problems.
 
-        *UPDATE*: CVXPY supports exponential cone and power cone constraints.
+        CVXPY supports exponential cone and power cone constraints.
         Such constraints could be used to handle the ``power`` atom in DCP problems
         without relying on approximations. Such an approach would also result in
         fewer variables than the current method, even when the current method is

--- a/cvxpy/atoms/elementwise/power.py
+++ b/cvxpy/atoms/elementwise/power.py
@@ -57,16 +57,22 @@ class power(Elementwise):
 
     .. note::
 
-        For DCP problems, ``p`` cannot be represented exactly, so a rational,
-        i.e., fractional, **approximation** must be made. (No such approximation
-        is made for DGP problems.)
-
-        Internally, ``power`` computes a rational approximation
+        For DCP problems, ``power`` assumes ``p`` has a rational representation
+        with a small denominator. **Approximations** are employed when this is not
+        the case. Specifically, ``power`` computes a rational approximation
         to ``p`` with a denominator up to ``max_denom``.
         Increasing ``max_denom`` can give better approximations.
-
         When ``p`` is an ``int`` or ``Fraction`` object, the approximation
-        is usually **exact**.
+        is usually *exact*. No such approximation
+        is used for DGP problems.
+
+        *UPDATE*: CVXPY supports exponential cone and power cone constraints.
+        Such constraints could be used to handle the ``power`` atom in DCP problems
+        without relying on approximations. Such an approach would also result in
+        fewer variables than the current method, even when the current method is
+        an exact reformulation. If you're interested in helping enhance CVXPY with
+        this ability, please get in touch with us and check out
+        `GitHub Issue 1222 <https://github.com/cvxpy/cvxpy/issues/1222>`_!
 
     .. note::
 

--- a/cvxpy/atoms/max.py
+++ b/cvxpy/atoms/max.py
@@ -19,13 +19,26 @@ import numpy as np
 
 from cvxpy.atoms.atom import Atom
 from cvxpy.atoms.axis_atom import AxisAtom
+from cvxpy.expressions import cvxtypes
 
 
 class max(AxisAtom):
     """:math:`\\max_{i,j}\\{X_{i,j}\\}`.
     """
 
+    __EXPR_AXIS_ERROR__ = """
+
+    The second argument to "max" was a cvxpy Expression, when it should have
+    been an int or None. This is probably a result of calling "cp.max" when you
+    should call "cp.maximum". The difference is that cp.max represents the
+    maximum entry in a single vector or matrix, while cp.maximum represents
+    the entry-wise max of a sequence of arguments that all have the same shape.
+
+    """
+
     def __init__(self, x, axis: Optional[int] = None, keepdims: bool = False) -> None:
+        if isinstance(axis, cvxtypes.expression()):
+            raise ValueError(max.__EXPR_AXIS_ERROR__)
         super(max, self).__init__(x, axis=axis, keepdims=keepdims)
 
     @Atom.numpy_numeric

--- a/cvxpy/atoms/min.py
+++ b/cvxpy/atoms/min.py
@@ -19,13 +19,26 @@ import numpy as np
 
 from cvxpy.atoms.atom import Atom
 from cvxpy.atoms.axis_atom import AxisAtom
+from cvxpy.expressions import cvxtypes
 
 
 class min(AxisAtom):
     """:math:`\\min{i,j}\\{X_{i,j}\\}`.
     """
 
+    __EXPR_AXIS_ERROR__ = """
+
+    The second argument to "min" was a cvxpy Expression, when it should have
+    been an int or None. This is probably a result of calling "cp.min" when you
+    should call "cp.minimum". The difference is that cp.min represents the
+    minimum entry in a single vector or matrix, while cp.minimum represents
+    the entry-wise min of a sequence of arguments that all have the same shape.
+
+    """
+
     def __init__(self, x, axis: Optional[int] = None, keepdims: bool = False) -> None:
+        if isinstance(axis, cvxtypes.expression()):
+            raise ValueError(min.__EXPR_AXIS_ERROR__)
         super(min, self).__init__(x, axis=axis, keepdims=keepdims)
 
     @Atom.numpy_numeric

--- a/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
@@ -16,13 +16,12 @@ limitations under the License.
 """
 import time
 
-from packaging.version import Version
-
 import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers import scs_conif
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from cvxpy.utilities.versioning import Version
 
 
 class DIFFCP(scs_conif.SCS):

--- a/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/diffcp_conif.py
@@ -15,7 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import time
-from distutils.version import StrictVersion
+
+from packaging.version import Version
 
 import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution, failure_solution
@@ -71,7 +72,7 @@ class DIFFCP(scs_conif.SCS):
         attr = {}
         if solution["solve_method"] == s.SCS:
             import scs
-            if StrictVersion(scs.__version__) < StrictVersion('3.0.0'):
+            if Version(scs.__version__) < Version('3.0.0'):
                 status = scs_conif.SCS.STATUS_MAP[solution["info"]["statusVal"]]
                 attr[s.SOLVE_TIME] = solution["info"]["solveTime"]
                 attr[s.SETUP_TIME] = solution["info"]["setupTime"]
@@ -142,7 +143,7 @@ class DIFFCP(scs_conif.SCS):
 
         if solver_opts["solve_method"] == s.SCS:
             import scs
-            if StrictVersion(scs.__version__) < StrictVersion('3.0.0'):
+            if Version(scs.__version__) < Version('3.0.0'):
                 # Default to eps = 1e-4 instead of 1e-3.
                 solver_opts["eps"] = solver_opts.get("eps", 1e-4)
             else:

--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -18,13 +18,13 @@ limitations under the License.
 import warnings
 
 import scipy  # For version checks
-from packaging.version import Version
 
 import cvxpy.settings as s
 from cvxpy.constraints import NonNeg, Zero
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from cvxpy.utilities.versioning import Version
 
 
 class SCIPY(ConicSolver):

--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -16,9 +16,9 @@ limitations under the License.
 
 
 import warnings
-from distutils.version import StrictVersion
 
 import scipy  # For version checks
+from packaging.version import Version
 
 import cvxpy.settings as s
 from cvxpy.constraints import NonNeg, Zero
@@ -98,7 +98,7 @@ class SCIPY(ConicSolver):
         from scipy import optimize as opt
 
         # Set default method which can be overriden by user inputs
-        if (StrictVersion(scipy.__version__) < StrictVersion('1.6.1')):
+        if (Version(scipy.__version__) < Version('1.6.1')):
             meth = "interior-point"
         else:
             meth = "highs"
@@ -130,7 +130,7 @@ class SCIPY(ConicSolver):
 
                 # Check to see if scipy version larger than 1.6.1 is installed
                 # if method chosen is one of the highs methods.
-                ver = (StrictVersion(scipy.__version__) < StrictVersion('1.6.1'))
+                ver = (Version(scipy.__version__) < Version('1.6.1'))
                 if ((meth in ['highs-ds', 'highs-ipm', 'highs']) & ver):
                     raise ValueError("The HiGHS solvers require a SciPy version >= 1.6.1")
 

--- a/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
@@ -14,10 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from distutils.version import StrictVersion
-
 import numpy as np
 import scipy.sparse as sp
+from packaging.version import Version
 
 import cvxpy.settings as s
 from cvxpy.constraints import PSD, SOC, ExpCone, PowCone3D
@@ -33,7 +32,7 @@ def dims_to_solver_dict(cone_dims):
     cones = dims_to_solver_dict_default(cone_dims)
 
     import scs
-    if StrictVersion(scs.__version__) >= StrictVersion('3.0.0'):
+    if Version(scs.__version__) >= Version('3.0.0'):
         cones['z'] = cones.pop('f')  # renamed to 'z' in SCS 3.0.0
     return cones
 
@@ -214,7 +213,7 @@ class SCS(ConicSolver):
         import scs
         attr = {}
         # SCS versions 1.*, SCS 2.*
-        if StrictVersion(scs.__version__) < StrictVersion('3.0.0'):
+        if Version(scs.__version__) < Version('3.0.0'):
             status = self.STATUS_MAP[solution["info"]["statusVal"]]
             attr[s.SOLVE_TIME] = solution["info"]["solveTime"]
             attr[s.SETUP_TIME] = solution["info"]["setupTime"]
@@ -281,7 +280,7 @@ class SCS(ConicSolver):
         cones = dims_to_solver_dict(data[ConicSolver.DIMS])
 
         # SCS versions 1.*, SCS 2.*
-        if StrictVersion(scs.__version__) < StrictVersion('3.0.0'):
+        if Version(scs.__version__) < Version('3.0.0'):
             if "eps_abs" in solver_opts or "eps_rel" in solver_opts:
                 # Take the min of eps_rel and eps_abs to be eps
                 solver_opts["eps"] = min(solver_opts.get("eps_abs", 1),
@@ -294,8 +293,8 @@ class SCS(ConicSolver):
             status = self.STATUS_MAP[results["info"]["statusVal"]]
 
             # anderson acceleration (introduced in scs 2.0) is sometimes unstable; retry without it
-            acceleration_lookback_available = (StrictVersion(scs.__version__) >=
-                                               StrictVersion('2.0.0'))
+            acceleration_lookback_available = (Version(scs.__version__) >=
+                                               Version('2.0.0'))
             if (
                     status == s.OPTIMAL_INACCURATE
                     and "acceleration_lookback" not in solver_opts

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -350,8 +350,10 @@ class TestAtoms(BaseTest):
         # Invalid axis.
         with self.assertRaises(Exception) as cm:
             cp.max(self.x, axis=4)
-        self.assertEqual(str(cm.exception),
-                         "Invalid argument for axis.")
+        self.assertEqual(str(cm.exception), "Invalid argument for axis.")
+        with self.assertRaises(ValueError) as cm:
+            cp.max(self.x, self.x)  # a common erroneous use-case
+        self.assertEqual(str(cm.exception), cp.max.__EXPR_AXIS_ERROR__)
 
     def test_min(self) -> None:
         """Test min.
@@ -371,8 +373,10 @@ class TestAtoms(BaseTest):
         # Invalid axis.
         with self.assertRaises(Exception) as cm:
             cp.min(self.x, axis=4)
-        self.assertEqual(str(cm.exception),
-                         "Invalid argument for axis.")
+        self.assertEqual(str(cm.exception), "Invalid argument for axis.")
+        with self.assertRaises(ValueError) as cm:
+            cp.min(self.x, self.x)  # a common erroneous use-case
+        self.assertEqual(str(cm.exception), cp.min.__EXPR_AXIS_ERROR__)
 
     # Test sign logic for maximum.
     def test_maximum_sign(self) -> None:

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -20,7 +20,6 @@ import unittest
 import numpy as np
 import pytest
 import scipy.linalg as la
-from packaging.version import Version
 
 import cvxpy as cp
 import cvxpy.tests.solver_test_helpers as sths
@@ -32,6 +31,7 @@ from cvxpy.tests.solver_test_helpers import (StandardTestECPs, StandardTestLPs,
                                              StandardTestPCPs,
                                              StandardTestSDPs,
                                              StandardTestSOCPs,)
+from cvxpy.utilities.versioning import Version
 
 
 class TestECOS(BaseTest):
@@ -153,7 +153,7 @@ class TestSCS(BaseTest):
         x = cp.Variable(2, name='x')
         prob = cp.Problem(cp.Minimize(cp.norm(x, 1) + 1.0), [x == 0])
         for i in range(2):
-            prob.solve(solver=cp.SCS, max_iters=50, eps=EPS, alpha=EPS,
+            prob.solve(solver=cp.SCS, max_iters=50, eps=EPS, alpha=1.2,
                        verbose=True, normalize=True, use_indirect=False)
         self.assertAlmostEqual(prob.value, 1.0, places=2)
         self.assertItemsAlmostEqual(x.value, [0, 0], places=2)
@@ -327,10 +327,10 @@ class TestSCS(BaseTest):
         StandardTestLPs.test_lp_4(solver='SCS')
 
     def test_scs_lp_5(self) -> None:
-        StandardTestLPs.test_lp_5(solver='SCS', eps=1e-5)
+        StandardTestLPs.test_lp_5(solver='SCS', eps=1e-6)
 
     def test_scs_socp_1(self) -> None:
-        StandardTestSOCPs.test_socp_1(solver='SCS', eps=1e-5)
+        StandardTestSOCPs.test_socp_1(solver='SCS', eps=1e-6)
 
     def test_scs_socp_3(self) -> None:
         # axis 0

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -16,11 +16,11 @@ limitations under the License.
 
 import math
 import unittest
-from distutils.version import StrictVersion
 
 import numpy as np
 import pytest
 import scipy.linalg as la
+from packaging.version import Version
 
 import cvxpy as cp
 import cvxpy.tests.solver_test_helpers as sths
@@ -1533,7 +1533,7 @@ class TestSCIPY(unittest.TestCase):
 
     def setUp(self):
         import scipy
-        self.d = StrictVersion(scipy.__version__) >= StrictVersion('1.7.0')
+        self.d = Version(scipy.__version__) >= Version('1.7.0')
 
     def test_scipy_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='SCIPY', duals=self.d)

--- a/cvxpy/tests/test_derivative.py
+++ b/cvxpy/tests/test_derivative.py
@@ -268,7 +268,7 @@ class TestBackward(BaseTest):
         constraints = [cp.trace(As[i] @ X) == bs[i] for i in range(p)]
         problem = cp.Problem(cp.Minimize(cp.trace(C @ X) + cp.sum_squares(X)),
                              constraints)
-        gradcheck(problem, solve_methods=[s.SCS], atol=1e-3)
+        gradcheck(problem, solve_methods=[s.SCS], atol=1e-3, eps=1e-10)
         perturbcheck(problem, solve_methods=[s.SCS])
 
     def test_forget_requires_grad(self) -> None:

--- a/cvxpy/tests/test_domain.py
+++ b/cvxpy/tests/test_domain.py
@@ -158,20 +158,21 @@ class TestDomain(BaseTest):
     def test_power(self) -> None:
         """Test domain for power.
         """
+        opts = {'eps': 1e-8, 'max_iters': 100000}
         dom = cp.sqrt(self.a).domain
-        Problem(Minimize(self.a), dom).solve(solver=cp.SCS, eps=1e-6)
+        Problem(Minimize(self.a), dom).solve(solver=cp.SCS, **opts)
         self.assertAlmostEqual(self.a.value, 0)
 
         dom = cp.square(self.a).domain
-        Problem(Minimize(self.a), dom + [self.a >= -100]).solve(solver=cp.SCS, eps=1e-6)
+        Problem(Minimize(self.a), dom + [self.a >= -100]).solve(solver=cp.SCS, **opts)
         self.assertAlmostEqual(self.a.value, -100)
 
         dom = ((self.a)**-1).domain
-        Problem(Minimize(self.a), dom + [self.a >= -100]).solve(solver=cp.SCS, eps=1e-6)
+        Problem(Minimize(self.a), dom + [self.a >= -100]).solve(solver=cp.SCS, **opts)
         self.assertAlmostEqual(self.a.value, 0)
 
         dom = ((self.a)**3).domain
-        Problem(Minimize(self.a), dom + [self.a >= -100]).solve(solver=cp.SCS, eps=1e-6)
+        Problem(Minimize(self.a), dom + [self.a >= -100]).solve(solver=cp.SCS, **opts)
         self.assertAlmostEqual(self.a.value, 0)
 
     def test_log_det(self) -> None:

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -996,21 +996,21 @@ class TestProblem(BaseTest):
         c = numpy.ones((1, 4))
         p = Problem(cp.Minimize(c @ cp.vstack([x, x])),
                     [x == [[1, 2]]])
-        result = p.solve(solver=cp.SCS, eps=1e-5)
+        result = p.solve(solver=cp.SCS, eps=1e-8)
         self.assertAlmostEqual(result, 6)
 
         c = numpy.ones((2, 2))
         p = Problem(cp.Minimize(cp.sum(cp.vstack([self.A, self.C]))),
                     [self.A >= 2*c,
                      self.C == -2])
-        result = p.solve(solver=cp.SCS, eps=1e-5)
+        result = p.solve(solver=cp.SCS, eps=1e-8)
         self.assertAlmostEqual(result, -4)
 
         c = numpy.ones((1, 2))
         p = Problem(cp.Minimize(cp.sum(cp.vstack([c @ self.A, c @ self.B]))),
                     [self.A >= 2,
                      self.B == -2])
-        result = p.solve(solver=cp.SCS, eps=1e-5)
+        result = p.solve(solver=cp.SCS, eps=1e-8)
         self.assertAlmostEqual(result, 0)
 
         c = numpy.array([[1, -1]]).T
@@ -1034,20 +1034,20 @@ class TestProblem(BaseTest):
         p = Problem(cp.Minimize(c @ cp.hstack([x.T, y.T]).T),
                     [x == [[1, 2]],
                      y == [[3, 4, 5]]])
-        result = p.solve(solver=cp.SCS, eps=1e-5)
+        result = p.solve(solver=cp.SCS, eps=1e-8)
         self.assertAlmostEqual(result, 15)
 
         c = numpy.ones((1, 4))
         p = Problem(cp.Minimize(c @ cp.hstack([x.T, x.T]).T),
                     [x == [[1, 2]]])
-        result = p.solve(solver=cp.SCS, eps=1e-5)
+        result = p.solve(solver=cp.SCS, eps=1e-8)
         self.assertAlmostEqual(result, 6)
 
         c = numpy.ones((2, 2))
         p = Problem(cp.Minimize(cp.sum(cp.hstack([self.A.T, self.C.T]))),
                     [self.A >= 2*c,
                      self.C == -2])
-        result = p.solve(solver=cp.SCS, eps=1e-5)
+        result = p.solve(solver=cp.SCS, eps=1e-8)
         self.assertAlmostEqual(result, -4)
 
         D = Variable((3, 3))
@@ -1055,7 +1055,7 @@ class TestProblem(BaseTest):
         p = Problem(cp.Minimize(expr[0, 1] + cp.sum(cp.hstack([expr, expr]))),
                     [self.C >= 0,
                      D >= 0, D[0, 0] == 2, self.C[0, 1] == 3])
-        result = p.solve(solver=cp.SCS, eps=1e-5)
+        result = p.solve(solver=cp.SCS, eps=1e-8)
         self.assertAlmostEqual(result, 13)
 
         c = numpy.array([[1, -1]]).T
@@ -1385,7 +1385,7 @@ class TestProblem(BaseTest):
         tt = cp.Variable(5)
         prob = cp.Problem(cp.Minimize(cp.sum(tt)),
                           [cp.cumsum(tt, 0) >= -0.0001])
-        result = prob.solve(solver=cp.SCS, eps=1e-5)
+        result = prob.solve(solver=cp.SCS, eps=1e-8)
         self.assertAlmostEqual(result, -0.0001)
 
     def test_cummax(self) -> None:

--- a/cvxpy/tests/test_versioning.py
+++ b/cvxpy/tests/test_versioning.py
@@ -1,0 +1,46 @@
+"""
+Copyright 2022, the CVXPY developers.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+
+from cvxpy.utilities.versioning import Version
+
+
+class TestVersioning(unittest.TestCase):
+
+    def test_typical_inputs(self):
+        self.assertTrue(Version('1.0.0') < Version('2.0.0'))
+        self.assertTrue(Version('1.0.0') < Version('1.1.0'))
+        self.assertTrue(Version('1.0.0') < Version('1.0.1'))
+        self.assertFalse(Version('1.0.0') < Version('1.0.0'))
+        self.assertTrue(Version('1.0.0') <= Version('1.0.0'))
+
+        self.assertFalse(Version('1.0.0') >= Version('2.0.0'))
+        self.assertFalse(Version('1.0.0') >= Version('1.1.0'))
+        self.assertFalse(Version('1.0.0') >= Version('1.0.1'))
+        self.assertTrue(Version('1.0.0') >= Version('1.0.0'))
+        self.assertFalse(Version('1.0.0') > Version('1.0.0'))
+
+    def test_tuple_construction(self):
+        self.assertTrue(Version('0100.2.03') == Version((100, 2, 3)))
+        self.assertTrue(Version('1.2.3') == Version((1, 2, 3, None)))
+        self.assertTrue(Version('1.2.3') == Version((1, 2, 3, 'junk')))
+        self.assertTrue(Version('1.2.3') == Version((1, 2, 3, -1)))
+
+    def test_local_version_identifiers(self):
+        self.assertTrue(Version('1.0.0') == Version('1.0.0+1'))
+        self.assertTrue(Version('1.0.0') == Version('1.0.0+xxx'))
+        self.assertTrue(Version('1.0.0') == Version('1.0.0+x.y.z'))

--- a/cvxpy/utilities/versioning.py
+++ b/cvxpy/utilities/versioning.py
@@ -51,3 +51,6 @@ class Version:
 
     def __ne__(self, other):
         return self.v != other.v
+
+    def __str__(self):
+        return '%s.%s.%s' % self.v

--- a/cvxpy/utilities/versioning.py
+++ b/cvxpy/utilities/versioning.py
@@ -1,0 +1,53 @@
+"""
+Copyright 2022, the CVXPY authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from typing import Tuple, Union
+
+
+class Version:
+    """
+    Parses strings of the form 'x.y.z+[STUFF]' and tuples of the form (x, y, z).
+    In the former case, '+[STUFF]' refers to a local version identifier in the
+    sense of https://www.python.org/dev/peps/pep-0440/#local-version-identifiers.
+    We don't actually store the local version identifier for comparisons.
+    """
+
+    def __init__(self, v: Union[str, Tuple[int, int, int]]):
+        if isinstance(v, str):
+            v = v.split('.')
+            assert len(v) >= 3  # anything after the third place doesn't matter
+            v[2] = v[2].split('+')[0]  # anything after the + doesn't matter
+        self.major = int(v[0])
+        self.minor = int(v[1])
+        self.micro = int(v[2])
+        self.v = (self.major, self.minor, self.micro)
+
+    def __le__(self, other):
+        return self.v <= other.v
+
+    def __lt__(self, other):
+        return self.v < other.v
+
+    def __ge__(self, other):
+        return self.v >= other.v
+
+    def __gt__(self, other):
+        return self.v > other.v
+
+    def __eq__(self, other):
+        return self.v == other.v
+
+    def __ne__(self, other):
+        return self.v != other.v

--- a/doc/source/api_reference/cvxpy.atoms.affine.rst
+++ b/doc/source/api_reference/cvxpy.atoms.affine.rst
@@ -30,17 +30,17 @@ DivExpression
 
 .. _bmat:
 
-Bmat
+bmat
 ---------------------------------
 
-.. autofunction:: cvxpy.atoms.affine.bmat.bmat
+.. autofunction:: cvxpy.bmat
 
 .. _conv:
 
 conv
 ---------------------------------
 
-.. autoclass:: cvxpy.atoms.affine.conv.conv
+.. autoclass:: cvxpy.conv
     :show-inheritance:
 
 .. _cumsum:
@@ -48,7 +48,7 @@ conv
 cumsum
 -----------------------------------
 
-.. autoclass:: cvxpy.atoms.affine.cumsum.cumsum
+.. autoclass:: cvxpy.cumsum
     :show-inheritance:
 
 .. _diag:
@@ -56,21 +56,21 @@ cumsum
 diag
 ---------------------------------
 
-.. autofunction:: cvxpy.atoms.affine.diag.diag
+.. autofunction:: cvxpy.diag
 
 .. _diff:
 
 diff
 ---------------------------------
 
-.. autofunction:: cvxpy.atoms.affine.diff.diff
+.. autofunction:: cvxpy.diff
 
 .. _hstack:
 
 hstack
 -----------------------------------
 
-.. autofunction:: cvxpy.atoms.affine.hstack.hstack
+.. autofunction:: cvxpy.hstack
 
 .. _index:
 
@@ -85,7 +85,7 @@ index
 kron
 ---------------------------------
 
-.. autoclass:: cvxpy.atoms.affine.kron.kron
+.. autoclass:: cvxpy.kron
     :show-inheritance:
 
 .. _matmul:
@@ -93,14 +93,14 @@ kron
 matmul
 --------------------------------
 
-.. autofunction:: cvxpy.atoms.affine.binary_operators.matmul
+.. autofunction:: cvxpy.matmul
 
 .. _multiply:
 
 multiply
 -------------------------------------
 
-.. autoclass:: cvxpy.atoms.affine.binary_operators.multiply
+.. autoclass:: cvxpy.multiply
     :show-inheritance:
 
 .. _promote:
@@ -115,22 +115,31 @@ promote
 reshape
 ------------------------------------
 
-.. autoclass:: cvxpy.atoms.affine.reshape.reshape
+.. autoclass:: cvxpy.reshape
     :show-inheritance:
+
+.. _scalar_product:
+
+scalar_product
+--------------
+
+.. autoclass:: cvxpy.scalar_product
+    :show-inheritance:
+
 
 .. _sum:
 
 sum
 --------------------------------
 
-.. autofunction:: cvxpy.atoms.affine.sum.sum
+.. autofunction:: cvxpy.sum
 
 .. _trace:
 
 trace
 ----------------------------------
 
-.. autoclass:: cvxpy.atoms.affine.trace.trace
+.. autoclass:: cvxpy.trace
     :show-inheritance:
 
 .. _transpose:
@@ -138,7 +147,7 @@ trace
 transpose
 --------------------------------------
 
-.. autoclass:: cvxpy.atoms.affine.transpose.transpose
+.. autoclass:: cvxpy.transpose
     :show-inheritance:
 
 .. _negexpression:
@@ -154,19 +163,36 @@ NegExpression
 upper_tri
 ---------------------------------------
 
-.. autoclass:: cvxpy.atoms.affine.upper_tri.upper_tri
+.. autoclass:: cvxpy.upper_tri
     :show-inheritance:
+
+
+.. _ptrace:
+
+partial_trace
+--------------------------------
+
+.. autofunction:: cvxpy.partial_trace
+
+
+.. _ptrans:
+
+partial_transpose
+--------------------------------
+
+.. autofunction:: cvxpy.partial_transpose
+
 
 .. _vec:
 
 vec
 --------------------------------
 
-.. autofunction:: cvxpy.atoms.affine.vec.vec
+.. autofunction:: cvxpy.vec
 
 .. _vstack:
 
 vstack
 -----------------------------------
 
-.. autofunction:: cvxpy.atoms.affine.vstack.vstack
+.. autofunction:: cvxpy.vstack

--- a/doc/source/api_reference/cvxpy.atoms.elementwise.rst
+++ b/doc/source/api_reference/cvxpy.atoms.elementwise.rst
@@ -9,7 +9,7 @@ expressions that are supplied to it.
 abs
 -------------------------------------
 
-.. autoclass:: cvxpy.atoms.elementwise.abs.abs
+.. autoclass:: cvxpy.abs
     :show-inheritance:
 
 .. _entr:
@@ -17,7 +17,7 @@ abs
 entr
 --------------------------------------
 
-.. autoclass:: cvxpy.atoms.elementwise.entr.entr
+.. autoclass:: cvxpy.entr
     :show-inheritance:
 
 .. _exp:
@@ -25,7 +25,7 @@ entr
 exp
 -------------------------------------
 
-.. autoclass:: cvxpy.atoms.elementwise.exp.exp
+.. autoclass:: cvxpy.exp
     :show-inheritance:
 
 .. _huber:
@@ -33,7 +33,7 @@ exp
 huber
 ---------------------------------------
 
-.. autoclass:: cvxpy.atoms.elementwise.huber.huber
+.. autoclass:: cvxpy.huber
     :show-inheritance:
 
 .. _inv-pos:
@@ -41,14 +41,14 @@ huber
 inv_pos
 ------------------------------------------
 
-.. autofunction:: cvxpy.atoms.elementwise.inv_pos.inv_pos
+.. autofunction:: cvxpy.inv_pos
 
 .. _kl-div:
 
 kl_div
 -----------------------------------------
 
-.. autoclass:: cvxpy.atoms.elementwise.kl_div.kl_div
+.. autoclass:: cvxpy.kl_div
     :show-inheritance:
 
 .. _log:
@@ -56,7 +56,15 @@ kl_div
 log
 -------------------------------------
 
-.. autoclass:: cvxpy.atoms.elementwise.log.log
+.. autoclass:: cvxpy.log
+    :show-inheritance:
+
+.. _log-normcdf:
+
+log_normcdf
+-------------------------------------
+
+.. autoclass:: cvxpy.log_normcdf
     :show-inheritance:
 
 .. _log1p:
@@ -64,15 +72,25 @@ log
 log1p
 ---------------------------------------
 
-.. autoclass:: cvxpy.atoms.elementwise.log1p.log1p
+.. autoclass:: cvxpy.log1p
     :show-inheritance:
+
+
+.. _loggamma:
+
+loggamma
+-------------------------------------
+
+.. autoclass:: cvxpy.loggamma
+    :show-inheritance:
+
 
 .. _logistic:
 
 logistic
 ------------------------------------------
 
-.. autoclass:: cvxpy.atoms.elementwise.logistic.logistic
+.. autoclass:: cvxpy.logistic
     :show-inheritance:
 
 
@@ -81,7 +99,7 @@ logistic
 maximum
 -----------------------------------------
 
-.. autoclass:: cvxpy.atoms.elementwise.maximum.maximum
+.. autoclass:: cvxpy.maximum
     :show-inheritance:
 
 .. _minimum:
@@ -89,36 +107,36 @@ maximum
 minimum
 -----------------------------------------
 
-.. autofunction:: cvxpy.atoms.elementwise.minimum.minimum
+.. autofunction:: cvxpy.minimum
 
 .. _neg:
 
 neg
 -------------------------------------
 
-.. autofunction:: cvxpy.atoms.elementwise.neg.neg
+.. autofunction:: cvxpy.neg
 
 .. _pos:
 
 pos
 -------------------------------------
 
-.. autofunction:: cvxpy.atoms.elementwise.pos.pos
+.. autofunction:: cvxpy.pos
 
 .. _power:
 
 power
 ---------------------------------------
 
-.. autoclass:: cvxpy.atoms.elementwise.power.power
+.. autoclass:: cvxpy.power
     :show-inheritance:
 
 .. _rel-entr:
 
-rel-entr
+rel_entr
 -----------------------------------------
 
-.. autoclass:: cvxpy.atoms.elementwise.rel_entr.rel_entr
+.. autoclass:: cvxpy.rel_entr
     :show-inheritance:
 
 .. _scalene:
@@ -126,18 +144,26 @@ rel-entr
 scalene
 -----------------------------------------
 
-.. autofunction:: cvxpy.atoms.elementwise.scalene.scalene
+.. autofunction:: cvxpy.scalene
 
 .. _sqrt:
 
 sqrt
 --------------------------------------
 
-.. autofunction:: cvxpy.atoms.elementwise.sqrt.sqrt
+.. autofunction:: cvxpy.sqrt
 
 .. _square:
 
 square
 ----------------------------------------
 
-.. autofunction:: cvxpy.atoms.elementwise.square.square
+.. autofunction:: cvxpy.square
+
+.. _xexp:
+
+xexp
+-------------------------------------
+
+.. autoclass:: cvxpy.xexp
+    :show-inheritance:

--- a/doc/source/api_reference/cvxpy.atoms.other_atoms.rst
+++ b/doc/source/api_reference/cvxpy.atoms.other_atoms.rst
@@ -259,6 +259,14 @@ sum_squares
 
 .. autofunction:: cvxpy.atoms.sum_squares.sum_squares
 
+
+.. _suppfuncatom:
+
+SuppFuncAtom
+------------
+
+.. autoclass:: cvxpy.atoms.suppfunc.SuppFuncAtom
+
 .. _tv:
 
 tv

--- a/doc/source/api_reference/cvxpy.reductions.back_end.rst
+++ b/doc/source/api_reference/cvxpy.reductions.back_end.rst
@@ -15,7 +15,7 @@ accepted by solvers. The problems output by both reductions must be passed
 through another sequence of reductions, not documented here, before they are
 ready for to be solved.
 
-Please see `our disclaimer <reductions_disclaimer>`_ about the
+Please see :ref:`our disclaimer <reductions_disclaimer>` about the
 Reductions API before using these directly in your code.
 
 .. contents:: :local:

--- a/doc/source/api_reference/cvxpy.reductions.back_end.rst
+++ b/doc/source/api_reference/cvxpy.reductions.back_end.rst
@@ -15,6 +15,9 @@ accepted by solvers. The problems output by both reductions must be passed
 through another sequence of reductions, not documented here, before they are
 ready for to be solved.
 
+Please see `our disclaimer <reductions_disclaimer>`_ about the
+Reductions API before using these directly in your code.
+
 .. contents:: :local:
 
 Dcp2Cone
@@ -31,3 +34,16 @@ Qp2SymbolicQp
 .. autoclass:: cvxpy.reductions.qp2quad_form.qp2symbolic_qp.Qp2SymbolicQp
     :members:
     :show-inheritance:
+
+Dualize
+------------------------------------------
+
+.. autoclass:: cvxpy.reductions.cone2cone.affine2direct.Dualize
+   :members:
+
+Slacks
+------------------------------------------
+
+.. autoclass:: cvxpy.reductions.cone2cone.affine2direct.Slacks
+   :members:
+

--- a/doc/source/api_reference/cvxpy.reductions.dcp2cone.rst
+++ b/doc/source/api_reference/cvxpy.reductions.dcp2cone.rst
@@ -1,6 +1,10 @@
 cvxpy\.reductions\.dcp2cone package
 ===================================
 
+
+Please see `our disclaimer <reductions_disclaimer>`_ about the
+Reductions API before using these directly in your code.
+
 Subpackages
 -----------
 

--- a/doc/source/api_reference/cvxpy.reductions.dcp2cone.rst
+++ b/doc/source/api_reference/cvxpy.reductions.dcp2cone.rst
@@ -2,7 +2,7 @@ cvxpy\.reductions\.dcp2cone package
 ===================================
 
 
-Please see `our disclaimer <reductions_disclaimer>`_ about the
+Please see :ref:`our disclaimer <reductions_disclaimer>` about the
 Reductions API before using these directly in your code.
 
 Subpackages

--- a/doc/source/api_reference/cvxpy.reductions.middle_end.rst
+++ b/doc/source/api_reference/cvxpy.reductions.middle_end.rst
@@ -5,7 +5,7 @@ The reductions listed here are not specific to a type of solver.
 They can be applied regardless of whether you wish to target, for example,
 a quadratic program solver or a conic solver.
 
-Please see `our disclaimer <reductions_disclaimer>`_ about the
+Please see :ref:`our disclaimer <reductions_disclaimer>` about the
 Reductions API before using these directly in your code.
 
 .. contents:: :local:

--- a/doc/source/api_reference/cvxpy.reductions.middle_end.rst
+++ b/doc/source/api_reference/cvxpy.reductions.middle_end.rst
@@ -1,9 +1,12 @@
 Middle-End Reductions
 ====================
 
-The reductions listed here are not specific to a back end (solver);
-they can be applied regardless of whether you wish to target, for example,
+The reductions listed here are not specific to a type of solver.
+They can be applied regardless of whether you wish to target, for example,
 a quadratic program solver or a conic solver.
+
+Please see `our disclaimer <reductions_disclaimer>`_ about the
+Reductions API before using these directly in your code.
 
 .. contents:: :local:
 

--- a/doc/source/api_reference/cvxpy.reductions.qp2quad_form.rst
+++ b/doc/source/api_reference/cvxpy.reductions.qp2quad_form.rst
@@ -1,7 +1,7 @@
 cvxpy\.reductions\.qp2quad\_form package
 ========================================
 
-Please see `our disclaimer <reductions_disclaimer>`_ about the
+Please see :ref:`our disclaimer <reductions_disclaimer>` about the
 Reductions API before using these directly in your code.
 
 Subpackages

--- a/doc/source/api_reference/cvxpy.reductions.qp2quad_form.rst
+++ b/doc/source/api_reference/cvxpy.reductions.qp2quad_form.rst
@@ -1,6 +1,9 @@
 cvxpy\.reductions\.qp2quad\_form package
 ========================================
 
+Please see `our disclaimer <reductions_disclaimer>`_ about the
+Reductions API before using these directly in your code.
+
 Subpackages
 -----------
 

--- a/doc/source/api_reference/cvxpy.reductions.rst
+++ b/doc/source/api_reference/cvxpy.reductions.rst
@@ -21,10 +21,20 @@ of solvers is called a :doc:`back-end reduction <cvxpy.reductions.back_end>`.
 Each solver (along with the mode in which it is invoked) is called a *back-end*
 or *target*.
 
-The majority of users will not need to know anything about the reduction
-API; indeed, most users need not even know that reductions exist.
-But those who wish to extend CVXPY or contribute to it may find the API useful,
-as might those who are simply curious to learn how CVXPY works.
+The majority of users do not need to know anything about CVXPY's reduction system.
+Indeed, most users need not even know that reductions exist!
+
+.. _reductions_disclaimer:
+
+Disclaimer
+~~~~~~~~~~
+
+*CVXPY's reductions are not considered part of the public API. They can change
+without notice in future releases.
+We document them here for potential CVXPY contributors, for the curious, and for
+those who are okay with building on an API that may not be available in future
+versions of CVXPY.*
+
 
 .. toctree::
 

--- a/doc/source/api_reference/cvxpy.reductions.rst
+++ b/doc/source/api_reference/cvxpy.reductions.rst
@@ -9,46 +9,62 @@ if a solution of one can be converted to a solution of the other with no
 more than a moderate amount of effort. CVXPY uses reductions to rewrite
 problems into forms that solvers will accept.
 
-Reductions allow CVXPY to simplify problems and target different
-categories of solvers (quadratic program solvers and conic
-solvers are two examples of solver categories). Appropriating terminology from
-software compilers, we classify reductions as either middle-end reductions or
-back-end reductions. A reduction that simplifies a source problem without
-regard to the targeted solver is called a
+.. _reductions_disclaimer:
+
+Disclaimer
+~~~~~~~~~~
+
+The majority of users do not need to know anything about CVXPY's reduction system.
+Indeed, most users need not even know that reductions exist!
+
+In order to make sure that we have flexibility to improve CVXPY's speed
+and capabilities while preserving backwards-compatibility, we have
+determined that the reduction system will not be considered part of CVXPY's
+public API. As such, aspects of this system can change without notice in future releases.
+
+We provide this documentation for CVXPY contributors, for the curious, and for
+those who are okay with building on an API that may not be available in future
+versions of CVXPY.
+Please contact us if you have an interesting application which requires direct
+access to the Reduction system and if you care about forward compatibility with
+future versions of CVXPY.
+
+Types of Reductions
+~~~~~~~~~~~~~~~~~~~
+
+Reductions allow CVXPY to support different problem classes such as convex
+and log-log convex programming. They also help CVXPY target different categories
+of solvers, such as quadratic programming solvers and conic solvers.
+
+Appropriating terminology from software compilers, we classify reductions as
+either middle-end reductions or back-end reductions. A reduction that simplifies
+a source problem without regard to the targeted solver is called a
 :doc:`middle-end reduction <cvxpy.reductions.middle_end>`, whereas a reduction
 that takes a source problem and converts it to a form acceptable to a category
 of solvers is called a :doc:`back-end reduction <cvxpy.reductions.back_end>`.
 Each solver (along with the mode in which it is invoked) is called a *back-end*
 or *target*.
 
-The majority of users do not need to know anything about CVXPY's reduction system.
-Indeed, most users need not even know that reductions exist!
-
-.. _reductions_disclaimer:
-
-Disclaimer
-~~~~~~~~~~
-
-*CVXPY's reductions are not considered part of the public API. They can change
-without notice in future releases.
-We document them here for potential CVXPY contributors, for the curious, and for
-those who are okay with building on an API that may not be available in future
-versions of CVXPY.*
-
+Here's a breakdown of CVXPY's reductions:
 
 .. toctree::
 
-    cvxpy.reductions.middle_end
-    cvxpy.reductions.back_end
+    Middle-End <cvxpy.reductions.middle_end>
+    Back-End <cvxpy.reductions.back_end>
 
-.. contents:: :local:
+Core classes
+~~~~~~~~~~~~
+
+Reductions exchange data and operate by way of the following classes.
+Other data structures can be used, such as dicts keyed by strings, but
+these are the main classes which define the Reduction system.
+
 
 Solution
 --------
 
 .. autoclass:: cvxpy.reductions.solution.Solution
     :members:
-    :show-inheritance:
 
 
 Reduction
@@ -56,7 +72,6 @@ Reduction
 
 .. autoclass:: cvxpy.reductions.reduction.Reduction
     :members: __init__, accepts, reduce, retrieve, apply, invert
-    :show-inheritance:
 
 Chain
 ------------------------------------------

--- a/doc/source/api_reference/cvxpy.rst
+++ b/doc/source/api_reference/cvxpy.rst
@@ -33,5 +33,5 @@ CVXPY objects;
    Constraints <cvxpy.constraints>
    Expressions <cvxpy.expressions>
    Problems <cvxpy.problems>
-   Reductions <cvxpy.reductions>
    Transforms <cvxpy.transforms>
+   Reductions <cvxpy.reductions>

--- a/doc/source/api_reference/cvxpy.transforms.rst
+++ b/doc/source/api_reference/cvxpy.transforms.rst
@@ -6,6 +6,19 @@ Transforms provide additional ways of manipulating CVXPY objects
 beyond the atomic functions.
 While atomic functions operate only on expressions,
 transforms may also take Problem, Objective, or Constraint objects as input.
+Transforms do not need to conform to any specific API.
+
+SuppFunc
+--------
+
+The *SuppFunc* transform accepts an implicit representation of a convex set in terms
+of some CVXPY Variable and returns a function handle representing the convex set's
+support function. When the function handle is evaluated it returns a `SuppFuncAtom object <suppfuncatom>`_.
+Such objects can be used like any other CVXPY Expression for purposes of convex optimization modeling.
+
+.. autoclass:: cvxpy.transforms.suppfunc.SuppFunc
+    :members:
+    :show-inheritance:
 
 
 Scalarize

--- a/doc/source/api_reference/cvxpy.transforms.rst
+++ b/doc/source/api_reference/cvxpy.transforms.rst
@@ -17,8 +17,7 @@ support function. When the function handle is evaluated it returns a `SuppFuncAt
 Such objects can be used like any other CVXPY Expression for purposes of convex optimization modeling.
 
 .. autoclass:: cvxpy.transforms.suppfunc.SuppFunc
-    :members:
-    :show-inheritance:
+    :members: __call__
 
 
 Scalarize

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -92,10 +92,11 @@ guide </contributing/index>` and join us `on Discord <https://discord.gg/4urRQeG
 
 **News.**
 
-* In early 2022 we moved CVXPY to semantic versioning. Starting with CVXPY v1.2.0, we will
+* In early 2022 we started moving CVXPY to semantic versioning. Starting with CVXPY v1.2.0, we will
   assign version numbers following the specification at `semver.org <https://semver.org/>`_.
   This will result in us incrementing CVXPY's minor version number (the "x" in "CVXPY 1.x.y")
-  much more often than before.
+  much more often than before. Moving forward we will also make it a priority to differentiate
+  between what is and is-not part of CVXPY's public API.
 * CVXPY v1.1.0 has been released. This version makes
   repeatedly canonicalizing :ref:`parametrized problems <dpp>` much faster than before,
   allows :ref:`differentiating the map <derivatives>` from parameters to optimal solutions, and introduces
@@ -115,7 +116,7 @@ guide </contributing/index>` and join us `on Discord <https://discord.gg/4urRQeG
     :maxdepth: 3
     :hidden:
 
-    tutorial/index
+    User's Guide <tutorial/index>
 
 .. toctree::
    :hidden:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -116,7 +116,7 @@ guide </contributing/index>` and join us `on Discord <https://discord.gg/4urRQeG
     :maxdepth: 3
     :hidden:
 
-    User's Guide <tutorial/index>
+    User Guide <tutorial/index>
 
 .. toctree::
    :hidden:

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -58,7 +58,7 @@ We strongly recommend using a fresh virtual environment (virtualenv or conda) wh
 
 CVXPY has the following dependencies:
 
- * Python >= 3.6
+ * Python >= 3.7
  * `OSQP`_ >= 0.4.1
  * `ECOS`_ >= 2
  * `SCS`_ >= 1.1.6

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -823,7 +823,7 @@ For others see `OSQP documentation <http://osqp.org/docs/interfaces/solver_setti
     solving the linear systems encountered in CVXOPT's interior-point algorithm. The API for
     KKT solvers of this form is a small wrapper around CVXOPT's API for function-handle KKT
     solvers. The precise API that CVXPY users are held to is described in the CVXPY source
-    code: cvxpy/reductions/solvers/kktsolver.py
+    code: `cvxpy/reductions/solvers/kktsolver.py <https://github.com/cvxpy/cvxpy/blob/master/cvxpy/reductions/solvers/kktsolver.py>`_.
 
 `SCS`_ options:
 

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -836,6 +836,18 @@ For others see `OSQP documentation <http://osqp.org/docs/interfaces/solver_setti
 ``'alpha'``
     relaxation parameter (default: 1.8).
 
+
+``'acceleration_lookback'``
+    Anderson Acceleration parameter for SCS 2.0 and higher. This can be any positive or negative integer;
+    its default value is 10. See `this page of the SCS documentation <https://www.cvxgrp.org/scs/algorithm/acceleration.html#in-scs>`_
+    for more information.
+
+    .. warning::
+        The value of this parameter often effects whether or not SCS 2.X will converge to an accurate solution.
+        If you don't *explicitly* set ``acceleration_lookback`` and SCS 2.X fails to converge, then CVXPY
+        will raise a warning and try to re-solve the problem with ``acceleration_lookback=0``.
+        No attempt will be made to re-solve with problem if you have SCS version 3.0 or higher.
+
 ``'scale'``
     balance between minimizing primal and dual residual (default: 5.0).
 

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -402,8 +402,8 @@ and returns a scalar.
      - |convex| convex
      - None
 
-Clarifications
-^^^^^^^^^^^^^^
+Clarifications for scalar functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The domain :math:`\mathbf{S}^n` refers to the set of symmetric matrices. The domains :math:`\mathbf{S}^n_+` and :math:`\mathbf{S}^n_-` refer to the set of positive semi-definite and negative semi-definite matrices, respectively. Similarly, :math:`\mathbf{S}^n_{++}` and :math:`\mathbf{S}^n_{--}` refer to the set of positive definite and negative definite matrices, respectively.
 
@@ -531,7 +531,7 @@ scalars, which are promoted.
 
    * - :ref:`log_normcdf(x) <log-normcdf>`
 
-     - log of the standard normal CDF
+     - :ref:`approximate <clarifyelementwise>` log of the standard normal CDF
      - :math:`x \in \mathbf{R}`
      - |negative| negative
      - |concave| concave
@@ -547,7 +547,7 @@ scalars, which are promoted.
 
    * - :ref:`loggamma(x) <loggamma>`
 
-     - `log of the Gamma function <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.loggamma.html>`_
+     - :ref:`approximate <clarifyelementwise>` `log of the Gamma function <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.loggamma.html>`_
      - :math:`x > 0`
      - |unknown| unknown
      - |convex| convex
@@ -703,11 +703,16 @@ scalars, which are promoted.
      - |convex| convex
      - |incr| incr.
 
-Clarifications
-^^^^^^^^^^^^^^
+.. _clarifyelementwise:
+
+Clarifications on elementwise functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The functions ``log_normcdf`` and ``loggamma`` are defined via approximations. ``log_normcdf`` has highest accuracy
 over the range -4 to 4, while ``loggamma`` has similar accuracy over all positive reals.
+See `CVXPY GitHub PR #1224 <https://github.com/cvxpy/cvxpy/pull/1224#issue-793221374>`_
+and `CVXPY GitHub Issue #228 <https://github.com/cvxpy/cvxpy/issues/228#issuecomment-544281906>`_
+for details on the approximations.
 
 Vector/matrix functions
 -----------------------
@@ -793,7 +798,7 @@ and returns a vector or matrix.
      - |affine| affine
      - depends |_| on C
 
-   * - :ref:`partial_trace(X, dims, axis=0) <partial-trace>`
+   * - :ref:`partial_trace(X, dims, axis=0) <ptrace>`
 
      - partial trace
      - :math:`X \in\mathbf{R}^{n \times n}`
@@ -801,7 +806,7 @@ and returns a vector or matrix.
      - |affine| affine
      - |incr| incr.
 
-   * - :ref:`partial_transpose(X, dims, axis=0) <partial-transpose>`
+   * - :ref:`partial_transpose(X, dims, axis=0) <ptrans>`
 
      - partial transpose
      - :math:`X \in\mathbf{R}^{n \times n}`
@@ -836,8 +841,8 @@ and returns a vector or matrix.
      - |incr| incr.
 
 
-Clarifications
-^^^^^^^^^^^^^^
+Clarifications on vector and matrix functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The input to ``bmat`` is a list of lists of CVXPY expressions.
 It constructs a block matrix.
 The elements of each inner list are stacked horizontally and then the resulting block matrices are stacked vertically.

--- a/doc/source/tutorial/index.rst
+++ b/doc/source/tutorial/index.rst
@@ -1,7 +1,7 @@
 .. _tutorial:
 
-Tutorial
-========
+User's Guide
+============
 
 .. toctree::
     :maxdepth: 2

--- a/doc/source/tutorial/index.rst
+++ b/doc/source/tutorial/index.rst
@@ -1,7 +1,7 @@
 .. _tutorial:
 
-User's Guide
-============
+User Guide
+==========
 
 .. toctree::
     :maxdepth: 2

--- a/doc/source/updates/index.rst
+++ b/doc/source/updates/index.rst
@@ -8,44 +8,50 @@ CVXPY's project maintainers currently provide support for CVXPY 1.2 and 1.1.
 
 CVXPY 1.2
 ---------
-Starting with CVXPY 1.2.0, we're adopting `semantic versioning <https://semver.org/>`_!
-Under this policy we'll increment the minor version number (the "x" in "CVXPY 1.x.y")
+We're taking a big step toward `semantic versioning <https://semver.org/>`_!
+Our new versioning policy will be to increment the minor version number (the "x" in "CVXPY 1.x.y")
 whenever we introduce new features.
 The patch number (the "y" in "CVXPY 1.x.y") will only be incremented for bugfixes.
 We'll support multiple minor releases of CVXPY at any given time.
+API-breaking changes will require incrementing the major version number (i.e., moving to CVXPY 2.x.y).
 
 This versioning policy is very different from what we've done in the past.
 Many new features were added *after* CVXPY 1.1.0 but *before* CVXPY 1.2.0.
 These features accumulated over the course of CVXPY 1.1.1 and 1.1.18.
-We summarize those accumulated features below.
+We review those features and the new features in CVXPY 1.2.0 below.
 
- * Solver interfaces
-     * 1.1.2: users can provide their own implementation of a KKT solver for use with CVXOPT
-     * 1.1.2: support for SCIP
-     * 1.1.4: support for FICO XPRESS
-     * 1.1.6: rewrote the MOSEK interface; it now dualizes all continuous problems
-     * 1.1.8: added a mechanism for users to create solver interfaces without modifying CVXPY source code
-     * 1.1.12: support warm-start with GUROBI
-     * 1.1.12: ECOS, ECOS_BB, and SCS report solver statistics
-     * 1.1.14: support for LP solvers callable from SciPy (most notably, HiGHS)
-     * 1.1.17: support for SCS 2.0
- * Constraints and atoms
-     * 1.1.8: an atom which approximates the log of the Gaussian distribution's CDF.
-     * 1.1.8: power cone constraints
-     * 1.1.14: an atom which approximates the log of the gamma function.
-     * 1.1.14: an atom called "rel_entr", with the same semantics as the SciPy's "rel_entr"
- * Other
-     * 1.1.6: a "Dualize" reduction
-     * 1.1.11: verbose logging
-     * 1.1.11: several improvements to CVXPY's  C++ backend rewriting system, "cvxcore."
-       In particular, CVXPY can now be compiled from source with openmp enabled, which allows
-       canonicalization to take advantage of multithreading.
-     * 1.1.18: A problem status "infeasible or unbounded", for use by specific solvers in rare situations
+Solver interfaces
+~~~~~~~~~~~~~~~~~
+ * 1.2.0: support GLOP, via OR-Tools
+ * 1.1.17: support for SCS 3.0
+ * 1.1.14: support for HiGHS (and other LP solvers that come with SciPy)
+ * 1.1.12: ECOS, ECOS_BB, and SCS report solver statistics
+ * 1.1.12: support warm-start with GUROBI
+ * 1.1.8: added a mechanism for users to create solver interfaces without modifying CVXPY source code
+ * 1.1.6: rewrote the MOSEK interface; it now dualizes all continuous problems
+ * 1.1.4: support for FICO XPRESS
+ * 1.1.2: support for SCIP
+ * 1.1.2: users can provide their own implementation of a KKT solver for use with CVXOPT
 
-The following features are new in 1.2.0 and have not appeared in any earlier release.
+Constraints and atoms
+~~~~~~~~~~~~~~~~~~~~~
+ * 1.2.0: added atoms for `partial trace <https://en.wikipedia.org/wiki/Partial_trace>`_ and partial transpose,
+   which are important linear operators in quantum information
+ * 1.2.0: updated ``kron`` so that either argument in ``kron(A, B)`` can be a non-constant affine Expression,
+   provided the other argument is constant. We previously required that ``A`` was constant.
+ * 1.1.14: added ``loggamma``: an atom which approximates the log of the gamma function
+ * 1.1.14: added ``rel_entr``: an atom with the same semantics as the SciPy's "rel_entr"
+ * 1.1.8: added ``log_normcdf``: an atom that approximates the log of the Gaussian distribution's CDF
+ * 1.1.8: added power cone constraints
 
- * `Partial trace <https://en.wikipedia.org/wiki/Partial_trace>`_ and partial transpose, 
- important linear operators in quantum information.
+Wider system changes
+~~~~~~~~~~~~~~~~~~~~
+ * 1.1.18: A problem status "infeasible or unbounded", for use by specific solvers in rare situations
+ * 1.1.11: verbose logging
+ * 1.1.11: several improvements to CVXPY's  C++ backend rewriting system, "cvxcore."
+   In particular, CVXPY can now be compiled from source with openmp enabled, which allows
+   canonicalization to take advantage of multithreading.
+ * 1.1.6: a "Dualize" reduction
 
 
 CVXPY 1.1
@@ -91,7 +97,13 @@ Breaking changes
 We no longer support Python 2 or Python 3.4.
 
 CVXPY 1.1.0 drops the SuperSCS and ECOS_BB solvers.
-(We reversed this change for ECOS_BB, and added it back in version 1.1.6.)
+
+.. note::
+
+	We added ECOS_BB back in version 1.1.6. Starting with
+	CVXPY 1.2.0, any backwards-incompatible change like removing a
+	solver interface will require incrementing CVXPY's major version
+	number (e.g., moving from series 1.X to 2.X).
 
 Bugfixes
 ~~~~~~~~

--- a/doc/source/updates/index.rst
+++ b/doc/source/updates/index.rst
@@ -20,6 +20,17 @@ Many new features were added *after* CVXPY 1.1.0 but *before* CVXPY 1.2.0.
 These features accumulated over the course of CVXPY 1.1.1 and 1.1.18.
 We review those features and the new features in CVXPY 1.2.0 below.
 
+Constraints and atoms
+~~~~~~~~~~~~~~~~~~~~~
+ * 1.2.0: added atoms for `partial trace <https://en.wikipedia.org/wiki/Partial_trace>`_ and partial transpose,
+   which are important linear operators in quantum information
+ * 1.2.0: updated ``kron`` so that either argument in ``kron(A, B)`` can be a non-constant affine Expression,
+   provided the other argument is constant. We previously required that ``A`` was constant.
+ * 1.1.14: added ``loggamma``: an atom which approximates the log of the gamma function
+ * 1.1.14: added ``rel_entr``: an atom with the same semantics as the SciPy's "rel_entr"
+ * 1.1.8: added ``log_normcdf``: an atom that approximates the log of the Gaussian distribution's CDF
+ * 1.1.8: added power cone constraints
+
 Solver interfaces
 ~~~~~~~~~~~~~~~~~
  * 1.2.0: support GLOP, via OR-Tools
@@ -33,26 +44,14 @@ Solver interfaces
  * 1.1.2: support for SCIP
  * 1.1.2: users can provide their own implementation of a KKT solver for use with CVXOPT
 
-Constraints and atoms
-~~~~~~~~~~~~~~~~~~~~~
- * 1.2.0: added atoms for `partial trace <https://en.wikipedia.org/wiki/Partial_trace>`_ and partial transpose,
-   which are important linear operators in quantum information
- * 1.2.0: updated ``kron`` so that either argument in ``kron(A, B)`` can be a non-constant affine Expression,
-   provided the other argument is constant. We previously required that ``A`` was constant.
- * 1.1.14: added ``loggamma``: an atom which approximates the log of the gamma function
- * 1.1.14: added ``rel_entr``: an atom with the same semantics as the SciPy's "rel_entr"
- * 1.1.8: added ``log_normcdf``: an atom that approximates the log of the Gaussian distribution's CDF
- * 1.1.8: added power cone constraints
-
-Wider system changes
-~~~~~~~~~~~~~~~~~~~~
+General system improvements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
  * 1.1.18: A problem status "infeasible or unbounded", for use by specific solvers in rare situations
  * 1.1.11: verbose logging
  * 1.1.11: several improvements to CVXPY's  C++ backend rewriting system, "cvxcore."
    In particular, CVXPY can now be compiled from source with openmp enabled, which allows
    canonicalization to take advantage of multithreading.
  * 1.1.6: a "Dualize" reduction
-
 
 CVXPY 1.1
 ---------

--- a/doc/source/updates/index.rst
+++ b/doc/source/updates/index.rst
@@ -26,6 +26,7 @@ Constraints and atoms
    which are important linear operators in quantum information
  * 1.2.0: updated ``kron`` so that either argument in ``kron(A, B)`` can be a non-constant affine Expression,
    provided the other argument is constant. We previously required that ``A`` was constant.
+ * 1.2.0: added ``xexp``: an atom that implements :math:`\\texttt{xexp}(x) = x e^{x}`.
  * 1.1.14: added ``loggamma``: an atom which approximates the log of the gamma function
  * 1.1.14: added ``rel_entr``: an atom with the same semantics as the SciPy's "rel_entr"
  * 1.1.8: added ``log_normcdf``: an atom that approximates the log of the Gaussian distribution's CDF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,12 @@ testpaths = [
 
 [build-system]
 requires = [
-    "numpy>=1.15,<1.16; python_version=='3.6'",
     "numpy>=1.15,<1.16; python_version=='3.7'",
     "numpy>=1.16,<1.17; python_version=='3.8'",
-    "numpy>=1.19,<1.20; python_version=='3.9'",
-    "numpy>=1.21,<1.22; python_version=='3.10'",
+    "numpy>=1.19,<1.20; python_version=='3.9'; platform_machine!='arm64' or os_name!='Darwin'",
+    "numpy>=1.21.4,<1.22; python_version=='3.9'; platform_machine=='arm64' and os_name=='Darwin'",
+    "numpy>=1.21,<1.22; python_version=='3.10'; platform_machine!='arm64' or os_name!='Darwin'",
+    "numpy>=1.21.4,<1.22; python_version=='3.10'; platform_machine=='arm64' and os_name=='Darwin'",
     "scipy >= 1.1.0",
     "setuptools>=40.8.0",
     "wheel"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@ testpaths = [
 requires = [
     "numpy>=1.15,<1.16; python_version=='3.7'",
     "numpy>=1.16,<1.17; python_version=='3.8'",
-    "numpy>=1.19,<1.20; python_version=='3.9'; platform_machine!='arm64' or os_name!='Darwin'",
-    "numpy>=1.21.4,<1.22; python_version=='3.9'; platform_machine=='arm64' and os_name=='Darwin'",
-    "numpy>=1.21,<1.22; python_version=='3.10'; platform_machine!='arm64' or os_name!='Darwin'",
-    "numpy>=1.21.4,<1.22; python_version=='3.10'; platform_machine=='arm64' and os_name=='Darwin'",
+    "numpy>=1.19,<1.20; python_version=='3.9' and (platform_machine!='arm64' or os_name!='Darwin')",
+    "numpy>=1.21.4,<1.22; python_version=='3.9' and (platform_machine=='arm64' and os_name=='Darwin')",
+    "numpy>=1.21,<1.22; python_version=='3.10' and (platform_machine!='arm64' or os_name!='Darwin')",
+    "numpy>=1.21.4,<1.22; python_version=='3.10' and (platform_machine=='arm64' and os_name=='Darwin')",
     "scipy >= 1.1.0",
     "setuptools>=40.8.0",
     "wheel"

--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,7 @@ setup(
     },
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
         "osqp >= 0.4.1",
         "ecos >= 2",


### PR DESCRIPTION
## Description

I originally set out to fix issue #1604 for getting wheels to build on M1 macs. I investigated various possibilities (see my comment here: https://github.com/cvxpy/cvxpy/issues/1604#issuecomment-1046051882) and came to the conclusion that a simple use of environment markers in ``pyproject.toml`` should solve the problem. @akshayka @phschiele @h-vetinari please comment on if you think this will be sufficient!

I also resolved the deprecation warnings mentioned in #1654 and took steps to remove support for Python 3.6.

At some point, I got started on a documentation spree. @SteveDiamond @akshayka @bstellato: please review my changes to web documentation concerning the Reductions API. I basically took a stance that nothing in that realm is part of the public API. We need to take a stance there because we need to be able to determine what it means for a change to be backward-compatible. Definitely review the web documentation changes by building locally. I used a lot of ReStructuredText which made for clean web docs at some expense of messier source docs.

Thanks in advance for anyone's comments on this PR!

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [X] Bug fix
- [X] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [X] Add our license to new files.
- [X] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [X] Run the unittests and check that they’re passing.
- [X] Run the benchmarks to make sure your change doesn’t introduce a regression.