### PR TITLE
Remove pruning added by 9672acf

### DIFF
--- a/cvxpy/cvxcore/src/Utils.cpp
+++ b/cvxpy/cvxcore/src/Utils.cpp
@@ -27,7 +27,7 @@ std::vector<Matrix> mat_vec_mul(const std::vector<Matrix> &lh_vec,
   for (unsigned i = 0; i < lh_vec.size(); ++i) {
     for (unsigned j = 0; j < rh_vec.size(); ++j) {
       // prune away explicit nonzeros
-      result.push_back((lh_vec[i] * rh_vec[j]).pruned());
+      result.push_back(lh_vec[i] * rh_vec[j]);
     }
   }
   return result;

--- a/cvxpy/tests/test_benchmarks.py
+++ b/cvxpy/tests/test_benchmarks.py
@@ -274,3 +274,28 @@ class TestBenchmarks(BaseTest):
         print('Quadratic canonicalization')
         print('(OSQP) solver time: ', prob.solver_stats.solve_time)
         print('cvxpy time: ', (end - start) - prob.solver_stats.solve_time)
+
+    def test_issue_1668_slow_pruning(self) -> None:
+        """Regression test for https://github.com/cvxpy/cvxpy/issues/1668
+
+        Pruning matrices caused order-of-magnitude slow downs in compilation times.
+        """
+        s = 2000
+        t = 10
+        x = np.linspace(-100.0, 100.0, s)
+        rows = 50
+        var = cp.Variable(shape=(rows, t))
+
+        cost = cp.sum_squares(
+            var @ np.tile(np.array([x]), t).reshape((t, x.shape[0]))
+            - np.tile(x, rows).reshape((rows, s))
+        )
+        objective = cp.Minimize(cost)
+        problem = cp.Problem(objective)
+
+        start = time.time()
+        problem.get_problem_data(cp.ECOS, verbose=True)
+        end = time.time()
+
+        print("Issue #1668 regression test")
+        print("Compilation time: ", end - start)


### PR DESCRIPTION
## Description

See discussion on https://github.com/cvxpy/cvxpy/issues/1668. The pruning in `Utils.cpp:mat_vec_mul` is causing order of magnitude slow-downs on some problems.

I've added a new benchmarking test -- this change takes its run time on my machine from ~8.4 seconds to ~0.7 seconds.

Closes #1668 

I think there is still discussion on #1668 about whether we want this change, but the consensus seems to be moving towards yes, so I thought I'd open a PR.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.