### PR TITLE
Updated cumsum_canon.py for axis bug

### DIFF
--- a/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/cumsum_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/cumsum_canon.py
@@ -26,7 +26,13 @@ def cumsum_canon(expr, args):
     # X = Y[1:,:] - Y[:-1, :]
     Y = Variable(expr.shape)
     if axis == 0:
-        constr = [X[1:] == Y[1:] - Y[:-1], Y[0] == X[0]]
+        if (expr.shape[0] == 1):
+            constr = [Y[0] == X[0]]
+        else:
+            constr = [X[1:] == Y[1:] - Y[:-1], Y[0] == X[0]]
     else:
-        constr = [X[:, 1:] == Y[:, 1:] - Y[:, :-1], Y[:, 0] == X[:, 0]]
+        if (expr.shape[1] == 1):
+            constr = [Y[:, 0] == X[:, 0]]
+        else:
+            constr = [X[:, 1:] == Y[:, 1:] - Y[:, :-1], Y[:, 0] == X[:, 0]]
     return (Y, constr)

--- a/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/cumsum_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/cumsum_canon.py
@@ -27,12 +27,12 @@ def cumsum_canon(expr, args):
     Y = Variable(expr.shape)
     if axis == 0:
         if (expr.shape[0] == 1):
-            constr = [Y[0] == X[0]]
+            return (X, [])
         else:
             constr = [X[1:] == Y[1:] - Y[:-1], Y[0] == X[0]]
     else:
         if (expr.shape[1] == 1):
-            constr = [Y[:, 0] == X[:, 0]]
+            return (X, [])
         else:
             constr = [X[:, 1:] == Y[:, 1:] - Y[:, :-1], Y[:, 0] == X[:, 0]]
     return (Y, constr)

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1987,3 +1987,23 @@ class TestProblem(BaseTest):
         param.value = np.array([1])
         prob.solve()
         assert prob.value == -np.inf
+
+    def test_cumsum_axis(self) -> None:
+        """Test the cumsum axis bug with row or column matrix
+           See issue #1678
+        """
+        n = 5
+
+        # Solve for axis = 0
+        x1 = cp.Variable((1, n))
+        expr1 = cp.cumsum(x1, axis=0)
+        prob1 = cp.Problem(cp.Minimize(0),
+                           [expr1 == 1])
+        prob1.solve()
+
+        # Solve for axis = 1
+        x2 = cp.Variable((n, 1))
+        expr2 = cp.cumsum(x2, axis=1)
+        prob2 = cp.Problem(cp.Minimize(0),
+                           [expr2 == 1])
+        prob2.solve()


### PR DESCRIPTION
## Description
Fixed the axis bug in cumsum() by adding special cases to https://github.com/cvxpy/cvxpy/blob/master/cvxpy/reductions/eliminate_pwl/atom_canonicalizers/cumsum_canon.py
Issue link (if applicable): Issue #1678 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.