### PR TITLE
Fix sign error with log_sum_exp

### DIFF
--- a/cvxpy/atoms/log_sum_exp.py
+++ b/cvxpy/atoms/log_sum_exp.py
@@ -69,7 +69,8 @@ class log_sum_exp(AxisAtom):
     def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
-        return (False, False)
+        # Positive when arg is positve.
+        return (self.args[0].is_nonneg(), False)
 
     def is_atom_convex(self) -> bool:
         """Is the atom convex?

--- a/cvxpy/atoms/log_sum_exp.py
+++ b/cvxpy/atoms/log_sum_exp.py
@@ -69,7 +69,7 @@ class log_sum_exp(AxisAtom):
     def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
-        # Positive when arg is positve.
+        # Non-negative when arg is non-negative.
         return (self.args[0].is_nonneg(), False)
 
     def is_atom_convex(self) -> bool:

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1305,3 +1305,18 @@ class TestAtoms(BaseTest):
             cp.partial_transpose(X, dims=[2, 4], axis=0)
         self.assertEqual(str(cm.exception),
                          "Dimension of system doesn't correspond to dimension of subsystems.")
+
+    def test_log_sum_exp(self) -> None:
+        """Test log_sum_exp.
+        """
+        # Test for positive x
+        x = Variable(nonneg=True)
+        atom = cp.log_sum_exp(x)
+        self.assertEqual(atom.curvature, s.CONVEX)
+        self.assertEqual(atom.sign, s.NONNEG)
+
+        # Test for negative x
+        x = Variable(nonpos=True)
+        atom = cp.log_sum_exp(x)
+        self.assertEqual(atom.curvature, s.CONVEX)
+        self.assertEqual(atom.sign, s.UNKNOWN)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1307,15 +1307,15 @@ class TestAtoms(BaseTest):
                          "Dimension of system doesn't correspond to dimension of subsystems.")
 
     def test_log_sum_exp(self) -> None:
-        """Test log_sum_exp.
+        """Test log_sum_exp sign.
         """
-        # Test for positive x
+        # Test for non-negative x
         x = Variable(nonneg=True)
         atom = cp.log_sum_exp(x)
         self.assertEqual(atom.curvature, s.CONVEX)
         self.assertEqual(atom.sign, s.NONNEG)
 
-        # Test for negative x
+        # Test for non-positive x
         x = Variable(nonpos=True)
         atom = cp.log_sum_exp(x)
         self.assertEqual(atom.curvature, s.CONVEX)


### PR DESCRIPTION
## Description:
Stephen Boyd noticed that log_sum_exp of a non-negative value has unknown sign, where it should be non-negative. This PR fixes the sign error.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.