### PR TITLE
Fix assertion sign comparison issues in LinOpOperations.cpp

### DIFF
--- a/cvxpy/cvxcore/src/LinOpOperations.cpp
+++ b/cvxpy/cvxcore/src/LinOpOperations.cpp
@@ -427,7 +427,7 @@ Tensor get_kronl_mat(const LinOp &lin, int arg_idx) {
 Tensor get_vstack_mat(const LinOp &lin, int arg_idx) {
   assert(lin.get_type() == VSTACK);
   int row_offset = 0;
-  assert(arg_idx <= lin.get_args().size());
+  assert(static_cast<size_t>(arg_idx) <= lin.get_args().size());
   std::vector<Triplet> tripletList;
   const LinOp &arg = *lin.get_args()[arg_idx];
   tripletList.reserve(vecprod(arg.get_shape()));
@@ -467,7 +467,7 @@ Tensor get_vstack_mat(const LinOp &lin, int arg_idx) {
 Tensor get_hstack_mat(const LinOp &lin, int arg_idx) {
   assert(lin.get_type() == HSTACK);
   int row_offset = 0;
-  assert(arg_idx <= lin.get_args().size());
+  assert(static_cast<size_t>(arg_idx) <= lin.get_args().size());
   std::vector<Triplet> tripletList;
   tripletList.reserve(vecprod(lin.get_shape()));
   const LinOp &arg = *lin.get_args()[arg_idx];


### PR DESCRIPTION
## Description
Please include a short summary of the change.
Fixes the warnings issue described in #1690 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [X] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [X] Add our license to new files.
- [X] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.