### PR TITLE
cvxpy/tests: Add test for infeasible boolean problem

### DIFF
--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -715,6 +715,32 @@ def mi_lp_4() -> SolverTestHelper:
     return sth
 
 
+def mi_lp_5() -> SolverTestHelper:
+    # infeasible boolean problem - https://trac.sagemath.org/ticket/31962#comment:48
+    z = cp.Variable(11, boolean=True)
+    constraints = [z[2] + z[1] == 1,
+                   z[4] + z[3] == 1,
+                   z[6] + z[5] == 1,
+                   z[8] + z[7] == 1,
+                   z[10] + z[9] == 1,
+                   z[4] + z[1] <= 1,
+                   z[2] + z[3] <= 1,
+                   z[6] + z[2] <= 1,
+                   z[1] + z[5] <= 1,
+                   z[8] + z[6] <= 1,
+                   z[5] + z[7] <= 1,
+                   z[10] + z[8] <= 1,
+                   z[7] + z[9] <= 1,
+                   z[9] + z[4] <= 1,
+                   z[3] + z[10] <= 1]
+    obj = cp.Minimize(0)
+    obj_pair = (obj, np.inf)
+    con_pairs = [(c, None) for c in constraints]
+    var_pairs = [(z, None)]
+    sth = SolverTestHelper(obj_pair, var_pairs, con_pairs)
+    return sth
+
+
 def mi_socp_1() -> SolverTestHelper:
     """
     Formulate the following mixed-integer SOCP with cvxpy
@@ -897,6 +923,14 @@ class StandardTestLPs:
     @staticmethod
     def test_mi_lp_4(solver, places: int = 4, **kwargs) -> SolverTestHelper:
         sth = mi_lp_4()
+        sth.solve(solver, **kwargs)
+        sth.verify_objective(places)
+        sth.verify_primal_values(places)
+        return sth
+
+    @staticmethod
+    def test_mi_lp_5(solver, places: int = 4, **kwargs) -> SolverTestHelper:
+        sth = mi_lp_5()
         sth.solve(solver, **kwargs)
         sth.verify_objective(places)
         sth.verify_primal_values(places)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -573,6 +573,14 @@ class TestCVXOPT(BaseTest):
         StandardTestSDPs.test_sdp_2(solver='CVXOPT')
 
 
+def _cylp_has_isProvenInfeasible():
+    try:
+        from cylp.cy.CyCBCModel import CyCbcModel
+        return hasattr(CyCbcModel, 'isProvenInfeasible')
+    except ImportError:
+        return False
+
+
 @unittest.skipUnless('CBC' in INSTALLED_SOLVERS, 'CBC is not installed.')
 class TestCBC(BaseTest):
 
@@ -640,6 +648,7 @@ class TestCBC(BaseTest):
     def test_cbc_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='CBC')
 
+    @unittest.skipUnless(_cylp_has_isProvenInfeasible(), 'CyLP <= 0.91.4 has no working integer infeasibility detection')
     def test_cbc_mi_lp_5(self) -> None:
         StandardTestLPs.test_mi_lp_5(solver='CBC')
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -589,7 +589,6 @@ class TestCBC(BaseTest):
         self.B = cp.Variable((2, 2), name='B')
         self.C = cp.Variable((3, 2), name='C')
 
-    @staticmethod
     def _cylp_has_isProvenInfeasible():
         try:
             from cylp.cy.CyCbcModel import CyCbcModel

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -573,14 +573,6 @@ class TestCVXOPT(BaseTest):
         StandardTestSDPs.test_sdp_2(solver='CVXOPT')
 
 
-def _cylp_has_isProvenInfeasible():
-    try:
-        from cylp.cy.CyCBCModel import CyCbcModel
-        return hasattr(CyCbcModel, 'isProvenInfeasible')
-    except ImportError:
-        return False
-
-
 @unittest.skipUnless('CBC' in INSTALLED_SOLVERS, 'CBC is not installed.')
 class TestCBC(BaseTest):
 
@@ -596,6 +588,14 @@ class TestCBC(BaseTest):
         self.A = cp.Variable((2, 2), name='A')
         self.B = cp.Variable((2, 2), name='B')
         self.C = cp.Variable((3, 2), name='C')
+
+    @staticmethod
+    def _cylp_has_isProvenInfeasible():
+        try:
+            from cylp.cy.CyCBCModel import CyCbcModel
+            return hasattr(CyCbcModel, 'isProvenInfeasible')
+        except ImportError:
+            return False
 
     def test_options(self) -> None:
         """Test that all the cvx.CBC solver options work.

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -647,7 +647,8 @@ class TestCBC(BaseTest):
     def test_cbc_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='CBC')
 
-    @unittest.skipUnless(_cylp_has_isProvenInfeasible(), 'CyLP <= 0.91.4 has no working integer infeasibility detection')
+    @unittest.skipUnless(_cylp_has_isProvenInfeasible(),
+                         'CyLP <= 0.91.4 has no working integer infeasibility detection')
     def test_cbc_mi_lp_5(self) -> None:
         StandardTestLPs.test_mi_lp_5(solver='CBC')
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -592,7 +592,7 @@ class TestCBC(BaseTest):
     @staticmethod
     def _cylp_has_isProvenInfeasible():
         try:
-            from cylp.cy.CyCBCModel import CyCbcModel
+            from cylp.cy.CyCbcModel import CyCbcModel
             return hasattr(CyCbcModel, 'isProvenInfeasible')
         except ImportError:
             return False

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -589,10 +589,11 @@ class TestCBC(BaseTest):
         self.B = cp.Variable((2, 2), name='B')
         self.C = cp.Variable((3, 2), name='C')
 
-    def _cylp_has_isProvenInfeasible():
+    def _cylp_checks_isProvenInfeasible():
         try:
-            from cylp.cy.CyCbcModel import CyCbcModel
-            return hasattr(CyCbcModel, 'isProvenInfeasible')
+            # https://github.com/coin-or/CyLP/pull/150
+            from cylp.cy.CyCbcModel import problemStatus
+            return problemStatus[0] == 'search completed'
         except ImportError:
             return False
 
@@ -647,7 +648,7 @@ class TestCBC(BaseTest):
     def test_cbc_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='CBC')
 
-    @unittest.skipUnless(_cylp_has_isProvenInfeasible(),
+    @unittest.skipUnless(_cylp_checks_isProvenInfeasible(),
                          'CyLP <= 0.91.4 has no working integer infeasibility detection')
     def test_cbc_mi_lp_5(self) -> None:
         StandardTestLPs.test_mi_lp_5(solver='CBC')

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -435,6 +435,9 @@ class TestMosek(unittest.TestCase):
     def test_mosek_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='MOSEK')
 
+    def test_mosek_mi_lp_5(self) -> None:
+        StandardTestLPs.test_mi_lp_5(solver='MOSEK')
+
     def test_mosek_mi_socp_1(self) -> None:
         StandardTestSOCPs.test_mi_socp_1(solver='MOSEK')
 
@@ -679,6 +682,9 @@ class TestGLPK(unittest.TestCase):
 
     def test_glpk_mi_lp_4(self) -> None:
         StandardTestLPs.test_mi_lp_4(solver='GLPK_MI')
+
+    def test_glpk_mi_lp_5(self) -> None:
+        StandardTestLPs.test_mi_lp_5(solver='GLPK_MI')
 
     def test_glpk_options(self) -> None:
         sth = sths.lp_1()
@@ -983,6 +989,9 @@ class TestCPLEX(BaseTest):
     def test_cplex_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='CPLEX')
 
+    def test_cplex_mi_lp_5(self) -> None:
+        StandardTestLPs.test_mi_lp_5(solver='CPLEX')
+
     def test_cplex_mi_socp_1(self) -> None:
         StandardTestSOCPs.test_mi_socp_1(solver='CPLEX', places=3)
 
@@ -1201,6 +1210,9 @@ class TestGUROBI(BaseTest):
     def test_gurobi_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='GUROBI')
 
+    def test_gurobi_mi_lp_5(self) -> None:
+        StandardTestLPs.test_mi_lp_5(solver='GUROBI')
+
     def test_gurobi_mi_socp_1(self) -> None:
         StandardTestSOCPs.test_mi_socp_1(solver='GUROBI', places=2)
 
@@ -1348,6 +1360,9 @@ class TestXPRESS(BaseTest):
     def test_xpress_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='XPRESS')
 
+    def test_xpress_mi_lp_5(self) -> None:
+        StandardTestLPs.test_mi_lp_5(solver='XPRESS')
+
     def test_xpress_mi_socp_1(self) -> None:
         StandardTestSOCPs.test_mi_socp_1(solver='XPRESS')
 
@@ -1436,6 +1451,9 @@ class TestSCIP(unittest.TestCase):
 
     def test_scip_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver="SCIP")
+
+    def test_scip_mi_lp_5(self) -> None:
+        StandardTestLPs.test_mi_lp_5(solver="SCIP")
 
     def get_simple_problem(self):
         """Example problem that can be used within additional tests."""
@@ -1608,6 +1626,9 @@ class TestECOS_BB(unittest.TestCase):
 
     def test_ecos_bb_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='ECOS_BB')
+
+    def test_ecos_bb_mi_lp_5(self) -> None:
+        StandardTestLPs.test_mi_lp_5(solver='ECOS_BB')
 
     @pytest.mark.skip(reason="Known bug in ECOS BB")
     def test_ecos_bb_mi_socp_1(self) -> None:

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -637,6 +637,9 @@ class TestCBC(BaseTest):
     def test_cbc_mi_lp_3(self) -> None:
         StandardTestLPs.test_mi_lp_3(solver='CBC')
 
+    def test_cbc_mi_lp_5(self) -> None:
+        StandardTestLPs.test_mi_lp_5(solver='CBC')
+
 
 @unittest.skipUnless('GLPK' in INSTALLED_SOLVERS, 'GLPK is not installed.')
 class TestGLPK(unittest.TestCase):

--- a/cvxpy/tests/test_mip_vars.py
+++ b/cvxpy/tests/test_mip_vars.py
@@ -80,6 +80,29 @@ class TestMIPVariable(BaseTest):
 
         self.assertItemsAlmostEqual(self.A_bool.value, C, places=4)
 
+        # Infeasible boolean problem.
+        # https://trac.sagemath.org/ticket/31962#comment:48
+        z = cp.Variable(11, boolean=True)
+        constraints = [z[2] + z[1] == 1,
+                       z[4] + z[3] == 1,
+                       z[6] + z[5] == 1,
+                       z[8] + z[7] == 1,
+                       z[10] + z[9] == 1,
+                       z[4] + z[1] <= 1,
+                       z[2] + z[3] <= 1,
+                       z[6] + z[2] <= 1,
+                       z[1] + z[5] <= 1,
+                       z[8] + z[6] <= 1,
+                       z[5] + z[7] <= 1,
+                       z[10] + z[8] <= 1,
+                       z[7] + z[9] <= 1,
+                       z[9] + z[4] <= 1,
+                       z[3] + z[10] <= 1]
+        obj = cp.Minimize(0)
+        p = cp.Problem(obj, constraints)
+        result = p.solve(solver=solver)
+        self.assertEqual(p.status in s.INF_OR_UNB, True)
+
     def int_prob(self, solver) -> None:
         # Int in objective.
         obj = cp.Minimize(cp.abs(self.y_int - 0.2))

--- a/cvxpy/tests/test_mip_vars.py
+++ b/cvxpy/tests/test_mip_vars.py
@@ -80,29 +80,6 @@ class TestMIPVariable(BaseTest):
 
         self.assertItemsAlmostEqual(self.A_bool.value, C, places=4)
 
-        # Infeasible boolean problem.
-        # https://trac.sagemath.org/ticket/31962#comment:48
-        z = cp.Variable(11, boolean=True)
-        constraints = [z[2] + z[1] == 1,
-                       z[4] + z[3] == 1,
-                       z[6] + z[5] == 1,
-                       z[8] + z[7] == 1,
-                       z[10] + z[9] == 1,
-                       z[4] + z[1] <= 1,
-                       z[2] + z[3] <= 1,
-                       z[6] + z[2] <= 1,
-                       z[1] + z[5] <= 1,
-                       z[8] + z[6] <= 1,
-                       z[5] + z[7] <= 1,
-                       z[10] + z[8] <= 1,
-                       z[7] + z[9] <= 1,
-                       z[9] + z[4] <= 1,
-                       z[3] + z[10] <= 1]
-        obj = cp.Minimize(0)
-        p = cp.Problem(obj, constraints)
-        result = p.solve(solver=solver)
-        self.assertEqual(p.status in s.INF_OR_UNB, True)
-
     def int_prob(self, solver) -> None:
         # Int in objective.
         obj = cp.Minimize(cp.abs(self.y_int - 0.2))


### PR DESCRIPTION
## Description
Please include a short summary of the change.

We add a new test `StandardTestLPs.test_mi_lp_5`. This test fails with CBC because of https://github.com/coin-or/CyLP/issues/81

#1703 attempts to fix it.

Issue link (if applicable):

https://trac.sagemath.org/ticket/31962#comment:48

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [X] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.