### PR TITLE
Cylp update

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/cbc_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cbc_conif.py
@@ -34,7 +34,6 @@ class CBC(ConicSolver):
     STATUS_MAP_MIP = {'solution': s.OPTIMAL,
                       'relaxation infeasible': s.INFEASIBLE,
                       'problem proven infeasible': s.INFEASIBLE,
-                      'relaxation abondoned': s.SOLVER_ERROR,  # sic
                       'relaxation abandoned': s.SOLVER_ERROR,
                       'stopped on user event': s.SOLVER_ERROR,
                       'stopped on nodes': s.OPTIMAL_INACCURATE,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [options.extras_require]
 # Solver names as in cvxpy.settings = pip-installable distribution providing it
-CBC = cylp
+CBC = cylp>=0.91.5
 CVXOPT = cvxopt
 DIFFCP = diffcp
 ECOS =


### PR DESCRIPTION
## Description
A new '''cylp''' release, https://pypi.org/project/cylp/0.91.5/, fixes the broken integer infeasibility detection with CBC (#1705). Thanks @tkralphs! 
We set a corresponding lower version bound in `extras_require` for '''cylp'''.

Also remove handling of a misspelled cylp problem status (#1707). The typo has not made it into a cylp release.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [X] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.