### PR TITLE
web documentation updates

### DIFF
--- a/doc/source/api_reference/cvxpy.atoms.affine.rst
+++ b/doc/source/api_reference/cvxpy.atoms.affine.rst
@@ -35,6 +35,13 @@ bmat
 
 .. autofunction:: cvxpy.bmat
 
+.. _cong:
+
+conj
+----
+
+.. autoclass:: cvxpy.conj
+
 .. _conv:
 
 conv
@@ -72,6 +79,13 @@ hstack
 
 .. autofunction:: cvxpy.hstack
 
+.. _imag
+
+imag
+----
+
+.. autoclass:: cvxpy.imag
+
 .. _index:
 
 index
@@ -103,12 +117,40 @@ multiply
 .. autoclass:: cvxpy.multiply
     :show-inheritance:
 
+.. _ptrace:
+
+partial_trace
+--------------------------------
+
+.. autofunction:: cvxpy.partial_trace
+
+.. _ptrans:
+
+partial_transpose
+--------------------------------
+
+.. autofunction:: cvxpy.partial_transpose
+
 .. _promote:
 
 promote
 ------------------------------------
 
 .. autofunction:: cvxpy.atoms.affine.promote.promote
+
+.. _psd_wrap:
+
+psd_wrap
+--------
+
+.. autoclass:: cvxpy.atoms.affine.wraps.psd_wrap
+
+.. _real:
+
+real
+----
+
+.. autofunction:: cvxpy.real
 
 .. _reshape:
 
@@ -165,23 +207,6 @@ upper_tri
 
 .. autoclass:: cvxpy.upper_tri
     :show-inheritance:
-
-
-.. _ptrace:
-
-partial_trace
---------------------------------
-
-.. autofunction:: cvxpy.partial_trace
-
-
-.. _ptrans:
-
-partial_transpose
---------------------------------
-
-.. autofunction:: cvxpy.partial_transpose
-
 
 .. _vec:
 

--- a/doc/source/api_reference/cvxpy.atoms.affine.rst
+++ b/doc/source/api_reference/cvxpy.atoms.affine.rst
@@ -35,7 +35,7 @@ bmat
 
 .. autofunction:: cvxpy.bmat
 
-.. _cong:
+.. _conj:
 
 conj
 ----

--- a/doc/source/api_reference/cvxpy.atoms.rst
+++ b/doc/source/api_reference/cvxpy.atoms.rst
@@ -1,8 +1,9 @@
 Atoms
 ====================
-Atoms are mathematical functions that can be applied to
-:class:`~cvxpy.expressions.expression.Expression` instances.
-Applying an atom to an expression yields another expression.
+
+An atom (with a lower-case "a") is a mathematical function that can be applied to
+:class:`~cvxpy.Expression` objects and returns an :class:`~cvxpy.Expression` object.
+
 Atoms and compositions thereof are precisely the mechanisms that allow you to
 build up mathematical expression trees in CVXPY.
 
@@ -16,6 +17,41 @@ for a compact, accessible summary of each atom's attributes.
     Affine Atoms <cvxpy.atoms.affine>
     Elementwise Atoms <cvxpy.atoms.elementwise>
     Other Atoms <cvxpy.atoms.other_atoms>
+
+Representation of atoms
+-----------------------
+
+From an implementation perspective, an atom might be the constructor for some class.
+For example, the atom :math:`X \mapsto \lambda_{\max}(X)` is applied by constructing
+an instance of the :class:`~cvxpy.atoms.lambda_max.lambda_max` class, which inherits
+directly from :class:`~cvxpy.atoms.atom.Atom` and indirectly from :class:`~cvxpy.expressions.expression.Expression`.
+Most atoms are implemented this way.
+
+Alternatively, an atom be a wrapper that initializes and returns
+an Atom of some other class. For example, running
+
+.. code:: python
+
+	import cvxpy as cp
+	X = cp.Variable(shape=(2,2), symmetric=True)
+	expr = cp.lambda_min(X)
+	print(type(expr))
+
+shows
+
+.. parsed-literal::
+
+	<class 'cvxpy.atoms.affine.unary_operators.NegExpression'>
+
+This happens because *(1)* CVXPY implements :func:`~cvxpy.atoms.lambda_min.lambda_min` as
+
+.. math::
+
+	\lambda_{\min}(X) = -\lambda_{\max}(-X),
+
+*(2)* the negation operator is a class-based atom, and *(3)* the precise type of an Expression is based
+on the last class-based atom applied to it (if any such atom has been applied).
+
 
 Atom
 ----

--- a/doc/source/api_reference/cvxpy.problems.rst
+++ b/doc/source/api_reference/cvxpy.problems.rst
@@ -2,8 +2,9 @@ Problems
 =======================
 The :class:`~cvxpy.problems.problem.Problem` class is the entry point to
 specifying and solving optimization problems. Each
-:class:`cvxpy.problems.problem.Problem` instance encapsulates an optimization
-problem, i.e., an objective and a set of constraints, and the
+:class:`~cvxpy.problems.problem.Problem` instance encapsulates an optimization
+problem, i.e., an objective and a set of constraints.
+The
 :meth:`~cvxpy.problems.problem.Problem.solve` method either solves the problem
 encoded by the instance, returning the optimal value and setting variables
 values to optimal points, or reports that the problem was in fact infeasible or
@@ -17,12 +18,12 @@ and the values of its variables like so:
     if problem.status not in ["infeasible", "unbounded"]:
         # Otherwise, problem.value is inf or -inf, respectively.
         print("Optimal value: %s" % problem.value)
-    for variable in problem.variables():
-        print("Variable %s: value %s" % (variable.name(), variable.value))
+        for variable in problem.variables():
+            print("Variable %s: value %s" % (variable.name(), variable.value))
 
-Problems are **immutable**, except through the specification of
+Problems are *immutable*, except through the specification of
 :class:`~cvxpy.expressions.constants.parameter.Parameter` values. This means
-that you **cannot** modify a problem's objective or constraints after you have
+that you *cannot* modify a problem's objective or constraints after you have
 created it. If you find yourself wanting to add a constraint to an existing
 problem, you should instead create a new problem using, for example, the
 following idiom:
@@ -52,39 +53,35 @@ accessed via the :meth:`~cvxpy.problems.problem.Problem.size_metrics` and
 
 Minimize
 --------
-.. autoclass:: cvxpy.problems.objective.Minimize
+.. autoclass:: cvxpy.Minimize
     :members: is_dcp, is_dgp
     :undoc-members:
-    :show-inheritance:
 
 Maximize
 --------
-.. autoclass:: cvxpy.problems.objective.Maximize
+.. autoclass:: cvxpy.Maximize
     :members: is_dcp, is_dgp
     :undoc-members:
-    :show-inheritance:
+
+
+Problem
+-------
+.. autoclass:: cvxpy.Problem
+    :members: value, status, objective, constraints, is_dcp, is_dgp, is_dqcp,
+              is_qp, is_dpp, variables, parameters, constants,
+              backward, derivative, atoms, size_metrics, solver_stats, solve,
+              register_solve, get_problem_data, unpack_results
+    :undoc-members:
+    :member-order: groupwise
 
 SizeMetrics
 -----------
 .. autoclass:: cvxpy.problems.problem.SizeMetrics
     :members:
     :undoc-members:
-    :show-inheritance:
 
 SolverStats
 -----------
 .. autoclass:: cvxpy.problems.problem.SolverStats
     :members:
     :undoc-members:
-    :show-inheritance:
-
-Problem
--------
-.. autoclass:: cvxpy.problems.problem.Problem
-    :members: value, status, objective, constraints, is_dcp, is_dgp, is_dqcp,
-              is_qp, is_dpp, variables, parameters, constants,
-              backward, derivative, atoms, size_metrics, solver_stats, solve,
-              register_solve, get_problem_data, unpack_results
-    :undoc-members:
-    :show-inheritance:
-

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -160,7 +160,7 @@ html_theme_options = {
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+html_title = f'CVXPY {version} documentation'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None

--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -154,7 +154,7 @@ Please add the following license to new files:
 
 Code style
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-We use `flake8 <http://flake8.pycqa.org/en/latest/>`_ and
+We use `flake8 <https://flake8.pycqa.org/en/latest/>`_ and
 `isort <https://pycqa.github.io/isort/>`_ to enforce our Python coding
 style. Before sending us a pull request, navigate to the project root
 and run
@@ -548,6 +548,6 @@ call modified versions of a test with different solver parameters, for example
 
 
 .. _Anaconda: https://store.continuum.io/cshop/anaconda/
-.. _CVXOPT: http://cvxopt.org/
-.. _NumPy: http://www.numpy.org/
-.. _SciPy: http://www.scipy.org/
+.. _CVXOPT: https://cvxopt.org/
+.. _NumPy: https://www.numpy.org/
+.. _SciPy: https://www.scipy.org/

--- a/doc/source/examples/applications/censored_data.rst
+++ b/doc/source/examples/applications/censored_data.rst
@@ -14,7 +14,7 @@ well known distributions.
 
 We can overcome this challenge by converting the MLE into a convex
 optimization problem and solving it using
-`CVXPY <http://www.cvxpy.org/en/latest/>`__.
+`CVXPY <https://www.cvxpy.org/en/latest/>`__.
 
 This example is adapted from a homework problem from Boyd's `CVX 101:
 Convex Optimization

--- a/doc/source/examples/applications/fault_detection.rst
+++ b/doc/source/examples/applications/fault_detection.rst
@@ -12,7 +12,7 @@ Topic references
    Bounds for Constrained Estimation with Uncertainty." Decision and
    Control, 2005 and 2005 European Control Conference. CDC-ECC'05. 44th
    IEEE Conference on. IEEE,
-   2005. <http://web.stanford.edu/~boyd/papers/pdf/map_bounds.pdf>`__
+   2005. <https://web.stanford.edu/~boyd/papers/pdf/map_bounds.pdf>`__
 
 Problem statement
 =================

--- a/doc/source/examples/applications/l1_trend_filter.rst
+++ b/doc/source/examples/applications/l1_trend_filter.rst
@@ -33,7 +33,7 @@ difference matrix, with rows
 .. math:: \begin{bmatrix}0 & \cdots & 0 & -1 & 2 & -1 & 0 & \cdots & 0 \end{bmatrix}.
 
 CVXPY is not optimized for the :math:`\ell_1` trend filtering problem.
-For large problems, use l1\_tf (http://www.stanford.edu/~boyd/l1\_tf/).
+For large problems, use l1\_tf (https://www.stanford.edu/~boyd/l1\_tf/).
 
 Formulate and solve problem
 ---------------------------

--- a/doc/source/examples/applications/parade_route.rst
+++ b/doc/source/examples/applications/parade_route.rst
@@ -6,7 +6,7 @@ Topic references
 ================
 
 -  Iterated weighted :math:`\ell_1`
-   heuristic: `slides <http://stanford.edu/class/ee364b/lectures/l1_ext_slides.pdf>`__
+   heuristic: `slides <https://stanford.edu/class/ee364b/lectures/l1_ext_slides.pdf>`__
 
 Problem statement
 =================
@@ -67,7 +67,7 @@ objective, picking the weight vector :math:`w \in \mathbf{R}^n_+` at
 each iteration to try and induce a sparse solution vector
 :math:`x^\star`. The details can be found in the `Stanford EE364B
 lecture
-notes <http://stanford.edu/class/ee364b/lectures/l1_ext_slides.pdf>`__.
+notes <https://stanford.edu/class/ee364b/lectures/l1_ext_slides.pdf>`__.
 
 The algorithm consists of initializing :math:`w = 0` and repeating the
 two steps

--- a/doc/source/examples/basic/mixed_integer_quadratic_program.rst
+++ b/doc/source/examples/basic/mixed_integer_quadratic_program.rst
@@ -41,6 +41,11 @@ Example
 
 In the following code, we solve a mixed-integer least-squares problem
 with CVXPY.
+You need to install a mixed-integer nonlinear solver to run this
+example.
+CVXPY's preferred open-source mixed-integer nonlinear solver is SCIP.
+It can be installed with ``pip install pyscipopt`` or
+``conda install -c conda-forge pyscipopt``.
 
 .. code:: python
 

--- a/doc/source/faq/index.rst
+++ b/doc/source/faq/index.rst
@@ -15,7 +15,7 @@ create an issue on the `CVXPY Github issue tracker <https://github.com/cvxpy/cvx
 
 Where can I learn more about convex optimization?
 -------------------------------------------------
-The book `Convex Optimization <http://web.stanford.edu/~boyd/cvxbook/>`_ by Boyd and Vandenberghe is available for free online and has extensive background on convex optimization.
+The book `Convex Optimization <https://web.stanford.edu/~boyd/cvxbook/>`_ by Boyd and Vandenberghe is available for free online and has extensive background on convex optimization.
 To learn more about disciplined convex programming,
 visit the `DCP tutorial website <http://dcp.stanford.edu/>`_.
 
@@ -119,6 +119,6 @@ Use the following BibTeX citation:
       title        = {{CVXPY}: A {P}ython-Embedded Modeling Language for Convex Optimization},
       journal      = {Journal of Machine Learning Research},
       note         = {To appear},
-      url          = {http://stanford.edu/~boyd/papers/pdf/cvxpy_paper.pdf},
+      url          = {https://stanford.edu/~boyd/papers/pdf/cvxpy_paper.pdf},
       year         = {2016},
     }

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to CVXPY
-================
+Welcome to CVXPY 1.2
+====================
 
 .. meta::
    :description: An open source Python-embedded modeling language for convex optimization problems.
@@ -56,7 +56,7 @@ For a guided tour of CVXPY, check out the :doc:`tutorial
 </tutorial/index>`. For applications to machine learning, control, finance, and
 more, browse the :doc:`library of examples </examples/index>`. For
 background on convex optimization, see the book `Convex Optimization
-<http://www.stanford.edu/~boyd/cvxbook/>`_ by Boyd and Vandenberghe.
+<https://www.stanford.edu/~boyd/cvxbook/>`_ by Boyd and Vandenberghe.
 
 CVXPY relies on the open source solvers `OSQP`_, `SCS`_, and `ECOS`_.
 Additional solvers are supported, but must be installed separately.

--- a/doc/source/related_projects/index.rst
+++ b/doc/source/related_projects/index.rst
@@ -23,13 +23,13 @@ Modeling frameworks
 
 - `CVX <http://cvxr.com/cvx/>`_ is a MATLAB-embedded modeling language for convex optimization problems. CVXPY is based on CVX.
 
-- `Convex.jl <http://convexjl.readthedocs.org/en/latest/>`_ is a Julia-embedded modeling language for convex optimization problems. Convex.jl is based on CVXPY and CVX.
+- `Convex.jl <https://convexjl.readthedocs.org/en/latest/>`_ is a Julia-embedded modeling language for convex optimization problems. Convex.jl is based on CVXPY and CVX.
 
 - `CVXR <https://cvxr.rbind.io/>`_ is a R-embedded modeling language for convex optimization problems. CVXR is based on CVXPY and CVX.
 
 - `GPkit <https://gpkit.readthedocs.org/en/latest/>`_ is a Python package for defining and manipulating geometric programming (GP) models.
 
-- `PICOS <http://picos.zib.de/>`_ is a user-friendly python interface to many linear and conic optimization solvers.
+- `PICOS <https://picos.zib.de/>`_ is a user-friendly python interface to many linear and conic optimization solvers.
 
 Solvers
 -------
@@ -44,7 +44,7 @@ Solvers
 
 - `GLPK <https://www.gnu.org/software/glpk/>`_ is an open-source C library for solving linear programs and mixed integer linear programs.
 
-- `GUROBI <http://www.gurobi.com/>`_ is a commercial solver for mixed integer second-order cone programs.
+- `GUROBI <https://www.gurobi.com/>`_ is a commercial solver for mixed integer second-order cone programs.
 
 - `MOSEK <https://www.mosek.com/>`_ is a commercial solver for mixed integer second-order cone programs and semidefinite programs.
 

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -3,7 +3,7 @@
 Advanced Features
 =================
 
-This section of the tutorial covers features of CVXPY intended for users with advanced knowledge of convex optimization. We recommend `Convex Optimization <http://www.stanford.edu/~boyd/cvxbook/>`_ by Boyd and Vandenberghe as a reference for any terms you are unfamiliar with.
+This section of the tutorial covers features of CVXPY intended for users with advanced knowledge of convex optimization. We recommend `Convex Optimization <https://www.stanford.edu/~boyd/cvxbook/>`_ by Boyd and Vandenberghe as a reference for any terms you are unfamiliar with.
 
 Dual variables
 --------------
@@ -731,7 +731,7 @@ Here is the complete list of solver options.
 ``'eps_rel'``
     relative accuracy (default: 1e-5).
 
-For others see `OSQP documentation <http://osqp.org/docs/interfaces/solver_settings.html>`_.
+For others see `OSQP documentation <https://osqp.org/docs/interfaces/solver_settings.html>`_.
 
 `ECOS`_ options:
 
@@ -1444,7 +1444,7 @@ on derivatives.
 .. _GLOP: https://developers.google.com/optimization
 .. _GLPK: https://www.gnu.org/software/glpk/
 .. _GLPK_MI: https://www.gnu.org/software/glpk/
-.. _GUROBI: http://www.gurobi.com/
+.. _GUROBI: https://www.gurobi.com/
 .. _MOSEK: https://www.mosek.com/
 .. _CBC: https://projects.coin-or.org/Cbc
 .. _CGL: https://projects.coin-or.org/Cgl

--- a/doc/source/tutorial/dqcp/index.rst
+++ b/doc/source/tutorial/dqcp/index.rst
@@ -7,7 +7,7 @@ Disciplined quasiconvex programming (DQCP) is a generalization of DCP for
 quasiconvex functions. Quasiconvexity generalizes convexity: a function
 :math:`f` is quasiconvex if and only if its domain is a convex set and its
 sublevel sets :math:`\{x : f(x) \leq t\}` are convex, for all :math:`t`. For a
-thorough overview of quasiconvexity, see the paper `Disciplined quasiconvex programming <http://web.stanford.edu/~boyd/papers/dqcp.html>`_.
+thorough overview of quasiconvexity, see the paper `Disciplined quasiconvex programming <https://web.stanford.edu/~boyd/papers/dqcp.html>`_.
 
 
 While DCP is a ruleset for constructing convex programs, DQCP

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -29,7 +29,7 @@ Elementwise multiplication can be applied with the :ref:`multiply` function.
 Indexing and slicing
 ^^^^^^^^^^^^^^^^^^^^
 
-Indexing in CVXPY follows exactly the same semantics as `NumPy ndarrays <http://docs.scipy.org/doc/numpy/reference/arrays.indexing.html>`_.
+Indexing in CVXPY follows exactly the same semantics as `NumPy ndarrays <https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html>`_.
 For example, if ``expr`` has shape ``(5,)`` then ``expr[1]`` gives the second entry.
 More generally, ``expr[i:j:k]`` selects every kth
 element of ``expr``, starting at ``i`` and ending at ``j-1``.
@@ -409,8 +409,8 @@ The domain :math:`\mathbf{S}^n` refers to the set of symmetric matrices. The dom
 
 For a vector expression ``x``, ``norm(x)`` and ``norm(x, 2)`` give the Euclidean norm. For a matrix expression ``X``, however, ``norm(X)`` and ``norm(X, 2)`` give the spectral norm.
 
-The function ``norm(X, "fro")`` is called the `Frobenius norm <http://en.wikipedia.org/wiki/Matrix_norm#Frobenius_norm>`__
-and ``norm(X, "nuc")`` the `nuclear norm <http://en.wikipedia.org/wiki/Matrix_norm#Schatten_norms>`__. The nuclear norm can also be defined as the sum of ``X``'s singular values.
+The function ``norm(X, "fro")`` is called the `Frobenius norm <https://en.wikipedia.org/wiki/Matrix_norm#Frobenius_norm>`__
+and ``norm(X, "nuc")`` the `nuclear norm <https://en.wikipedia.org/wiki/Matrix_norm#Schatten_norms>`__. The nuclear norm can also be defined as the sum of ``X``'s singular values.
 
 The functions ``max`` and ``min`` give the largest and smallest entry, respectively, in a single expression. These functions should not be confused with ``maximum`` and ``minimum`` (see :ref:`elementwise`). Use ``maximum`` and ``minimum`` to find the max or min of a list of scalar expressions.
 

--- a/doc/source/updates/index.rst
+++ b/doc/source/updates/index.rst
@@ -26,7 +26,7 @@ Constraints and atoms
    which are important linear operators in quantum information
  * 1.2.0: updated ``kron`` so that either argument in ``kron(A, B)`` can be a non-constant affine Expression,
    provided the other argument is constant. We previously required that ``A`` was constant.
- * 1.2.0: added ``xexp``: an atom that implements :math:`\\texttt{xexp}(x) = x e^{x}`.
+ * 1.2.0: added ``xexp``: an atom that implements :math:`\texttt{xexp}(x) = x e^{x}`.
  * 1.1.14: added ``loggamma``: an atom which approximates the log of the gamma function
  * 1.1.14: added ``rel_entr``: an atom with the same semantics as the SciPy's "rel_entr"
  * 1.1.8: added ``log_normcdf``: an atom that approximates the log of the Gaussian distribution's CDF
@@ -172,7 +172,7 @@ Overview
 
 * Disciplined geometric programming (DGP): Starting with version 1.0.11, CVXPY lets you formulate and solve log-log convex programs, which generalize both traditional geometric programs and generalized geometric programs. To get started with DGP, check out :ref:`the tutorial <dgp>` and consult the `accompanying paper <https://web.stanford.edu/~boyd/papers/dgp.html>`_.
 
-* Reductions: CVXPY 1.0 uses a modular system of *reductions* to convert problems input by the user into the format required by the solver, which makes it easy to support new standard forms, such as quadratic programs, and more advanced user inputs, such as problems with complex variables. See :ref:`reductions-api` and the `accompanying paper <http://stanford.edu/~boyd/papers/cvxpy_rewriting.html>`_ for further details.
+* Reductions: CVXPY 1.0 uses a modular system of *reductions* to convert problems input by the user into the format required by the solver, which makes it easy to support new standard forms, such as quadratic programs, and more advanced user inputs, such as problems with complex variables. See :ref:`reductions-api` and the `accompanying paper <https://stanford.edu/~boyd/papers/cvxpy_rewriting.html>`_ for further details.
 
 * Attributes: Variables and parameters now support a variety of attributes that describe their symbolic properties, such as nonnegative or symmetric. This unifies the treatment of symbolic properties for variables and parameters and replaces specialized variable classes such as ``Bool`` and ``Semidef``.
 


### PR DESCRIPTION
This resolves #1710 and #1713. I also added material that explains the precise meaning of "atom" in cvxpy's code base, slightly changed some text formatting, and moved a bit of content around within a single ``.rst`` file.

This PR is pulling into the release/1.2.x branch. If merged, then I'll tag the commit with "doc1.2.0-update" (currently the name of this branch) and manually trigger a doc build with GitHub actions. The build will happen with the unreleased version of 1.2.1, which is functionally equivalent to 1.2.0 (the only difference is version flags in setup.py). I made a change to sphinx's ``conf.py`` to make sure the patch number doesn't appear in metadata for the web documentation.

Once web docs are fixed on this branch I'll propagate changes to master.