### PR TITLE
Bugfixes for the SCIP interface

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
@@ -28,6 +28,7 @@ from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import (
     ConicSolver, dims_to_solver_dict,)
+from cvxpy.utilities.versioning import Version
 
 log = logging.getLogger(__name__)
 
@@ -87,8 +88,12 @@ class SCIP(ConicSolver):
 
     def import_solver(self) -> None:
         """Imports the solver."""
-        from pyscipopt import scip
-        scip  # For flake8
+        import pyscipopt
+        v = pyscipopt.__version__
+        if Version(v) >= Version('4.0.0'):
+            msg = 'PySCIPOpt (SCIP\'s Python wrapper) is installed and its' \
+                  'version is %s. CVXPY only supports PySCIPOpt < 4.0.0.' % v
+            raise NotImplementedError(msg)
 
     def apply(self, problem: ParamConeProg) -> Tuple[Dict, Dict]:
         """Returns a new problem and data for inverting the new solution."""
@@ -309,10 +314,14 @@ class SCIP(ConicSolver):
     ) -> Dict[str, Any]:
         """Solve and return a solution if one exists."""
 
-        solution = {}
         try:
             model.optimize()
+        except Exception as e:
+            log.warning("Error encountered when optimising %s: %s", model, e)
 
+        solution = {}
+
+        if max(model.getNSols(), model.getNCountedSols()) > 0:
             solution["value"] = model.getObjVal()
             sol = model.getBestSol()
             solution["primal"] = array([sol[v] for v in variables])
@@ -337,9 +346,6 @@ class SCIP(ConicSolver):
                 solution["y"] = -array(vals)
                 solution[s.EQ_DUAL] = solution["y"][0:dims[s.EQ_DIM]]
                 solution[s.INEQ_DUAL] = solution["y"][dims[s.EQ_DIM]:]
-
-        except Exception as e:
-            log.warning("Error encountered when optimising %s: %s", model, e)
 
         solution[s.SOLVE_TIME] = model.getSolvingTime()
         solution['status'] = STATUS_MAP[model.getStatus()]

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -204,8 +204,9 @@ version 9.3 or greater is required.
 Install with SCIP support
 -------------------------
 
-CVXPY supports the SCIP solver.
-Simply install SCIP such that you can ``from pyscipopt.scip import Model`` in Python.
+CVXPY supports the SCIP solver through the ``pyscipopt`` Python package;
+we do not support pyscipopt version 4.0.0 or higher; you need to use pyscipopt version 3.x.y
+for some (x,y).
 See the `PySCIPOpt <https://github.com/SCIP-Interfaces/PySCIPOpt#installation>`_ github for installation instructions.
 
 CVXPY's SCIP interface does not reliably recover dual variables for constraints. If you require dual variables for a continuous problem, you will need to use another solver. We welcome additional contributions to the SCIP interface, to recover dual variables for constraints in continuous problems.

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ HIGHS = scipy>=1.6.1
 MOSEK = Mosek
 OSQP =
 PDLP = ortools
-SCIP = PySCIPOpt
+SCIP = PySCIPOpt<4.0.0
 SCIPY = scipy
 SCS =
 XPRESS = xpress


### PR DESCRIPTION
This PR makes three changes relating to SCIP:

* it narrows the scope of the "try" step in a try-except block within ``SCIP._solve``.
* it checks for the existence of solutions before trying to access the model objective value (fixing a problem reported in #1702),
* it specifies a version limit that pyscipopt < 4.0.0.

That third point is a follow-up on PR #1628. It turns out that tests fail when pyscipopt 4.x is installed (note: pyscipopt 3 works exclusively with SCIP 7, and pyscipopt 4 works exclusively with SCIP 8). The specific test I saw fail used the problem defined by ``socp_1(axis=0)`` in ``solver_test_helpers.py``. SCIP incorrectly claimed that the problem was infeasible.

