### PR TITLE
Finite sets

### DIFF
--- a/cvxpy/constraints/__init__.py
+++ b/cvxpy/constraints/__init__.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from cvxpy.constraints.exponential import ExpCone
+from cvxpy.constraints.finite_set import FiniteSet
 from cvxpy.constraints.nonpos import Inequality, NonNeg, NonPos
 from cvxpy.constraints.power import PowCone3D, PowConeND
 from cvxpy.constraints.psd import PSD

--- a/cvxpy/constraints/finite_set.py
+++ b/cvxpy/constraints/finite_set.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import numpy as np
+
+from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions import cvxtypes
+from cvxpy.utilities import scopes
+
+
+class FiniteSet(Constraint):
+    def __init__(self, expre, vec, ineq_form: bool=True, constr_id=None) -> None:
+        Expression = cvxtypes.expression()
+        vec = Expression.cast_to_const(vec)
+        self.expre = expre
+        self.vec = vec
+        self.ineq_form = ineq_form
+        super(FiniteSet, self).__init__([expre, vec], constr_id)
+
+    def name(self) -> str:
+        return "%s FS 0" % self.args[0]
+
+    def is_dcp(self, dpp: bool = False) -> bool:
+        """A FiniteSet constraint imposed by exprval_in_vec makes the MICP problem DCP"""
+        if dpp:
+            with scopes.dpp_scope():
+                return self.args[0].is_affine()
+        return self.args[0].is_affine()
+
+    def is_dgp(self, dpp: bool = False) -> bool:
+        return False
+
+    def is_dqcp(self) -> bool:
+        return self.is_dcp()
+
+    @property
+    def size(self):
+        return self.expre.size
+
+    @property
+    def ineq_form(self) -> bool:
+        return self.ineq_form
+
+    @property
+    def shape(self):
+        return self.expre.shape
+
+    @property
+    def residual(self):
+        """
+        The residual of the constraint.
+        Returns
+        -------
+        float
+        """
+        val = self.expre.value
+        res = np.min(np.abs(val - self.vec.value))
+        return res

--- a/cvxpy/constraints/finite_set.py
+++ b/cvxpy/constraints/finite_set.py
@@ -22,8 +22,23 @@ from cvxpy.utilities import scopes
 
 
 class FiniteSet(Constraint):
+    """A class for constraining given expressions to a set of finite size composed of real numbers.
 
-    def __init__(self, expre, vec, ineq_form: bool = True, constr_id=None) -> None:
+    Parameters
+    ----------
+    expre : Expression
+        The given expression to be constrained. Note that, ``expre`` can have multiple features, and the
+        constraint is applied element-wise to each feature of the ``Expression`` i.e.:
+
+        .. code-block:: python
+
+            for i in range(expre.size):
+                print(expre[i] in vec) # => True
+
+    vec : NumPy.ndarray/set
+        The finite set of values to which the given (affine) expression is to be constrained.
+    """
+    def __init__(self, expre, vec, ineq_form: bool = False, constr_id=None) -> None:
         Expression = cvxtypes.expression()
         if isinstance(vec, set):
             vec = list(vec)
@@ -40,7 +55,9 @@ class FiniteSet(Constraint):
         return [self._ineq_form]
 
     def is_dcp(self, dpp: bool = False) -> bool:
-        """A FiniteSet constraint imposed by exprval_in_vec makes the MICP problem DCP"""
+        """
+        A ``FiniteSet`` constraint is DCP, if the constrained expression is affine
+        """
         if dpp:
             with scopes.dpp_scope():
                 return self.args[0].is_affine()
@@ -58,6 +75,10 @@ class FiniteSet(Constraint):
 
     @property
     def ineq_form(self) -> bool:
+        """
+        Choose between two constraining methodologies, use ``ineq_form=False`` while working with
+        ``Parameter`` types
+        """
         return self._ineq_form
 
     @property
@@ -68,6 +89,7 @@ class FiniteSet(Constraint):
     def residual(self):
         """
         The residual of the constraint.
+
         Returns
         -------
         float

--- a/cvxpy/constraints/finite_set.py
+++ b/cvxpy/constraints/finite_set.py
@@ -22,16 +22,20 @@ from cvxpy.utilities import scopes
 
 
 class FiniteSet(Constraint):
-    def __init__(self, expre, vec, ineq_form: bool=True, constr_id=None) -> None:
+
+    def __init__(self, expre, vec, ineq_form: bool = True, constr_id=None) -> None:
         Expression = cvxtypes.expression()
         vec = Expression.cast_to_const(vec)
         self.expre = expre
         self.vec = vec
-        self.ineq_form = ineq_form
+        self._ineq_form = ineq_form
         super(FiniteSet, self).__init__([expre, vec], constr_id)
 
     def name(self) -> str:
         return "%s FS 0" % self.args[0]
+
+    def get_data(self):
+        return [self._ineq_form]
 
     def is_dcp(self, dpp: bool = False) -> bool:
         """A FiniteSet constraint imposed by exprval_in_vec makes the MICP problem DCP"""
@@ -52,7 +56,7 @@ class FiniteSet(Constraint):
 
     @property
     def ineq_form(self) -> bool:
-        return self.ineq_form
+        return self._ineq_form
 
     @property
     def shape(self):

--- a/cvxpy/constraints/finite_set.py
+++ b/cvxpy/constraints/finite_set.py
@@ -25,6 +25,8 @@ class FiniteSet(Constraint):
 
     def __init__(self, expre, vec, ineq_form: bool = True, constr_id=None) -> None:
         Expression = cvxtypes.expression()
+        if isinstance(vec, set):
+            vec = list(vec)
         vec = Expression.cast_to_const(vec)
         self.expre = expre
         self.vec = vec

--- a/cvxpy/constraints/finite_set.py
+++ b/cvxpy/constraints/finite_set.py
@@ -27,8 +27,8 @@ class FiniteSet(Constraint):
     Parameters
     ----------
     expre : Expression
-        The given expression to be constrained. Note that, ``expre`` can have multiple features, and the
-        constraint is applied element-wise to each feature of the ``Expression`` i.e.:
+        The given expression to be constrained. Note that, ``expre`` can have multiple features,
+        and the constraint is applied element-wise to each feature of the ``Expression`` i.e.:
 
         .. code-block:: python
 

--- a/cvxpy/reductions/discrete2mixedint/valinvec2mixedint.py
+++ b/cvxpy/reductions/discrete2mixedint/valinvec2mixedint.py
@@ -76,9 +76,9 @@ def finite_set_canon2(con, args):
 
 def finite_set_canon(con, args):
     if con.ineq_form:
-        return finite_set_canon2(con, args)
-    else:
         return finite_set_canon1(con, args)
+    else:
+        return finite_set_canon2(con, args)
 
 
 class Valinvec2mixedint(Canonicalization):

--- a/cvxpy/reductions/discrete2mixedint/valinvec2mixedint.py
+++ b/cvxpy/reductions/discrete2mixedint/valinvec2mixedint.py
@@ -51,7 +51,7 @@ def finite_set_canon1(con, args):
     vec = con.vec.value
     expre = con.expre.flatten()
     for i in range(expre.size):
-        cons += exprval_in_vec2(expre[i], vec)
+        cons += exprval_in_vec1(expre[i], vec)
     main_con = cons[-1]
     aux_cons = cons[:-1]
     return main_con, aux_cons

--- a/cvxpy/reductions/discrete2mixedint/valinvec2mixedint.py
+++ b/cvxpy/reductions/discrete2mixedint/valinvec2mixedint.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import numpy as np
+
+import cvxpy as cp
+from cvxpy.constraints import FiniteSet
+from cvxpy.expressions.variable import Variable
+from cvxpy.reductions.canonicalization import Canonicalization
+
+
+def exprval_in_vec1(expr, vec):
+    assert expr.is_affine()
+    assert expr.size == 1
+    if vec.size == 1:
+        # handling for when vec only has a single element
+        cons = expr == vec[0]
+        return [cons]
+    vec = np.sort(vec)
+    d = np.diff(vec)
+    z = Variable(shape=(d.size,), boolean=True)
+    cons = [z[1:] <= z[:-1]]
+    cons.append(expr == vec[0] + d @ z)
+    return cons
+
+
+def exprval_in_vec2(expr, vec):
+    z = Variable(len(vec), boolean=True)
+    constraints = [
+        cp.sum(cp.multiply(vec, z)) == expr,
+        cp.sum(z) == 1
+    ]
+    return constraints
+
+
+def finite_set_canon1(con, args):
+    cons = []
+    vec = con.vec.value
+    if con.expre.shape != tuple():
+        for i in range(con.expre.shape[0]):
+            cons += exprval_in_vec1(con.expre[i], vec)
+    else:
+        expr = args[0]
+        cons = exprval_in_vec1(expr, vec)
+    main_con = cons[-1]
+    aux_cons = cons[:-1]
+    return main_con, aux_cons
+
+
+def finite_set_canon2(con, args):
+    cons = []
+    vec = con.vec.value
+    if con.expre.shape != tuple():
+        for i in range(con.expre.shape[0]):
+            cons += exprval_in_vec2(con.expre[i], vec)
+    else:
+        expr = args[0]
+        cons = exprval_in_vec2(expr, vec)
+    main_con = cons[0]
+    aux_cons = cons[1:]
+    return main_con, aux_cons
+
+
+def finite_set_canon(con, args):
+    if con.ineq_form:
+        return finite_set_canon2(con, args)
+    else:
+        return finite_set_canon1(con, args)
+
+
+class Valinvec2mixedint(Canonicalization):
+    CANON_METHODS = {
+        FiniteSet: finite_set_canon
+    }
+
+    def __init__(self, problem=None) -> None:
+        super(Valinvec2mixedint, self).__init__(problem=problem,
+                                                canon_methods=Valinvec2mixedint.CANON_METHODS)

--- a/cvxpy/reductions/discrete2mixedint/valinvec2mixedint.py
+++ b/cvxpy/reductions/discrete2mixedint/valinvec2mixedint.py
@@ -27,13 +27,15 @@ def exprval_in_vec1(expr, vec):
     assert expr.size == 1
     if vec.size == 1:
         # handling for when vec only has a single element
-        cons = expr == vec[0]
-        return [cons]
+        cons = [expr == vec[0]]
+        return cons
     vec = np.sort(vec)
     d = np.diff(vec)
     z = Variable(shape=(d.size,), boolean=True)
-    cons = [z[1:] <= z[:-1]]
-    cons.append(expr == vec[0] + d @ z)
+    cons = [
+        z[1:] <= z[:-1],
+        expr == vec[0] + d @ z
+    ]
     return cons
 
 

--- a/cvxpy/reductions/discrete2mixedint/valinvec2mixedint.py
+++ b/cvxpy/reductions/discrete2mixedint/valinvec2mixedint.py
@@ -49,12 +49,9 @@ def exprval_in_vec2(expr, vec):
 def finite_set_canon1(con, args):
     cons = []
     vec = con.vec.value
-    if con.expre.shape != tuple():
-        for i in range(con.expre.shape[0]):
-            cons += exprval_in_vec1(con.expre[i], vec)
-    else:
-        expr = args[0]
-        cons = exprval_in_vec1(expr, vec)
+    expre = con.expre.flatten()
+    for i in range(expre.size):
+        cons += exprval_in_vec2(expre[i], vec)
     main_con = cons[-1]
     aux_cons = cons[:-1]
     return main_con, aux_cons
@@ -63,12 +60,9 @@ def finite_set_canon1(con, args):
 def finite_set_canon2(con, args):
     cons = []
     vec = con.vec.value
-    if con.expre.shape != tuple():
-        for i in range(con.expre.shape[0]):
-            cons += exprval_in_vec2(con.expre[i], vec)
-    else:
-        expr = args[0]
-        cons = exprval_in_vec2(expr, vec)
+    expre = con.expre.flatten()
+    for i in range(expre.size):
+        cons += exprval_in_vec2(expre[i], vec)
     main_con = cons[0]
     aux_cons = cons[1:]
     return main_con, aux_cons

--- a/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
@@ -28,6 +28,7 @@ from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import (
     ConicSolver, dims_to_solver_dict,)
+from cvxpy.utilities.versioning import Version
 
 log = logging.getLogger(__name__)
 
@@ -87,8 +88,12 @@ class SCIP(ConicSolver):
 
     def import_solver(self) -> None:
         """Imports the solver."""
-        from pyscipopt import scip
-        scip  # For flake8
+        import pyscipopt
+        v = pyscipopt.__version__
+        if Version(v) >= Version('4.0.0'):
+            msg = 'PySCIPOpt (SCIP\'s Python wrapper) is installed and its' \
+                  'version is %s. CVXPY only supports PySCIPOpt < 4.0.0.' % v
+            raise NotImplementedError(msg)
 
     def apply(self, problem: ParamConeProg) -> Tuple[Dict, Dict]:
         """Returns a new problem and data for inverting the new solution."""
@@ -309,10 +314,14 @@ class SCIP(ConicSolver):
     ) -> Dict[str, Any]:
         """Solve and return a solution if one exists."""
 
-        solution = {}
         try:
             model.optimize()
+        except Exception as e:
+            log.warning("Error encountered when optimising %s: %s", model, e)
 
+        solution = {}
+
+        if max(model.getNSols(), model.getNCountedSols()) > 0:
             solution["value"] = model.getObjVal()
             sol = model.getBestSol()
             solution["primal"] = array([sol[v] for v in variables])
@@ -337,9 +346,6 @@ class SCIP(ConicSolver):
                 solution["y"] = -array(vals)
                 solution[s.EQ_DUAL] = solution["y"][0:dims[s.EQ_DIM]]
                 solution[s.INEQ_DUAL] = solution["y"][dims[s.EQ_DIM]:]
-
-        except Exception as e:
-            log.warning("Error encountered when optimising %s: %s", model, e)
 
         solution[s.SOLVE_TIME] = model.getSolvingTime()
         solution['status'] = STATUS_MAP[model.getStatus()]

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -4,8 +4,8 @@ from typing import Any, List
 import numpy as np
 
 from cvxpy.atoms import EXP_ATOMS, NONPOS_ATOMS, PSD_ATOMS, SOC_ATOMS
-from cvxpy.constraints import (PSD, SOC, Equality, ExpCone, Inequality, NonNeg,
-                               NonPos, PowCone3D, Zero,)
+from cvxpy.constraints import (PSD, SOC, Equality, ExpCone, FiniteSet,
+                               Inequality, NonNeg, NonPos, PowCone3D, Zero,)
 from cvxpy.error import DCPError, DGPError, DPPError, SolverError
 from cvxpy.problems.objective import Maximize
 from cvxpy.reductions.chain import Chain
@@ -16,6 +16,8 @@ from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
 from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
 from cvxpy.reductions.dcp2cone.dcp2cone import Dcp2Cone
 from cvxpy.reductions.dgp2dcp.dgp2dcp import Dgp2Dcp
+from cvxpy.reductions.discrete2mixedint.valinvec2mixedint import (
+    Valinvec2mixedint,)
 from cvxpy.reductions.eval_params import EvalParams
 from cvxpy.reductions.flip_objective import FlipObjective
 from cvxpy.reductions.qp2quad_form import qp2symbolic_qp
@@ -117,6 +119,11 @@ def _reductions_for_problem_class(problem, candidates, gp: bool = False) -> List
                               "(%s)." % candidates)
         else:
             reductions += [Dcp2Cone(), CvxAttr2Constr()]
+
+    constr_types = {type(c) for c in problem.constraints}
+    if FiniteSet in constr_types:
+        reductions += [Valinvec2mixedint()]
+
     return reductions
 
 

--- a/cvxpy/tests/test_valinvec2mixedint.py
+++ b/cvxpy/tests/test_valinvec2mixedint.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import numpy as np
+
+import cvxpy as cp
+from cvxpy.constraints import FiniteSet
+from cvxpy.tests import solver_test_helpers as STH
+from cvxpy.tests.base_test import BaseTest
+
+
+class TestFiniteSet(BaseTest):
+    @staticmethod
+    def make_test_1():
+        """vec contains a contiguous range of integers"""
+        x = cp.Variable(shape=(4,))
+        expect_x = np.array([0., 7., 3., 0.])
+        vec = np.arange(10)
+        objective = cp.Maximize(x[0] + x[1] + 2 * x[2] - 2 * x[3])
+        constr1 = FiniteSet(x[0], vec)
+        constr2 = FiniteSet(x[1], vec)
+        constr3 = FiniteSet(x[2], vec)
+        constr4 = FiniteSet(x[3], vec)
+        constr5 = x[0] + 2 * x[2] <= 700
+        constr6 = 2 * x[1] - 8 * x[2] <= 0
+        constr7 = x[1] - 2 * x[2] + x[3] >= 1
+        constr8 = x[0] + x[1] + x[2] + x[3] == 10
+        obj_pair = (objective, 13.0)
+        con_pairs = [
+            (constr1, None),
+            (constr2, None),
+            (constr3, None),
+            (constr4, None),
+            (constr5, None),
+            (constr6, None),
+            (constr7, None),
+            (constr8, None)
+        ]
+        var_pairs = [
+            (x, expect_x)
+        ]
+        sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
+        return sth
+
+    def test_1(self):
+        sth = TestFiniteSet.make_test_1()
+        sth.solve(solver='GLPK_MI')
+        sth.verify_objective(places=3)
+        sth.verify_primal_values(places=3)
+        pass
+
+    @staticmethod
+    def make_test_2():
+        x = cp.Variable()
+        expect_x = np.array([-1.125])
+        objective = cp.Minimize(x)
+        vec = [-1.125, 1, 2]
+        constr1 = x >= -1.25
+        constr2 = x <= 10
+        constr3 = FiniteSet(x, vec)
+        obj_pairs = (objective, -1.125)
+        var_pairs = [
+            (x, expect_x)
+        ]
+        con_pairs = [
+            (constr1, None),
+            (constr2, None),
+            (constr3, None)
+        ]
+        sth = STH.SolverTestHelper(obj_pairs, var_pairs, con_pairs)
+        return sth
+
+    def test_2(self):
+        sth = TestFiniteSet.make_test_2()
+        sth.solve(solver='GLPK_MI')
+        sth.verify_objective(places=3)
+        sth.verify_primal_values(places=3)
+        pass
+
+    @staticmethod
+    def make_test_3():
+        """Case when vec.size==1"""
+        x = cp.Variable()
+        objective = cp.Minimize(cp.abs(x - 3))
+        vec = [1]
+        cons1 = FiniteSet(x, vec)
+        expected_x = np.array([1.])
+        obj_pair = (objective, 2.0)
+        var_pairs = [
+            (x, expected_x)
+        ]
+        con_pairs = [
+            (cons1, None)
+        ]
+        sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
+        return sth
+
+    def test_3(self):
+        sth = TestFiniteSet.make_test_3()
+        sth.solve(solver='GLPK_MI')
+        sth.verify_objective(places=3)
+        sth.verify_primal_values(places=3)
+        pass
+
+    @staticmethod
+    def make_test_4():
+        """Case when vec houses duplicates"""
+        x = cp.Variable()
+        objective = cp.Minimize(cp.abs(x - 3))
+        vec = [1, 1, 1, 2, 2, 3, 3]
+        cons1 = FiniteSet(x, vec)
+        expected_x = np.array([3.])
+        obj_pair = (objective, 0.0)
+        var_pairs = [
+            (x, expected_x)
+        ]
+        con_pairs = [
+            (cons1, None)
+        ]
+        sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
+        return sth
+
+    def test_4(self):
+        sth = TestFiniteSet.make_test_4()
+        sth.solve(solver='GLPK_MI')
+        sth.verify_objective(places=3)
+        sth.verify_primal_values(places=3)
+        pass
+
+    @staticmethod
+    def make_test_5():
+        """Case when input expression to FiniteSet constraint is affine"""
+        x = cp.Variable(shape=(4,))
+        vec = np.arange(10)
+        objective = cp.Maximize(x[0] + x[1] + 2 * x[2] - 2 * x[3])
+        expr0 = 2 * x[0] + 1
+        expr2 = 3 * x[2] + 5
+        constr1 = FiniteSet(expr0, vec)
+        constr2 = FiniteSet(x[1], vec)
+        constr3 = FiniteSet(expr2, vec)
+        constr4 = FiniteSet(x[3], vec)
+        constr5 = x[0] + 2 * x[2] <= 700
+        constr6 = 2 * x[1] - 8 * x[2] <= 0
+        constr7 = x[1] - 2 * x[2] + x[3] >= 1
+        constr8 = x[0] + x[1] + x[2] + x[3] == 10
+        expected_x = np.array([4., 4., 1., 1.])
+        obj_pair = (objective, 8.0)
+        con_pairs = [
+            (constr1, None),
+            (constr2, None),
+            (constr3, None),
+            (constr4, None),
+            (constr5, None),
+            (constr6, None),
+            (constr7, None),
+            (constr8, None)
+        ]
+        var_pairs = [
+            (x, expected_x)
+        ]
+        sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
+        return sth
+
+    def test_5(self):
+        sth = TestFiniteSet.make_test_5()
+        sth.solve(solver='GLPK_MI')
+        sth.verify_objective(places=3)
+        sth.verify_primal_values(places=3)
+        pass
+
+    @staticmethod
+    def make_test_6():
+        """vec contains only real quantities + passed expression is affine"""
+        x = cp.Variable()
+        expect_x = np.array([-1.0625])
+        objective = cp.Minimize(x)
+        vec = [-1.125, 1.5, 2.24]
+        constr1 = x >= -1.25
+        constr2 = x <= 10
+        expr = 2 * x + 1
+        constr3 = FiniteSet(expr, vec)
+        obj_pairs = (objective, -1.0625)
+        var_pairs = [
+            (x, expect_x)
+        ]
+        con_pairs = [
+            (constr1, None),
+            (constr2, None),
+            (constr3, None)
+        ]
+        sth = STH.SolverTestHelper(obj_pairs, var_pairs, con_pairs)
+        return sth
+
+    def test_6(self):
+        sth = TestFiniteSet.make_test_6()
+        sth.solve(solver='GLPK_MI')
+        sth.verify_objective(places=3)
+        sth.verify_primal_values(places=3)
+        pass
+
+    @staticmethod
+    def make_test_7():
+        """For testing vectorization of FiniteSet class"""
+        x = cp.Variable(shape=(4,))
+        expect_x = np.array([0., 7., 3., 0.])
+        vec = np.arange(10)
+        objective = cp.Maximize(x[0] + x[1] + 2 * x[2] - 2 * x[3])
+        constr1 = FiniteSet(x, vec, ineq_form=False)
+        constr2 = x[0] + 2 * x[2] <= 700
+        constr3 = 2 * x[1] - 8 * x[2] <= 0
+        constr4 = x[1] - 2 * x[2] + x[3] >= 1
+        constr5 = x[0] + x[1] + x[2] + x[3] == 10
+        obj_pair = (objective, 13.0)
+        con_pairs = [
+            (constr1, None),
+            (constr2, None),
+            (constr3, None),
+            (constr4, None),
+            (constr5, None)
+        ]
+        var_pairs = [
+            (x, expect_x)
+        ]
+        sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
+        return sth
+
+    def test_7(self):
+        sth = TestFiniteSet.make_test_7()
+        sth.solve(solver='GLPK_MI')
+        sth.verify_objective(places=3)
+        sth.verify_primal_values(places=3)
+        pass
+
+    @staticmethod
+    def make_test_8():
+        """Testing the alternative constraining pathway"""
+        x = cp.Variable()
+        expect_x = np.array([-1.125])
+        objective = cp.Minimize(x)
+        vec = [-1.125, 1, 2]
+        constr1 = x >= -1.25
+        constr2 = x <= 10
+        constr3 = FiniteSet(x, vec, ineq_form=True)
+        obj_pairs = (objective, -1.125)
+        var_pairs = [
+            (x, expect_x)
+        ]
+        con_pairs = [
+            (constr1, None),
+            (constr2, None),
+            (constr3, None)
+        ]
+        sth = STH.SolverTestHelper(obj_pairs, var_pairs, con_pairs)
+        return sth
+
+    def test_8(self):
+        sth = TestFiniteSet.make_test_8()
+        sth.solve(solver='GLPK_MI')
+        sth.verify_objective(places=3)
+        sth.verify_primal_values(places=3)
+        pass
+
+    @staticmethod
+    def make_test_9():
+        """For testing vectorization of FiniteSet class + new constraining method"""
+        x = cp.Variable(shape=(4,))
+        expect_x = np.array([0., 7., 3., 0.])
+        vec = np.arange(10)
+        objective = cp.Maximize(x[0] + x[1] + 2 * x[2] - 2 * x[3])
+        constr1 = FiniteSet(x, vec, ineq_form=True)
+        constr2 = x[0] + 2 * x[2] <= 700
+        constr3 = 2 * x[1] - 8 * x[2] <= 0
+        constr4 = x[1] - 2 * x[2] + x[3] >= 1
+        constr5 = x[0] + x[1] + x[2] + x[3] == 10
+        obj_pair = (objective, 13.0)
+        con_pairs = [
+            (constr1, None),
+            (constr2, None),
+            (constr3, None),
+            (constr4, None),
+            (constr5, None)
+        ]
+        var_pairs = [
+            (x, expect_x)
+        ]
+        sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
+        return sth
+
+    def test_9(self):
+        sth = TestFiniteSet.make_test_9()
+        sth.solve(solver='GLPK_MI')
+        sth.verify_objective(places=3)
+        sth.verify_primal_values(places=3)
+        pass

--- a/doc/source/api_reference/cvxpy.constraints.rst
+++ b/doc/source/api_reference/cvxpy.constraints.rst
@@ -85,3 +85,11 @@ PowConeND
     :members: value, violation, is_dcp
     :undoc-members:
     :show-inheritance:
+
+FiniteSet
+---------------------
+
+.. autoclass:: cvxpy.constraints.finite_set.FiniteSet
+    :members: is_dcp, size, shape, ineq_form, violation
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -204,8 +204,9 @@ version 9.3 or greater is required.
 Install with SCIP support
 -------------------------
 
-CVXPY supports the SCIP solver.
-Simply install SCIP such that you can ``from pyscipopt.scip import Model`` in Python.
+CVXPY supports the SCIP solver through the ``pyscipopt`` Python package;
+we do not support pyscipopt version 4.0.0 or higher; you need to use pyscipopt version 3.x.y
+for some (x,y).
 See the `PySCIPOpt <https://github.com/SCIP-Interfaces/PySCIPOpt#installation>`_ github for installation instructions.
 
 CVXPY's SCIP interface does not reliably recover dual variables for constraints. If you require dual variables for a continuous problem, you will need to use another solver. We welcome additional contributions to the SCIP interface, to recover dual variables for constraints in continuous problems.

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ HIGHS = scipy>=1.6.1
 MOSEK = Mosek
 OSQP =
 PDLP = ortools
-SCIP = PySCIPOpt
+SCIP = PySCIPOpt<4.0.0
 SCIPY = scipy
 SCS =
 XPRESS = xpress


### PR DESCRIPTION
## Description
These changes add support for a `finiteSet` constraint class, that allows for restricting a variable to a given set of arbitrary (finite) lengths, composed of any real quantities. These changes are motivated by the [issue](https://github.com/cvxpy/cvxpy/issues/1590) --- in this PR, only support for DCP problems is offered, I would be open to working on extending the same to DGP problems as well.

A short rundown of the files changed/added:
1. The `cvxpy/constraints/MI_FS.py` file houses the structure of the new constraint class itself.
2. `cvxpy/reductions/discrete2mixedint/valinvec2mixedint.py` consists of the `Canonicalization` class for the `finiteSet` constraint, in addition to the concerned canonicalization method (`exprval_in_vec`, wrapped around `finite_set_canon`)
3. The change to `cvxpy/reductions/solvers/solver_chain.py` is a simple patch-up to ensure that the `Valinvec2mixedint()` reduction is added to the constructed solver chain.
4. The unit tests for the new class reside in `cvxpy/tests/test_valinvec2mixedint.py`

Issue link (if applicable): https://github.com/cvxpy/cvxpy/issues/1590