### PR TITLE
Skip test gurobi write if not exist

### DIFF
--- a/cvxpy/tests/test_gurobi_write.py
+++ b/cvxpy/tests/test_gurobi_write.py
@@ -20,8 +20,8 @@ import numpy as np
 
 import cvxpy as cp
 from cvxpy.tests.base_test import BaseTest
-from cvxpy.reductions.solvers.defines import (INSTALLED_MI_SOLVERS,
-                                              INSTALLED_SOLVERS)
+from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS
+
 
 @unittest.skipUnless('GUROBI' in INSTALLED_SOLVERS, 'GUROBI is not installed.')
 class TestGurobiWrite(BaseTest):

--- a/cvxpy/tests/test_gurobi_write.py
+++ b/cvxpy/tests/test_gurobi_write.py
@@ -14,16 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import os
+import unittest
 
 import numpy as np
 
 import cvxpy as cp
 from cvxpy.tests.base_test import BaseTest
+from cvxpy.reductions.solvers.defines import (INSTALLED_MI_SOLVERS,
+                                              INSTALLED_SOLVERS)
 
-
+@unittest.skipUnless('GUROBI' in INSTALLED_SOLVERS, 'GUROBI is not installed.')
 class TestGurobiWrite(BaseTest):
-    """ Gurobi model tests for write gurobi model files. """
-
     def test_write(self) -> None:
         """Test the Gurobi model.write().
         """

--- a/cvxpy/tests/test_gurobi_write.py
+++ b/cvxpy/tests/test_gurobi_write.py
@@ -19,8 +19,8 @@ import unittest
 import numpy as np
 
 import cvxpy as cp
-from cvxpy.tests.base_test import BaseTest
 from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS
+from cvxpy.tests.base_test import BaseTest
 
 
 @unittest.skipUnless('GUROBI' in INSTALLED_SOLVERS, 'GUROBI is not installed.')


### PR DESCRIPTION
## Description
Based on setup.py and requirements, gurobi is no mandatory.

Thus, we need to skip test gurobi write if not exist

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [v] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [v] Add our license to new files.
- [v] Check that your code adheres to our coding style.
- [v] Write unittests.
- [v] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.