### PR TITLE
Follow-up FiniteSet

### DIFF
--- a/cvxpy/constraints/finite_set.py
+++ b/cvxpy/constraints/finite_set.py
@@ -6,7 +6,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -56,7 +56,7 @@ class FiniteSet(Constraint):
         solvers that use simple branch and bound methods.
     """
 
-    def __init__(self, expre, vec, ineq_form: bool = False, constr_id=None) -> None:
+    def __init__(self, expre, vec, ineq_form: bool = True, constr_id=None) -> None:
         Expression = cvxtypes.expression()
         if isinstance(vec, set):
             vec = list(vec)

--- a/cvxpy/constraints/finite_set.py
+++ b/cvxpy/constraints/finite_set.py
@@ -56,7 +56,7 @@ class FiniteSet(Constraint):
         solvers that use simple branch and bound methods.
     """
 
-    def __init__(self, expre, vec, ineq_form: bool = True, constr_id=None) -> None:
+    def __init__(self, expre, vec, ineq_form: bool = False, constr_id=None) -> None:
         Expression = cvxtypes.expression()
         if isinstance(vec, set):
             vec = list(vec)

--- a/cvxpy/reductions/discrete2mixedint/valinvec2mixedint.py
+++ b/cvxpy/reductions/discrete2mixedint/valinvec2mixedint.py
@@ -6,7 +6,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,32 +14,33 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from typing import Callable, List, Tuple
+
 import numpy as np
 
 import cvxpy as cp
 from cvxpy.constraints import FiniteSet
+from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.variable import Variable
 from cvxpy.reductions.canonicalization import Canonicalization
 
 
-def exprval_in_vec1(expr, vec):
-    assert expr.is_affine()
-    assert expr.size == 1
-    if vec.size == 1:
-        # handling for when vec only has a single element
-        cons = [expr == vec[0]]
-        return cons
+def exprval_in_vec_ineq(expr, vec):
+
     vec = np.sort(vec)
     d = np.diff(vec)
     z = Variable(shape=(d.size,), boolean=True)
     cons = [
-        z[1:] <= z[:-1],
-        expr == vec[0] + d @ z
+        expr == vec[0] + d @ z,
     ]
+    if d.size > 1:
+        cons.append(z[1:] <= z[:-1])
     return cons
 
 
-def exprval_in_vec2(expr, vec):
+def exprval_in_vec_eq(expr, vec):
+    # Reference: https://docs.mosek.com/modeling-cookbook/mio.html#fixed-set-of-values
+
     z = Variable(len(vec), boolean=True)
     constraints = [
         cp.sum(cp.multiply(vec, z)) == expr,
@@ -48,36 +49,33 @@ def exprval_in_vec2(expr, vec):
     return constraints
 
 
-def finite_set_canon1(con, args):
-    cons = []
-    vec = con.vec.value
-    expre = con.expre.flatten()
-    for i in range(expre.size):
-        cons += exprval_in_vec1(expre[i], vec)
-    main_con = cons[-1]
-    aux_cons = cons[:-1]
-    return main_con, aux_cons
+def get_exprval_in_vec_func(ineq_form: bool) -> Callable:
+    if ineq_form:
+        return exprval_in_vec_ineq
+    else:
+        return exprval_in_vec_eq
 
 
-def finite_set_canon2(con, args):
+def finite_set_canon(con, _args) -> Tuple[Constraint, List]:
     cons = []
     vec = con.vec.value
+    if vec.size == 1:
+        # handling for when vec only has a single element
+        return con.expre == vec[0], []
+
     expre = con.expre.flatten()
     for i in range(expre.size):
-        cons += exprval_in_vec2(expre[i], vec)
+        exprval_in_vec = get_exprval_in_vec_func(con.ineq_form)
+        cons += exprval_in_vec(expre[i], vec)
     main_con = cons[0]
     aux_cons = cons[1:]
     return main_con, aux_cons
 
 
-def finite_set_canon(con, args):
-    if con.ineq_form:
-        return finite_set_canon1(con, args)
-    else:
-        return finite_set_canon2(con, args)
-
-
 class Valinvec2mixedint(Canonicalization):
+    def accepts(self, problem) -> bool:
+        return any(FiniteSet in {type(c) for c in problem.constraints})
+
     CANON_METHODS = {
         FiniteSet: finite_set_canon
     }

--- a/cvxpy/tests/test_valinvec2mixedint.py
+++ b/cvxpy/tests/test_valinvec2mixedint.py
@@ -6,7 +6,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,26 +14,34 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import numpy as np
+import pytest
 
 import cvxpy as cp
 from cvxpy.constraints import FiniteSet
+from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS
 from cvxpy.tests import solver_test_helpers as STH
-from cvxpy.tests.base_test import BaseTest
+
+solver_installed = pytest.mark.skipif(
+    cp.GLPK_MI not in INSTALLED_SOLVERS, reason="Required solver not installed"
+)
 
 
-class TestFiniteSet(BaseTest):
+@solver_installed
+@pytest.mark.parametrize("ineq_form", [True, False])
+class TestFiniteSet:
     @staticmethod
-    def make_test_1():
+    def make_test_1(ineq_form: bool):
         """vec contains a contiguous range of integers"""
         x = cp.Variable(shape=(4,))
         expect_x = np.array([0., 7., 3., 0.])
         vec = np.arange(10)
         objective = cp.Maximize(x[0] + x[1] + 2 * x[2] - 2 * x[3])
-        constr1 = FiniteSet(x[0], vec)
-        constr2 = FiniteSet(x[1], vec)
-        constr3 = FiniteSet(x[2], vec)
-        constr4 = FiniteSet(x[3], vec)
+        constr1 = FiniteSet(x[0], vec, ineq_form=ineq_form)
+        constr2 = FiniteSet(x[1], vec, ineq_form=ineq_form)
+        constr3 = FiniteSet(x[2], vec, ineq_form=ineq_form)
+        constr4 = FiniteSet(x[3], vec, ineq_form=ineq_form)
         constr5 = x[0] + 2 * x[2] <= 700
         constr6 = 2 * x[1] - 8 * x[2] <= 0
         constr7 = x[1] - 2 * x[2] + x[3] >= 1
@@ -55,22 +63,21 @@ class TestFiniteSet(BaseTest):
         sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
         return sth
 
-    def test_1(self):
-        sth = TestFiniteSet.make_test_1()
+    def test_1(self, ineq_form: bool):
+        sth = TestFiniteSet.make_test_1(ineq_form)
         sth.solve(solver='GLPK_MI')
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
-        pass
 
     @staticmethod
-    def make_test_2():
+    def make_test_2(ineq_form: bool):
         x = cp.Variable()
         expect_x = np.array([-1.125])
         objective = cp.Minimize(x)
         vec = [-1.125, 1, 2]
         constr1 = x >= -1.25
         constr2 = x <= 10
-        constr3 = FiniteSet(x, vec)
+        constr3 = FiniteSet(x, vec, ineq_form=ineq_form)
         obj_pairs = (objective, -1.125)
         var_pairs = [
             (x, expect_x)
@@ -83,20 +90,20 @@ class TestFiniteSet(BaseTest):
         sth = STH.SolverTestHelper(obj_pairs, var_pairs, con_pairs)
         return sth
 
-    def test_2(self):
-        sth = TestFiniteSet.make_test_2()
+    @staticmethod
+    def test_2(ineq_form: bool):
+        sth = TestFiniteSet.make_test_2(ineq_form)
         sth.solve(solver='GLPK_MI')
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
-        pass
 
     @staticmethod
-    def make_test_3():
+    def make_test_3(ineq_form: bool):
         """Case when vec.size==1"""
         x = cp.Variable()
         objective = cp.Minimize(cp.abs(x - 3))
         vec = [1]
-        cons1 = FiniteSet(x, vec)
+        cons1 = FiniteSet(x, vec, ineq_form=ineq_form)
         expected_x = np.array([1.])
         obj_pair = (objective, 2.0)
         var_pairs = [
@@ -108,20 +115,20 @@ class TestFiniteSet(BaseTest):
         sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
         return sth
 
-    def test_3(self):
-        sth = TestFiniteSet.make_test_3()
+    @staticmethod
+    def test_3(ineq_form: bool):
+        sth = TestFiniteSet.make_test_3(ineq_form)
         sth.solve(solver='GLPK_MI')
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
-        pass
 
     @staticmethod
-    def make_test_4():
+    def make_test_4(ineq_form: bool):
         """Case when vec houses duplicates"""
         x = cp.Variable()
         objective = cp.Minimize(cp.abs(x - 3))
         vec = [1, 1, 1, 2, 2, 3, 3]
-        cons1 = FiniteSet(x, vec)
+        cons1 = FiniteSet(x, vec, ineq_form=ineq_form)
         expected_x = np.array([3.])
         obj_pair = (objective, 0.0)
         var_pairs = [
@@ -133,25 +140,25 @@ class TestFiniteSet(BaseTest):
         sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
         return sth
 
-    def test_4(self):
-        sth = TestFiniteSet.make_test_4()
+    @staticmethod
+    def test_4(ineq_form: bool):
+        sth = TestFiniteSet.make_test_4(ineq_form)
         sth.solve(solver='GLPK_MI')
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
-        pass
 
     @staticmethod
-    def make_test_5():
+    def make_test_5(ineq_form: bool):
         """Case when input expression to FiniteSet constraint is affine"""
         x = cp.Variable(shape=(4,))
         vec = np.arange(10)
         objective = cp.Maximize(x[0] + x[1] + 2 * x[2] - 2 * x[3])
         expr0 = 2 * x[0] + 1
         expr2 = 3 * x[2] + 5
-        constr1 = FiniteSet(expr0, vec)
-        constr2 = FiniteSet(x[1], vec)
-        constr3 = FiniteSet(expr2, vec)
-        constr4 = FiniteSet(x[3], vec)
+        constr1 = FiniteSet(expr0, vec, ineq_form=ineq_form)
+        constr2 = FiniteSet(x[1], vec, ineq_form=ineq_form)
+        constr3 = FiniteSet(expr2, vec, ineq_form=ineq_form)
+        constr4 = FiniteSet(x[3], vec, ineq_form=ineq_form)
         constr5 = x[0] + 2 * x[2] <= 700
         constr6 = 2 * x[1] - 8 * x[2] <= 0
         constr7 = x[1] - 2 * x[2] + x[3] >= 1
@@ -174,15 +181,15 @@ class TestFiniteSet(BaseTest):
         sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
         return sth
 
-    def test_5(self):
-        sth = TestFiniteSet.make_test_5()
+    @staticmethod
+    def test_5(ineq_form: bool):
+        sth = TestFiniteSet.make_test_5(ineq_form)
         sth.solve(solver='GLPK_MI')
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
-        pass
 
     @staticmethod
-    def make_test_6():
+    def make_test_6(ineq_form: bool):
         """vec contains only real quantities + passed expression is affine"""
         x = cp.Variable()
         expect_x = np.array([-1.0625])
@@ -191,7 +198,7 @@ class TestFiniteSet(BaseTest):
         constr1 = x >= -1.25
         constr2 = x <= 10
         expr = 2 * x + 1
-        constr3 = FiniteSet(expr, vec)
+        constr3 = FiniteSet(expr, vec, ineq_form=ineq_form)
         obj_pairs = (objective, -1.0625)
         var_pairs = [
             (x, expect_x)
@@ -204,21 +211,21 @@ class TestFiniteSet(BaseTest):
         sth = STH.SolverTestHelper(obj_pairs, var_pairs, con_pairs)
         return sth
 
-    def test_6(self):
-        sth = TestFiniteSet.make_test_6()
+    @staticmethod
+    def test_6(ineq_form: bool):
+        sth = TestFiniteSet.make_test_6(ineq_form)
         sth.solve(solver='GLPK_MI')
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
-        pass
 
     @staticmethod
-    def make_test_7():
+    def make_test_7(ineq_form: bool):
         """For testing vectorization of FiniteSet class"""
         x = cp.Variable(shape=(4,))
         expect_x = np.array([0., 7., 3., 0.])
         vec = np.arange(10)
         objective = cp.Maximize(x[0] + x[1] + 2 * x[2] - 2 * x[3])
-        constr1 = FiniteSet(x, vec, ineq_form=False)
+        constr1 = FiniteSet(x, vec, ineq_form=ineq_form)
         constr2 = x[0] + 2 * x[2] <= 700
         constr3 = 2 * x[1] - 8 * x[2] <= 0
         constr4 = x[1] - 2 * x[2] + x[3] >= 1
@@ -237,71 +244,80 @@ class TestFiniteSet(BaseTest):
         sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
         return sth
 
-    def test_7(self):
-        sth = TestFiniteSet.make_test_7()
+    @staticmethod
+    def test_7(ineq_form: bool):
+        sth = TestFiniteSet.make_test_7(ineq_form)
         sth.solve(solver='GLPK_MI')
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
-        pass
 
     @staticmethod
-    def make_test_8():
-        """Testing the alternative constraining pathway"""
+    def test_8(ineq_form: bool):
+        # Test parametrized FiniteSet
         x = cp.Variable()
-        expect_x = np.array([-1.125])
-        objective = cp.Minimize(x)
-        vec = [-1.125, 1, 2]
-        constr1 = x >= -1.25
-        constr2 = x <= 10
-        constr3 = FiniteSet(x, vec, ineq_form=True)
-        obj_pairs = (objective, -1.125)
-        var_pairs = [
-            (x, expect_x)
-        ]
-        con_pairs = [
-            (constr1, None),
-            (constr2, None),
-            (constr3, None)
-        ]
-        sth = STH.SolverTestHelper(obj_pairs, var_pairs, con_pairs)
-        return sth
+        objective = cp.Maximize(x)
+        set_vals = cp.Parameter((5,), value=np.arange(5))
+        constraints = [FiniteSet(x, set_vals, ineq_form=ineq_form)]
+        problem = cp.Problem(objective, constraints)
+        problem.solve(solver=cp.GLPK_MI)
+        assert np.allclose(x.value, 4)
 
-    def test_8(self):
-        sth = TestFiniteSet.make_test_8()
-        sth.solve(solver='GLPK_MI')
-        sth.verify_objective(places=3)
-        sth.verify_primal_values(places=3)
-        pass
+        set_vals.value = np.arange(5) + 1
+        problem = cp.Problem(objective, constraints)
+        problem.solve(solver=cp.GLPK_MI)
+        assert np.allclose(x.value, 5)
 
     @staticmethod
-    def make_test_9():
-        """For testing vectorization of FiniteSet class + new constraining method"""
-        x = cp.Variable(shape=(4,))
-        expect_x = np.array([0., 7., 3., 0.])
-        vec = np.arange(10)
-        objective = cp.Maximize(x[0] + x[1] + 2 * x[2] - 2 * x[3])
-        constr1 = FiniteSet(x, vec, ineq_form=True)
-        constr2 = x[0] + 2 * x[2] <= 700
-        constr3 = 2 * x[1] - 8 * x[2] <= 0
-        constr4 = x[1] - 2 * x[2] + x[3] >= 1
-        constr5 = x[0] + x[1] + x[2] + x[3] == 10
-        obj_pair = (objective, 13.0)
-        con_pairs = [
-            (constr1, None),
-            (constr2, None),
-            (constr3, None),
-            (constr4, None),
-            (constr5, None)
-        ]
-        var_pairs = [
-            (x, expect_x)
-        ]
-        sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
-        return sth
+    def test_9(ineq_form: bool):
+        # Test passing a Python set
+        x = cp.Variable()
+        objective = cp.Maximize(x)
+        set_vals = set(range(5))
+        constraints = [FiniteSet(x, set_vals, ineq_form=ineq_form)]
+        problem = cp.Problem(objective, constraints)
+        problem.solve(solver=cp.GLPK_MI)
+        assert np.allclose(x.value, 4)
 
-    def test_9(self):
-        sth = TestFiniteSet.make_test_9()
-        sth.solve(solver='GLPK_MI')
-        sth.verify_objective(places=3)
-        sth.verify_primal_values(places=3)
-        pass
+    @staticmethod
+    def test_10(ineq_form: bool):
+        # Test set with two elements
+        x = cp.Variable()
+        objective = cp.Maximize(x)
+        set_vals = {1, 2}
+        constraints = [FiniteSet(x, set_vals, ineq_form=ineq_form)]
+        problem = cp.Problem(objective, constraints)
+        problem.solve(solver=cp.GLPK_MI)
+        assert np.allclose(x.value, 2)
+
+    @staticmethod
+    def test_11(ineq_form: bool):
+        # Test 2D Variable
+        shape = (2, 2)
+        x = cp.Variable(shape)
+        objective = cp.Maximize(cp.sum(x))
+        set_vals = {1, 2, 3}
+        constraints = [FiniteSet(x, set_vals, ineq_form=ineq_form)]
+        problem = cp.Problem(objective, constraints)
+        problem.solve(solver=cp.GLPK_MI)
+        assert np.allclose(x.value, np.ones(shape)*max(set_vals))
+
+    @staticmethod
+    def test_non_affine_exception(ineq_form: bool):
+        # Exception test: non-affine expression
+        x = cp.Variable()
+        x_abs = cp.abs(x)
+        set_vals = {1, 2, 3}
+        with pytest.raises(ValueError, match="must be affine"):
+            FiniteSet(x_abs, set_vals, ineq_form=ineq_form)
+
+
+@solver_installed
+def test_default_argument():
+    # Test passing a Python set
+    x = cp.Variable()
+    objective = cp.Maximize(x)
+    set_vals = set(range(5))
+    constraints = [FiniteSet(x, set_vals)]
+    problem = cp.Problem(objective, constraints)
+    problem.solve(solver=cp.GLPK_MI)
+    assert np.allclose(x.value, 4)

--- a/cvxpy/tests/test_valinvec2mixedint.py
+++ b/cvxpy/tests/test_valinvec2mixedint.py
@@ -310,6 +310,18 @@ class TestFiniteSet:
         with pytest.raises(ValueError, match="must be affine"):
             FiniteSet(x_abs, set_vals, ineq_form=ineq_form)
 
+    @staticmethod
+    def test_independent_entries(ineq_form: bool):
+        shape = (2, 2)
+        x = cp.Variable(shape)
+        objective = cp.Maximize(cp.sum(x))
+        set_vals = {0, 1, 2}
+        constraints = [FiniteSet(x, set_vals, ineq_form=ineq_form),
+                       x <= np.arange(4).reshape(shape)]
+        problem = cp.Problem(objective, constraints)
+        problem.solve(solver=cp.GLPK_MI)
+        assert np.allclose(x.value, np.array([[0, 1], [2, 2]]))
+
 
 @solver_installed
 def test_default_argument():

--- a/cvxpy/tests/test_valinvec2mixedint.py
+++ b/cvxpy/tests/test_valinvec2mixedint.py
@@ -313,7 +313,6 @@ class TestFiniteSet:
 
 @solver_installed
 def test_default_argument():
-    # Test passing a Python set
     x = cp.Variable()
     objective = cp.Maximize(x)
     set_vals = set(range(5))


### PR DESCRIPTION
## Description
As discussed, this PR is a follow-up to #1740, containing the following changes:
- ~Using @rileyjmurray 's suggested implementation as the default. I believe this was accidentally changed in 2eab70c974300b8901943994fc50c1c57a389bfa Renamed the functions to improve readability~ This was intentional, see comment below
- Small refactoring to reduce code duplication as suggested 
- Adding a few more tests
- Parametrizing the tests to use both canonicalization functions (+ one test to check that using the default works)
- Skipping the tests if GPLK-MI is not installed as suggested by @SteveDiamond [here](https://github.com/cvxpy/cvxpy/pull/1740#issuecomment-1094513642)
- Special handling for the case where `len(vec) == 2`, as `z[1:] <= z[:-1]` failed in that scenario
- Added a suggestion for the abstractmethod `accepts()`

cc: @aryamanJgl 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Refactoring)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.