### PR TITLE
WIP: Benchmark setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ tags
 
 # Things specific to this project
 cvxpy/version.py
+cvxpy/benchmarks/benchmark_report.md

--- a/cvxpy/benchmarks/benchmark.py
+++ b/cvxpy/benchmarks/benchmark.py
@@ -1,0 +1,78 @@
+import time
+import tracemalloc
+from abc import ABC, abstractmethod
+from typing import Callable
+
+import cvxpy as cp
+
+
+class Benchmark(ABC):
+
+    data_folder = "benchmark_data/"
+
+    def __init__(self):
+        self._timing = None
+        self._memory_peak = None
+
+    @staticmethod
+    @abstractmethod
+    def name() -> str:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def get_problem_instance() -> cp.Problem:
+        pass
+
+    def run_benchmark(self) -> None:
+        print(f"Running benchmark {self.name()}")
+        timing, memory_peak = self.measure_time_and_memory(self.compile_problem)
+        self.timing = timing
+        self.memory_peak = memory_peak
+
+    def compile_problem(self):
+        prob = self.get_problem_instance()
+        prob.get_problem_data(solver=self.get_solver())
+
+    @staticmethod
+    def measure_time_and_memory(func: Callable):
+        tracemalloc.start()
+        start = time.time()
+        func()
+        timing = time.time() - start
+        _, memory_peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        memory_peak = memory_peak / 1024 ** 3  # bytes to GiB
+        return timing, memory_peak
+
+    def print_benchmark_results(self):
+        print(self.name())
+        print(f"Timing: {self.timing:.2f}s")
+        print(f"Peak memory usage: {self.memory_peak:.2f}GiB\n\n")
+
+    @property
+    def timing(self):
+        assert self._timing is not None
+        return self._timing
+
+    @timing.setter
+    def timing(self, value):
+        self._timing = value
+
+    @property
+    def memory_peak(self):
+        assert self._memory_peak is not None
+        return self._memory_peak
+
+    @memory_peak.setter
+    def memory_peak(self, value):
+        self._memory_peak = value
+
+    @staticmethod
+    def get_solver():
+        return cp.SCS
+
+    @staticmethod
+    @abstractmethod
+    def data_available(download_missing_data: bool) -> bool:
+        pass

--- a/cvxpy/benchmarks/benchmark.py
+++ b/cvxpy/benchmarks/benchmark.py
@@ -1,3 +1,16 @@
+"""
+Copyright, the CVXPY authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import time
 import tracemalloc
 from abc import ABC, abstractmethod

--- a/cvxpy/benchmarks/benchmark_report_template.md
+++ b/cvxpy/benchmarks/benchmark_report_template.md
@@ -1,0 +1,27 @@
+# CVXPY Benchmark Report
+
+## Compilation times
+
+Timings are normalized with respect to the fastest implementation.
+
+COMPILATION_PLACEHOLDER
+
+## Memory Usage
+
+MEMORY_PLACEHOLDER
+
+## Benchmark information
+
+CVXPY Version: CVXPY_VERSION
+
+Date: DATE
+
+Total Time: TOTAL_TIME
+
+Max Memory Usage: MAX_MEMORY
+
+Available Memory: MEMORY_INFO
+
+CPU: CPU_INFO
+
+

--- a/cvxpy/benchmarks/cvar_benchmark.py
+++ b/cvxpy/benchmarks/cvar_benchmark.py
@@ -1,3 +1,16 @@
+"""
+Copyright, the CVXPY authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import numpy as np
 import scipy.sparse as sp
 

--- a/cvxpy/benchmarks/cvar_benchmark.py
+++ b/cvxpy/benchmarks/cvar_benchmark.py
@@ -1,0 +1,75 @@
+import numpy as np
+import scipy.sparse as sp
+
+import cvxpy as cp
+from cvxpy.benchmarks.benchmark import Benchmark
+
+
+class CVaRBenchmark(Benchmark):
+
+    @staticmethod
+    def name() -> str:
+        return "CVaR"
+
+    @staticmethod
+    def data_available(download_missing_data: bool) -> bool:
+        return True
+
+    @staticmethod
+    def get_problem_instance() -> cp.Problem:
+        # Replaced real data with random values
+        np.random.seed(0)
+        price_scenarios = np.random.randn(131072, 192)
+        forward_price_scenarios = np.random.randn(131072, 192)
+        asset_energy_limits = np.random.randn(192, 2)
+        bid_curve_prices = np.random.randn(192, 3)
+        cvar_prob = 0.95
+        cvar_kappa = 2.0
+
+        num_scenarios, num_assets = price_scenarios.shape
+        num_energy_segments = bid_curve_prices.shape[1] + 1
+
+        price_segments = np.sum(
+            forward_price_scenarios[:, :, None] > bid_curve_prices[None], axis=2
+        )
+        price_segments_flat = (
+            price_segments + np.arange(num_assets) * num_energy_segments
+        ).reshape(-1)
+        price_segments_sp = sp.coo_matrix(
+            (
+                np.ones(num_scenarios * num_assets),
+                (np.arange(num_scenarios * num_assets), price_segments_flat),
+            ),
+            shape=(num_scenarios * num_assets, num_assets * num_energy_segments),
+        )
+
+        prices_flat = (price_scenarios - forward_price_scenarios).reshape(-1)
+        scenario_sum = sp.coo_matrix(
+            (
+                np.ones(num_scenarios * num_assets),
+                (
+                    np.repeat(np.arange(num_scenarios), num_assets),
+                    np.arange(num_scenarios * num_assets),
+                ),
+            )
+        )
+
+        A = np.asarray((scenario_sum @ sp.diags(prices_flat) @ price_segments_sp).todense())
+        c = np.mean(A, axis=0)
+        gamma = 1.0 / (1.0 - cvar_prob) / num_scenarios
+        kappa = cvar_kappa
+        x_min = np.tile(asset_energy_limits[:, 0:1], (1, num_energy_segments)).reshape(-1)
+        x_max = np.tile(asset_energy_limits[:, 1:2], (1, num_energy_segments)).reshape(-1)
+
+        alpha = cp.Variable()
+        x = cp.Variable(num_assets * num_energy_segments)
+
+        problem = cp.Problem(
+            cp.Minimize(c.T @ x),
+            [
+                alpha + gamma * cp.sum(cp.pos(A @ x - alpha)) <= kappa,
+                x >= x_min,
+                x <= x_max,
+            ])
+
+        return problem

--- a/cvxpy/benchmarks/qp_1611_benchmark.py
+++ b/cvxpy/benchmarks/qp_1611_benchmark.py
@@ -1,3 +1,16 @@
+"""
+Copyright, the CVXPY authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import os
 import shelve
 import zipfile

--- a/cvxpy/benchmarks/qp_1611_benchmark.py
+++ b/cvxpy/benchmarks/qp_1611_benchmark.py
@@ -1,0 +1,49 @@
+import os
+import shelve
+import zipfile
+
+import requests
+
+import cvxpy as cp
+from cvxpy.benchmarks.benchmark import Benchmark
+
+
+class QP1611Benchmark(Benchmark):
+    filename = os.path.join(Benchmark.data_folder, '1611/Problem.prob')
+    zip_name = "Problem.prob.zip"
+    url = "https://github.com/cvxpy/cvxpy/files/7922520/"
+
+    @staticmethod
+    def data_available(download_missing_data: bool) -> bool:
+        if os.path.isfile(QP1611Benchmark.filename + ".dat"):
+            return True
+        local_zip = os.path.join(Benchmark.data_folder, QP1611Benchmark.zip_name)
+        if download_missing_data:
+            print(f"Downloading data for {QP1611Benchmark.name()} benchmark")
+            with open(local_zip, "wb") as f:
+                f.write(requests.get(QP1611Benchmark.url+QP1611Benchmark.zip_name).content)
+            with zipfile.ZipFile(local_zip, 'r') as zip_ref:
+                zip_ref.extractall(os.path.join(Benchmark.data_folder, "1611"))
+            os.remove(local_zip)
+            return True
+        return False
+
+    @staticmethod
+    def name() -> str:
+        return "QP issue 1611"
+
+    @staticmethod
+    def get_problem_instance() -> cp.Problem:
+        with shelve.open(QP1611Benchmark.filename) as ps:
+            problem = ps['Problem']
+        return problem
+
+    @staticmethod
+    def get_solver():
+        return cp.ECOS_BB
+
+
+if __name__ == '__main__':
+    bench = QP1611Benchmark()
+    bench.run_benchmark()
+    bench.print_benchmark_results()

--- a/cvxpy/benchmarks/run_benchmarks.py
+++ b/cvxpy/benchmarks/run_benchmarks.py
@@ -1,3 +1,16 @@
+"""
+Copyright, the CVXPY authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import argparse
 import subprocess
 import time

--- a/cvxpy/benchmarks/run_benchmarks.py
+++ b/cvxpy/benchmarks/run_benchmarks.py
@@ -1,0 +1,250 @@
+import argparse
+import subprocess
+import time
+import warnings
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import List, Tuple
+
+import pandas as pd
+import psutil as psutil
+from cpuinfo import get_cpu_info
+
+import cvxpy
+from cvxpy.benchmarks.cvar_benchmark import CVaRBenchmark
+from cvxpy.benchmarks.qp_1611_benchmark import QP1611Benchmark
+from cvxpy.benchmarks.sdp_segfault_1132_benchmark import (
+    SDPSegfault1132Benchmark,)
+from cvxpy.benchmarks.simple_LP_benchmarks import (
+    SimpleFullyParametrizedLPBenchmark, SimpleLPBenchmark,
+    SimpleScalarParametrizedLPBenchmark,)
+
+
+class BenchmarkSuite(ABC):
+
+    def __init__(self, download_missing_data: bool):
+        self.start_time = None
+        self.end_time = None
+        self.download_missing_data = download_missing_data
+
+    def get_registered_benchmarks(self):
+        benchmarks = [
+            CVaRBenchmark,
+            QP1611Benchmark,
+            SimpleLPBenchmark,
+            SimpleScalarParametrizedLPBenchmark,
+            SimpleFullyParametrizedLPBenchmark,
+            SDPSegfault1132Benchmark,
+        ]
+
+        available_benchmarks = []
+        for b in benchmarks:
+            if b.data_available(self.download_missing_data):
+                available_benchmarks.append(b())
+            else:
+                warnings.warn(f"Skipping benchmark {b.name()} due to missing data."
+                              f"Set the --download_missing_data flag to download automatically.")
+        return available_benchmarks
+
+    @staticmethod
+    def check_report_dependencies():
+        # Generating the benchmark report requires the optional pandas dependency 'tabulate'.
+        import tabulate
+        tabulate  # For flake8
+
+    def run_benchmarks(self, repetitions):
+        assert repetitions > 0
+
+        self.check_report_dependencies()
+        self.start_time = time.time()
+
+        repeated_timings, memory_traces = self.get_timings_and_memory_traces(repetitions)
+
+        self.end_time = time.time()
+        print("Finished running benchmarks, generating report.")
+
+        if repetitions == 1:
+            self.create_single_report(repeated_timings[0], memory_traces)
+        else:
+            self.create_multiple_report(repeated_timings, memory_traces)
+        print("Report generated successfully.")
+
+    def create_single_report(self, timings: pd.DataFrame, memory_traces: pd.DataFrame):
+        timings_formatted = self.format_result(timings, unit="s").to_markdown(floatfmt=".2f")
+        memory_traces_formatted = self.format_result(memory_traces, unit="GiB").\
+            to_markdown(floatfmt=".2f")
+        self.create_report(timings_formatted, memory_traces_formatted, memory_traces.max().max())
+
+    @staticmethod
+    def format_result(df: pd.DataFrame, unit: str) -> pd.DataFrame:
+        return df.sort_index(axis=0).applymap(lambda x: f"{x:.2f}") + unit
+
+    def create_multiple_report(self,
+                               repeated_timings: List[pd.DataFrame],
+                               memory_traces: pd.DataFrame):
+        timings_output = self.format_multiple_dataframes(repeated_timings, unit="s")
+        memory_traces_formatted = self.format_result(memory_traces, unit="GiB")\
+            .to_markdown(floatfmt=".2f")
+        self.create_report(timings_output, memory_traces_formatted, memory_traces.max().max())
+
+    def format_multiple_dataframes(self, dataframes: List[pd.DataFrame], unit):
+        df_repeated_timings = pd.concat(dataframes)
+        grouper = df_repeated_timings.groupby(df_repeated_timings.index)
+
+        df_min, df_max, df_mean, df_std = \
+            grouper.min(), grouper.max(), grouper.mean(), grouper.std()
+
+        df_min_formatted = self.format_result(df_min, unit)
+        df_max_formatted = self.format_result(df_max, unit)
+        df_mean_formatted = self.format_result(df_mean, unit)
+        std_formatted = self.format_result(df_std, "")
+
+        output = f"Summary statistics of {len(dataframes)} runs:\n\n"
+        output += "Best:\n\n"
+        output += df_min_formatted.to_markdown(floatfmt=".2f")
+        output += "\n\nWorst:\n\n"
+        output += df_max_formatted.to_markdown(floatfmt=".2f")
+        output += "\n\nMean (SD):\n\n"
+        output += (df_mean_formatted + " (" + std_formatted + ")").to_markdown() + "\n\n"
+        return output
+
+    def create_report(self, timings: str, memory: str, max_memory: float):
+        template_file = "benchmark_report_template.md"
+        output_file = "benchmark_report.md"
+
+        with open(template_file) as f:
+            template = f.read()
+
+        template = template.replace("COMPILATION_PLACEHOLDER", timings)
+        template = template.replace("MEMORY_PLACEHOLDER", memory)
+
+        template = template.replace("CVXPY_VERSION", cvxpy.__version__)
+        template = template.replace("DATE", datetime.now().isoformat())
+        template = template.replace("TOTAL_TIME", f"{self.end_time - self.start_time:.2f}s")
+        template = template.replace("MAX_MEMORY", f"{max_memory:.2f}GiB")
+        template = template.replace("MEMORY_INFO",
+                                    f"{psutil.virtual_memory().total // 1024 ** 3}GiB")
+        template = template.replace("CPU_INFO", get_cpu_info()["brand_raw"])
+
+        with open(output_file, "w") as f:
+            f.write(template)
+
+    @abstractmethod
+    def get_timings_and_memory_traces(self,
+                                      repetitions: int) -> Tuple[List[pd.DataFrame], pd.DataFrame]:
+        pass
+
+
+class InteractiveComparisonBenchmarkSuite(BenchmarkSuite):
+
+    def get_timings_and_memory_traces(self,
+                                      repetitions: int) -> Tuple[List[pd.DataFrame], pd.DataFrame]:
+
+        input("Checkout the feature branch in a different terminal window. "
+              "Press any key to continue.")
+
+        repeated_feature_timings = []
+        feature_memory_traces = None
+        for repetition in range(1, repetitions + 1):
+            print(f"\n\nRunning feature {repetition=}/{repetitions}...")
+            feature_timings, feature_memory_traces = self.single_branch_run()
+            feature_timings.name = "FEATURE"
+            repeated_feature_timings.append(feature_timings)
+            feature_memory_traces.name = "FEATURE"
+        assert feature_memory_traces is not None
+
+        input("Checkout the reference branch in a different terminal window. "
+              "Press any key to continue.")
+
+        repeated_reference_timings = []
+        reference_memory_traces = None
+        for repetition in range(1, repetitions + 1):
+            print(f"\n\nRunning reference {repetition=}/{repetitions}...")
+            reference_timings, reference_memory_traces = self.single_branch_run()
+            reference_timings.name = "REFERENCE"
+            repeated_reference_timings.append(reference_timings)
+            reference_memory_traces.name = "REFERENCE"
+        assert reference_memory_traces is not None
+
+        repeated_timings = [pd.concat([feat, ref], axis=1)
+                            for feat, ref in
+                            zip(repeated_feature_timings, repeated_reference_timings)]
+
+        return repeated_timings, pd.concat([feature_memory_traces, reference_memory_traces], axis=1)
+
+    def single_branch_run(self):
+        benchs = self.get_registered_benchmarks()
+
+        timings = []
+        memory_traces = []
+        for bench in benchs:
+            # Switching branches requires a dynamic reload of modules,
+            # which is achieved by running the benchmark in
+            # a subprocess, creating a suboptimal interface here.
+            command = f"python -c " \
+                      f"'from {bench.__class__.__module__} import {bench.__class__.__name__}; " \
+                      f"bench={bench.__class__.__name__}(); " \
+                      f"bench.run_benchmark(); " \
+                      f"print(\"TIMING\", bench.timing); " \
+                      f"print(\"MEMORY\", bench.memory_peak)'"
+            output = subprocess.check_output(command, shell=True).decode("utf-8").split("\n")
+            timings.append(float(next(iter([x.split(" ")[-1]
+                                            for x in output if "TIMING" in x]))))
+            memory_traces.append(float(next(iter([x.split(" ")[-1]
+                                                  for x in output if "MEMORY" in x]))))
+
+        bench_names = [b.name() for b in benchs]
+        return pd.Series(timings, bench_names), pd.Series(memory_traces, bench_names)
+
+
+class CurrentVersionBenchmarkSuite(BenchmarkSuite):
+
+    def get_timings_and_memory_traces(self,
+                                      repetitions: int) -> Tuple[List[pd.DataFrame], pd.DataFrame]:
+        repeated_timings = []
+        memory_traces = None
+        for repetition in range(1, repetitions + 1):
+            print(f"\n\nRunning {repetition=}/{repetitions}...")
+            timings, memory_traces = self.single_run()
+            memory_traces = memory_traces
+            repeated_timings.append(timings)
+        assert memory_traces is not None
+        return repeated_timings, memory_traces
+
+    def single_run(self):
+        benchs = self.get_registered_benchmarks()
+
+        timings = []
+        memory_traces = []
+        for bench in benchs:
+
+            bench_timings = {}
+            bench_memory = {}
+
+            bench.run_benchmark()
+            bench_timings["CurrentVersion"] = bench.timing
+            bench_memory["CurrentVersion"] = bench.memory_peak
+
+            timings.append(pd.Series(bench_timings, name=bench.name()))
+            memory_traces.append(pd.Series(bench_memory, name=bench.name()))
+
+        return pd.concat(timings, axis=1).T, pd.concat(memory_traces, axis=1).T
+
+
+def main(repetitions: int, mode: str, download_missing_data: bool):
+    if mode == "current":
+        suite = CurrentVersionBenchmarkSuite(download_missing_data)
+    elif mode == "interactive":
+        suite = InteractiveComparisonBenchmarkSuite(download_missing_data)
+    else:
+        raise ValueError(f"Unknown benchmark mode {mode}")
+    suite.run_benchmarks(repetitions)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--repetitions', default=1, type=int)
+    parser.add_argument('--mode', default="current", type=str)
+    parser.add_argument('--download_missing_data', action='store_true')
+    args = parser.parse_args()
+    main(args.repetitions, args.mode, args.download_missing_data)

--- a/cvxpy/benchmarks/sdp_segfault_1132_benchmark.py
+++ b/cvxpy/benchmarks/sdp_segfault_1132_benchmark.py
@@ -1,0 +1,61 @@
+import numpy as np
+
+import cvxpy as cp
+from cvxpy.benchmarks.benchmark import Benchmark
+
+
+class SDPSegfault1132Benchmark(Benchmark):
+
+    @staticmethod
+    def name() -> str:
+        return "SDP Segfault issue 1132"
+
+    @staticmethod
+    def data_available(download_missing_data: bool) -> bool:
+        return True
+
+    @staticmethod
+    def get_problem_instance() -> cp.Problem:
+        n = 100
+        alpha = 1
+        np.random.seed(0)
+        points = np.random.rand(5, n)
+        xtx = points.T @ points
+        xtxd = np.diag(xtx)
+        e = np.ones((n,))
+        D = np.outer(e, xtxd) - 2 * xtx + np.outer(xtxd, e)
+        # Construct W
+        W = np.ones((n, n))
+
+        # Define V and e
+        n = D.shape[0]
+        x = -1 / (n + np.sqrt(n))
+        y = -1 / np.sqrt(n)
+        V = np.ones((n, n - 1))
+        V[0, :] *= y
+        V[1:, :] *= x
+        V[1:, :] += np.eye(n - 1)
+        e = np.ones((n, 1))
+
+        # Solve optimization problem
+        G = cp.Variable((n - 1, n - 1), PSD=True)
+        objective = cp.Maximize(cp.trace(G) - alpha *
+                                cp.norm(cp.multiply(W, cp.kron(e, cp.reshape(cp.diag(V @ G @ V.T),
+
+                                                                             (1, n))) + cp.kron(
+                                    e.T,
+                                    cp.reshape(
+                                        cp.diag(
+                                            V @ G @ V.T),
+                                        (
+                                            n,
+                                            1))) - 2 * V @ G @ V.T - D),
+                                        p='fro'))
+        problem = cp.Problem(objective, [])
+        return problem
+
+
+if __name__ == '__main__':
+    bench = SDPSegfault1132Benchmark()
+    bench.run_benchmark()
+    bench.print_benchmark_results()

--- a/cvxpy/benchmarks/sdp_segfault_1132_benchmark.py
+++ b/cvxpy/benchmarks/sdp_segfault_1132_benchmark.py
@@ -1,3 +1,16 @@
+"""
+Copyright, the CVXPY authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import numpy as np
 
 import cvxpy as cp

--- a/cvxpy/benchmarks/simple_LP_benchmarks.py
+++ b/cvxpy/benchmarks/simple_LP_benchmarks.py
@@ -1,0 +1,82 @@
+import numpy as np
+
+import cvxpy as cp
+from cvxpy.benchmarks.benchmark import Benchmark
+
+
+class SimpleLPBenchmark(Benchmark):
+
+    @staticmethod
+    def name() -> str:
+        return "Simple LP"
+
+    @staticmethod
+    def data_available(download_missing_data: bool) -> bool:
+        return True
+
+    @staticmethod
+    def get_problem_instance() -> cp.Problem:
+        n = int(1e7)
+        c = np.arange(n)
+        x = cp.Variable(n)
+        objective = cp.Minimize(c @ x)
+        constraints = [0 <= x, x <= 1]
+        problem = cp.Problem(objective, constraints)
+        return problem
+
+
+class SimpleFullyParametrizedLPBenchmark(Benchmark):
+
+    @staticmethod
+    def name() -> str:
+        return "Simple fully parametrized LP"
+
+    @staticmethod
+    def data_available(download_missing_data: bool) -> bool:
+        return True
+
+    @staticmethod
+    def get_problem_instance() -> cp.Problem:
+        n = int(1e4)
+        p = cp.Parameter(n)
+        x = cp.Variable(n)
+        objective = cp.Minimize(p @ x)
+        constraints = [0 <= x, x <= 1]
+        problem = cp.Problem(objective, constraints)
+        return problem
+
+
+class SimpleScalarParametrizedLPBenchmark(Benchmark):
+
+    @staticmethod
+    def name() -> str:
+        return "Simple scalar parametrized LP"
+
+    @staticmethod
+    def data_available(download_missing_data: bool) -> bool:
+        return True
+
+    @staticmethod
+    def get_problem_instance() -> cp.Problem:
+        n = int(1e6)
+        p = cp.Parameter()
+        c = np.arange(n)
+        x = cp.Variable(n)
+        objective = cp.Minimize((p * c)  @ x)
+        constraints = [0 <= x, x <= 1]
+        problem = cp.Problem(objective, constraints)
+        return problem
+
+
+if __name__ == '__main__':
+    bench = SimpleLPBenchmark()
+    bench.run_benchmark()
+    bench.print_benchmark_results()
+
+    bench = SimpleFullyParametrizedLPBenchmark()
+    bench.run_benchmark()
+    bench.print_benchmark_results()
+
+    bench = SimpleFullyParametrizedLPBenchmark()
+    bench.run_benchmark()
+    bench.print_benchmark_results()

--- a/cvxpy/benchmarks/simple_LP_benchmarks.py
+++ b/cvxpy/benchmarks/simple_LP_benchmarks.py
@@ -1,3 +1,16 @@
+"""
+Copyright, the CVXPY authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import numpy as np
 
 import cvxpy as cp


### PR DESCRIPTION
## Description
While working on CVXCORE, it became apparent that a benchmarking setup was required to assess the performance more easily. This PR adds a basic framework, which can be extended going forward (both in terms of features, and benchmarks).

Features (to be discussed which ones are relevant):
- Timing the current branch only
- Interactively compare two branches
- Run benchmarks multiple times to get the best, worst, mean, and standard deviation
- Include information about the local machine (CPU model, available RAM) -> I would remove this, as it adds two additional dependencies

Open points:
- Where should the data for the benchmarks be stored? (@rileyjmurray mentioned it might go into a new repo)
- What to do with the existing `tests/test_benchmarks` -> potentially could be kept small versions as unit tests and larger versions as benchmarks
- CI integration

Possible extension:
- Allow comparison of multiple solvers for compilation + solve time

Related issue: #1631

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.