### PR TITLE
Fix bug with length atom

### DIFF
--- a/cvxpy/atoms/length.py
+++ b/cvxpy/atoms/length.py
@@ -17,6 +17,7 @@ from typing import Tuple
 
 import numpy as np
 
+import cvxpy.settings as s
 from cvxpy.atoms.atom import Atom
 
 
@@ -33,7 +34,8 @@ class length(Atom):
     def numeric(self, values) -> int:
         """Returns the length of x.
         """
-        return np.max(np.nonzero(values[0])) + 1
+        outside_tol = np.abs(values[0]) > s.ATOM_EVAL_TOL
+        return np.max(np.nonzero(outside_tol)) + 1
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Returns the (row, col) shape of the expression.

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -383,6 +383,22 @@ class TestDqcp(base_test.BaseTest):
         self.assertEqual(problem.objective.value, 2)
         np.testing.assert_almost_equal(x.value, np.array([2, 1, 0, 0, 0]))
 
+    def test_length_example(self) -> None:
+        """Fix #1760."""
+        n = 10
+        np.random.seed(1)
+        A = np.random.randn(n, n)
+        x_star = np.random.randn(n)
+        b = A @ x_star
+        epsilon = 1e-2
+        x = cp.Variable(n)
+        mse = cp.sum_squares(A @ x - b)/n
+        problem = cp.Problem(cp.Minimize(cp.length(x)), [mse <= epsilon])
+        assert problem.is_dqcp()
+
+        problem.solve(qcp=True)
+        assert np.isclose(problem.value, 8)
+
     def test_infeasible(self) -> None:
         x = cp.Variable(2)
         problem = cp.Problem(


### PR DESCRIPTION
## Description
The length atom is too strict about non-zeros. It should consider values with magnitude below a numerical tolerance zero.
Issue link (if applicable): #1760

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.