### PR TITLE
replace np.prod with utilities.shape.size_from_shape to improve performance

### DIFF
--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -24,6 +24,7 @@ from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.atoms.affine.hstack import hstack
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.expression import Expression
+from cvxpy.utilities.shape import size_from_shape
 
 
 class reshape(AffAtom):
@@ -73,7 +74,7 @@ class reshape(AffAtom):
         """Checks that the new shape has the same number of entries as the old.
         """
         old_len = self.args[0].size
-        new_len = np.prod(self._shape, dtype=int)
+        new_len = size_from_shape(self._shape)
         if not old_len == new_len:
             raise ValueError(
                 "Invalid reshape dimensions %s." % (self._shape,)

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -29,6 +29,7 @@ from cvxpy import error
 from cvxpy.constraints import PSD, Equality, Inequality
 from cvxpy.expressions import cvxtypes
 from cvxpy.utilities import scopes
+from cvxpy.utilities.shape import size_from_shape
 
 
 def _cast_other(binary_op):
@@ -412,7 +413,7 @@ class Expression(u.Canonical):
     def size(self) -> int:
         """int : The number of entries in the expression.
         """
-        return np.prod(self.shape, dtype=int)
+        return size_from_shape(self.shape)
 
     @property
     def ndim(self) -> int:

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -978,7 +978,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(str(cm.exception), "Index -100 is out of bounds for axis 0 with size 2.")
 
         exp = self.x[:-100]
-        self.assertEqual(exp.size, (0,))
+        self.assertEqual(exp.size, 0)
         self.assertItemsAlmostEqual(exp.value, np.array([]))
 
         exp = self.C[100:2]

--- a/cvxpy/utilities/shape.py
+++ b/cvxpy/utilities/shape.py
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from functools import reduce
+from operator import mul
 from typing import List, Tuple
 
 

--- a/cvxpy/utilities/shape.py
+++ b/cvxpy/utilities/shape.py
@@ -150,7 +150,7 @@ def mul_shapes(lh_shape: Tuple[int, ...], rh_shape: Tuple[int, ...]) -> Tuple[in
 
 
 def size_from_shape(shape) -> int:
-    """ Compute the size of a given shape by multiplying the size of its dimensions.
+    """ Compute the size of a given shape by multiplying the sizes of each axis.
 
     This is a replacement for np.prod(shape, dtype=int) which is much slower for
     small arrays than the implementation below.
@@ -165,7 +165,4 @@ def size_from_shape(shape) -> int:
     int
         The size of an object corresponding to shape.
     """
-    if shape:
-        return reduce(mul, shape)
-    else:
-        return 1
+    return reduce(mul, shape, 1)

--- a/cvxpy/utilities/shape.py
+++ b/cvxpy/utilities/shape.py
@@ -145,3 +145,25 @@ def mul_shapes(lh_shape: Tuple[int, ...], rh_shape: Tuple[int, ...]) -> Tuple[in
     if rh_shape != rh_old:
         shape = shape[:-1]
     return shape
+
+
+def size_from_shape(shape) -> int:
+    """ Compute the size of a given shape by multiplying the size of its dimensions.
+
+    This is a replacement for np.prod(shape, dtype=int) which is much slower for
+    small arrays than the implementation below.
+
+    Parameters
+    ----------
+    shape : tuple
+        a tuple of integers describing the shape of an object
+
+    Returns
+    -------
+    int
+        The size of an object corresponding to shape.
+    """
+    if shape:
+        return reduce(mul, shape)
+    else:
+        return 1


### PR DESCRIPTION
This pull request follows the discussion in issue #1784, which replaces calls to np.prod in expression.py and reshape.py with calls to functools.reduce, as recommended by @phschiele 

## Description
Performance improvement of hstack.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.