### PR TITLE
[CI] Build wheels for M1 (release/1.2.x)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,7 @@ jobs:
           CIBW_BUILD: "cp3${{env.PYTHON_SUBVERSION}}-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
+          CIBW_ARCHS_MACOS: x86_64 universal2
         uses: joerick/cibuildwheel@v2.3.1
 
       - name: Build source
@@ -215,6 +216,7 @@ jobs:
           CIBW_BUILD: "cp3${{env.PYTHON_SUBVERSION}}-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
+          CIBW_ARCHS_MACOS: x86_64 universal2
         uses: joerick/cibuildwheel@v2.3.1
 
       - name: Build source


### PR DESCRIPTION
## Description
Added CI changes to build M1 wheels to 1.2.x release branch.
After this PR is merged, we need to undo the "prepare for next release" commit, trigger a deploy, and then redo the "prepare for the next release commit". I can create separate PRs for this, or it can be done directly in the release branches.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.