### PR TITLE
Hide SCIP warning.

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
@@ -91,9 +91,9 @@ class SCIP(ConicSolver):
         import pyscipopt
         v = pyscipopt.__version__
         if Version(v) >= Version('4.0.0'):
-            msg = 'PySCIPOpt (SCIP\'s Python wrapper) is installed and its' \
+            msg = 'PySCIPOpt (SCIP\'s Python wrapper) is installed and its ' \
                   'version is %s. CVXPY only supports PySCIPOpt < 4.0.0.' % v
-            raise NotImplementedError(msg)
+            raise ModuleNotFoundError(msg)
 
     def apply(self, problem: ParamConeProg) -> Tuple[Dict, Dict]:
         """Returns a new problem and data for inverting the new solution."""


### PR DESCRIPTION
## Description
This PR addresses fixes a typo and hides the warning for having the wrong version of SCIP on import.
Issue link (if applicable): #1805

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.