### PR TITLE
[doc] Clarify that abs() supports complex numbers

### DIFF
--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -487,7 +487,7 @@ scalars, which are promoted.
    * - :ref:`abs(x) <abs>`
 
      - :math:`\lvert x \rvert`
-     - :math:`x \in \mathbf{R}`
+     - :math:`x \in \mathbf{C}`
      - |positive| positive
      - |convex| convex
      - |incr| for :math:`x \geq 0`


### PR DESCRIPTION
## Description
In the table of elementwise functions, clarify that CVXPY's `abs()` function supports complex numbers.

See: https://www.cvxpy.org/_modules/cvxpy/atoms/elementwise/abs.html

Issue link (if applicable): N/A

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist): N/A