### PR TITLE
contribute a atomic operation of trace(inv(X))

### DIFF
--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -96,6 +96,7 @@ from cvxpy.atoms.sum_smallest import sum_smallest
 from cvxpy.atoms.sum_squares import sum_squares
 from cvxpy.atoms.total_variation import tv
 from cvxpy.atoms.von_neumann_entr import von_neumann_entr
+from cvxpy.atoms.tr_inv import tr_inv
 
 # TODO(akshayka): Perhaps couple this information with the atom classes
 # themselves.
@@ -112,6 +113,7 @@ SOC_ATOMS = [
 EXP_ATOMS = [
     log_sum_exp,
     log_det,
+    tr_inv,
     entr,
     exp,
     kl_div,

--- a/cvxpy/atoms/tr_inv.py
+++ b/cvxpy/atoms/tr_inv.py
@@ -25,6 +25,12 @@ from cvxpy.atoms.atom import Atom
 from cvxpy.constraints.constraint import Constraint
 
 
+#############################################
+# File Name: tr_inv.py
+# Author: Cai Jianping
+# Mail: jpingcai@163.com
+# Created Time:  2022-7-9 11:25:34 AM
+#############################################
 class tr_inv(Atom):
     """:math:`\\trace\\inv A`
 
@@ -34,10 +40,9 @@ class tr_inv(Atom):
         super(tr_inv, self).__init__(A)
 
     def numeric(self, values):
-        """Returns the logdet of PSD matrix A.
+        """Returns the trinv of PSD matrix A.
 
-        For PSD matrix A, this is the sum of logs of eigenvalues of A
-        and is equivalent to the nuclear norm of the matrix logarithm of A.
+        For PSD matrix A, this is the trace of inverse of A.
         """
         # take symmetric part of the input.
         symm = (values[0] + values[0].T)/2

--- a/cvxpy/atoms/tr_inv.py
+++ b/cvxpy/atoms/tr_inv.py
@@ -1,0 +1,118 @@
+"""
+Copyright 2013 Steven Diamond
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import List, Tuple
+
+import numpy as np
+import scipy.sparse as sp
+from numpy import linalg as LA
+
+import cvxpy.settings as s
+from cvxpy.atoms.atom import Atom
+from cvxpy.constraints.constraint import Constraint
+
+
+class tr_inv(Atom):
+    """:math:`\\trace\\inv A`
+
+    """
+
+    def __init__(self, A) -> None:
+        super(tr_inv, self).__init__(A)
+
+    def numeric(self, values):
+        """Returns the logdet of PSD matrix A.
+
+        For PSD matrix A, this is the sum of logs of eigenvalues of A
+        and is equivalent to the nuclear norm of the matrix logarithm of A.
+        """
+        # take symmetric part of the input.
+        symm = (values[0] + values[0].T)/2
+        return np.trace(LA.inv(symm))
+
+    # Any argument shape is valid.
+    def validate_arguments(self) -> None:
+        X = self.args[0]
+        if len(X.shape) == 1 or X.shape[0] != X.shape[1]:
+            raise TypeError("The argument to tr_inv must be a square matrix.")
+
+    def shape_from_args(self) -> Tuple[int, ...]:
+        """Returns the (row, col) shape of the expression.
+        """
+        return tuple()
+
+    def sign_from_args(self) -> Tuple[bool, bool]:
+        """Returns sign (is positive, is negative) of the expression.
+        """
+        return (True, False)
+
+    def is_atom_convex(self) -> bool:
+        """Is the atom convex?
+        """
+        return True
+
+    def is_atom_concave(self) -> bool:
+        """Is the atom concave?
+        """
+        return False
+
+    def is_incr(self, idx) -> bool:
+        """Is the composition non-decreasing in argument idx?
+        """
+        return False
+
+    def is_decr(self, idx) -> bool:
+        """Is the composition non-increasing in argument idx?
+        """
+        return False
+
+    def _grad(self, values):
+        """Gives the (sub/super)gradient of the atom w.r.t. each argument.
+
+        Matrix expressions are vectorized, so the gradient is a matrix.
+
+        Args:
+            values: A list of numeric values for the arguments.
+
+        Returns:
+            A list of SciPy CSC sparse matrices or None.
+        """
+        X = values[0]
+        eigen_val = LA.eigvalsh(X)
+        if np.min(eigen_val) > 0:
+            # Grad: -X^{-2}.T
+            D = np.linalg.inv(X).T
+            D = - D @ D
+            return [sp.csc_matrix(D.ravel(order='F')).T]
+        # Outside domain.
+        else:
+            return [None]
+
+    def _domain(self) -> List[Constraint]:
+        """Returns constraints describing the domain of the node.
+        """
+        return [self.args[0] >> 0]
+
+    @property
+    def value(self) -> float:
+        if not np.allclose(self.args[0].value,
+                           self.args[0].value.T.conj(),
+                           rtol=s.ATOM_EVAL_TOL,
+                           atol=s.ATOM_EVAL_TOL):
+            raise ValueError("Input matrix was not Hermitian/symmetric.")
+        if any([p.value is None for p in self.parameters()]):
+            return None
+        return self._value_impl()

--- a/cvxpy/atoms/tr_inv.py
+++ b/cvxpy/atoms/tr_inv.py
@@ -25,7 +25,7 @@ from cvxpy.atoms.atom import Atom
 from cvxpy.constraints.constraint import Constraint
 
 class tr_inv(Atom):
-    """:math:`\\trace\\inv A`
+    """:math:`\\trace\\inv A, where A is positive definite`
 
     """
 
@@ -33,13 +33,19 @@ class tr_inv(Atom):
         super(tr_inv, self).__init__(A)
 
     def numeric(self, values):
-        """Returns the trinv of PSD matrix A.
+        """Returns the trinv of positive definite matrix A.
 
-        For PSD matrix A, this is the trace of inverse of A.
+        For positive definite matrix A, this is the trace of inverse of A.
         """
-        # take symmetric part of the input.
+        # if values[0] isn't Hermitian then return np.inf
+        if (LA.norm(values[0] - values[0].T)>=1e-8):
+            return np.inf
+        # take symmetric part of the input to enhance numerical stability
         symm = (values[0] + values[0].T)/2
-        return np.trace(LA.inv(symm))
+        eigVal=LA.eigvalsh(symm);
+        if min(eigVal)<=0:
+            return np.inf;
+        return np.sum(eigVal**-1)
 
     # Any argument shape is valid.
     def validate_arguments(self) -> None:

--- a/cvxpy/atoms/tr_inv.py
+++ b/cvxpy/atoms/tr_inv.py
@@ -38,7 +38,7 @@ class tr_inv(Atom):
         For positive definite matrix A, this is the trace of inverse of A.
         """
         # if values[0] isn't Hermitian then return np.inf
-        if (LA.norm(values[0] - values[0].T)>=1e-8):
+        if (LA.norm(values[0] - values[0].T.conj())>=1e-8):
             return np.inf
         # take symmetric part of the input to enhance numerical stability
         symm = (values[0] + values[0].T)/2
@@ -47,7 +47,7 @@ class tr_inv(Atom):
             return np.inf;
         return np.sum(eigVal**-1)
 
-    # Any argument shape is valid.
+    # The shape of argument must be square.
     def validate_arguments(self) -> None:
         X = self.args[0]
         if len(X.shape) == 1 or X.shape[0] != X.shape[1]:

--- a/cvxpy/atoms/tr_inv.py
+++ b/cvxpy/atoms/tr_inv.py
@@ -1,5 +1,5 @@
 """
-Copyright 2013 Steven Diamond
+Copyright 2022, the CVXPY authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,13 +24,6 @@ import cvxpy.settings as s
 from cvxpy.atoms.atom import Atom
 from cvxpy.constraints.constraint import Constraint
 
-
-#############################################
-# File Name: tr_inv.py
-# Author: Cai Jianping
-# Mail: jpingcai@163.com
-# Created Time:  2022-7-9 11:25:34 AM
-#############################################
 class tr_inv(Atom):
     """:math:`\\trace\\inv A`
 

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/__init__.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/__init__.py
@@ -28,6 +28,7 @@ from cvxpy.reductions.dcp2cone.atom_canonicalizers.lambda_sum_largest_canon impo
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.log_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.log1p_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.log_det_canon import *
+from cvxpy.reductions.dcp2cone.atom_canonicalizers.tr_inv_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.log_sum_exp_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.logistic_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.matrix_frac_canon import *
@@ -86,4 +87,5 @@ CANON_METHODS = {
     xexp : xexp_canon,
     dotsort : dotsort_canon,
     von_neumann_entr : von_neumann_entr_canon,
+    tr_inv : tr_inv_canon,
 }

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/tr_inv_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/tr_inv_canon.py
@@ -1,5 +1,5 @@
 """
-Copyright 2013 Steven Diamond
+Copyright 2022, the CVXPY authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,12 +18,6 @@ from cvxpy.atoms.affine.bmat import bmat
 from cvxpy.expressions.variable import Variable
 import numpy as np
 
-#############################################
-# File Name: tr_inv_canon.py
-# Author: Cai Jianping
-# Mail: jpingcai@163.com
-# Created Time:  2022-7-9 11:25:34 AM
-#############################################
 def tr_inv_canon(expr, args):
     """Reduces the atom to an affine expression and list of constraints.
 

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/tr_inv_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/tr_inv_canon.py
@@ -18,6 +18,12 @@ from cvxpy.atoms.affine.bmat import bmat
 from cvxpy.expressions.variable import Variable
 import numpy as np
 
+#############################################
+# File Name: tr_inv_canon.py
+# Author: Cai Jianping
+# Mail: jpingcai@163.com
+# Created Time:  2022-7-9 11:25:34 AM
+#############################################
 def tr_inv_canon(expr, args):
     """Reduces the atom to an affine expression and list of constraints.
 

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/tr_inv_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/tr_inv_canon.py
@@ -1,0 +1,63 @@
+"""
+Copyright 2013 Steven Diamond
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from cvxpy.atoms.affine.bmat import bmat
+from cvxpy.expressions.variable import Variable
+import numpy as np
+
+def tr_inv_canon(expr, args):
+    """Reduces the atom to an affine expression and list of constraints.
+
+    Creates the equivalent problem::
+
+       maximize    sum(u[i])
+       subject to: [A ei; ei.T u[i]] is positive semidefinite
+
+       where ei is the n dimensional column vector whose i-th entry is 1 and other entries are 0
+
+    This follows from the inequality:
+
+    .. math::
+
+       u[i] >= R[i][i] for all i, where R=A^-1
+
+    Parameters
+    ----------
+    expr : tr_inv
+    args : list
+        The arguments for the expression
+
+    Returns
+    -------
+    tuple
+        (Variable for objective, list of constraints)
+    """
+    A = args[0]
+    n, _ = A.shape
+    su=None
+    constraints=[];
+    for i in range(n):
+        ei = np.zeros((n,1))
+        ei[i]=1.0
+        ui = Variable((1,1))
+        R = bmat([[A, ei],
+                [ei.T, ui]])
+        constraints += [R >> 0]
+        if su is None:
+            su=ui;
+        else:
+            su+=ui;
+    return su, constraints

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1343,14 +1343,9 @@ class TestAtoms(BaseTest):
         prob.solve(verbose=True)
         # Check result.
         self.assertAlmostEqual(prob.value, T**2) # the best value is T^2
-        bestX=X.value;
-        for i in range(T):
-            for j in range(T):
-                if i==j:
-                    self.assertAlmostEqual(bestX[i][j], 1.0/T) # Diagonal elements are 1/T
-                else:
-                    self.assertAlmostEqual(bestX[i][j], 0.0) # Others are 0
-
+        X_actual = X.value
+        X_expect = np.eye(T) / T
+        self.assertItemsAlmostEqual(X_actual, X_expect, places=4)
         # Second SDP problem, given a row full-rank matrix M:
         #           minimize    trace(inv(M * X * M.T))
         #               s.t.    X is PSD

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1322,6 +1322,25 @@ class TestAtoms(BaseTest):
         self.assertEqual(atom.sign, s.UNKNOWN)
 
 
+    def test_tr_inv(self) -> None:
+        """Test tr_inv atom. """
+        T = 5
+        # Define and solve the CVXPY problem.
+        # Create a symmetric matrix variable.0
+        # X should be a PSD
+        X = cp.Variable((T, T), symmetric=True)
+        # The operator >> denotes matrix inequality.
+        constraints = [X >> 0]
+        constraints += [
+            cp.trace(X) == 1
+        ]
+        prob = cp.Problem(cp.Minimize(cp.tr_inv(X)), constraints)
+        prob.solve(verbose=True)
+        # Print result.
+        print("The optimal value is", prob.value)
+        print("A solution X is")
+        print(X.value)
+
 class TestDotsort(BaseTest):
     """ Unit tests for the dotsort atom. """
 

--- a/examples/ex_tr_inv.py
+++ b/examples/ex_tr_inv.py
@@ -1,0 +1,43 @@
+"""
+Copyright 2013 Steven Diamond
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+# Taken from CVX website http://cvxr.com/cvx/examples/
+# An example for our contributing atoms tr_inv
+# Created by Jianping Cai
+
+# Solves the following SDP problem:
+#           minimize    trace(inv(X))
+#               s.t.    X is PSD
+#                       trace(X)==1
+
+import cvxpy as cp
+T = 5
+
+# Define and solve the CVXPY problem.
+# Create a symmetric matrix variable.0
+X = cp.Variable((T, T), symmetric=True)
+# The operator >> denotes matrix inequality.
+constraints = [X >> 0]
+constraints += [
+    cp.trace(X) == 1
+]
+
+prob = cp.Problem(cp.Minimize(cp.tr_inv(X)), constraints)
+prob.solve(verbose=True)
+
+# Print result.
+print("The optimal value is", prob.value)
+print("A solution X is")
+print(X.value)

--- a/examples/ex_tr_inv.py
+++ b/examples/ex_tr_inv.py
@@ -1,5 +1,5 @@
 """
-Copyright 2013 Steven Diamond
+Copyright 2022, the CVXPY authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Hello, since the current cvxpy does not support the atomic operation 
$$\operatorname{trace}\left( \operatorname{inv}\left( X \right) \right)$$
where $X$ is PSD, but I need that feature in my research work. I designed the atomic operation and contributed it to the cvxpy community. Our main work is to demonstrate that 
$$\operatorname{trace}\left( \operatorname{inv}\left( X \right) \right)$$
is convex and to implement an equivalent cone form of it. In addition, we provided an example in "examples/ex_tr_inv.py"

The code we submitted in
1. "cvxpy/atoms/tr_inv.py"
2. "cvxpy/reductions/dcp2cone/atom_canonicalizers/tr_inv_canon.py"
3. "cvxpy/reductions/dcp2cone/atom_canonicalizers/tr_inv_canon.py"
4. "cvxpy/atoms/__init__.py"
5. "cvxpy/reductions/dcp2cone/atom_canonicalizers/__init__.py"
6. "examples/ex_tr_inv.py"

## Type of change
- [ ] New feature (backwards compatible)
- [*] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [*] Add our license to new files.
- [*] Check that your code adheres to our coding style.
- [*] Write unittests.
- [*] Run the unittests and check that they’re passing.
- [*] Run the benchmarks to make sure your change doesn’t introduce a regression.