### PR TITLE
Fix DQCP issue with sign function

### DIFF
--- a/cvxpy/atoms/sign.py
+++ b/cvxpy/atoms/sign.py
@@ -56,12 +56,12 @@ class sign(Atom):
     def is_atom_quasiconvex(self) -> bool:
         """Is the atom quasiconvex?
         """
-        return True
+        return self.args[0].is_scalar()
 
     def is_atom_quasiconcave(self) -> bool:
         """Is the atom quasiconvex?
         """
-        return True
+        return self.args[0].is_scalar()
 
     def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -429,6 +429,14 @@ class TestDqcp(base_test.BaseTest):
         cp.sign(variable).value
         self.assertItemsAlmostEqual(value, variable.value)
 
+        # sign is only QCP for univariate input.
+        # See issue #1828
+        x = cp.Variable(2)
+        obj = cp.sum_squares(np.ones(2) - x)
+        constr = [cp.sum(cp.sign(x)) <= 1]
+        prob = cp.Problem(cp.Minimize(obj), constr)
+        assert not prob.is_dqcp()
+
     def test_dist_ratio(self) -> None:
         x = cp.Variable(2)
         a = np.ones(2)


### PR DESCRIPTION
## Description
The sign function is only quasilinear when applied to univariate input. Currently the function is marked as quasilinear for inputs of any dimension.
Issue link (if applicable): #1828 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.