### PR TITLE
Fix bug with diff

### DIFF
--- a/cvxpy/atoms/affine/diff.py
+++ b/cvxpy/atoms/affine/diff.py
@@ -39,7 +39,8 @@ def diff(x, k: int = 1, axis: int = 0):
     elif axis == 1:
         x = x.T
 
-    if k < 0 or k >= x.shape[axis]:
+    # Always test shape[0] because if axis == 1 x is transposed.
+    if k < 0 or k >= x.shape[0]:
         raise ValueError("Must have k >= 0 and X must have < k elements along "
                          "axis")
     for i in range(k):

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1118,6 +1118,16 @@ class TestAtoms(BaseTest):
         self.assertEqual(cp.diff(A, axis=1).shape,
                          np.diff(B, axis=1).shape)
 
+        # Issue #1834
+
+        x1 = np.array([[1, 2, 3, 4, 5]])
+        x2 = cp.Variable((1, 5), value=x1)
+
+        expr = cp.diff(x1, axis=1)
+        self.assertItemsAlmostEqual(expr.value, np.ones(5))
+        expr = cp.diff(x2, axis=1)
+        self.assertItemsAlmostEqual(expr.value, np.ones(5))
+
     def test_log_normcdf(self) -> None:
         self.assertEqual(cp.log_normcdf(self.x).sign, s.NONPOS)
         self.assertEqual(cp.log_normcdf(self.x).curvature, s.CONCAVE)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1124,9 +1124,12 @@ class TestAtoms(BaseTest):
         x2 = cp.Variable((1, 5), value=x1)
 
         expr = cp.diff(x1, axis=1)
-        self.assertItemsAlmostEqual(expr.value, np.ones(5))
+        self.assertItemsAlmostEqual(expr.value, np.diff(x1, axis=1))
         expr = cp.diff(x2, axis=1)
-        self.assertItemsAlmostEqual(expr.value, np.ones(5))
+        self.assertItemsAlmostEqual(expr.value, np.diff(x1, axis=1))
+
+        with pytest.raises(ValueError, match="< k elements"):
+            cp.diff(x1, axis=0).value
 
     def test_log_normcdf(self) -> None:
         self.assertEqual(cp.log_normcdf(self.x).sign, s.NONPOS)


### PR DESCRIPTION
## Description
There was a bug in diff that made it impossible to use on some arrays with dimension 1.
Issue link (if applicable): #1834 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.