### PR TITLE
Fix linters

### DIFF
--- a/cvxpy/atoms/dotsort.py
+++ b/cvxpy/atoms/dotsort.py
@@ -56,8 +56,9 @@ class dotsort(Atom):
         super(dotsort, self).validate_arguments()
 
     def numeric(self, values):
-        """Returns the inner product of the sorted values of vec(X) and the sorted (and potentially padded)
-        values of vec(W).
+        """
+        Returns the inner product of the sorted values of vec(X) and the sorted
+        (and potentially padded) values of vec(W).
         """
         x, w_padded = self._get_args_from_values(values)
         return np.sort(x) @ np.sort(w_padded)

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -809,7 +809,7 @@ class Problem(u.Canonical):
         """
         if custom_solver.name() in SOLVERS:
             message = "Custom solvers must have a different name than the officially supported ones"
-            raise(error.SolverError(message))
+            raise error.SolverError(message)
 
         candidates = {'qp_solvers': [], 'conic_solvers': []}
         if not self.is_mixed_integer() or custom_solver.MIP_CAPABLE:

--- a/cvxpy/tests/test_custom_solver.py
+++ b/cvxpy/tests/test_custom_solver.py
@@ -18,7 +18,7 @@ class CustomQPSolver(OSQP):
         return "CUSTOM_QP_SOLVER"
 
     def solve_via_data(self, *args, **kwargs):
-        raise(CustomQPSolverCalled())
+        raise CustomQPSolverCalled()
 
 
 class CustomConicSolver(SCS):
@@ -26,7 +26,7 @@ class CustomConicSolver(SCS):
         return "CUSTOM_CONIC_SOLVER"
 
     def solve_via_data(self, *args, **kwargs):
-        raise(CustomConicSolverCalled())
+        raise CustomConicSolverCalled()
 
 
 class ConflictingCustomSolver(OSQP):


### PR DESCRIPTION
## Description
Looks like there was a new release of flake8 that requires a few small changes to make the linters pass again:
![image](https://user-images.githubusercontent.com/44360364/182042839-34a86949-9f4c-48f8-9a7f-995d4abbeec7.png)



## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.