### PR TITLE
fix gradient for multidimensional quad form

### DIFF
--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -113,8 +113,8 @@ class QuadForm(Atom):
     def _grad(self, values):
         x = np.array(values[0])
         P = np.array(values[1])
-        D = (P + np.conj(P.T)) @ x.T
         return [sp.csc_matrix(D.ravel(order='F')).T]
+        D = (P + np.conj(P.T)) @ x
 
     def shape_from_args(self) -> Tuple[int, ...]:
         return tuple() if self.args[0].ndim == 0 else (1, 1)

--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -113,8 +113,8 @@ class QuadForm(Atom):
     def _grad(self, values):
         x = np.array(values[0])
         P = np.array(values[1])
-        return [sp.csc_matrix(D.ravel(order='F')).T]
         D = (P + np.conj(P.T)) @ x
+        return [sp.csc_matrix(D.ravel(order="F")).T]
 
     def shape_from_args(self) -> Tuple[int, ...]:
         return tuple() if self.args[0].ndim == 0 else (1, 1)

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -267,6 +267,21 @@ class TestGrad(BaseTest):
         # access quad_form.expr.grad without error
         prob.constraints[1].expr.grad
 
+        # define the optimization problem with a two-dimensional decision variable
+        x = cp.Variable((n, 1))
+        prob = cp.Problem(
+            cp.Maximize(q.T @ x - (1 / 2) * cp.quad_form(x, P)),
+            [
+                cp.norm(x, 1) <= 1.0,
+                cp.quad_form(x, P) <= 10,  # quad form constraint
+                cp.abs(x) <= 0.01,
+            ],
+        )
+        prob.solve(solver=cp.SCS)
+
+        # access quad_form.expr.grad without error
+        prob.constraints[1].expr.grad
+
     def test_max(self) -> None:
         """Test gradient for max
         """


### PR DESCRIPTION
## Description
Implement a fix for retrieving gradient of quad_form for a two-dimensional optimization problem.

Current unit test for gradient of quad_form still passes. I added an additional unittest for multidimension quad_form gradient.

Fix for https://github.com/cvxpy/cvxpy/issues/1837

New test would fail under the original code:
![image](https://user-images.githubusercontent.com/74955560/182374967-6905c49d-63b9-4fe3-ba9b-ffd16f7166a3.png)


## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.