### PR TITLE
Fix time_limit_sec for GLOP and PDLP

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
@@ -152,7 +152,7 @@ class GLOP(ConicSolver):
             if not solver.SetSolverSpecificParametersAsString(proto_str):
                 return {"status": s.SOLVER_ERROR}
         if "time_limit_sec" in solver_opts:
-            solver.SetTimeLimit(1000 * float(solver_opts["time_limit_sec"]))
+            solver.SetTimeLimit(int(1000 * solver_opts["time_limit_sec"]))
         solver.Solve()
         solver.FillSolutionResponseProto(response)
 

--- a/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
@@ -158,7 +158,7 @@ class PDLP(ConicSolver):
                 return {"status": s.SOLVER_ERROR}
             parameters.MergeFrom(proto)
         if "time_limit_sec" in solver_opts:
-            request.solver_time_limit_sec = float(solver_opts["time_limit_sec"])
+            request.solver_time_limit_seconds = float(solver_opts["time_limit_sec"])
 
         request.solver_specific_parameters = text_format.MessageToString(parameters)
         solver = model_builder_helper.ModelSolverHelper()

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -800,6 +800,12 @@ class TestGLOP(unittest.TestCase):
         with self.assertRaises(cp.error.SolverError):
             prob.solve(solver='GLOP', parameters_proto="not a proto")
 
+    def test_glop_time_limit(self) -> None:
+        sth = sths.lp_1()
+        # Checks that the option doesn't error. A better test would be to solve
+        # a large instance and check that the time limit is hit.
+        sth.solve(solver='GLOP', time_limit_sec=1.0)
+
 
 @unittest.skipUnless('PDLP' in INSTALLED_SOLVERS, 'PDLP is not installed.')
 class TestPDLP(unittest.TestCase):
@@ -858,6 +864,12 @@ class TestPDLP(unittest.TestCase):
         prob = cp.Problem(cp.Maximize(x), [x <= 1])
         with self.assertRaises(cp.error.SolverError):
             prob.solve(solver='PDLP', parameters_proto="not a proto")
+
+    def test_pdlp_time_limit(self) -> None:
+        sth = sths.lp_1()
+        # Checks that the option doesn't error. A better test would be to solve
+        # a large instance and check that the time limit is hit.
+        sth.solve(solver='PDLP', time_limit_sec=1.0)
 
 
 @unittest.skipUnless('CPLEX' in INSTALLED_SOLVERS, 'CPLEX is not installed.')


### PR DESCRIPTION
Fixes #1858

I looked for examples of tests that check that the time limit is actually hit but didn't find any. These are potentially flaky, but still useful to check that the time limit is actually enforced.