### PR TITLE
Update README to reflect Python 3.7+ requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ conda install -c conda-forge cvxpy
 
 CVXPY has the following dependencies:
 
-- Python >= 3.6
+- Python >= 3.7
 - OSQP >= 0.4.1
 - ECOS >= 2
 - SCS >= 1.1.6


### PR DESCRIPTION
cvxpy requires Python 3.7+, as stated on the [Installation Guide](https://www.cvxpy.org/install/index.html) and in [setup.py](https://github.com/cvxpy/cvxpy/blob/v1.2.1/setup.py#L227).