### PR TITLE
Typing annotation improvements

### DIFF
--- a/cvxpy/expressions/constants/parameter.py
+++ b/cvxpy/expressions/constants/parameter.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import List, Optional, Tuple
+from __future__ import annotations
 
 import cvxpy.lin_ops.lin_utils as lu
 from cvxpy import settings as s
@@ -44,7 +44,7 @@ class Parameter(Leaf):
     PARAM_COUNT = 0
 
     def __init__(
-        self, shape: Tuple[int, ...] = (), name: Optional[str] = None, value=None, id=None, **kwargs
+        self, shape: int | tuple[int, ...] = (), name: str | None = None, value=None, id=None, **kwargs
     ) -> None:
         if id is None:
             self.id = lu.get_id()
@@ -96,7 +96,7 @@ class Parameter(Leaf):
         """
         return {}
 
-    def parameters(self) -> List["Parameter"]:
+    def parameters(self) -> list[Parameter]:
         """Returns itself as a parameter.
         """
         return [self]

--- a/cvxpy/expressions/constants/parameter.py
+++ b/cvxpy/expressions/constants/parameter.py
@@ -44,7 +44,8 @@ class Parameter(Leaf):
     PARAM_COUNT = 0
 
     def __init__(
-        self, shape: int | tuple[int, ...] = (), name: str | None = None, value=None, id=None, **kwargs
+        self, shape: int | tuple[int, ...] = (), name: str | None = None, value=None,
+        id=None, **kwargs
     ) -> None:
         if id is None:
             self.id = lu.get_id()

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -13,12 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING, List, Tuple, Union
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from cvxpy import Constant, Variable
+    from cvxpy import Constant, Parameter, Variable
     from cvxpy.atoms.atom import Atom
 
 import numbers
@@ -91,7 +92,7 @@ class Leaf(expression.Expression):
     __metaclass__ = abc.ABCMeta
 
     def __init__(
-        self, shape: Union[int, Tuple[int, ...]], value=None, nonneg: bool = False,
+        self, shape: int | tuple[int, ...]], value=None, nonneg: bool = False,
         nonpos: bool = False, complex: bool = False, imag: bool = False,
         symmetric: bool = False, diag: bool = False, PSD: bool = False,
         NSD: bool = False, hermitian: bool = False,
@@ -181,22 +182,22 @@ class Leaf(expression.Expression):
         """
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> tuple[int, ...]:
         """ tuple : The dimensions of the expression.
         """
         return self._shape
 
-    def variables(self) -> List['Variable']:
+    def variables(self) -> list[Variable]:
         """Default is empty list of Variables.
         """
         return []
 
-    def parameters(self):
+    def parameters(self) -> list[Parameter]:
         """Default is empty list of Parameters.
         """
         return []
 
-    def constants(self) -> List['Constant']:
+    def constants(self) -> list[Constant]:
         """Default is empty list of Constants.
         """
         return []
@@ -265,7 +266,7 @@ class Leaf(expression.Expression):
         return self.attributes['complex'] or self.is_imag() or self.attributes['hermitian']
 
     @property
-    def domain(self) -> List[Constraint]:
+    def domain(self) -> list[Constraint]:
         """A list of constraints describing the closure of the region
            where the expression is finite.
         """
@@ -471,5 +472,5 @@ class Leaf(expression.Expression):
         """
         return True
 
-    def atoms(self) -> List['Atom']:
+    def atoms(self) -> list[Atom]:
         return []

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -92,7 +92,7 @@ class Leaf(expression.Expression):
     __metaclass__ = abc.ABCMeta
 
     def __init__(
-        self, shape: int | tuple[int, ...]], value=None, nonneg: bool = False,
+        self, shape: int | tuple[int, ...], value=None, nonneg: bool = False,
         nonpos: bool = False, complex: bool = False, imag: bool = False,
         symmetric: bool = False, diag: bool = False, PSD: bool = False,
         NSD: bool = False, hermitian: bool = False,

--- a/cvxpy/expressions/variable.py
+++ b/cvxpy/expressions/variable.py
@@ -13,8 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Any
 
 import scipy.sparse as sp
 
@@ -23,7 +24,7 @@ from cvxpy import settings as s
 from cvxpy.expressions.leaf import Leaf
 
 
-def upper_tri_to_full(n):
+def upper_tri_to_full(n: int) -> sp.csc_matrix:
     """Returns a coefficient matrix to create a symmetric matrix.
 
     Parameters
@@ -66,8 +67,9 @@ class Variable(Leaf):
     """
 
     def __init__(
-        self, shape=(), name: Optional[str] = None, var_id: Optional[int] = None, **kwargs: Any
-    ) -> None:
+        self, shape: int | tuple[int, ...] = (), name: str | None = None,
+        var_id: int | None = None, **kwargs: Any
+    ):
         if var_id is None:
             self.id = lu.get_id()
         else:
@@ -79,7 +81,7 @@ class Variable(Leaf):
         else:
             raise TypeError("Variable name %s must be a string." % name)
 
-        self._variable_with_attributes: Optional["Variable"] = None
+        self._variable_with_attributes: Variable | None = None
         self._value = None
         self.delta = None
         self.gradient = None
@@ -93,7 +95,7 @@ class Variable(Leaf):
         return False
 
     @property
-    def grad(self):
+    def grad(self) -> dict[Variable, sp.csc_matrix]:
         """Gives the (sub/super)gradient of the expression w.r.t. each variable.
 
         Matrix expressions are vectorized, so the gradient is a matrix.
@@ -104,7 +106,7 @@ class Variable(Leaf):
         # TODO(akshayka): Do not assume shape is 2D.
         return {self: sp.eye(self.size).tocsc()}
 
-    def variables(self) -> List["Variable"]:
+    def variables(self) -> list[Variable]:
         """Returns itself as a variable.
         """
         return [self]
@@ -123,11 +125,11 @@ class Variable(Leaf):
         """
         return self._variable_with_attributes is not None
 
-    def set_variable_of_provenance(self, variable: "Variable"):
+    def set_variable_of_provenance(self, variable: Variable) -> None:
         assert variable.attributes
         self._variable_with_attributes = variable
 
-    def variable_of_provenance(self):
+    def variable_of_provenance(self) -> Variable | None:
         """Returns a variable with attributes from which this variable was generated."""
         return self._variable_with_attributes
 


### PR DESCRIPTION
This pull requests improves typing annotations. The main changes are:

- adds `int` as a valid type for shape argument in `cp.Parameter()` and `cp.Variable()`
- using [`__future__.annotations`](https://peps.python.org/pep-0563/), we can simplify the typing annotations