### PR TITLE
Make log_det robust to numerica

### DIFF
--- a/cvxpy/atoms/log_det.py
+++ b/cvxpy/atoms/log_det.py
@@ -39,10 +39,10 @@ class log_det(Atom):
         For PSD matrix A, this is the sum of logs of eigenvalues of A
         and is equivalent to the nuclear norm of the matrix logarithm of A.
         """
-        # take symmetric part of the input.
-        symm = (values[0] + values[0].T)/2
+        # take Hermitian part of the input.
+        symm = (values[0] + np.conj(values[0].T))/2
         sign, logdet = LA.slogdet(symm)
-        if sign == 1:
+        if np.real(sign) == 1:
             return logdet
         else:
             return -np.inf

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -314,11 +314,26 @@ class TestComplex(BaseTest):
         P = np.arange(9) - 2j*np.arange(9)
         P = np.reshape(P, (3, 3))
         P = np.conj(P.T).dot(P)/100 + np.eye(3)*.1
-        value = cp.log_det(P).value
+        logdet_value = cp.log_det(P).value
         X = Variable((3, 3), complex=True)
-        prob = Problem(cp.Maximize(cp.log_det(X)), [X == P])
+        objective = cp.log_det(X)
+        prob = Problem(cp.Maximize(objective), [X == P])
         result = prob.solve(solver=cp.SCS, eps=1e-6)
-        self.assertAlmostEqual(result, value, places=2)
+        self.assertAlmostEqual(result, logdet_value, places=2)
+        objective_value = objective.value
+        s, ld = np.linalg.slogdet(P)
+        self.assertAlmostEqual(objective_value, ld)
+
+        # Test case for Issue 1816.
+        #   The optimal solution is the identity matrix scaled by 3.
+        #   NumPy's slogdet function returns a sign "s" with a tiny complex
+        #   part which causes 1 == s to fail.
+        cons = [X >> 0, cp.real(cp.trace(X)) <= 9]
+        obj = cp.Maximize(cp.log_det(X))
+        prob = cp.Problem(objective=obj, constraints=cons)
+        prob.solve(solver=cp.SCS, eps=1e-6)
+        self.assertAlmostEqual(obj.value, 3*np.log(3))
+        pass
 
     def test_eigval_atoms(self) -> None:
         """Test eigenvalue atoms.


### PR DESCRIPTION
…"sign" from numpys slogdet is real.

This fixes #1816. The current ``log_det`` implementation can return wrong results if (1) the matrix was complex but not diagonal (2) the matrix is complex and diagonal, but numpy's ``slogdet`` function returns a sign with an extremely small imaginary part. The solution is simple since the atom is supposed to project onto the set of Hermtian matrices as a first step: Hermitian matrices always have real eigenvalues, so we should just check the real part of the sign returned from numpy's ``slogdet``.