### PR TITLE
Upper bound or-tools to 9.3

### DIFF
--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -28,7 +28,7 @@ elif [[ "$PYTHON_VERSION" == "3.10" ]]; then
     python -m pip install sdpa-python
 fi
 
-python -m pip install ortools coptpy
+python -m pip install ortools<9.4 coptpy
 
 # CBC comes with wheels for windows and needs coin-or-cbc to compile otherwise
 # conda-forge in progress: https://github.com/conda-forge/staged-recipes/pull/14950

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -28,7 +28,7 @@ elif [[ "$PYTHON_VERSION" == "3.10" ]]; then
     python -m pip install sdpa-python
 fi
 
-python -m pip install ortools<9.4 coptpy
+python -m pip install "ortools>=9.3,<9.4" coptpy
 
 # CBC comes with wheels for windows and needs coin-or-cbc to compile otherwise
 # conda-forge in progress: https://github.com/conda-forge/staged-recipes/pull/14950

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,14 +5,14 @@ CVXOPT = cvxopt
 DIFFCP = diffcp
 ECOS =
 ECOS_BB =
-GLOP = ortools
+GLOP = ortools<9.4
 GLPK = cvxopt
 GLPK_MI = cvxopt
 GUROBI = gurobipy
 HIGHS = scipy>=1.6.1
 MOSEK = Mosek
 OSQP =
-PDLP = ortools
+PDLP = ortools<9.4
 SCIP = PySCIPOpt<4.0.0
 SCIPY = scipy
 SCS =


### PR DESCRIPTION
Re https://github.com/cvxpy/cvxpy/pull/1866#issuecomment-1214264182, or-tools 9.4 was recently released with breaking API changes. Upper bounding should get tests passing again.

CC @mizux