### PR TITLE
Adding edge case handling for string inputs into norm

### DIFF
--- a/cvxpy/atoms/norm.py
+++ b/cvxpy/atoms/norm.py
@@ -69,6 +69,10 @@ def norm(x, p: Union[int, str] = 2, axis=None):
             return norm1(x, axis=axis)
         elif p in [np.inf, "inf", "Inf"]:
             return norm_inf(x, axis)
+        elif p == 'fro':
+            return pnorm(vec(x), 2, axis)
+        elif isinstance(p, str):
+            raise RuntimeError(f'Unsupported norm option {p} for non-matrix.')
         else:
             return pnorm(x, p, axis)
 

--- a/cvxpy/atoms/norm.py
+++ b/cvxpy/atoms/norm.py
@@ -72,7 +72,7 @@ def norm(x, p: Union[int, str] = 2, axis=None):
         elif p == 'fro':
             return pnorm(vec(x), 2, axis)
         elif isinstance(p, str):
-            raise RuntimeError(f'Unsupported norm option {p} for non-matrix.')
+            raise RuntimeError(f'Unsupported norm option {p} for non-matrix .')
         else:
             return pnorm(x, p, axis)
 


### PR DESCRIPTION
## Description
Raising an error for non-supported string arguments into norm atom, and handling the `fro` norm.
Addressing issue: https://github.com/cvxpy/cvxpy/issues/1865

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.