### PR TITLE
Adding edge case handling for string inputs into norm

### DIFF
--- a/cvxpy/atoms/norm.py
+++ b/cvxpy/atoms/norm.py
@@ -67,9 +67,9 @@ def norm(x, p: Union[int, str] = 2, axis=None):
     else:
         if p == 1 or x.is_scalar():
             return norm1(x, axis=axis)
-        elif p in [np.inf, "inf", "Inf"]:
+        elif str(p).lower() == "inf":
             return norm_inf(x, axis)
-        elif p == 'fro':
+        elif str(p).lower() == "fro":
             return pnorm(vec(x), 2, axis)
         elif isinstance(p, str):
             raise RuntimeError(f'Unsupported norm option {p} for non-matrix.')

--- a/cvxpy/atoms/norm.py
+++ b/cvxpy/atoms/norm.py
@@ -69,6 +69,10 @@ def norm(x, p: Union[int, str] = 2, axis=None):
             return norm1(x, axis=axis)
         elif p in [np.inf, "inf", "Inf"]:
             return norm_inf(x, axis)
+        elif p == 'fro':
+            return pnorm(vec(x), 2, axis)
+        elif isinstance(p, str):
+            raise RuntimeError(f'Unsupported norm option {p} for non-matrix.')
         else:
             return pnorm(x, p, axis)
 

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -111,6 +111,15 @@ class TestAtoms(BaseTest):
             "The input must be a single CVXPY Expression, not a list. "
             "Combine Expressions using atoms such as bmat, hstack, and vstack."))
 
+    def test_norm_exceptions(self) -> None:
+        """Test that norm exceptions are raised as expected.
+        """
+        x = cp.Variable(2)
+        with self.assertRaises(Exception) as cm:
+            cp.norm(x, 'nuc')
+        self.assertTrue(str(cm.exception) in (
+            "Unsupported norm option nuc for non-matrix."))
+
     def test_quad_form(self) -> None:
         """Test quad_form atom.
         """


### PR DESCRIPTION
Signed-off-by: KerimovEmil 

## Description
Raising an error for non-supported string arguments into norm atom, and handling the fro norm.
Addressing issue: https://github.com/cvxpy/cvxpy/issues/1865

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.