### PR TITLE
Update PDLP interface for ortools 9.4

### DIFF
--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -28,7 +28,7 @@ elif [[ "$PYTHON_VERSION" == "3.10" ]]; then
     python -m pip install sdpa-python
 fi
 
-python -m pip install ortools coptpy
+python -m pip install "ortools>=9.3,<9.5" coptpy
 
 # CBC comes with wheels for windows and needs coin-or-cbc to compile otherwise
 # conda-forge in progress: https://github.com/conda-forge/staged-recipes/pull/14950

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -27,6 +27,7 @@ python -m pip install "ortools>=9.3,<9.5" coptpy cplex sdpa-python diffcp gurobi
 # cylp has wheels for all versions 3.7 - 3.10, except for 3.7 on Windows
 if [[ "$PYTHON_VERSION" != "3.7" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then
   python -m pip install cylp
+fi
 
 # SCIP only works with scipy >= 1.5 due to dependency conflicts when installing on Linux/macOS
 if [[ "$PYTHON_VERSION" == "3.9" ]] || [[ "$RUNNER_OS" == "Windows" ]]; then

--- a/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
@@ -51,6 +51,11 @@ class GLOP(ConicSolver):
         if Version(ortools.__version__) < Version('9.3.0'):
             raise RuntimeError(f'Version of ortools ({ortools.__version__}) '
                                f'is too old. Expected >= 9.3.0.')
+        if Version(ortools.__version__) >= Version('9.5.0'):
+            raise RuntimeError('Unrecognized new version of ortools '
+                               f'({ortools.__version__}). Expected < 9.5.0.'
+                               'Please open a feature request on cvxpy to '
+                               'enable support for this version.')
         ortools, google.protobuf  # For flake8
 
     def apply(self, problem: ParamConeProg) -> Tuple[Dict, Dict]:

--- a/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
@@ -51,6 +51,11 @@ class PDLP(ConicSolver):
         if Version(ortools.__version__) < Version('9.3.0'):
             raise RuntimeError(f'Version of ortools ({ortools.__version__}) '
                                f'is too old. Expected >= 9.3.0.')
+        if Version(ortools.__version__) >= Version('9.5.0'):
+            raise RuntimeError('Unrecognized new version of ortools '
+                               f'({ortools.__version__}). Expected < 9.5.0.'
+                               'Please open a feature request on cvxpy to '
+                               'enable support for this version.')
         ortools, google.protobuf  # For flake8
 
     def apply(self, problem: ParamConeProg) -> Tuple[Dict, Dict]:
@@ -133,9 +138,9 @@ class PDLP(ConicSolver):
             solver_cache: Dict = None,
     ) -> Solution:
         """Returns the result of the call to the solver."""
+        import ortools
         from google.protobuf import text_format
         from ortools.linear_solver import linear_solver_pb2
-        from ortools.model_builder.python import model_builder_helper
         from ortools.pdlp import solvers_pb2
 
         # TODO: Switch to a direct numpy interface to PDLP when available.
@@ -161,8 +166,17 @@ class PDLP(ConicSolver):
             request.solver_time_limit_seconds = float(solver_opts["time_limit_sec"])
 
         request.solver_specific_parameters = text_format.MessageToString(parameters)
-        solver = model_builder_helper.ModelSolverHelper()
-        response = solver.Solve(request)
+        if Version(ortools.__version__) >= Version('9.4.0'):
+            from ortools.model_builder.python import (
+                pywrap_model_builder_helper,)
+            solver = pywrap_model_builder_helper.ModelSolverHelper("pdlp")
+            response_str = solver.solve_serialized_request(request.SerializeToString())
+            response = linear_solver_pb2.MPSolutionResponse.FromString(response_str)
+        else:
+            # Version 9.3
+            from ortools.model_builder.python import model_builder_helper
+            solver = model_builder_helper.ModelSolverHelper()
+            response = solver.Solve(request)
 
         solution = {}
         solution["value"] = response.objective_value

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,14 +5,14 @@ CVXOPT = cvxopt
 DIFFCP = diffcp
 ECOS =
 ECOS_BB =
-GLOP = ortools
+GLOP = ortools>=9.3,<9.5
 GLPK = cvxopt
 GLPK_MI = cvxopt
 GUROBI = gurobipy
 HIGHS = scipy>=1.6.1
 MOSEK = Mosek
 OSQP =
-PDLP = ortools
+PDLP = ortools>=9.3,<9.5
 SCIP = PySCIPOpt<4.0.0
 SCIPY = scipy
 SCS =


### PR DESCRIPTION
The code remains compatible with both 9.3 and 9.4. Also place conservative upper bounds on the supported version because the ortools API may change in any point release.

Closes #1868