### PR TITLE
Switch SCS timings to seconds

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
@@ -236,14 +236,14 @@ class SCS(ConicSolver):
         # SCS versions 1.*, SCS 2.*
         if Version(scs.__version__) < Version('3.0.0'):
             status = self.STATUS_MAP[solution["info"]["statusVal"]]
-            attr[s.SOLVE_TIME] = solution["info"]["solveTime"]
-            attr[s.SETUP_TIME] = solution["info"]["setupTime"]
+            attr[s.SOLVE_TIME] = solution["info"]["solveTime"] / 1000
+            attr[s.SETUP_TIME] = solution["info"]["setupTime"] / 1000
 
         # SCS version 3.*
         else:
             status = self.STATUS_MAP[solution["info"]["status_val"]]
-            attr[s.SOLVE_TIME] = solution["info"]["solve_time"]
-            attr[s.SETUP_TIME] = solution["info"]["setup_time"]
+            attr[s.SOLVE_TIME] = solution["info"]["solve_time"] / 1000
+            attr[s.SETUP_TIME] = solution["info"]["setup_time"] / 1000
 
         attr[s.NUM_ITERS] = solution["info"]["iter"]
         attr[s.EXTRA_STATS] = solution


### PR DESCRIPTION
## Description
Switches SCS timings from milliseconds to seconds.
Issue link (if applicable): #1878 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.