### PR TITLE
fix osqp warm start

### DIFF
--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -80,7 +80,7 @@ class OSQP(QpSolver):
                 P_triu = sp.triu(P).tocsc()
                 new_args['Px'] = P_triu.data
                 factorizing = True
-            if A.data.shape != old_data['Ax'].shape or any(
+            if A.data.shape != old_data['Ax'].data.shape or any(
                     A.data != old_data['Ax'].data):
                 new_args['Ax'] = A.data
                 factorizing = True


### PR DESCRIPTION
## Description
[Warm start example](https://www.cvxpy.org/tutorial/advanced/index.html#warm-start) with osqp is currently not working with the same speed as in the docs. The problem is the incorrect comparison of the shapes of A, which leads to a new factorization even if the problem did not change at all.

```
import cvxpy as cp
import numpy

# Problem data.
m = 2000
n = 1000
numpy.random.seed(1)
A = numpy.random.randn(m, n)
b = cp.Parameter(m)

# Construct the problem.
x = cp.Variable(n)
prob = cp.Problem(cp.Minimize(cp.sum_squares(A @ x - b)),
                   [x >= 0])

b.value = numpy.random.randn(m)
prob.solve()
print("First solve time:", prob.solver_stats.solve_time)

prob.solve(warm_start=True)
print("Second solve time:", prob.solver_stats.solve_time)

```
leads currently to
```
First solve time: 9.593317918
Second solve time: 4.873378319
```
while after this fix it is
```
First solve time: 9.829249348000001
Second solve time: 0.175010187
```

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.