### PR TITLE
[CI] Bump Ubuntu runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,13 +37,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, macos-11, windows-2019 ]
+        os: [ ubuntu-20.04, macos-11, windows-2019 ]
         python-version: [ 3.7, 3.9, "3.10" ]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             python-version: 3.8
             openmp: "True"
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             python-version: 3.8
           - os: macos-11
             python-version: 3.8
@@ -93,10 +93,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, macos-11, windows-2019 ]
+        os: [ ubuntu-20.04, macos-11, windows-2019 ]
         python-version: [ 3.7, 3.9, "3.10" ]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             python-version: 3.8
           - os: macos-11
             python-version: 3.8
@@ -159,10 +159,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, macos-11, windows-2019 ]
+        os: [ ubuntu-20.04, macos-11, windows-2019 ]
         python-version: [ 3.7, 3.9, "3.10" ]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             python-version: 3.8
             pip_intall: "True"
           - os: macos-11


### PR DESCRIPTION
## Description
> The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002

Noted by @SteveDiamond 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.