### PR TITLE
Add clarabel to cvxpy/__init__.py

### DIFF
--- a/cvxpy/__init__.py
+++ b/cvxpy/__init__.py
@@ -28,7 +28,7 @@ from cvxpy.problems.problem import Problem
 from cvxpy.transforms import linearize, partial_optimize, suppfunc
 from cvxpy.reductions import *
 from cvxpy.reductions.solvers.defines import installed_solvers
-from cvxpy.settings import (CBC, COPT, CPLEX, CVXOPT, DIFFCP, ECOS, ECOS_BB, GLPK,
+from cvxpy.settings import (CBC, CLARABEL, COPT, CPLEX, CVXOPT, DIFFCP, ECOS, ECOS_BB, GLPK,
                             GLPK_MI, GUROBI, INFEASIBLE, INFEASIBLE_INACCURATE,
                             MOSEK, NAG, PDLP, OPTIMAL, OPTIMAL_INACCURATE, OSQP,
                             ROBUST_KKTSOLVER, GLOP, SCIP, SCIPY, SCS, SDPA,

--- a/cvxpy/reductions/solvers/defines.py
+++ b/cvxpy/reductions/solvers/defines.py
@@ -76,7 +76,7 @@ SOLVER_MAP_QP = {solver.name(): solver for solver in solver_qp_intf}
 # CONIC_SOLVERS and QP_SOLVERS are sorted in order of decreasing solver
 # preference. QP_SOLVERS are those for which we have written interfaces
 # and are supported by QpSolver.
-CONIC_SOLVERS = [s.CLARABEL, s.MOSEK, s.ECOS, s.SCS, s.SDPA,
+CONIC_SOLVERS = [s.MOSEK, s.ECOS, s.CLARABEL, s.SCS, s.SDPA,
                  s.CPLEX, s.GUROBI, s.COPT, s.GLPK, s.NAG,
                  s.GLPK_MI, s.CBC, s.CVXOPT, s.XPRESS, s.DIFFCP,
                  s.SCIP, s.SCIPY, s.GLOP, s.PDLP, s.ECOS_BB]

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -404,7 +404,7 @@ class TestClarabel(BaseTest):
         self.C = cp.Variable((3, 2), name='C')
 
     def test_clarabel_lp_0(self) -> None:
-        StandardTestLPs.test_lp_0(solver='CLARABEL')
+        StandardTestLPs.test_lp_0(solver=cp.CLARABEL)
 
     def test_clarabel_lp_1(self) -> None:
         StandardTestLPs.test_lp_1(solver='CLARABEL')


### PR DESCRIPTION
## Description
Tiny follow up to #1888 , allowing the usage `cp.CLARABEL`.

Also just a small note on adding CLARABEL at index 0 of `CONIC_SOLVERS` in `solvers/defines.py`:
This implicitly makes CLARABEL (if installed) the default solver for supported problems. As soon as CLARABEL is being 
added as a dependency, this _could_ cause some regressions for users simply calling `.solve()`, which we should be aware of.

Again, many thanks to @goulart-paul for the great contribution.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.