### PR TITLE
Allow setting use_quad_obj=False for Clarabel

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
@@ -150,6 +150,11 @@ class CLARABEL(ConicSolver):
 
         settings = clarabel.DefaultSettings()
         settings.verbose = verbose
+
+        # use_quad_obj is only for canonicalization.
+        if "use_quad_obj" in opts:
+            del opts["use_quad_obj"]
+
         for opt in opts.keys():
             try:
                 settings.__setattr__(opt, opts[opt])

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -424,6 +424,9 @@ class TestClarabel(BaseTest):
     def test_clarabel_qp_0(self) -> None:
         StandardTestQPs.test_qp_0(solver='CLARABEL')
 
+    def test_clarabel_qp_0_linear_obj(self) -> None:
+        StandardTestQPs.test_qp_0(solver='CLARABEL', use_quad_obj=False)
+
     def test_clarabel_socp_0(self) -> None:
         StandardTestSOCPs.test_socp_0(solver='CLARABEL')
 


### PR DESCRIPTION
## Description
When setting `use_quad_obj=False` a `TypeError` is raised for Clarabel. 
Like in the SCS interface, we need to delete the key before parsing the options.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.