### PR TITLE
New SCIP interface

### DIFF
--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -31,7 +31,7 @@ fi
 
 # SCIP only works with scipy >= 1.5 due to dependency conflicts when installing on Linux/macOS
 if [[ "$PYTHON_VERSION" == "3.9" ]] || [[ "$RUNNER_OS" == "Windows" ]]; then
-  conda install pyscipopt  # TODO: update interface https://github.com/cvxpy/cvxpy/pull/1628
+  conda install pyscipopt
 fi
 
 # Only install Mosek if license is available (secret is not copied to forks)

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -31,7 +31,7 @@ fi
 
 # SCIP only works with scipy >= 1.5 due to dependency conflicts when installing on Linux/macOS
 if [[ "$PYTHON_VERSION" == "3.9" ]] || [[ "$RUNNER_OS" == "Windows" ]]; then
-  conda install pyscipopt"<4.0"  # TODO: update interface https://github.com/cvxpy/cvxpy/pull/1628
+  conda install pyscipopt  # TODO: update interface https://github.com/cvxpy/cvxpy/pull/1628
 fi
 
 # Only install Mosek if license is available (secret is not copied to forks)

--- a/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
@@ -267,14 +267,6 @@ class SCIP(ConicSolver):
         """Set model solve parameters."""
         from pyscipopt import SCIP_PARAMSETTING
 
-        is_mip = data[s.BOOL_IDX] or data[s.INT_IDX]
-        has_soc_constr = len(dims[s.SOC_DIM]) > 1
-        if not (is_mip or has_soc_constr):
-            # These settings are needed  to allow the dual to be calculated
-            model.setPresolve(SCIP_PARAMSETTING.OFF)
-            model.setHeuristics(SCIP_PARAMSETTING.OFF)
-            model.disablePropagation()
-
         # Set model verbosity
         hide_output = not verbose
         model.hideOutput(hide_output)
@@ -303,6 +295,14 @@ class SCIP(ConicSolver):
                         e,
                     )
                 )
+
+        is_mip = data[s.BOOL_IDX] or data[s.INT_IDX]
+        has_soc_constr = len(dims[s.SOC_DIM]) > 1
+        if not (is_mip or has_soc_constr):
+            # These settings are needed  to allow the dual to be calculated
+            model.setPresolve(SCIP_PARAMSETTING.OFF)
+            model.setHeuristics(SCIP_PARAMSETTING.OFF)
+            model.disablePropagation()
 
     def _solve(
             self,

--- a/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
@@ -315,7 +315,6 @@ class SCIP(ConicSolver):
         """Solve and return a solution if one exists."""
 
         try:
-            model.writeProblem("test.cip")
             model.optimize()
         except Exception as e:
             log.warning("Error encountered when optimising %s: %s", model, e)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1583,7 +1583,7 @@ class TestSCIP(unittest.TestCase):
         StandardTestSOCPs.test_socp_0(solver="SCIP")
 
     def test_scip_socp_1(self) -> None:
-        StandardTestSOCPs.test_socp_1(solver="SCIP", places=3, duals=False)
+        StandardTestSOCPs.test_socp_1(solver="SCIP", places=2, duals=False)
 
     def test_scip_socp_2(self) -> None:
         StandardTestSOCPs.test_socp_2(solver="SCIP", places=2, duals=False)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1609,6 +1609,12 @@ class TestSCIP(unittest.TestCase):
     def test_scip_mi_lp_5(self) -> None:
         StandardTestLPs.test_mi_lp_5(solver="SCIP")
 
+    def test_scip_mi_socp_1(self) -> None:
+        StandardTestSOCPs.test_mi_socp_1(solver="SCIP", places=3)
+
+    def test_scip_mi_socp_2(self) -> None:
+        StandardTestSOCPs.test_mi_socp_2(solver="SCIP")
+
     def get_simple_problem(self):
         """Example problem that can be used within additional tests."""
         x = cp.Variable()

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -218,9 +218,7 @@ version 9.3 or greater is required.
 Install with SCIP support
 -------------------------
 
-CVXPY supports the SCIP solver through the ``pyscipopt`` Python package;
-we do not support pyscipopt version 4.0.0 or higher; you need to use pyscipopt version 3.x.y
-for some (x,y).
+CVXPY supports the SCIP solver through the ``pyscipopt`` Python package.
 See the `PySCIPOpt <https://github.com/SCIP-Interfaces/PySCIPOpt#installation>`_ github for installation instructions.
 
 CVXPY's SCIP interface does not reliably recover dual variables for constraints. If you require dual variables for a continuous problem, you will need to use another solver. We welcome additional contributions to the SCIP interface, to recover dual variables for constraints in continuous problems.

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ HIGHS = scipy>=1.6.1
 MOSEK = Mosek
 OSQP =
 PDLP = ortools>=9.3,<9.5
-SCIP = PySCIPOpt<4.0.0
+SCIP = PySCIPOpt
 SCIPY = scipy
 SCS =
 XPRESS = xpress


### PR DESCRIPTION
## Description
This interface works with the latest pyscipopt and SCIP. It does not provide dual variables for SOCPs, only for LPs.
Issue link (if applicable): https://github.com/cvxpy/cvxpy/issues/1889

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.