### PR TITLE
Approximate canonicalization for `von_neumann_entr`

### DIFF
--- a/cvxpy/atoms/von_neumann_entr.py
+++ b/cvxpy/atoms/von_neumann_entr.py
@@ -101,7 +101,7 @@ class von_neumann_entr(Atom):
         return False
 
     def get_data(self):
-        return self.quad_approx
+        return [self.quad_approx]
 
     def _grad(self, values):
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.

--- a/cvxpy/atoms/von_neumann_entr.py
+++ b/cvxpy/atoms/von_neumann_entr.py
@@ -100,6 +100,9 @@ class von_neumann_entr(Atom):
         """
         return False
 
+    def get_data(self):
+        return self.quad_approx
+
     def _grad(self, values):
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.
 

--- a/cvxpy/atoms/von_neumann_entr.py
+++ b/cvxpy/atoms/von_neumann_entr.py
@@ -49,8 +49,9 @@ class von_neumann_entr(Atom):
         A PSD matrix
     """
 
-    def __init__(self, X) -> None:
+    def __init__(self, X, quad_approx: Tuple[int, int] = ()) -> None:
         # TODO: add a check that N is symmetric/Hermitian.
+        self.quad_approx = quad_approx
         super(von_neumann_entr, self).__init__(X)
 
     def numeric(self, values):

--- a/cvxpy/reductions/cone2cone/approximations.py
+++ b/cvxpy/reductions/cone2cone/approximations.py
@@ -167,10 +167,11 @@ def OpRelConeQuad_canon(con: OpRelConeQuad, args) -> Tuple[Constraint, List[Cons
 def von_neumann_entr_QuadApprox(expr, args):
     N, m, k = args[0], expr.quad_approx[0], expr.quad_approx[1]
     n = N.shape[0]
-    t = Variable(shape=N.shape)
+    t = Variable(shape=N.shape, symmetric=True)
     con = OpRelConeQuad(N, cp.Constant(np.eye(n)), t, m, k)
     lead_con, cons = OpRelConeQuad_canon(con, con.args)
-    return -cp.trace(con.Z), ([lead_con] + cons)
+    cons.append(lead_con)
+    return -cp.trace(con.Z), cons
 
 
 def von_neumann_entr_canon_dispatch(expr, args):

--- a/cvxpy/reductions/cone2cone/approximations.py
+++ b/cvxpy/reductions/cone2cone/approximations.py
@@ -25,6 +25,8 @@ from cvxpy.constraints.exponential import OpRelConeQuad, RelEntrQuad
 from cvxpy.constraints.zero import Zero
 from cvxpy.expressions.variable import Variable
 from cvxpy.reductions.canonicalization import Canonicalization
+from cvxpy.reductions.dcp2cone.atom_canonicalizers.von_neumann_entr_canon import (
+    von_neumann_entr_canon,)
 
 APPROX_CONES = {
     RelEntrQuad: {cp.SOC},
@@ -160,6 +162,22 @@ def OpRelConeQuad_canon(con: OpRelConeQuad, args) -> Tuple[Constraint, List[Cons
         constrs.append(cp.bmat([[Zs[k] - X - Ts[i], off_diag], [off_diag.T, X-t[i]*Ts[i]]]) >> 0)
 
     return lead_con, constrs
+
+
+def von_neumann_entr_QuadApprox(expr, args):
+    N, m, k = args[0], expr.quad_approx[0], expr.quad_approx[1]
+    n = N.shape[0]
+    t = Variable(shape=N.shape)
+    con = OpRelConeQuad(N, cp.Constant(np.eye(n)), t, m, k)
+    lead_con, cons = OpRelConeQuad_canon(con, con.args)
+    return -cp.trace(con.Z), ([lead_con] + cons)
+
+
+def von_neumann_entr_canon_dispatch(expr, args):
+    if expr.quad_approx:
+        return von_neumann_entr_QuadApprox(expr, args)
+    else:
+        return von_neumann_entr_canon(expr, args)
 
 
 class QuadApprox(Canonicalization):

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/__init__.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/__init__.py
@@ -17,6 +17,7 @@ limitations under the License.
 from cvxpy.atoms import *
 from cvxpy.atoms.affine.index import special_index
 from cvxpy.atoms.suppfunc import SuppFuncAtom
+from cvxpy.reductions.cone2cone.approximations import von_neumann_entr_canon_dispatch
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.entr_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.exp_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.geo_mean_canon import *
@@ -41,7 +42,6 @@ from cvxpy.reductions.dcp2cone.atom_canonicalizers.rel_entr_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.sigma_max_canon import *
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.suppfunc_canon import (
     suppfunc_canon,)
-from cvxpy.reductions.dcp2cone.atom_canonicalizers.von_neumann_entr_canon import von_neumann_entr_canon
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.xexp_canon import *
 from cvxpy.reductions.eliminate_pwl.atom_canonicalizers import (
     abs_canon, cummax_canon, cumsum_canon, max_canon, maximum_canon, min_canon,
@@ -86,6 +86,6 @@ CANON_METHODS = {
     SuppFuncAtom : suppfunc_canon,
     xexp : xexp_canon,
     dotsort : dotsort_canon,
-    von_neumann_entr : von_neumann_entr_canon,
+    von_neumann_entr : von_neumann_entr_canon_dispatch,
     tr_inv : tr_inv_canon,
 }

--- a/cvxpy/tests/test_von_neumann_entr.py
+++ b/cvxpy/tests/test_von_neumann_entr.py
@@ -269,7 +269,7 @@ class Test_von_neumann_entr:
         ref_X_val = ref_X.value.A
 
         expect_N = ref_X_val
-        objective = cp.Minimize(-von_neumann_entr(N, (8, 8)))
+        objective = cp.Minimize(-von_neumann_entr(N, (3, 2)))
         obj_pair = (objective, ref_obj_val)
         cons1 = trace(A1 @ N) == b[0]
         cons2 = trace(A2 @ N) == b[1]

--- a/cvxpy/tests/test_von_neumann_entr.py
+++ b/cvxpy/tests/test_von_neumann_entr.py
@@ -108,7 +108,7 @@ class Test_von_neumann_entr:
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
 
-    def make_test_3():
+    def make_test_3(quad_approx=False):
         """Expect unspecified EV to be 0.35"""
         n = 4
         N = cp.Variable(shape=(n, n), PSD=True)
@@ -136,7 +136,10 @@ class Test_von_neumann_entr:
         cons2 = N @ v2 == lambda2 * v2
         cons3 = N @ v3 == lambda3 * v3
         cons4 = trace(N) <= trMax
-        objective = cp.Maximize(von_neumann_entr(N))
+        if quad_approx:
+            objective = cp.Maximize(von_neumann_entr(N, (5, 5)))
+        else:
+            objective = cp.Maximize(von_neumann_entr(N))
         obj_pair = (objective, 1.2041518326298097)
         con_pairs = [
             (cons1, None),
@@ -157,7 +160,7 @@ class Test_von_neumann_entr:
         sth.verify_primal_values(places=3)
 
     @staticmethod
-    def make_test_4():
+    def make_test_4(quad_approx=False):
         A1 = np.array([[8.38972, 1.02671, 0.87991],
                        [1.02671, 8.41455, 7.31307],
                        [0.87991, 7.31307, 2.35915]])
@@ -181,7 +184,10 @@ class Test_von_neumann_entr:
         ref_X_val = ref_X.value.A
 
         expect_N = ref_X_val
-        objective = cp.Minimize(-von_neumann_entr(N))
+        if quad_approx:
+            objective = cp.Minimize(-von_neumann_entr(N, (5, 5)))
+        else:
+            objective = cp.Minimize(-von_neumann_entr(N))
         obj_pair = (objective, ref_obj_val)
         cons1 = trace(A1 @ N) == b[0]
         cons2 = trace(A2 @ N) == b[1]
@@ -204,89 +210,14 @@ class Test_von_neumann_entr:
         sth.verify_primal_values(places=3)
         sth.check_primal_feasibility(places=3)
 
-    @staticmethod
-    def make_test_5():
-        """Test#1 for the approximate canonicalization"""
-        n = 3
-        N = cp.Variable(shape=(n, n), PSD=True)
-        expect_N = np.array([[0.14523781, 0.02381009, 0.10238067],
-                             [0.02381009, 0.28095125, 0.13809581],
-                             [0.10238067, 0.13809581, 0.37380924]])
-        v1 = np.array([[-0.26726124],
-                       [-0.53452248],
-                       [-0.80178373]])
-        v2 = np.array([[0.87287156],
-                       [0.21821789],
-                       [-0.43643578]])
-        lambda1 = 0.5
-        lambda2 = 0.1
-        trMax = 0.8
-        cons1 = N @ v1 == lambda1 * v1
-        cons2 = N @ v2 == lambda2 * v2
-        cons3 = trace(N) <= trMax
-        objective = cp.Maximize(von_neumann_entr(N, (5, 5)))
-        obj_pair = (objective, 0.8987186478352693)
-        con_pairs = [
-            (cons1, None),
-            (cons2, None),
-            (cons3, None)
-        ]
-        var_pairs = [
-            (N, expect_N)
-        ]
-        sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
-        return sth
-
     def test_5(self):
-        sth = Test_von_neumann_entr.make_test_5()
+        sth = Test_von_neumann_entr.make_test_3(quad_approx=True)
         sth.solve(**self.SOLVE_ARGS)
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
 
-    @staticmethod
-    def make_test_6():
-        """Test#2 for the approximate canonicalization"""
-        A1 = np.array([[8.38972, 1.02671, 0.87991],
-                       [1.02671, 8.41455, 7.31307],
-                       [0.87991, 7.31307, 2.35915]])
-
-        A2 = np.array([[6.92907, 4.37713, 5.11915],
-                       [4.37713, 7.96725, 4.42217],
-                       [5.11915, 4.42217, 2.72919]])
-
-        b = np.array([19.16342, 17.62551])
-
-        N = cp.Variable(shape=(3, 3), PSD=True)
-
-        # The below problem generates the reference values:
-        ref_X = cp.Variable(shape=(3, 3), diag=True)
-        ref_objective = cp.Minimize(-cp.sum(cp.entr(cp.diag(ref_X))))
-        ref_cons1 = trace(A1 @ ref_X) == b[0]
-        ref_cons2 = trace(A2 @ ref_X) == b[1]
-        ref_cons3 = ref_X >> 0
-        ref_prob = cp.Problem(ref_objective, [ref_cons1, ref_cons2, ref_cons3])
-        ref_obj_val = ref_prob.solve()
-        ref_X_val = ref_X.value.A
-
-        expect_N = ref_X_val
-        objective = cp.Minimize(-von_neumann_entr(N, (3, 2)))
-        obj_pair = (objective, ref_obj_val)
-        cons1 = trace(A1 @ N) == b[0]
-        cons2 = trace(A2 @ N) == b[1]
-        cons3 = N - cp.diag(cp.diag(N)) == 0
-        con_pairs = [
-            (cons1, None),
-            (cons2, None),
-            (cons3, None),
-        ]
-        var_pairs = [
-            (N, expect_N)
-        ]
-        sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
-        return sth
-
     def test_6(self):
-        sth = Test_von_neumann_entr.make_test_6()
+        sth = Test_von_neumann_entr.make_test_4(quad_approx=True)
         sth.solve(**self.SOLVE_ARGS)
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)


### PR DESCRIPTION
This PR implements an alternate, approximate canonicalization pathway for the `von_neumann_entr` atom. 
I adapted the same series of semi-definite approximations that I have been implementing so far for the previous `Constraint` classes to get a representation for `von_neumann_entr`. 

The API for `von_neumann_entr` remains unchanged --- if the user wants to employ this approximate formulation in their program, then they can just pass in the usual parameters for the approximation along with the input matrix, like so: `atom=von_neumann_entr(N, (m, k))`.

Some documentation in `von_neumann_entr`'s docstring still remains, but other than that, this is mostly complete!

Thanks!