### PR TITLE
Allow lists as shapes

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -16,7 +16,7 @@ limitations under the License.
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable
 
 if TYPE_CHECKING:
     from cvxpy import Constant, Parameter, Variable
@@ -50,9 +50,9 @@ class Leaf(expression.Expression):
 
     Parameters
     ----------
-    shape : tuple or int
-        The leaf dimensions. Either an integer n for a 1D shape, or a
-        tuple where the semantics are the same as NumPy ndarray shapes.
+    shape : Iterable of ints or int
+        The leaf dimensions. Either an integer n for a 1D shape, or an
+        iterable where the semantics are the same as NumPy ndarray shapes.
         **Shapes cannot be more than 2D**.
     value : numeric type
         A value to assign to the leaf.
@@ -92,7 +92,7 @@ class Leaf(expression.Expression):
     __metaclass__ = abc.ABCMeta
 
     def __init__(
-        self, shape: int | tuple[int, ...], value=None, nonneg: bool = False,
+        self, shape: int | Iterable[int, ...], value=None, nonneg: bool = False,
         nonpos: bool = False, complex: bool = False, imag: bool = False,
         symmetric: bool = False, diag: bool = False, PSD: bool = False,
         NSD: bool = False, hermitian: bool = False,
@@ -107,7 +107,8 @@ class Leaf(expression.Expression):
         for d in shape:
             if not isinstance(d, numbers.Integral) or d <= 0:
                 raise ValueError("Invalid dimensions %s." % (shape,))
-        self._shape = tuple(np.int32(d) for d in shape)
+        shape = tuple(np.int32(d) for d in shape)
+        self._shape = shape
 
         if (PSD or NSD or symmetric or diag or hermitian) and (len(shape) != 2
                                                                or shape[0] != shape[1]):

--- a/cvxpy/expressions/variable.py
+++ b/cvxpy/expressions/variable.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Iterable
 
 import scipy.sparse as sp
 
@@ -67,7 +67,7 @@ class Variable(Leaf):
     """
 
     def __init__(
-        self, shape: int | tuple[int, ...] = (), name: str | None = None,
+        self, shape: int | Iterable[int, ...] = (), name: str | None = None,
         var_id: int | None = None, **kwargs: Any
     ):
         if var_id is None:

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -63,6 +63,9 @@ class TestExpressions(BaseTest):
         self.assertEqual(repr(self.x), "Variable((2,))")
         self.assertEqual(repr(self.A), "Variable((2, 2))")
 
+        # Test shape provided as list instead of tuple
+        self.assertEqual(cp.Variable(shape=[2], integer=True).shape, (2,))
+
         # # Scalar variable
         # coeff = self.a.coefficients()
         # self.assertEqual(coeff[self.a.id], [1])


### PR DESCRIPTION
## Description
Allow shapes to be passed as lists to be consistent with the NumPy API. 
Issue link (if applicable): #1921 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.