### PR TITLE
[Doc] Add documentation for tr_inv

### DIFF
--- a/cvxpy/atoms/tr_inv.py
+++ b/cvxpy/atoms/tr_inv.py
@@ -26,17 +26,18 @@ from cvxpy.constraints.constraint import Constraint
 
 
 class tr_inv(Atom):
-    """:math:`\\trace\\inv A, where A is positive definite`
-
+    r"""
+    :math:`\mathrm{tr}\left(X^{-1} \right),`
+    where :math:`X` is positive definite.
     """
 
-    def __init__(self, A) -> None:
-        super(tr_inv, self).__init__(A)
+    def __init__(self, X) -> None:
+        super(tr_inv, self).__init__(X)
 
     def numeric(self, values):
-        """Returns the trinv of positive definite matrix A.
+        """Returns the trinv of positive definite matrix X.
 
-        For positive definite matrix A, this is the trace of inverse of A.
+        For positive definite matrix X, this is the trace of inverse of X.
         """
         # if values[0] isn't Hermitian then return np.inf
         if (LA.norm(values[0] - values[0].T.conj()) >= 1e-8):

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/tr_inv_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/tr_inv_canon.py
@@ -26,7 +26,7 @@ def tr_inv_canon(expr, args):
     Creates the equivalent problem::
 
        maximize    sum(u[i])
-       subject to: [A ei; ei.T u[i]] is positive semidefinite
+       subject to: [X ei; ei.T u[i]] is positive semidefinite
 
        where ei is the n dimensional column vector whose i-th entry is 1 and other entries are 0
 
@@ -34,7 +34,7 @@ def tr_inv_canon(expr, args):
 
     .. math::
 
-       u[i] >= R[i][i] for all i, where R=A^-1
+       u[i] >= R[i][i] for all i, where R=X^-1
 
     Parameters
     ----------
@@ -47,15 +47,15 @@ def tr_inv_canon(expr, args):
     tuple
         (Variable for objective, list of constraints)
     """
-    A = args[0]
-    n, _ = A.shape
+    X = args[0]
+    n, _ = X.shape
     su = None
     constraints = []
     for i in range(n):
         ei = np.zeros((n, 1))
         ei[i] = 1.0
         ui = Variable((1, 1))
-        R = bmat([[A, ei],
+        R = bmat([[X, ei],
                   [ei.T, ui]])
         constraints += [R >> 0]
         if su is None:

--- a/doc/source/api_reference/cvxpy.atoms.other_atoms.rst
+++ b/doc/source/api_reference/cvxpy.atoms.other_atoms.rst
@@ -275,6 +275,13 @@ SuppFuncAtom
 
 .. autoclass:: cvxpy.atoms.suppfunc.SuppFuncAtom
 
+.. _tr_inv:
+
+tr_inv
+-------------------------------------
+
+.. autofunction:: cvxpy.atoms.tr_inv.tr_inv
+
 .. _tv:
 
 tv

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -391,6 +391,14 @@ and returns a scalar.
      - |affine| affine
      - |incr| incr.
 
+   * - :ref:`tr_inv(X) <tr_inv>`
+
+     - :math:`\mathrm{tr}\left(X^{-1} \right)`
+     - :math:`X \in\mathbf{S}^n_{++}`
+     - |positive| positive
+     - |convex| convex
+     - None
+
    * - :ref:`tv(x) <tv>`
 
      - :math:`\sum_{i}|x_{i+1} - x_i|`


### PR DESCRIPTION
## Description
Fixes #1932 

Note: I have changed the symbol of the argument from `A` to `X` to indicate that it is a variable, not a constant (more consistent with other atoms).

Docs:
![image](https://user-images.githubusercontent.com/44360364/200141545-9a023369-f221-4e1e-9415-35c9969c31fb.png)
and
![image](https://user-images.githubusercontent.com/44360364/200141562-bc6f10c3-40ad-48f5-93ae-4f2b3a5b365a.png)


## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.