### PR TITLE
Add option for skipping generation of IIS

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
@@ -308,9 +308,7 @@ class XPRESS(ConicSolver):
             if not (data[s.BOOL_IDX] or data[s.INT_IDX]):
                 results_dict['y'] = - np.array(self.prob_.getDual())
 
-        elif status == s.INFEASIBLE and \
-             'save_iis' in solver_opts and \
-             solver_opts['save_iis'] != 0:
+        elif status == s.INFEASIBLE and 'save_iis' in solver_opts and solver_opts['save_iis'] != 0:
 
             # Retrieve all IIS. For LPs there can be more than one,
             # but for QCQPs there is only support for one IIS.
@@ -343,9 +341,8 @@ class XPRESS(ConicSolver):
                                            'isolrow':  isrows,
                                            'isolcol':  icols}]
 
-            while self.prob_.iisnext() == 0 and \
-                  (solver_opts['save_iis'] < 0 or \
-                   iisIndex < solver_opts['save_iis']):
+            while self.prob_.iisnext() == 0 and (solver_opts['save_iis'] < 0 or
+                                                 iisIndex < solver_opts['save_iis']):
                 iisIndex += 1
                 self.prob_.getiisdata(iisIndex,
                                       row, col, rtype, btype, duals, rdcs, isrows, icols)

--- a/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
@@ -308,7 +308,9 @@ class XPRESS(ConicSolver):
             if not (data[s.BOOL_IDX] or data[s.INT_IDX]):
                 results_dict['y'] = - np.array(self.prob_.getDual())
 
-        elif status == s.INFEASIBLE:
+        elif status == s.INFEASIBLE and \
+             'save_iis' in solver_opts and \
+             solver_opts['save_iis'] != 0:
 
             # Retrieve all IIS. For LPs there can be more than one,
             # but for QCQPs there is only support for one IIS.
@@ -341,7 +343,9 @@ class XPRESS(ConicSolver):
                                            'isolrow':  isrows,
                                            'isolcol':  icols}]
 
-            while self.prob_.iisnext() == 0:
+            while self.prob_.iisnext() == 0 and \
+                  (solver_opts['save_iis'] < 0 or \
+                   iisIndex < solver_opts['save_iis']):
                 iisIndex += 1
                 self.prob_.getiisdata(iisIndex,
                                       row, col, rtype, btype, duals, rdcs, isrows, icols)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1515,6 +1515,34 @@ class TestXPRESS(BaseTest):
                 "lpiterlimit": 1000,  # maximum number of simplex iterations
                 "maxtime": 1000.0     # time limit
             }
+            problem.solve(solver=cp.XPRESS, **params)
+
+    def test_xpress_iis_none(self) -> None:
+        if cp.XPRESS in INSTALLED_SOLVERS:
+            A = np.array([[2, 1], [1, 2], [-3, -3]])
+            b = np.array([2, 2, -5])
+            c = np.array([1, 1])
+            x = cp.Variable(2)
+            objective = cp.Maximize(x[0] + x[1])
+            constraint = [A @ x <= b]
+            problem = cp.Problem(objective, constraint)
+
+            params = {'save_iis': 0}
+
+            problem.solve(solver=cp.XPRESS, solver_opts=params)
+
+    def test_xpress_iis_full(self) -> None:
+        if cp.XPRESS in INSTALLED_SOLVERS:
+            A = np.array([[2, 1], [1, 2], [-3, -3]])
+            b = np.array([2, 2, -5])
+            c = np.array([1, 1])
+            x = cp.Variable(2)
+            objective = cp.Maximize(x[0] + x[1])
+            constraint = [A @ x <= b]
+            problem = cp.Problem(objective, constraint)
+
+            params = {'save_iis': -1}
+
             problem.solve(solver=cp.XPRESS, solver_opts=params)
 
     def test_xpress_lp_0(self) -> None:

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1547,7 +1547,6 @@ class TestXPRESS(BaseTest):
 
             assert 'XPRESS_IIS' in problem.solution.attr
 
-            print("IIS list", problem.solution.attr['XPRESS_IIS'])
 
     def test_xpress_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='XPRESS')

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1521,29 +1521,29 @@ class TestXPRESS(BaseTest):
         if cp.XPRESS in INSTALLED_SOLVERS:
             A = np.array([[2, 1], [1, 2], [-3, -3]])
             b = np.array([2, 2, -5])
-            c = np.array([1, 1])
+
             x = cp.Variable(2)
-            objective = cp.Maximize(x[0] + x[1])
+            objective = cp.Minimize(cp.norm2(x))
             constraint = [A @ x <= b]
             problem = cp.Problem(objective, constraint)
 
             params = {'save_iis': 0}
 
-            problem.solve(solver=cp.XPRESS, solver_opts=params)
+            problem.solve(solver=cp.XPRESS, **params)
 
     def test_xpress_iis_full(self) -> None:
         if cp.XPRESS in INSTALLED_SOLVERS:
             A = np.array([[2, 1], [1, 2], [-3, -3]])
             b = np.array([2, 2, -5])
-            c = np.array([1, 1])
+
             x = cp.Variable(2)
-            objective = cp.Maximize(x[0] + x[1])
+            objective = cp.Minimize(cp.norm2(x))
             constraint = [A @ x <= b]
             problem = cp.Problem(objective, constraint)
 
             params = {'save_iis': -1}
 
-            problem.solve(solver=cp.XPRESS, solver_opts=params)
+            problem.solve(solver=cp.XPRESS, **params)
 
     def test_xpress_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='XPRESS')

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1513,7 +1513,7 @@ class TestXPRESS(BaseTest):
 
             params = {
                 "lpiterlimit": 1000,  # maximum number of simplex iterations
-                "maxtime": 1000.0     # time limit
+                "maxtime": 1000       # time limit
             }
             problem.solve(solver=cp.XPRESS, **params)
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1547,7 +1547,6 @@ class TestXPRESS(BaseTest):
 
             assert 'XPRESS_IIS' in problem.solution.attr
 
-
     def test_xpress_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='XPRESS')
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1545,6 +1545,10 @@ class TestXPRESS(BaseTest):
 
             problem.solve(solver=cp.XPRESS, **params)
 
+            assert('XPRESS_IIS' in problem.solution.attr)
+
+            print("IIS list", problem.solution.attr['XPRESS_IIS'])
+
     def test_xpress_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='XPRESS')
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1545,7 +1545,7 @@ class TestXPRESS(BaseTest):
 
             problem.solve(solver=cp.XPRESS, **params)
 
-            assert('XPRESS_IIS' in problem.solution.attr)
+            assert 'XPRESS_IIS' in problem.solution.attr
 
             print("IIS list", problem.solution.attr['XPRESS_IIS'])
 

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -1077,6 +1077,26 @@ In addition to Gurobi's parameters, the following options are available:
 
 For others see `CLARABEL documentation <https://oxfordcontrol.github.io/ClarabelDocs/stable/api_settings/>`_.
 
+
+`XPRESS`_ options:
+
+``'save_iis'``
+    Whether (and how many) Irreduceable Infeasible Subsystems
+    (IISs) should be saved in the event a problem is found to be
+    infeasible. If 0 (default), no IIS is saved; if negative, all
+    IISs are stored; if a positive ``'k>0'``, at most ``'k'`` IISs
+    are saved.
+
+``'write_mps'``
+    Filename (with extension ``'.mps'``) in which Xpress will save
+    the quadratic or conic problem.
+
+``'maxtime'``
+    Time limit in seconds (must be integer).
+
+All controls of the Xpress Optimizer can be specified within the ``'solve'``
+command. For all controls see `FICO Xpress Optimizer manual https://www.fico.com/fico-xpress-optimization/docs/dms2019-03/solver/optimizer/HTML/chapter7.html`_.
+
 Getting the standard form
 -------------------------
 


### PR DESCRIPTION
This change introduces option "save_iis" for the FICO Xpress conic solver. For infeasible problems, the user can choose if and how many IIS (Irreducible Infeasible Subsystems) should be returned together with the infeasibility result. Returning IIS is now off by default because of its performance impact.

If solver_opts['save_iis'] is positive, at most as many IISs are returned. If negative, all IIS are returned. If zero or not specified, no IIS is returned.
