### PR TITLE
Pin setuptools version to fix installation with pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,6 @@ requires = [
     "numpy>=1.21,<1.22; python_version=='3.10' and (platform_machine!='arm64' or platform_system!='Darwin')",
     "numpy>=1.21.4,<1.22; python_version=='3.10' and (platform_machine=='arm64' and platform_system=='Darwin')",
     "scipy >= 1.1.0",
-    "setuptools>=40.8.0",
+    "setuptools>=40.8.0,<=64.0.2",
     "wheel"
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ PDLP = ortools>=9.3,<9.5
 PROXQP = proxsuite
 SCIP = PySCIPOpt
 SCIPY = scipy
-SCS =
+SCS = setuptools<64.0.2
 XPRESS = xpress
 
 [flake8]

--- a/setup.py
+++ b/setup.py
@@ -231,6 +231,7 @@ setup(
         "scs >= 1.1.6",
         "numpy >= 1.15",
         "scipy >= 1.1.0",
+        "setuptools <= 64.0.2",
     ],
     setup_requires=["numpy >= 1.15"],
 )


### PR DESCRIPTION
## Description
This PR pins the setuptools version to the latest version that's used in the project's CI.
Resolves #1950 that was introduced due to https://github.com/pypa/setuptools/issues/3693


## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- ~~[ ] Add our license to new files.~~
- [x] Check that your code adheres to our coding style.
- ~~[ ] Write unittests.~~
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.

Test procedure:
- Install package from source with `python setup.py develop && pip install .`
- Run unit tests with `cd cvxpy/tests && pytest`
- Run benchmarks with ``

Test results:
- Unit tests: `852 passed, 289 skipped, 543 warnings in 41.25s`
- Benchmark: `9 passed, 3 skipped, 1 warning in 6.43s`
