### PR TITLE
Fix a typo in Dgp2Dcp example

### DIFF
--- a/cvxpy/reductions/dgp2dcp/dgp2dcp.py
+++ b/cvxpy/reductions/dgp2dcp/dgp2dcp.py
@@ -47,7 +47,7 @@ class Dgp2Dcp(Canonicalization):
     >>> dcp_problem = gp2dcp.reduce()
     >>>
     >>> assert dcp2cone.accepts(dcp_problem)
-    >>> dcp_probem.solve()
+    >>> dcp_problem.solve()
     >>>
     >>> dgp_problem.unpack(gp2dcp.retrieve(dcp_problem.solution))
     >>> print(dgp_problem.value)


### PR DESCRIPTION
## Description
Fix a typo in Dgp2Dcp example for the dcp_problem variable name.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.