### PR TITLE
Quad approx and vn entr improvements

### DIFF
--- a/cvxpy/constraints/__init__.py
+++ b/cvxpy/constraints/__init__.py
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.constraints.exponential import ExpCone, OpRelEntrConeQuad, RelEntrConeQuad
+from cvxpy.constraints.exponential import (ExpCone, OpRelEntrConeQuad,
+                                           RelEntrConeQuad,)
 from cvxpy.constraints.finite_set import FiniteSet
 from cvxpy.constraints.nonpos import Inequality, NonNeg, NonPos
 from cvxpy.constraints.power import PowCone3D, PowConeND

--- a/cvxpy/constraints/__init__.py
+++ b/cvxpy/constraints/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright 2013 Steven Diamond
+Copyright 2013 Steven Diamond, 2022 - the CVXPY Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.constraints.exponential import ExpCone, OpRelConeQuad, RelEntrQuad
+from cvxpy.constraints.exponential import ExpCone, OpRelEntrConeQuad, RelEntrConeQuad
 from cvxpy.constraints.finite_set import FiniteSet
 from cvxpy.constraints.nonpos import Inequality, NonNeg, NonPos
 from cvxpy.constraints.power import PowCone3D, PowConeND

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -24,7 +24,6 @@ from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
 from cvxpy.utilities import scopes
 
-
 Expression = TypeVar('Expression')
 
 

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -297,11 +297,12 @@ class OpRelEntrConeQuad(Constraint):
         if (not X.is_hermitian()) or (not Y.is_hermitian()) or (not Z.is_hermitian()):
             msg = ("One of the input matrices has not explicitly been declared as symmetric or"
                    "Hermitian. If the inputs are Variable objects, try declaring them with the"
-                   "symmetric=True or Hermitian=True properties. If the inputs are general Expression"
-                   "objects that are known to be symmetric or Hermitian, then you can wrap them"
-                   "with the symmetric_wrap and hermitian_wrap atoms. Failure to do one of these"
-                   "things will cause this function to impose a symmetry or conjugate-symmetry"
-                   "constraint internally, in a way that is very inefficient.")
+                   "symmetric=True or Hermitian=True properties. If the inputs are general "
+                   "Expression objects that are known to be symmetric or Hermitian, then you"
+                   "can wrap them with the symmetric_wrap and hermitian_wrap atoms. Failure to"
+                   "do one of these things will cause this function to impose a symmetry or"
+                   "conjugate-symmetry constraint internally, in a way that is very"
+                   "inefficient.")
             warnings.warn(msg)
         self.m = m
         self.k = k

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -1,6 +1,5 @@
 """
-Copyright 2013 Steven Diamond
-
+Copyright 2013 Steven Diamond, 2022 - the CVXPY Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,13 +16,16 @@ limitations under the License.
 from __future__ import annotations
 
 import warnings
-from typing import List, Tuple
+from typing import List, Tuple, TypeVar
 
 import numpy as np
 
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
 from cvxpy.utilities import scopes
+
+
+Expression = TypeVar('Expression')
 
 
 class ExpCone(Constraint):
@@ -47,15 +49,15 @@ class ExpCone(Constraint):
 
     Parameters
     ----------
-    x : Variable
+    x : Expression
         x in the exponential cone.
-    y : Variable
+    y : Expression
         y in the exponential cone.
-    z : Variable
+    z : Expression
         z in the exponential cone.
     """
 
-    def __init__(self, x, y, z, constr_id=None) -> None:
+    def __init__(self, x: Expression, y: Expression, z: Expression, constr_id=None) -> None:
         Expression = cvxtypes.expression()
         self.x = Expression.cast_to_const(x)
         self.y = Expression.cast_to_const(y)
@@ -100,8 +102,8 @@ class ExpCone(Constraint):
         """
         return self.x.size
 
-    def as_quad_approx(self, m: int, k: int) -> RelEntrQuad:
-        return RelEntrQuad(self.y, self.z, -self.x, m, k)
+    def as_quad_approx(self, m: int, k: int) -> RelEntrConeQuad:
+        return RelEntrConeQuad(self.y, self.z, -self.x, m, k)
 
     def cone_sizes(self) -> List[int]:
         """The dimensions of the exponential cones.
@@ -143,7 +145,7 @@ class ExpCone(Constraint):
         self.dual_variables[2].save_value(dv2)
 
 
-class RelEntrQuad(Constraint):
+class RelEntrConeQuad(Constraint):
     """An approximate construction of the scalar relative entropy cone
 
     Definition:
@@ -169,7 +171,8 @@ class RelEntrQuad(Constraint):
     k: Another parameter controlling the approximation
     """
 
-    def __init__(self, x, y, z, m, k, constr_id=None) -> None:
+    def __init__(self, x: Expression, y: Expression, z: Expression,
+                 m: int, k: int, constr_id=None) -> None:
         Expression = cvxtypes.expression()
         self.x = Expression.cast_to_const(x)
         self.y = Expression.cast_to_const(y)
@@ -181,14 +184,14 @@ class RelEntrQuad(Constraint):
             msg = ("All arguments must have the same shapes. Provided arguments have"
                    "shapes %s" % str((xs, ys, zs)))
             raise ValueError(msg)
-        super(RelEntrQuad, self).__init__([self.x, self.y, self.z], constr_id)
+        super(RelEntrConeQuad, self).__init__([self.x, self.y, self.z], constr_id)
 
     def get_data(self):
         return [self.m, self.k]
 
     def __str__(self) -> str:
         tup = (self.x, self.y, self.z, self.m, self.k)
-        return "RelEntrQuad(%s, %s, %s, %s, %s)" % tup
+        return "RelEntrConeQuad(%s, %s, %s, %s, %s)" % tup
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -203,7 +206,7 @@ class RelEntrQuad(Constraint):
         x = Variable(self.x.shape)
         y = Variable(self.y.shape)
         z = Variable(self.z.shape)
-        constr = [RelEntrQuad(x, y, z, self.m, self.k)]
+        constr = [RelEntrConeQuad(x, y, z, self.m, self.k)]
         obj = Minimize(norm2(hstack([x, y, z]) -
                              hstack([self.x.value, self.y.value, self.z.value])))
         problem = Problem(obj, constr)
@@ -254,7 +257,7 @@ class RelEntrQuad(Constraint):
         pass
 
 
-class OpRelConeQuad(Constraint):
+class OpRelEntrConeQuad(Constraint):
     """An approximate construction of the operator relative entropy cone
 
     Definition:
@@ -286,16 +289,20 @@ class OpRelConeQuad(Constraint):
     This approximation uses :math:`m + k` semidefinite constraints.
     """
 
-    def __init__(self, X: cvxtypes.expression(), Y: cvxtypes.expression(), Z: cvxtypes.expression(),
+    def __init__(self, X: Expression, Y: Expression, Z: Expression,
                  m: int, k: int, constr_id=None) -> None:
         Expression = cvxtypes.expression()
         self.X = Expression.cast_to_const(X)
         self.Y = Expression.cast_to_const(Y)
         self.Z = Expression.cast_to_const(Z)
-        if (not X.is_symmetric()) or (not Y.is_symmetric()) or (not Z.is_symmetric()):
-            msg = ("One of the input matrices to the program has not explicitly been declared"
-                   " to be symmetric, we recommend setting 'symmetric=True' for the same, or it"
-                   " will be done in a less efficient way internally.")
+        if (not X.is_hermitian()) or (not Y.is_hermitian()) or (not Z.is_hermitian()):
+            msg = ("One of the input matrices has not explicitly been declared as symmetric or"
+                   "Hermitian. If the inputs are Variable objects, try declaring them with the"
+                   "symmetric=True or Hermitian=True properties. If the inputs are general Expression"
+                   "objects that are known to be symmetric or Hermitian, then you can wrap them"
+                   "with the symmetric_wrap and hermitian_wrap atoms. Failure to do one of these"
+                   "things will cause this function to impose a symmetry or conjugate-symmetry"
+                   "constraint internally, in a way that is very inefficient.")
             warnings.warn(msg)
         self.m = m
         self.k = k
@@ -304,14 +311,14 @@ class OpRelConeQuad(Constraint):
             msg = ("All arguments must have the same shapes. Provided arguments have"
                    "shapes %s" % str((Xs, Ys, Zs)))
             raise ValueError(msg)
-        super(OpRelConeQuad, self).__init__([self.X, self.Y, self.Z], constr_id)
+        super(OpRelEntrConeQuad, self).__init__([self.X, self.Y, self.Z], constr_id)
 
     def get_data(self):
         return [self.m, self.k]
 
     def __str__(self) -> str:
         tup = (self.X, self.Y, self.Z, self.m, self.k)
-        return "OpRelConeQuad(%s, %s, %s, %s, %s)" % tup
+        return "OpRelEntrConeQuad(%s, %s, %s, %s, %s)" % tup
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/cvxpy/reductions/cone2cone/approximations.py
+++ b/cvxpy/reductions/cone2cone/approximations.py
@@ -132,23 +132,6 @@ def RelEntrQuad_canon(con: RelEntrConeQuad, args) -> Tuple[Constraint, List[Cons
     return lead_con, constrs
 
 
-def QuantumRelEntr_canon(expr, args):
-    X, Y, m, k = args[0], args[1], expr.quad_approx[0], expr.quad_approx[1]
-    n = X.shape[0]
-    matrix_epi = Variable(shape=(n**2, n**2), symmetric=True)
-
-    # Dop(X, Y) << matrix_epi
-    I = cp.Constant(np.eye(n))
-    con = OpRelEntrConeQuad(cp.kron(X, I), cp.kron(I, cp.conj(Y)), matrix_epi, m, k)
-    lead_con, cons = OpRelEntrConeQuad_canon(con, con.args)
-    cons.append(lead_con)
-    In = np.eye(n)
-    e = In.ravel()
-    # Next, use "e @ Dop(A, B) @ e <= e @ matrix_epi @ e"
-    scalar_epi = e @ matrix_epi @ e
-    return scalar_epi, cons
-
-
 def OpRelEntrConeQuad_canon(con: OpRelEntrConeQuad, args) -> Tuple[Constraint, List[Constraint]]:
     k, m = con.k, con.m
     X, Y = con.X, con.Y

--- a/cvxpy/reductions/cone2cone/approximations.py
+++ b/cvxpy/reductions/cone2cone/approximations.py
@@ -172,9 +172,9 @@ def OpRelEntrConeQuad_canon(con: OpRelEntrConeQuad, args) -> Tuple[Constraint, L
 
 
 def von_neumann_entr_QuadApprox(expr, args):
-    #TODO: use RelEntrConeQuad with the exponential cone representation.
-    # Much more efficient than approximating the operator relative entropy
-    # cone in full generality.
+    # TODO: use RelEntrConeQuad with the exponential cone representation.
+    #  Much more efficient than approximating the operator relative entropy
+    #  cone in full generality.
     N, m, k = args[0], expr.quad_approx[0], expr.quad_approx[1]
     n = N.shape[0]
     t = Variable(shape=N.shape, symmetric=True)

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/von_neumann_entr_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/von_neumann_entr_canon.py
@@ -18,8 +18,8 @@ from cvxpy.atoms.affine.sum import sum
 from cvxpy.constraints.nonpos import NonPos
 from cvxpy.constraints.zero import Zero
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.entr_canon import entr_canon
-from cvxpy.reductions.dcp2cone.atom_canonicalizers.lambda_sum_largest_canon import \
-    lambda_sum_largest_canon
+from cvxpy.reductions.dcp2cone.atom_canonicalizers.lambda_sum_largest_canon import (
+    lambda_sum_largest_canon,)
 
 
 def von_neumann_entr_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/von_neumann_entr_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/von_neumann_entr_canon.py
@@ -18,18 +18,18 @@ from cvxpy.atoms.affine.sum import sum
 from cvxpy.constraints.nonpos import NonPos
 from cvxpy.constraints.zero import Zero
 from cvxpy.reductions.dcp2cone.atom_canonicalizers.entr_canon import entr_canon
-from cvxpy.reductions.dcp2cone.atom_canonicalizers.lambda_sum_largest_canon import (
-    lambda_sum_largest_canon,)
+from cvxpy.reductions.dcp2cone.atom_canonicalizers.lambda_sum_largest_canon import \
+    lambda_sum_largest_canon
 
 
 def von_neumann_entr_canon(expr, args):
     N = args[0]
+    assert N.is_real()
     n = N.shape[0]
     x = Variable(shape=(n,))
     t = Variable()
 
     # START code that applies to all spectral functions #
-
     constrs = []
     for r in range(1, n):
         # lambda_sum_largest(N, r) <= sum(x[:r])

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -8,7 +8,7 @@ import numpy as np
 from cvxpy.atoms import EXP_ATOMS, NONPOS_ATOMS, PSD_ATOMS, SOC_ATOMS
 from cvxpy.constraints import (PSD, SOC, Equality, ExpCone, FiniteSet,
                                Inequality, NonNeg, NonPos, PowCone3D, Zero,)
-from cvxpy.constraints.exponential import OpRelConeQuad, RelEntrQuad
+from cvxpy.constraints.exponential import OpRelEntrConeQuad, RelEntrConeQuad
 from cvxpy.error import DCPError, DGPError, DPPError, SolverError
 from cvxpy.problems.objective import Maximize
 from cvxpy.reductions.chain import Chain
@@ -287,7 +287,7 @@ def construct_solving_chain(problem, candidates,
                 and (has_constr or not solver_instance.REQUIRES_CONSTR)):
             if ex_cos:
                 reductions.append(Exotic2Common())
-            if RelEntrQuad in approx_cos or OpRelConeQuad in approx_cos:
+            if RelEntrConeQuad in approx_cos or OpRelEntrConeQuad in approx_cos:
                 reductions.append(QuadApprox())
 
             # Should the objective be canonicalized to a quadratic?

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -596,7 +596,7 @@ class TestOpRelConeQuad(BaseTest):
     def oprelcone_1(self) -> STH.SolverTestHelper:
         """
         These tests construct two matrices that commute (imposing all eigenvectors equal)
-        and then use the fact that: T=Dop(A, B) for (A, B, T) in OpRelConeQuad i.e. T >> Dop(A, B)
+        and then use the fact that: T=Dop(A, B) for (A, B, T) in OpRelEntrConeQuad i.e. T >> Dop(A, B)
         for an objective that is an increasing function of the eigenvalues (which we here take
         to be the trace), we compute the reference objective value as tr(Dop) whose correctness
         can be seen by writing out tr(T)=tr(T-Dop)+tr(Dop), where tr(T-Dop)>=0 because of PSD-ness
@@ -615,8 +615,8 @@ class TestOpRelConeQuad(BaseTest):
         A = U @ cp.diag(a_diag) @ U.T
         B = U @ cp.diag(b_diag) @ U.T
         T = cp.Variable(shape=(n, n))
-        # constrains A,B,T \in OpRelConeQuad
-        con1 = cp.constraints.OpRelConeQuad(A, B, T, 5, 5)
+        # constrains A,B,T \in OpRelEntrConeQuad
+        con1 = cp.constraints.OpRelEntrConeQuad(A, B, T, 5, 5)
         # imposing some non-trivial constraints to ensure feasibility
         a_lower = np.cumsum(np.random.rand(n))
         a_upper = a_lower + 0.05*np.random.rand(n)
@@ -649,7 +649,7 @@ class TestOpRelConeQuad(BaseTest):
 
     def test_oprelcone_1(self):
         sth = self.oprelcone_1()
-        sth.solve(solver='SCS')
+        sth.solve(solver='CVXOPT')
         sth.verify_primal_values(places=2)
         sth.verify_objective(places=2)
 
@@ -665,8 +665,8 @@ class TestOpRelConeQuad(BaseTest):
         A = U @ cp.diag(a_diag) @ U.T
         B = U @ cp.diag(b_diag) @ U.T
         T = cp.Variable(shape=(n, n))
-        # constrains A,B,T \in OpRelConeQuad
-        con1 = cp.constraints.OpRelConeQuad(A, B, T, 8, 5)
+        # constrains A,B,T \in OpRelEntrConeQuad
+        con1 = cp.constraints.OpRelEntrConeQuad(A, B, T, 8, 5)
         # imposing some non-trivial constraints to ensure feasibility
         a_lower = np.cumsum(np.random.rand(n))
         a_upper = a_lower + 0.15*np.random.rand(n)
@@ -699,7 +699,7 @@ class TestOpRelConeQuad(BaseTest):
 
     def test_oprelcone_2(self):
         sth = self.oprelcone_2()
-        sth.solve(solver='SCS')
+        sth.solve(solver='CVXOPT')
         sth.verify_primal_values(places=2)
         sth.verify_objective(places=2)
 
@@ -707,7 +707,7 @@ class TestOpRelConeQuad(BaseTest):
         """
         This test uses the same idea from the tests with commutative matrices,
         instead, here, we make the input matrices to Dop, non-commutative,
-        the same condition as before i.e. T=Dop(A, B) for (A, B, T) in OpRelConeQuad
+        the same condition as before i.e. T=Dop(A, B) for (A, B, T) in OpRelEntrConeQuad
         (for an objective that is an increasing function of the eigenvalues) holds,
         the difference here then, is in how we compute the reference values, which
         has been done by assuming correctness of the original CVXQUAD matlab implementation
@@ -732,7 +732,7 @@ class TestOpRelConeQuad(BaseTest):
         a_upper = np.array([1.36158501, 1.61289351, 1.85065805, 3.06140939])
         b_lower = np.array([0.06858235, 0.36798274, 0.95956627, 1.16286541])
         b_upper = np.array([0.70446555, 1.16635299, 1.46126732, 1.81367755])
-        con1 = cp.constraints.OpRelConeQuad(A, B, T, m, k)
+        con1 = cp.constraints.OpRelEntrConeQuad(A, B, T, m, k)
         con2 = a_lower <= a_diag
         con3 = a_diag <= a_upper
         con4 = b_lower <= b_diag

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -596,13 +596,15 @@ class TestOpRelConeQuad(BaseTest):
     def oprelcone_1(self) -> STH.SolverTestHelper:
         """
         These tests construct two matrices that commute (imposing all eigenvectors equal)
-        and then use the fact that: T=Dop(A, B) for (A, B, T) in OpRelEntrConeQuad i.e. T >> Dop(A, B)
-        for an objective that is an increasing function of the eigenvalues (which we here take
-        to be the trace), we compute the reference objective value as tr(Dop) whose correctness
-        can be seen by writing out tr(T)=tr(T-Dop)+tr(Dop), where tr(T-Dop)>=0 because of PSD-ness
-        of (T-Dop), and at optimality we have (T-Dop)=0 (the zero matrix of corresponding size)
-        For the case that the input matrices commute, Dop takes on a particularly simplified form,
-        i.e.: U @ diag(a * log(a/b)) @ U^{-1} (which is implemented in the Dop_commute method above)
+        and then use the fact that: T=Dop(A, B) for (A, B, T) in OpRelEntrConeQuad
+        i.e. T >> Dop(A, B) for an objective that is an increasing function of the
+        eigenvalues (which we here take to be the trace), we compute the reference
+        objective value as tr(Dop) whose correctness can be seen by writing out
+        tr(T)=tr(T-Dop)+tr(Dop), where tr(T-Dop)>=0 because of PSD-ness of (T-Dop),
+        and at optimality we have (T-Dop)=0 (the zero matrix of corresponding size)
+        For the case that the input matrices commute, Dop takes on a particularly
+        simplified form, i.e.: U @ diag(a * log(a/b)) @ U^{-1} (which is implemented
+        in the Dop_commute method above)
         """
         n = 3
         # generates `n` independent, orthonormal vectors

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -647,6 +647,8 @@ class TestOpRelConeQuad(BaseTest):
         sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
         return sth
 
+    @unittest.skipUnless('CVXOPT' in cp.installed_solvers(),
+                         'SCS is too slow.')
     def test_oprelcone_1(self):
         sth = self.oprelcone_1()
         sth.solve(solver='CVXOPT')
@@ -697,6 +699,8 @@ class TestOpRelConeQuad(BaseTest):
         sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
         return sth
 
+    @unittest.skipUnless('CVXOPT' in cp.installed_solvers(),
+                         'SCS is too slow.')
     def test_oprelcone_2(self):
         sth = self.oprelcone_2()
         sth.solve(solver='CVXOPT')

--- a/cvxpy/tests/test_von_neumann_entr.py
+++ b/cvxpy/tests/test_von_neumann_entr.py
@@ -108,7 +108,7 @@ class Test_von_neumann_entr:
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
 
-    def make_test_3(quad_approx=False):
+    def make_test_3(self, quad_approx=False):
         """Expect unspecified EV to be 0.35"""
         n = 4
         N = cp.Variable(shape=(n, n), PSD=True)
@@ -154,7 +154,7 @@ class Test_von_neumann_entr:
         return sth
 
     def test_3(self):
-        sth = Test_von_neumann_entr.make_test_3()
+        sth = self.make_test_3()
         sth.solve(**self.SOLVE_ARGS)
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
@@ -211,13 +211,13 @@ class Test_von_neumann_entr:
         sth.check_primal_feasibility(places=3)
 
     def test_5(self):
-        sth = Test_von_neumann_entr.make_test_3(quad_approx=True)
+        sth = self.make_test_3(quad_approx=True)
         sth.solve(**self.SOLVE_ARGS)
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
 
     def test_6(self):
-        sth = Test_von_neumann_entr.make_test_4(quad_approx=True)
+        sth = self.make_test_4(quad_approx=True)
         sth.solve(**self.SOLVE_ARGS)
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)

--- a/doc/source/api_reference/cvxpy.constraints.rst
+++ b/doc/source/api_reference/cvxpy.constraints.rst
@@ -70,6 +70,16 @@ ExpCone
     :undoc-members:
     :show-inheritance:
 
+.. _rel_entr_cone_quad
+
+RelEntrConeQuad
+--------------------------------------
+
+.. autoclass:: cvxpy.constraints.exponential.RelEntrConeQuad
+    :members: value, is_dcp
+    :undoc-members:
+    :show-inheritance:
+
 PowCone3D
 --------------------------------------
 
@@ -94,10 +104,10 @@ FiniteSet
     :undoc-members:
     :show-inheritance:
 
-OpRelConeQuad
+OpRelEntrConeQuad
 --------------------------------------
 
-.. autoclass:: cvxpy.constraints.exponential.OpRelConeQuad
+.. autoclass:: cvxpy.constraints.exponential.OpRelEntrConeQuad
     :members: value, is_dcp
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
This renames the ``OpRelConeQuad`` and ``RelEntrQuad`` constraint classes to ``OpRelEntrConeQuad`` and ``RelEntrConeQuad``. It also introduces more informative warning messages.