### PR TITLE
Operator relative entropy and von Neumann entropy: allow Hermitian input

### DIFF
--- a/cvxpy/atoms/affine/trace.py
+++ b/cvxpy/atoms/affine/trace.py
@@ -65,6 +65,9 @@ class trace(AffAtom):
     def is_real(self) -> bool:
         return self.args[0].is_real() or self.args[0].is_hermitian()
 
+    def is_complex(self) -> bool:
+        return not self.is_real()
+
     def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """

--- a/cvxpy/atoms/affine/trace.py
+++ b/cvxpy/atoms/affine/trace.py
@@ -62,6 +62,9 @@ class trace(AffAtom):
         """
         return tuple()
 
+    def is_real(self) -> bool:
+        return self.args[0].is_real() or self.args[0].is_hermitian()
+
     def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """

--- a/cvxpy/constraints/constraint.py
+++ b/cvxpy/constraints/constraint.py
@@ -40,6 +40,8 @@ class Constraint(u.Canonical):
 
     __metaclass__ = abc.ABCMeta
 
+    REAL_DUALS_IMPLEMENTED = True
+
     def __init__(self, args, constr_id=None) -> None:
         # TODO cast constants.
         # self.args = [cvxtypes.expression().cast_to_const(arg) for arg in args]

--- a/cvxpy/constraints/constraint.py
+++ b/cvxpy/constraints/constraint.py
@@ -40,8 +40,6 @@ class Constraint(u.Canonical):
 
     __metaclass__ = abc.ABCMeta
 
-    REAL_DUALS_IMPLEMENTED = True
-
     def __init__(self, args, constr_id=None) -> None:
         # TODO cast constants.
         # self.args = [cvxtypes.expression().cast_to_const(arg) for arg in args]

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -149,10 +149,10 @@ class RelEntrConeQuad(Constraint):
 
     Definition:
     .. math::
-        K_{re}=\text{cl}\\{(x,y,\\tau)\\in\\mathbb{R}_{++}\\times
-                \\mathbb{R}_{++}\\times\\mathbb{R}_{++}\\:x\\log(x/y)\\leq\\tau\\}
+        K_{re}=\text{cl}\\{(x,y,z)\\in\\mathbb{R}_{++}\\times
+                \\mathbb{R}_{++}\\times\\mathbb{R}_{++}\\:x\\log(x/y)\\leq z\\}
 
-    Since the above definition is very similar to the ExpCone, we provide a conversion method
+    Since the above definition is very similar to the ExpCone, we provide a conversion method.
 
     More details on the approximation can be found in Theorem-3 on page-10 in the paper:
     Semidefinite Approximations of the Matrix Logarithm.
@@ -163,8 +163,8 @@ class RelEntrConeQuad(Constraint):
         x in the (approximate) scalar relative entropy cone
     y : Expression
         y in the (approximate) scalar relative entropy cone
-    $\\tau$ : Expression
-        $\\tau$ in the (approximate) scalar relative entropy cone
+    z : Expression
+        z in the (approximate) scalar relative entropy cone
     m: Parameter directly related to the number of generated nodes for the quadrature
     approximation used in the algorithm
     k: Another parameter controlling the approximation
@@ -273,8 +273,8 @@ class OpRelEntrConeQuad(Constraint):
         x in the (approximate) operator relative entropy cone
     Y : Expression
         y in the (approximate) operator relative entropy cone
-    T : Expression
-        T in the (approximate) operator relative entropy cone
+    Z : Expression
+        Z in the (approximate) operator relative entropy cone
     m: int
         Must be positive. Controls the number of quadrature nodes used in a local
         approximation of the matrix logarithm. Increasing this value results in

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -170,8 +170,6 @@ class RelEntrConeQuad(Constraint):
     k: Another parameter controlling the approximation
     """
 
-    REAL_DUALS_IMPLEMENTED = False
-
     def __init__(self, x: Expression, y: Expression, z: Expression,
                  m: int, k: int, constr_id=None) -> None:
         Expression = cvxtypes.expression()
@@ -289,8 +287,6 @@ class OpRelEntrConeQuad(Constraint):
 
     This approximation uses :math:`m + k` semidefinite constraints.
     """
-
-    REAL_DUALS_IMPLEMENTED = False
 
     def __init__(self, X: Expression, Y: Expression, Z: Expression,
                  m: int, k: int, constr_id=None) -> None:

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -170,6 +170,8 @@ class RelEntrConeQuad(Constraint):
     k: Another parameter controlling the approximation
     """
 
+    REAL_DUALS_IMPLEMENTED = False
+
     def __init__(self, x: Expression, y: Expression, z: Expression,
                  m: int, k: int, constr_id=None) -> None:
         Expression = cvxtypes.expression()
@@ -287,6 +289,8 @@ class OpRelEntrConeQuad(Constraint):
 
     This approximation uses :math:`m + k` semidefinite constraints.
     """
+
+    REAL_DUALS_IMPLEMENTED = False
 
     def __init__(self, X: Expression, Y: Expression, Z: Expression,
                  m: int, k: int, constr_id=None) -> None:

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -153,8 +153,6 @@ class PowConeND(Constraint):
     of constraint.
     """
 
-    REAL_DUALS_IMPLEMENTED = False
-
     _TOL_ = 1e-6
 
     def __init__(self, W, z, alpha, axis: int = 0, constr_id=None) -> None:

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -153,6 +153,8 @@ class PowConeND(Constraint):
     of constraint.
     """
 
+    REAL_DUALS_IMPLEMENTED = False
+
     _TOL_ = 1e-6
 
     def __init__(self, W, z, alpha, axis: int = 0, constr_id=None) -> None:

--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -21,7 +21,7 @@ import scipy.sparse as sp
 
 import cvxpy.interface as intf
 import cvxpy.lin_ops.lin_utils as lu
-import cvxpy.utilities.eigvals as eig_util
+import cvxpy.utilities.linalg as eig_util
 from cvxpy.expressions.leaf import Leaf
 from cvxpy.settings import EIGVAL_TOL
 from cvxpy.utilities import performance_utils as perf

--- a/cvxpy/reductions/complex2real/canonicalizers/__init__.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/__init__.py
@@ -17,7 +17,8 @@ limitations under the License.
 from cvxpy.atoms import (MatrixFrac, Pnorm, QuadForm, abs, bmat, conj, conv,
                          cumsum, imag, kron, lambda_max, lambda_sum_largest,
                          log_det, norm1, norm_inf, quad_over_lin, real,
-                         reshape, sigma_max, trace, upper_tri,)
+                         reshape, sigma_max, trace, upper_tri,
+                         von_neumann_entr,)
 from cvxpy.atoms.affine.add_expr import AddExpression
 from cvxpy.atoms.affine.binary_operators import (DivExpression, MulExpression,
                                                  multiply,)
@@ -48,7 +49,7 @@ from cvxpy.reductions.complex2real.canonicalizers.inequality_canon import (
 from cvxpy.reductions.complex2real.canonicalizers.matrix_canon import (
     hermitian_canon, lambda_sum_largest_canon, matrix_frac_canon,
     norm_nuc_canon, op_rel_entr_cone_canon, quad_canon, quad_over_lin_canon,
-    trace_canon,)
+    trace_canon, von_neumann_entr_canon,)
 from cvxpy.reductions.complex2real.canonicalizers.param_canon import (
     param_canon,)
 from cvxpy.reductions.complex2real.canonicalizers.pnorm_canon import (
@@ -110,5 +111,6 @@ CANON_METHODS = {
     quad_over_lin: quad_over_lin_canon,
     MatrixFrac: matrix_frac_canon,
     lambda_sum_largest: lambda_sum_largest_canon,
-    OpRelEntrConeQuad: op_rel_entr_cone_canon
+    OpRelEntrConeQuad: op_rel_entr_cone_canon,
+    von_neumann_entr: von_neumann_entr_canon,
 }

--- a/cvxpy/reductions/complex2real/canonicalizers/__init__.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/__init__.py
@@ -32,7 +32,7 @@ from cvxpy.atoms.affine.vstack import Vstack
 from cvxpy.atoms.affine.wraps import hermitian_wrap
 from cvxpy.atoms.norm_nuc import normNuc
 from cvxpy.constraints import (PSD, SOC, Equality, Inequality, NonNeg, NonPos,
-                               Zero,)
+                               OpRelEntrConeQuad, Zero,)
 from cvxpy.expressions.constants import Constant, Parameter
 from cvxpy.expressions.variable import Variable
 from cvxpy.reductions.complex2real.canonicalizers.abs_canon import abs_canon
@@ -47,7 +47,8 @@ from cvxpy.reductions.complex2real.canonicalizers.inequality_canon import (
     inequality_canon, nonneg_canon, nonpos_canon,)
 from cvxpy.reductions.complex2real.canonicalizers.matrix_canon import (
     hermitian_canon, lambda_sum_largest_canon, matrix_frac_canon,
-    norm_nuc_canon, quad_canon, quad_over_lin_canon,)
+    norm_nuc_canon, op_rel_entr_cone_canon, quad_canon, quad_over_lin_canon,
+    trace_canon,)
 from cvxpy.reductions.complex2real.canonicalizers.param_canon import (
     param_canon,)
 from cvxpy.reductions.complex2real.canonicalizers.pnorm_canon import (
@@ -69,7 +70,7 @@ CANON_METHODS = {
     Promote: separable_canon,
     reshape: separable_canon,
     Sum: separable_canon,
-    trace: separable_canon,
+    trace: trace_canon,
     transpose: separable_canon,
     NegExpression: separable_canon,
     upper_tri: separable_canon,
@@ -109,4 +110,5 @@ CANON_METHODS = {
     quad_over_lin: quad_over_lin_canon,
     MatrixFrac: matrix_frac_canon,
     lambda_sum_largest: lambda_sum_largest_canon,
+    OpRelEntrConeQuad: op_rel_entr_cone_canon
 }

--- a/cvxpy/reductions/complex2real/canonicalizers/aff_canon.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/aff_canon.py
@@ -21,7 +21,7 @@ from cvxpy.expressions.constants import Constant
 
 
 def separable_canon(expr, real_args, imag_args, real2imag):
-    """Canonicalize linear functions that are seprable
+    """Canonicalize linear functions that are separable
        in real and imaginary parts.
     """
     if all(val is None for val in imag_args):

--- a/cvxpy/reductions/complex2real/canonicalizers/matrix_canon.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/matrix_canon.py
@@ -116,8 +116,7 @@ def von_neumann_entr_canon(expr: von_neumann_entr,
     The von Neumann entropy of X is sum(entr(eigvals(X)).
     Each eigenvalue of X appears twice as an eigenvalue of the Hermitian dilation of X.
     """
-    args = expr.args
-    canon_expr = expand_and_reapply(args[0], real_args[0], imag_args[0])
+    canon_expr = expand_and_reapply(expr, real_args[0], imag_args[0])
     if imag_args[0] is not None:
         canon_expr /= 2
     return canon_expr, None

--- a/cvxpy/reductions/complex2real/complex2real.py
+++ b/cvxpy/reductions/complex2real/complex2real.py
@@ -18,7 +18,7 @@ from cvxpy import problems
 from cvxpy import settings as s
 from cvxpy.atoms.affine.upper_tri import vec_to_upper_tri
 from cvxpy.constraints import (PSD, SOC, Equality, Inequality, NonNeg, NonPos,
-                               OpRelEntrConeQuad, Zero,)
+                               OpRelEntrConeQuad, PowConeND, RelEntrConeQuad, Zero,)
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
 from cvxpy.lin_ops import lin_utils as lu
@@ -35,6 +35,9 @@ def accepts(problem) -> bool:
 
 class Complex2Real(Reduction):
     """Lifts complex numbers to a real representation."""
+
+    UNIMPLEMENTED_REAL_DUALS = (OpRelEntrConeQuad, RelEntrConeQuad, PowConeND)
+    UNIMPLEMENTED_COMPLEX_DUALS = (SOC, OpRelEntrConeQuad)
 
     def accepts(self, problem) -> None:
         accepts(problem)
@@ -59,10 +62,14 @@ class Complex2Real(Reduction):
             # created for the imaginary part.
             real_constrs, imag_constrs = self.canonicalize_tree(
                 constraint, inverse_data.real2imag, leaf_map)
-            if real_constrs is not None:
+            if isinstance(real_constrs, list):
                 constrs.extend(real_constrs)
-            if imag_constrs is not None:
+            elif isinstance(real_constrs, Constraint):
+                constrs.append(real_constrs)
+            if isinstance(imag_constrs, list):
                 constrs.extend(imag_constrs)
+            elif isinstance(imag_constrs, Constraint):
+                constrs.append(imag_constrs)
 
         new_problem = problems.problem.Problem(real_obj,
                                                constrs)
@@ -105,26 +112,24 @@ class Complex2Real(Reduction):
                 #
                 for cid, cons in inverse_data.id2cons.items():
                     if cons.is_real():
-                        if cons.REAL_DUALS_IMPLEMENTED:  # else, do nothing.
+                        if not isinstance(cons, self.UNIMPLEMENTED_REAL_DUALS):
                             dvars[cid] = solution.dual_vars[cid]
                     elif cons.is_imag():
                         imag_id = inverse_data.real2imag[cid]
                         dvars[cid] = 1j*solution.dual_vars[imag_id]
-                    # For equality and inequality constraints.
-                    elif isinstance(cons,
-                                    (Equality, Zero, Inequality,
-                                     NonNeg, NonPos)
-                                    ) and cons.is_complex():
+                    # All cases that follow are for complex-valued constraints:
+                    #   1. check inequality / equality constraints.
+                    #   2. check PSD constraints.
+                    #   3. check if a constraint is known to lack a complex dual implementation
+                    #   4. raise an error
+                    elif isinstance(cons, (Equality, Zero, Inequality, NonNeg, NonPos)):
                         imag_id = inverse_data.real2imag[cid]
                         if imag_id in solution.dual_vars:
                             dvars[cid] = solution.dual_vars[cid] + \
                                 1j*solution.dual_vars[imag_id]
                         else:
                             dvars[cid] = solution.dual_vars[cid]
-                    elif isinstance(cons, SOC) and cons.is_complex():
-                        # TODO add dual variables for complex SOC.
-                        pass
-                    elif isinstance(cons, PSD) and cons.is_complex():
+                    elif isinstance(cons, PSD):
                         # Suppose we have a constraint con_x = X >> 0 where X is Hermitian.
                         #
                         # Define the matrix
@@ -140,7 +145,7 @@ class Complex2Real(Reduction):
                         n = cons.args[0].shape[0]
                         dual = solution.dual_vars[cid]
                         dvars[cid] = dual[:n, :n] + 1j*dual[n:, :n]
-                    elif isinstance(cons, OpRelEntrConeQuad):
+                    elif isinstance(cons, self.UNIMPLEMENTED_COMPLEX_DUALS):
                         # TODO: implement dual variable recovery
                         pass
                     else:
@@ -177,12 +182,4 @@ class Complex2Real(Reduction):
         else:
             assert all(v is None for v in imag_args)
             real_out = expr.copy(real_args)
-            if isinstance(expr, Constraint):
-                real_out = [real_out]
             return real_out, None
-            # ^ The check above is mostly handled by having complex2real canonicalizers
-            # for atoms like PSD, SOC, Zero, etc.. in elim_cplx_methods
-            # which handle all real inputs. I think a change here is preferable to
-            # adding more functions in elim_cplx_methods. For one thing, I uncovered
-            # a bug that applies to ExpCone and PowCone canonicalization even though
-            # it only showed during testing with RelEntrConeQuad canonicalization.

--- a/cvxpy/reductions/complex2real/complex2real.py
+++ b/cvxpy/reductions/complex2real/complex2real.py
@@ -18,7 +18,8 @@ from cvxpy import problems
 from cvxpy import settings as s
 from cvxpy.atoms.affine.upper_tri import vec_to_upper_tri
 from cvxpy.constraints import (PSD, SOC, Equality, Inequality, NonNeg, NonPos,
-                               OpRelEntrConeQuad, PowConeND, RelEntrConeQuad, Zero,)
+                               OpRelEntrConeQuad, PowConeND, RelEntrConeQuad,
+                               Zero,)
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
 from cvxpy.lin_ops import lin_utils as lu

--- a/cvxpy/reductions/complex2real/complex2real.py
+++ b/cvxpy/reductions/complex2real/complex2real.py
@@ -18,7 +18,7 @@ from cvxpy import problems
 from cvxpy import settings as s
 from cvxpy.atoms.affine.upper_tri import vec_to_upper_tri
 from cvxpy.constraints import (PSD, SOC, Equality, Inequality, NonNeg, NonPos,
-                               Zero,)
+                               OpRelEntrConeQuad, Zero,)
 from cvxpy.expressions import cvxtypes
 from cvxpy.lin_ops import lin_utils as lu
 from cvxpy.reductions import InverseData, Solution
@@ -138,6 +138,9 @@ class Complex2Real(Reduction):
                         n = cons.args[0].shape[0]
                         dual = solution.dual_vars[cid]
                         dvars[cid] = dual[:n, :n] + 1j*dual[n:, :n]
+                    elif isinstance(cons, OpRelEntrConeQuad):
+                        # TODO: implement dual variable recovery
+                        pass
                     else:
                         raise Exception("Unknown constraint type.")
 

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -705,7 +705,7 @@ class TestOpRelConeQuad(BaseTest):
         sth.verify_objective(places=3)
         pass
 
-    def oprelcone_3(self) -> STH.SolverTestHelper:
+    def oprelcone_2(self) -> STH.SolverTestHelper:
         """
         This test uses the same idea from the tests with commutative matrices,
         instead, here, we make the input matrices to Dop, non-commutative,
@@ -744,25 +744,21 @@ class TestOpRelConeQuad(BaseTest):
                      (con3, None),
                      (con4, None),
                      (con5, None)]
-        # objective is increasing_func_lambda(T)
         obj = cp.Minimize(trace(T))
-        prob = cp.Problem(obj, [con1, con2, con3, con4, con5])
-        prob.solve()
 
-        obj_OPT = 1.85476
-
+        expect_obj = 1.85476
         expect_T = np.array([[0.49316819, 0.20845265, 0.60474713, -0.5820242],
                              [0.20845265, 0.31084053, 0.2264112, -0.8442255],
                              [0.60474713, 0.2264112, 0.4687153, -0.85667283],
                              [-0.5820242, -0.8442255, -0.85667283, 0.58206723]])
 
-        obj_pair = (obj, obj_OPT)
+        obj_pair = (obj, expect_obj)
         var_pairs = [(T, expect_T)]
         sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
         return sth
 
-    def test_oprelcone_3(self):
-        sth = self.oprelcone_3()
+    def test_oprelcone_2(self):
+        sth = self.oprelcone_2()
         sth.solve(self.solver)
         sth.verify_primal_values(places=2)
         sth.verify_objective(places=2)

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -580,10 +580,15 @@ class TestOpRelConeQuad(BaseTest):
             self.rng = np.random.default_rng(0)
         else:
             self.rng = np.random.RandomState(0)
-        self.a_lower = np.cumsum(self.rng.random(n))
-        self.a_upper = self.a_lower + 0.05*self.rng.random(n)
-        self.b_lower = np.cumsum(self.rng.random(n))
-        self.b_upper = self.b_lower + 0.05*self.rng.random(n)
+        if hasattr(self.rng, 'random'):
+            rand_gen_func = self.rng.random
+        else:
+            rand_gen_func = self.rng.random_sample
+
+        self.a_lower = np.cumsum(rand_gen_func(n))
+        self.a_upper = self.a_lower + 0.05*rand_gen_func(n)
+        self.b_lower = np.cumsum(rand_gen_func(n))
+        self.b_upper = self.b_lower + 0.05*rand_gen_func(n)
         self.base_cons = [
             self.a_lower <= self.a,
             self.a <= self.a_upper,

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -563,37 +563,61 @@ class TestRelEntrQuad(BaseTest):
         sth.verify_objective(places=2)
 
 
+def sdp_ipm_installed():
+    viable = {cp.CVXOPT, cp.MOSEK, cp.COPT}.intersection(cp.installed_solvers())
+    return len(viable) > 0
+
+
+@unittest.skipUnless(sdp_ipm_installed(),
+                     'First-order solvers are too slow for the accuracy we need.')
 class TestOpRelConeQuad(BaseTest):
 
-    @staticmethod
-    def tr_Dop_commute(a, b, U):
-        return np.trace(TestOpRelConeQuad.Dop_commute(a, b, U))
+    def setUp(self, n=3) -> None:
+        self.n = n
+        self.a = cp.Variable(shape=(n,), pos=True)
+        self.b = cp.Variable(shape=(n,), pos=True)
+        self.rng = np.random.default_rng(0)
+        self.a_lower = np.cumsum(self.rng.random(n))
+        self.a_upper = self.a_lower + 0.05*self.rng.random(n)
+        self.b_lower = np.cumsum(self.rng.random(n))
+        self.b_upper = self.b_lower + 0.05*self.rng.random(n)
+        self.base_cons = [
+            self.a_lower <= self.a,
+            self.a <= self.a_upper,
+            self.b_lower <= self.b,
+            self.b <= self.b_upper
+        ]
+        installed_solvers = cp.installed_solvers()
+        if cp.MOSEK in installed_solvers:
+            self.solver = cp.MOSEK
+        elif cp.CVXOPT in installed_solvers:
+            self.solver = cp.CVXOPT
+        elif cp.COPT in installed_solvers:
+            self.solver = cp.COPT
+        else:
+            raise RuntimeError('No viable solver installed.')
+        pass
 
     @staticmethod
-    def Dop_commute(a, b, U):
-        return U @ np.diag(a.value * np.log(a.value/b.value)) @ U.T
+    def Dop_commute(a: np.ndarray, b: np.ndarray, U: np.ndarray):
+        D = np.diag(a * np.log(a/b))
+        if np.iscomplexobj(U):
+            out = U @ D @ U.conj().T
+        else:
+            out = U @ D @ U.T
+        return out
 
     @staticmethod
-    def Dop(a, U1, B):
-        """
-        Computes Operator relative entropy of matrices A and B, where A is specified
-        in terms of its eigendecomposition, hence:
-        a: 1-D array of the eigenvalues of A
-        U1: column stacked eigenvectors of A
-        Dop is the non-commutative perspective of the negative logarithm, following is the defn.
-        of the noncommutative perspective of a function `g`:
-        $P_g(X,Y)=Y^{1/2}g(Y^{-1/2}XY^{-1/2})Y^{1/2}$
-        We reproduce the same for the negative logarithm below:
-        """
-        flank = U1 @ np.diag(a)**(0.5) @ U1.T
-        in_flank = U1 @ np.diag(a**(-0.5)) @ U1.T
-        return -(flank @ sp.linalg.logm(in_flank @ B @ in_flank) @ flank)
+    def sum_rel_entr_approx(a: cp.Expression, b: cp.Expression,
+                            apx_m: int, apx_k: int):
+        n = a.size
+        assert n == b.size
+        epi_vec = cp.Variable(shape=n)
+        con = cp.constraints.RelEntrConeQuad(a, b, epi_vec, apx_m, apx_k)
+        objective = cp.Minimize(cp.sum(epi_vec))
+        return objective, con
 
-    @staticmethod
-    def tr_Dop(a, U1, B):
-        return np.trace(TestOpRelConeQuad.Dop(a.value, U1, B.value))
-
-    def oprelcone_1(self) -> STH.SolverTestHelper:
+    def oprelcone_1(self, apx_m, apx_k, real) -> STH.SolverTestHelper:
         """
         These tests construct two matrices that commute (imposing all eigenvectors equal)
         and then use the fact that: T=Dop(A, B) for (A, B, T) in OpRelEntrConeQuad
@@ -606,108 +630,80 @@ class TestOpRelConeQuad(BaseTest):
         simplified form, i.e.: U @ diag(a * log(a/b)) @ U^{-1} (which is implemented
         in the Dop_commute method above)
         """
-        n = 3
-        # generates `n` independent, orthonormal vectors
-        U = sp.linalg.qr(np.random.randn(n, n), mode='economic')[0]
-        a_diag = cp.Variable(shape=(n,), pos=True)
-        b_diag = cp.Variable(shape=(n,), pos=True)
-        # the below constraint ensures that `A` and `B` are
-        # defined in terms of their eigendecomposition and have the same eigenvectors
-        # i.e. they commute
-        A = U @ cp.diag(a_diag) @ U.T
-        B = U @ cp.diag(b_diag) @ U.T
-        T = cp.Variable(shape=(n, n))
-        # constrains A,B,T \in OpRelEntrConeQuad
-        con1 = cp.constraints.OpRelEntrConeQuad(A, B, T, 5, 5)
-        # imposing some non-trivial constraints to ensure feasibility
-        a_lower = np.cumsum(np.random.rand(n))
-        a_upper = a_lower + 0.05*np.random.rand(n)
-        b_lower = np.cumsum(np.random.rand(n))
-        b_upper = b_lower + 0.05*np.random.rand(n)
-        con2 = a_lower <= a_diag
-        con3 = a_diag <= a_upper
-        con4 = b_lower <= b_diag
-        con5 = b_diag <= b_upper
-        con_pairs = [(con1, None),
-                     (con2, None),
-                     (con3, None),
-                     (con4, None),
-                     (con5, None)]
-        # objective is increasing_func_lambda(T)
+        # Compute the expected optimal solution
+        temp_obj, temp_con = TestOpRelConeQuad.sum_rel_entr_approx(
+            self.a, self.b, apx_m, apx_k
+        )
+        temp_constraints = [con for con in self.base_cons]
+        temp_constraints.append(temp_con)
+        temp_prob = cp.Problem(temp_obj, temp_constraints)
+        temp_prob.solve()
+        expect_a = self.a.value
+        expect_b = self.b.value
+        expect_objective = temp_obj.value
+
+        # Next: create a matrix representation of the same problem,
+        # using operator relative entropy.
+        n = self.n
+        if real:
+            randmat = self.rng.normal(size=(n, n))
+            U = sp.linalg.qr(randmat)[0]
+            A = cp.symmetric_wrap(U @ cp.diag(self.a) @ U.T)
+            B = cp.symmetric_wrap(U @ cp.diag(self.b) @ U.T)
+            T = cp.Variable(shape=(n, n), symmetric=True)
+        else:
+            randmat = 1j * self.rng.normal(size=(n, n))
+            randmat += self.rng.normal(size=(n, n))
+            U = sp.linalg.qr(randmat)[0]
+            A = cp.hermitian_wrap(U @ cp.diag(self.a) @ U.conj().T)
+            B = cp.hermitian_wrap(U @ cp.diag(self.b) @ U.conj().T)
+            T = cp.Variable(shape=(n, n), hermitian=True)
+        main_con = cp.constraints.OpRelEntrConeQuad(A, B, T, apx_m, apx_k)
         obj = cp.Minimize(trace(T))
-        prob = cp.Problem(obj, [con1, con2, con3, con4, con5])
-        prob.solve()
+        expect_T = TestOpRelConeQuad.Dop_commute(expect_a, expect_b, U)
 
-        # Generating the objective value to be compared against:
-        obj_OPT = TestOpRelConeQuad.tr_Dop_commute(a_diag, b_diag, U)
-
-        # Generating the optimal value of `T` by using the `T=Dop` at OPT condition
-        expect_T = TestOpRelConeQuad.Dop_commute(a_diag, b_diag, U)
-
-        obj_pair = (obj, obj_OPT)
+        # Define the SolverTestHelper object
+        con_pairs = [(con, None) for con in self.base_cons]
+        con_pairs.append((main_con, None))
+        obj_pair = (obj, expect_objective)
         var_pairs = [(T, expect_T)]
         sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
         return sth
 
-    @unittest.skipUnless('CVXOPT' in cp.installed_solvers(),
-                         'SCS is too slow.')
-    def test_oprelcone_1(self):
-        sth = self.oprelcone_1()
-        sth.solve(solver='CVXOPT')
-        sth.verify_primal_values(places=2)
-        sth.verify_objective(places=2)
+    def test_oprelcone_1_m1_k3_real(self):
+        sth = self.oprelcone_1(1, 3, True)
+        sth.solve(self.solver)
+        sth.verify_primal_values(places=3)
+        sth.verify_objective(places=3)
+        pass
 
-    def oprelcone_2(self) -> STH.SolverTestHelper:
-        n = 6
-        # generates `n` independent, orthonormal vectors
-        U = sp.linalg.qr(np.random.randn(n, n), mode='economic')[0]
-        a_diag = cp.Variable(shape=(n,), pos=True)
-        b_diag = cp.Variable(shape=(n,), pos=True)
-        # the below constraint ensures that `A` and `B` are
-        # defined in terms of their eigendecomposition and have the same eigenvectors
-        # i.e. they commute
-        A = U @ cp.diag(a_diag) @ U.T
-        B = U @ cp.diag(b_diag) @ U.T
-        T = cp.Variable(shape=(n, n))
-        # constrains A,B,T \in OpRelEntrConeQuad
-        con1 = cp.constraints.OpRelEntrConeQuad(A, B, T, 8, 5)
-        # imposing some non-trivial constraints to ensure feasibility
-        a_lower = np.cumsum(np.random.rand(n))
-        a_upper = a_lower + 0.15*np.random.rand(n)
-        b_lower = np.cumsum(np.random.rand(n))
-        b_upper = b_lower + 0.2*np.random.rand(n)
-        con2 = a_lower <= a_diag
-        con3 = a_diag <= a_upper
-        con4 = b_lower <= b_diag
-        con5 = b_diag <= b_upper
-        con_pairs = [(con1, None),
-                     (con2, None),
-                     (con3, None),
-                     (con4, None),
-                     (con5, None)]
-        # objective is increasing_func_lambda(T)
-        obj = cp.Minimize(trace(T))
-        prob = cp.Problem(obj, [con1, con2, con3, con4, con5])
-        prob.solve()
+    def test_oprelcone_1_m3_k1_real(self):
+        sth = self.oprelcone_1(3, 1, True)
+        sth.solve(self.solver)
+        sth.verify_primal_values(places=3)
+        sth.verify_objective(places=3)
+        pass
 
-        # Generating the objective value to be compared against:
-        obj_OPT = TestOpRelConeQuad.tr_Dop_commute(a_diag, b_diag, U)
+    def test_oprelcone_1_m4_k4_real(self):
+        sth = self.oprelcone_1(4, 4, True)
+        sth.solve(self.solver)
+        sth.verify_primal_values(places=3)
+        sth.verify_objective(places=3)
+        pass
 
-        # Generating the optimal value of `T` by using the `T=Dop` at OPT condition
-        expect_T = TestOpRelConeQuad.Dop_commute(a_diag, b_diag, U)
+    def test_oprelcone_1_m1_k3_complex(self):
+        sth = self.oprelcone_1(1, 3, False)
+        sth.solve(self.solver)
+        sth.verify_primal_values(places=3)
+        sth.verify_objective(places=3)
+        pass
 
-        obj_pair = (obj, obj_OPT)
-        var_pairs = [(T, expect_T)]
-        sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
-        return sth
-
-    @unittest.skipUnless('CVXOPT' in cp.installed_solvers(),
-                         'SCS is too slow.')
-    def test_oprelcone_2(self):
-        sth = self.oprelcone_2()
-        sth.solve(solver='CVXOPT')
-        sth.verify_primal_values(places=2)
-        sth.verify_objective(places=2)
+    def test_oprelcone_1_m3_k1_complex(self):
+        sth = self.oprelcone_1(3, 1, False)
+        sth.solve(self.solver)
+        sth.verify_primal_values(places=3)
+        sth.verify_objective(places=3)
+        pass
 
     def oprelcone_3(self) -> STH.SolverTestHelper:
         """
@@ -767,6 +763,6 @@ class TestOpRelConeQuad(BaseTest):
 
     def test_oprelcone_3(self):
         sth = self.oprelcone_3()
-        sth.solve(solver='SCS')
+        sth.solve(self.solver)
         sth.verify_primal_values(places=2)
         sth.verify_objective(places=2)

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -576,7 +576,10 @@ class TestOpRelConeQuad(BaseTest):
         self.n = n
         self.a = cp.Variable(shape=(n,), pos=True)
         self.b = cp.Variable(shape=(n,), pos=True)
-        self.rng = np.random.default_rng(0)
+        if hasattr(np.random, 'default_rng'):
+            self.rng = np.random.default_rng(0)
+        else:
+            self.rng = np.random.RandomState(0)
         self.a_lower = np.cumsum(self.rng.random(n))
         self.a_upper = self.a_lower + 0.05*self.rng.random(n)
         self.b_lower = np.cumsum(self.rng.random(n))

--- a/cvxpy/tests/test_constant_atoms.py
+++ b/cvxpy/tests/test_constant_atoms.py
@@ -57,7 +57,9 @@ def log_sum_exp_axis_1(x): return cp.log_sum_exp(x, axis=1)  # noqa E371
 
 
 # Atom, solver pairs known to fail.
-KNOWN_SOLVER_ERRORS = []
+KNOWN_SOLVER_ERRORS = [
+    (cp.xexp, cp.MOSEK)  # really, cp.xexp(cp.pos(expr)).
+]
 
 atoms_minimize = [
     (cp.abs, (2, 2), [[[-5, 2], [-3, 1]]],

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -27,7 +27,7 @@ from cvxpy.atoms.affine.add_expr import AddExpression
 from cvxpy.expressions.constants import Constant, Parameter
 from cvxpy.expressions.variable import Variable
 from cvxpy.tests.base_test import BaseTest
-from cvxpy.utilities.eigvals import gershgorin_psd_check
+from cvxpy.utilities.linalg import gershgorin_psd_check
 
 
 class TestExpressions(BaseTest):

--- a/cvxpy/tests/test_von_neumann_entr.py
+++ b/cvxpy/tests/test_von_neumann_entr.py
@@ -36,7 +36,10 @@ class Test_von_neumann_entr:
     def make_test_1(complex):
         """Expect un-specified EV to be 0.2"""
         n = 3
-        rng = np.random.default_rng(0)
+        if hasattr(np.random, 'default_rng'):
+            rng = np.random.default_rng(0)
+        else:
+            rng = np.random.RandomState(0)
         if complex:
             N = cp.Variable(shape=(n, n), hermitian=True)
             V12 = rng.normal(size=(n, n)) + 1j * rng.normal(size=(n, n))

--- a/cvxpy/tests/test_von_neumann_entr.py
+++ b/cvxpy/tests/test_von_neumann_entr.py
@@ -34,7 +34,8 @@ class Test_von_neumann_entr:
 
     @staticmethod
     def make_test_1(complex):
-        """Expect un-specified EV to be 0.2"""
+        """Enforce an upper bound of 0.8 on trace(N);
+        Expect N's unspecified eigenvalue to be 0.2"""
         n = 3
         if hasattr(np.random, 'default_rng'):
             rng = np.random.default_rng(0)
@@ -83,7 +84,8 @@ class Test_von_neumann_entr:
 
     @staticmethod
     def make_test_2(quad_approx):
-        """expect unspecified EV to be 0.4"""
+        """Enforce a lower bound of 0.9 on trace(N);
+        Expect N's unspecified eigenvalue to be 0.4"""
         n = 3
         N = cp.Variable(shape=(n, n), PSD=True)
         V12 = np.array([[-0.12309149, 0.90453403],
@@ -124,57 +126,120 @@ class Test_von_neumann_entr:
         sth.verify_primal_values(places=3)
 
     @staticmethod
-    def make_test_3(quad_approx=False):
-        A1 = np.array([[8.38972, 1.02671, 0.87991],
-                       [1.02671, 8.41455, 7.31307],
-                       [0.87991, 7.31307, 2.35915]])
+    def sum_entr_approx(a: cp.Expression, apx_m: int, apx_k: int):
+        n = a.size
+        epi_vec = cp.Variable(shape=n)
+        b = cp.Constant(np.ones(n))
+        con = cp.constraints.RelEntrConeQuad(a, b, epi_vec, apx_m, apx_k)
+        objective = cp.Minimize(cp.sum(epi_vec))
+        return objective, con
 
-        A2 = np.array([[6.92907, 4.37713, 5.11915],
-                       [4.37713, 7.96725, 4.42217],
-                       [5.11915, 4.42217, 2.72919]])
+    @staticmethod
+    def make_test_3(quad_approx=False, real=False):
+        np.random.seed(0)
+        ###################################################
+        #
+        #   Construct matrix/vector coefficient data
+        #
+        ###################################################
+        apx_m, apx_k = 2, 2
+        A1_real = np.array([[8.38972, 1.02671, 0.87991],
+                            [1.02671, 8.41455, 7.31307],
+                            [0.87991, 7.31307, 2.35915]])
 
+        A2_real = np.array([[6.92907, 4.37713, 5.11915],
+                            [4.37713, 7.96725, 4.42217],
+                            [5.11915, 4.42217, 2.72919]])
+        if real:
+            U = np.eye(3)
+            A1 = A1_real
+            A2 = A2_real
+        else:
+            randmat = 1j * np.random.normal(size=(3, 3))
+            randmat += np.random.normal(size=(3, 3))
+            U = sp.linalg.qr(randmat)[0]
+            A1 = U @ A1_real @ U.conj().T
+            A2 = U @ A2_real @ U.conj().T
         b = np.array([19.16342, 17.62551])
 
-        N = cp.Variable(shape=(3, 3), PSD=True)
-
-        # The below problem generates the reference values:
-        ref_X = cp.Variable(shape=(3, 3), diag=True)
-        ref_objective = cp.Minimize(-cp.sum(cp.entr(cp.diag(ref_X))))
-        ref_cons1 = trace(A1 @ ref_X) == b[0]
-        ref_cons2 = trace(A2 @ ref_X) == b[1]
-        ref_cons3 = ref_X >> 0
-        ref_prob = cp.Problem(ref_objective, [ref_cons1, ref_cons2, ref_cons3])
-        ref_obj_val = ref_prob.solve()
-        ref_X_val = ref_X.value.A
-
-        expect_N = ref_X_val
+        ###################################################
+        #
+        #   define and solve a reference problem
+        #
+        ###################################################
+        diag_X = cp.Variable(shape=(3,))
+        ref_X = cp.diag(diag_X)
+        if real:
+            ref_cons = [trace(A1 @ ref_X) == b[0],
+                        trace(A2 @ ref_X) == b[1]]
+        else:
+            conjugated_X = U @ ref_X @ U.conj().T
+            ref_cons = [trace(A1 @ conjugated_X) == b[0],
+                        trace(A2 @ conjugated_X) == b[1]]
         if quad_approx:
-            objective = cp.Minimize(-von_neumann_entr(N, (5, 5)))
+            ref_objective, con = Test_von_neumann_entr.sum_entr_approx(diag_X, apx_m, apx_k)
+            ref_cons.append(con)
+        else:
+            ref_objective = cp.Minimize(-cp.sum(cp.entr(diag_X)))
+        ref_prob = cp.Problem(ref_objective, ref_cons)
+        ref_obj_val = ref_prob.solve()
+
+        ###################################################
+        #
+        #   define a new problem that is equivalent to the
+        #   reference, but makes use of von_neumann_entr.
+        #
+        ###################################################
+        if real:
+            N = cp.Variable(shape=(3, 3), PSD=True)
+            cons = [trace(A1 @ N) == b[0],
+                    trace(A2 @ N) == b[1],
+                    N - cp.diag(cp.diag(N)) == 0]
+            expect_N = ref_X.value
+        else:
+            N = cp.Variable(shape=(3, 3), hermitian=True)
+            aconj_N = U.conj().T @ N @ U
+            cons = [trace(A1 @ N) == b[0],
+                    trace(A2 @ N) == b[1],
+                    aconj_N - cp.diag(cp.diag(aconj_N)) == 0]
+            expect_N = conjugated_X.value
+        if quad_approx:
+            objective = cp.Minimize(-von_neumann_entr(N, (apx_m, apx_k)))
         else:
             objective = cp.Minimize(-von_neumann_entr(N))
+
+        ###################################################
+        #
+        #   construct and return the SolverTestHelper
+        #
+        ###################################################
         obj_pair = (objective, ref_obj_val)
-        cons1 = trace(A1 @ N) == b[0]
-        cons2 = trace(A2 @ N) == b[1]
-        cons3 = N - cp.diag(cp.diag(N)) == 0
-        con_pairs = [
-            (cons1, None),
-            (cons2, None),
-            (cons3, None),
-        ]
-        var_pairs = [
-            (N, expect_N)
-        ]
+        var_pairs = [(N, expect_N)]
+        con_pairs = [(con, None) for con in cons]
         sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
         return sth
 
-    def test_3_exact(self):
-        sth = self.make_test_3(quad_approx=False)
+    def test_3_exact_real(self):
+        sth = self.make_test_3(quad_approx=False, real=True)
         sth.solve(**self.SOLVE_ARGS)
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
 
-    def test_3_approx(self):
-        sth = self.make_test_3(quad_approx=True)
+    def test_3_approx_real(self):
+        sth = self.make_test_3(quad_approx=True, real=True)
+        sth.solve(**self.SOLVE_ARGS)
+        sth.verify_objective(places=3)
+        sth.verify_primal_values(places=3)
+        sth.check_primal_feasibility(places=3)
+
+    def test_3_exact_complex(self):
+        sth = self.make_test_3(quad_approx=False, real=False)
+        sth.solve(**self.SOLVE_ARGS)
+        sth.verify_objective(places=3)
+        sth.verify_primal_values(places=3)
+
+    def test_3_approx_complex(self):
+        sth = self.make_test_3(quad_approx=True, real=False)
         sth.solve(**self.SOLVE_ARGS)
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)

--- a/cvxpy/utilities/linalg.py
+++ b/cvxpy/utilities/linalg.py
@@ -1,6 +1,37 @@
 import numpy as np
+import scipy.linalg as la
 import scipy.sparse as spar
 import scipy.sparse.linalg as sparla
+
+
+def orth(V, tol=1e-12):
+    Q, R, p = la.qr(V, mode='economic', pivoting=True)
+    # ^ V[:, p] == Q @ R.
+    rank = np.count_nonzero(np.sum(np.abs(R) > tol, axis=1))
+    Q = Q[:, :rank].reshape((V.shape[0], rank))  # ensure 2-dimensional
+    return Q
+
+
+def onb_for_orthogonal_complement(V):
+    """
+    Let U = the orthogonal complement of range(V).
+
+    This function returns an array Q whose columns are
+    an orthonormal basis for U. It requires that dim(U) > 0.
+
+    If dim(U) == 1, then Q can be returned as a vector,
+    rather than a matrix with "columns" in a formal sense.
+    """
+    n = V.shape[0]
+    Q1 = orth(V)
+    rank = Q1.shape[1]
+    assert n > rank
+    if np.iscomplexobj(V):
+        P = np.eye(n) - Q1 @ Q1.conj().T
+    else:
+        P = np.eye(n) - Q1 @ Q1.T
+    Q2 = orth(P)
+    return Q2
 
 
 def is_psd_within_tol(A, tol):

--- a/cvxpy/utilities/linalg.py
+++ b/cvxpy/utilities/linalg.py
@@ -5,6 +5,7 @@ import scipy.sparse.linalg as sparla
 
 
 def orth(V, tol=1e-12):
+    """Return a matrix whose columns are an orthonormal basis for range(V)"""
     Q, R, p = la.qr(V, mode='economic', pivoting=True)
     # ^ V[:, p] == Q @ R.
     rank = np.count_nonzero(np.sum(np.abs(R) > tol, axis=1))
@@ -18,9 +19,6 @@ def onb_for_orthogonal_complement(V):
 
     This function returns an array Q whose columns are
     an orthonormal basis for U. It requires that dim(U) > 0.
-
-    If dim(U) == 1, then Q can be returned as a vector,
-    rather than a matrix with "columns" in a formal sense.
     """
     n = V.shape[0]
     Q1 = orth(V)


### PR DESCRIPTION
@SteveDiamond @phschiele this is ready for review. Once this PR is merged we will have all the functionality I wanted ready for CVXPY 1.3. (There's still more to do, but it's reasonable to hold until CVXPY 1.4.)

### Main changes
The quadrature-based approximation of the operator relative entropy cone: ``OpRelEntrConeQuad``.
* This constraint class now accepts Hermitian input. Previously, it only accepted symmetric input.
* The ``TestOpRelConeQuad`` class  in ``tests/test_cone2cone.py`` has been rewritten.

The ``von_neumann_entr`` atom.
* This now accepts Hermitian input. Previously it only accepted symmetric input.
* The ``Test_von_neumann_entr`` class in ``tests/test_von_neumann_entr.py`` has been rewritten.
* Since its introduction into cvxpy's master branch,``von_neumann_entr``'s default canonicalization codepath has used PSD + ExpCone constraints. It also had the option of using a quadrature-based approximation technique to remove the ExpCone constraints and replace them with more PSD constraints. This reformulation was very inefficient. This PR makes it so that if the user provides approximation parameters to ``von_neumann_entr``, then the ExpCone constraints will be replaced with SOC constraints.

### Bigger incidental changes

I changed the ``canonicalize_expr()`` function in ``complex2real/complex2real.py``, see [here](https://github.com/cvxpy/cvxpy/pull/1978/files#diff-06ac9467275a4f02950ff75e8cc0f196fae9c2475e68ea88beb0b80606966a5aR180-R188). The change makes sure that any Constraint objects are wrapped by a list before being returned. Previously this hasn't been necessary because most other Constraint objects had canonicalizers in ``complex2real/canonicalizers`` that were called _even when their inputs were exclusively real-valued_. However, that existing approach has a longstanding bug where someone using ``ExpCone`` or ``PowCone3D`` _anywhere_ in a model with complex-valued expressions would result in an error.

That change isn't sufficient to address all bugs. I added a ``REAL_DUALS_IMPLEMENTED`` attribute to the ``Constraint`` class. It defaults to True, but I've set it to False in a handful of classes: ``PowConeND`` and both quadrature-based approximation cones. This change should be propagated to earlier CVXPY releases, since it amounts to a bugfix for models that use ``PowConeND` alongside complex expressions.

### Small incidental changes
* The trace atom now recognizes that the trace of a Hermitian matrix (or a real matrix) is real. Making this change involved moving the complex2real canonicalization path for trace from ``separable_canon()`` in ``complex2real/canonicalizers/aff_canon.py`` into a new ``trace_canon()`` function in ``complex2real/canonicalizers/matrix_canon.py``.
* MOSEK encounters a solver failure when testing the composite atom ``xexp(pos(expr))`` in ``test_constant_atoms.py``. I've added that atom-solver pair to the list of known solver errors, so that test won't run. It's an esoteric test, but the folks at @aszekMosek might want to investigate if the latest release of MOSEK has some numerical problems.
* I renamed the file ``utilities/eigvals.py`` to ``utilities/linalg.py``, and added some functions to the renamed file. One new function computes an orthonormal basis for the range of an input matrix. Another function computes an orthonormal basis for the orthogonal complement of the range of an input matrix.