### PR TITLE
Remove usage of deprecated np.int 

### DIFF
--- a/doc/source/examples/applications/fault_detection.rst
+++ b/doc/source/examples/applications/fault_detection.rst
@@ -106,7 +106,7 @@ That is,
     sigma = np.sqrt(p*n/(snr**2))
     A = np.random.randn(m,n)
     
-    x_true = (np.random.rand(n) <= p).astype(np.int)
+    x_true = (np.random.rand(n) <= p).astype(int)
     v = sigma*np.random.randn(m)
     
     y = A.dot(x_true) + v

--- a/examples/notebooks/WWW/fault_detection.ipynb
+++ b/examples/notebooks/WWW/fault_detection.ipynb
@@ -81,7 +81,7 @@
     "sigma = np.sqrt(p*n/(snr**2))\n",
     "A = np.random.randn(m,n)\n",
     "\n",
-    "x_true = (np.random.rand(n) <= p).astype(np.int)\n",
+    "x_true = (np.random.rand(n) <= p).astype(int)\n",
     "v = sigma*np.random.randn(m)\n",
     "\n",
     "y = A.dot(x_true) + v"


### PR DESCRIPTION
## Description
Numpy just released a new version that deprecated `np.int`. Removing two non-urgent cases in CVXPY codebase.
More urgent ecos PR is here: https://github.com/embotech/ecos-python/pull/45
Not marking this one as a bug fix, as it only affects one example

Issue link (if applicable): https://discord.com/channels/845323972962549790/845327242456203295/1054122743001526413

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.