### PR TITLE
Support for Native Quadforms (x.T @ A @ x) 

### DIFF
--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -54,7 +54,7 @@ class QuadForm(Atom):
         if self.args[1].shape[1] != n or self.args[0].shape not in [(n, 1), (n,)]:
             raise ValueError("Invalid dimensions for arguments.")
         if not self.args[1].is_hermitian():
-            raise ValueError("P must be symmetric/Hermitian.")
+            raise ValueError("Quadratic form matrices must be symmetric/Hermitian.")
 
     def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.

--- a/cvxpy/expressions/cvxtypes.py
+++ b/cvxpy/expressions/cvxtypes.py
@@ -165,3 +165,8 @@ def vec():
 def vstack():
     from cvxpy.atoms.affine import vstack
     return vstack.vstack
+
+
+def quad_form():
+    from cvxpy.atoms.quad_form import QuadForm
+    return QuadForm

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -624,10 +624,8 @@ class Expression(u.Canonical):
         if isinstance(self, cvxtypes.matmul_expr()):
             # LHS is matrix multiplication expr, so candidate for QuadForm:
             # Specifically, iff the matrix multiplication is of the form x.T @ A @ y
-            # such that x == y, A is hermitian/symmetric constant matrix and x is a variable,
-            # then it is a QuadForm.
-            if self.args[0] is other and not other.is_constant() \
-                    and self.args[1].is_hermitian() and self.args[1].is_constant():
+            # such that x == y, A is constant matrix and x is a variable, then it is a QuadForm.
+            if self.args[0] is other and not other.is_constant() and self.args[1].is_constant():
                 from cvxpy.expressions.cvxtypes import quad_form
                 return quad_form()(other, self.args[1])
 

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -620,6 +620,17 @@ class Expression(u.Canonical):
         """
         if self.shape == () or other.shape == ():
             raise ValueError("Scalar operands are not allowed, use '*' instead")
+
+        if isinstance(self, cvxtypes.matmul_expr()):
+            # LHS is matrix multiplication expr, so candidate for QuadForm:
+            # Specifically, iff the matrix multiplication is of the form x.T @ A @ y
+            # such that x == y, A is hermitian/symmetric constant matrix and x is a variable,
+            # then it is a QuadForm.
+            if self.args[0] is other and not other.is_constant() \
+                    and self.args[1].is_hermitian() and self.args[1].is_constant():
+                from cvxpy.expressions.cvxtypes import quad_form
+                return quad_form()(other, self.args[1])
+
         return cvxtypes.matmul_expr()(self, other)
 
     @_cast_other

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1401,11 +1401,16 @@ class TestExpressions(BaseTest):
         expr = x.T.__matmul__(A).__matmul__(x)
         assert isinstance(expr, cp.QuadForm)
 
-        # Not a quad_form because matrix is not symmetric
+        # Expect error for asymmetric/nonhermitian matrices
         x = Variable(shape=(2,))
-        A = Constant([[1, 0], [-1, -1]])
-        expr = x.T.__matmul__(A).__matmul__(x)
-        assert not isinstance(expr, cp.QuadForm)
+        A = Constant([[1, 0], [1, 1]])
+        with self.assertRaises(ValueError) as _:
+            x.T.__matmul__(A).__matmul__(x)
+
+        x = Variable(shape=(2,))
+        A = Constant([[1, 1j], [1j, 1]])
+        with self.assertRaises(ValueError) as _:
+            x.T.__matmul__(A).__matmul__(x)
 
         # Not a quad_form because x.T @ A @ y where x, y not necessarily equal
         x = Variable(shape=(2,))

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -24,6 +24,7 @@ import cvxpy.interface.matrix_utilities as intf
 import cvxpy.settings as s
 from cvxpy import Minimize, Problem
 from cvxpy.atoms.affine.add_expr import AddExpression
+from cvxpy.atoms.affine.wraps import psd_wrap
 from cvxpy.expressions.constants import Constant, Parameter
 from cvxpy.expressions.variable import Variable
 from cvxpy.tests.base_test import BaseTest
@@ -1338,3 +1339,88 @@ class TestExpressions(BaseTest):
 
         llcv = 1/(x*x*x + x)
         assert llcv.curvature == s.LOG_LOG_CONCAVE
+
+    def test_quad_form_matmul(self) -> None:
+        """Test conversion of native x.T @ A @ x into QuadForms.
+        """
+
+        # Trivial quad form
+        x = Variable(shape=(2,))
+        A = Constant([[1, 0], [0, -1]])
+        expr = x.T.__matmul__(A).__matmul__(x)
+        assert isinstance(expr, cp.QuadForm)
+
+        # QuadForm inside nested expr: 0.5 * (x.T @ A @ x) + x.T @ x
+        x = Variable(shape=(2,))
+        A = Constant([[1, 0], [0, -1]])
+        expr = (1 / 2) * (x.T.__matmul__(A).__matmul__(x)) + x.T.__matmul__(x)
+        assert isinstance(expr.args[0].args[1], cp.QuadForm)
+        assert expr.args[0].args[1].args[0] is x
+
+        # QuadForm inside nested expr: (0.5 * c.T @ c) * (x.T @ A @ x) + x.T @ x
+        x = Variable(shape=(2,))
+        A = Constant([[1, 0], [0, -1]])
+        c = Constant([2, -2])
+        expr = (1 / 2 * c.T.__matmul__(c)) * (x.T.__matmul__(A).__matmul__(x)) + x.T.__matmul__(x)
+        assert isinstance(expr.args[0].args[1], cp.QuadForm)
+        assert expr.args[0].args[1].args[0] is x
+
+        # QuadForm with sparse matrices
+        x = Variable(shape=(2,))
+        A = Constant(sp.eye(2))
+        expr = x.T.__matmul__(A).__matmul__(x)
+        assert isinstance(expr, cp.QuadForm)
+
+        # QuadForm with mismatched dimensions raises error
+        x = Variable(shape=(2,))
+        A = Constant(np.eye(3))
+        with self.assertRaises(Exception) as _:
+            x.T.__matmul__(A).__matmul__(x)
+
+        # QuadForm with PSD-wrapped matrix
+        x = cp.Variable(shape=(2,))
+        A = cp.Constant([[1, 0], [0, 1]])
+        expr = x.T.__matmul__(psd_wrap(A)).__matmul__(x)
+        assert isinstance(expr, cp.QuadForm)
+
+        # QuadForm with nested subexpr
+        x = cp.Variable(shape=(2,))
+        A = cp.Constant([[2, 0, 0], [0, 0, 1]])
+        M = cp.Constant([[2, 0, 0], [0, 2, 0], [0, 0, 2]])
+        b = cp.Constant([1, 2, 3])
+
+        y = A.__matmul__(x) - b
+        expr = y.T.__matmul__(M).__matmul__(y)
+        assert isinstance(expr, cp.QuadForm)
+        assert expr.args[0] is y
+        assert expr.args[1] is M
+
+        # QuadForm with parameters
+        x = Variable(shape=(2,))
+        A = Parameter(shape=(2, 2), symmetric=True)
+        expr = x.T.__matmul__(A).__matmul__(x)
+        assert isinstance(expr, cp.QuadForm)
+
+        # Not a quad_form because matrix is not symmetric
+        x = Variable(shape=(2,))
+        A = Constant([[1, 0], [-1, -1]])
+        expr = x.T.__matmul__(A).__matmul__(x)
+        assert not isinstance(expr, cp.QuadForm)
+
+        # Not a quad_form because x.T @ A @ y where x, y not necessarily equal
+        x = Variable(shape=(2,))
+        y = Variable(shape=(2,))
+        A = Constant([[1, 0], [0, -1]])
+        expr = x.T.__matmul__(A).__matmul__(y)
+        assert not isinstance(expr, cp.QuadForm)
+
+        # Not a quad_form because M is variable
+        x = Variable(shape=(2,))
+        M = Variable(shape=(2, 2))
+        expr = x.T.__matmul__(M).__matmul__(x)
+        assert not isinstance(expr, cp.QuadForm)
+
+        x = Constant([1, 0])
+        M = Variable(shape=(2, 2))
+        expr = x.T.__matmul__(M).__matmul__(x)
+        assert not isinstance(expr, cp.QuadForm)

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -118,7 +118,7 @@ class TestNonOptimal(BaseTest):
         x = cp.Variable(2)
         with self.assertRaises(Exception) as cm:
             cp.quad_form(x, P)
-        self.assertTrue("P must be symmetric/Hermitian."
+        self.assertTrue("Quadratic form matrices must be symmetric/Hermitian."
                         in str(cm.exception))
 
     def test_non_psd(self) -> None:


### PR DESCRIPTION
Hi -- small QOL upgrade for my personal cvxpy usage to automatically turn native matmul into quadratic forms where applicable. See issue #1762. When expressions are being constructed, then some MulExpression are automatically turned into a QuadForm, when certain criteria hold. 


Notes: 
1) Does not handle associativity. If we have a constant vector c, then `1/2 * c.T @ c @ x.T @ A @ x` is technically a quadratic form `(1/2 * c.T @ c) * QuadForm(x, A)`, but will not be converted in the below change. 
Reasoning here is that the expression tree leading up to the quadratic form can be arbitrarily tall and would require a search for the right-most leaf (to avoid QuadForms in cases like `1/2 * (c.T @ (c @ (d.T @ (d @ x.T)))) @ A @ y`).  However, as long as parantheses are included around `x.T @ A @ x`, the Expr will have a correct QuadForm leaf.  

2) Does not handle asymmetric/non-hermitian matrices. I noticed that the default QuadForm behavior currently is to throw an error if QuadForm(x, A) is called with A being asymmetric/nonhermitian. Could simply replace A with (A + A.H) / 2 but saw that was removed a while back. 

Let me know if these are not the desired behavior -- thanks! 


Best,
Jeffrey


## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files. (N/A) 
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.

<details>
  <summary>Benchmark Results</summary>

Without Changes: 

```
============================================================================================================================== test session starts ==============================================================================================================================
platform darwin -- Python 3.9.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/jchen/Desktop/cvxpy, configfile: pyproject.toml
plugins: dash-2.1.0, hypothesis-6.24.1, cov-3.0.0
collected 12 items                                                                                                                                                                                                                                                              

cvxpy/tests/test_benchmarks.py cone_matrix_stuffing_with_many_constraints: avg=1.159e+00 s , std=0.000e+00 s (1 iterations)
.diffcp_sdp: avg=6.678e+00 s , std=0.000e+00 s (1 iterations)
.-------------------------------------------------------------------------------
                                  Compilation                                  
-------------------------------------------------------------------------------
(CVXPY) Dec 25 01:40:42 PM: Compiling problem (target solver=ECOS).
(CVXPY) Dec 25 01:40:42 PM: Reduction chain: Dcp2Cone -> CvxAttr2Constr -> ConeMatrixStuffing -> ECOS
(CVXPY) Dec 25 01:40:42 PM: Applying reduction Dcp2Cone
(CVXPY) Dec 25 01:40:42 PM: Applying reduction CvxAttr2Constr
(CVXPY) Dec 25 01:40:42 PM: Applying reduction ConeMatrixStuffing
(CVXPY) Dec 25 01:40:43 PM: Applying reduction ECOS
(CVXPY) Dec 25 01:40:43 PM: Finished problem compilation (took 6.253e-01 seconds).
Issue #1668 regression test
Compilation time:  0.6262228488922119
.least_squares: avg=4.767e-03 s , std=0.000e+00 s (1 iterations)
.sConic canonicalization
(ECOS) solver time:  0.059706222
cvxpy time:  0.8578147779084473
Quadratic canonicalization
(OSQP) solver time:  0.02199917
cvxpy time:  0.932844112699585
.qp: avg=8.303e-03 s , std=0.000e+00 s (1 iterations)
.small_cone_matrix_stuffing: avg=4.381e-02 s , std=8.711e-03 s (10 iterations)
.small_lp: avg=1.545e-02 s , std=0.000e+00 s (1 iterations)
small_lp_second_time: avg=1.258e-03 s , std=0.000e+00 s (1 iterations)
.sstv_inpainting: avg=4.951e+00 s , std=0.000e+00 s (1 iterations)
.

=============================================================================================================================== warnings summary ================================================================================================================================
cvxpy/tests/test_benchmarks.py::TestBenchmarks::test_parameterized_qp
  /Users/jchen/Desktop/cvxpy/cvxpy/reductions/solvers/solving_chain.py:209: UserWarning: Your problem has too many parameters for efficient DPP compilation. We suggest setting 'ignore_dpp = True'.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```
  
With Changes:
```

============================================================================================================================== test session starts ==============================================================================================================================
platform darwin -- Python 3.9.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/jchen/Desktop/cvxpy, configfile: pyproject.toml
plugins: dash-2.1.0, hypothesis-6.24.1, cov-3.0.0
collected 12 items                                                                                                                                                                                                                                                              

cvxpy/tests/test_benchmarks.py cone_matrix_stuffing_with_many_constraints: avg=1.166e+00 s , std=0.000e+00 s (1 iterations)
.diffcp_sdp: avg=6.146e+00 s , std=0.000e+00 s (1 iterations)
.-------------------------------------------------------------------------------
                                  Compilation                                  
-------------------------------------------------------------------------------
(CVXPY) Dec 25 01:40:15 PM: Compiling problem (target solver=ECOS).
(CVXPY) Dec 25 01:40:15 PM: Reduction chain: Dcp2Cone -> CvxAttr2Constr -> ConeMatrixStuffing -> ECOS
(CVXPY) Dec 25 01:40:15 PM: Applying reduction Dcp2Cone
(CVXPY) Dec 25 01:40:15 PM: Applying reduction CvxAttr2Constr
(CVXPY) Dec 25 01:40:15 PM: Applying reduction ConeMatrixStuffing
(CVXPY) Dec 25 01:40:15 PM: Applying reduction ECOS
(CVXPY) Dec 25 01:40:16 PM: Finished problem compilation (took 5.758e-01 seconds).
Issue #1668 regression test
Compilation time:  0.5766229629516602
.least_squares: avg=4.683e-03 s , std=0.000e+00 s (1 iterations)
.sConic canonicalization
(ECOS) solver time:  0.0435112
cvxpy time:  0.8134698390472412
Quadratic canonicalization
(OSQP) solver time:  0.019287906
cvxpy time:  0.873811163595337
.qp: avg=7.598e-03 s , std=0.000e+00 s (1 iterations)
.small_cone_matrix_stuffing: avg=3.792e-02 s , std=8.338e-03 s (10 iterations)
.small_lp: avg=1.440e-02 s , std=0.000e+00 s (1 iterations)
small_lp_second_time: avg=1.113e-03 s , std=0.000e+00 s (1 iterations)
.sstv_inpainting: avg=3.103e+00 s , std=0.000e+00 s (1 iterations)
.

=============================================================================================================================== warnings summary ================================================================================================================================
cvxpy/tests/test_benchmarks.py::TestBenchmarks::test_parameterized_qp
  /Users/jchen/Desktop/cvxpy/cvxpy/reductions/solvers/solving_chain.py:209: UserWarning: Your problem has too many parameters for efficient DPP compilation. We suggest setting 'ignore_dpp = True'.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

</details>