### PR TITLE
Bugfixes for dual variables in Complex2Real, check for real input to certain Constraint objects

### DIFF
--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -61,13 +61,16 @@ class ExpCone(Constraint):
         self.x = Expression.cast_to_const(x)
         self.y = Expression.cast_to_const(y)
         self.z = Expression.cast_to_const(z)
+        args = [self.x, self.y, self.z]
+        for val in args:
+            if not (val.is_affine() and val.is_real()):
+                raise ValueError('All arguments must be affine and real.')
         xs, ys, zs = self.x.shape, self.y.shape, self.z.shape
         if xs != ys or xs != zs:
             msg = ("All arguments must have the same shapes. Provided arguments have"
                    "shapes %s" % str((xs, ys, zs)))
             raise ValueError(msg)
-        super(ExpCone, self).__init__([self.x, self.y, self.z],
-                                      constr_id)
+        super(ExpCone, self).__init__(args, constr_id)
 
     def __str__(self) -> str:
         return "ExpCone(%s, %s, %s)" % (self.x, self.y, self.z)
@@ -176,6 +179,10 @@ class RelEntrConeQuad(Constraint):
         self.x = Expression.cast_to_const(x)
         self.y = Expression.cast_to_const(y)
         self.z = Expression.cast_to_const(z)
+        args = [self.x, self.y, self.z]
+        for val in args:
+            if not (val.is_affine() and val.is_real()):
+                raise ValueError('All Expression arguments must be affine and real.')
         self.m = m
         self.k = k
         xs, ys, zs = self.x.shape, self.y.shape, self.z.shape

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -186,7 +186,7 @@ class RelEntrConeQuad(Constraint):
         super(RelEntrConeQuad, self).__init__([self.x, self.y, self.z], constr_id)
 
     def get_data(self):
-        return [self.m, self.k]
+        return [self.m, self.k, self.id]
 
     def __str__(self) -> str:
         tup = (self.x, self.y, self.z, self.m, self.k)
@@ -314,7 +314,7 @@ class OpRelEntrConeQuad(Constraint):
         super(OpRelEntrConeQuad, self).__init__([self.X, self.Y, self.Z], constr_id)
 
     def get_data(self):
-        return [self.m, self.k]
+        return [self.m, self.k, self.id]
 
     def __str__(self) -> str:
         tup = (self.X, self.Y, self.Z, self.m, self.k)

--- a/cvxpy/constraints/finite_set.py
+++ b/cvxpy/constraints/finite_set.py
@@ -76,7 +76,7 @@ class FiniteSet(Constraint):
         return "FiniteSet(%s, %s)" % (self.args[0], self.args[1])
 
     def get_data(self):
-        return [self._ineq_form]
+        return [self._ineq_form, self.id]
 
     def is_dcp(self, dpp: bool = False) -> bool:
         """

--- a/cvxpy/constraints/nonpos.py
+++ b/cvxpy/constraints/nonpos.py
@@ -41,6 +41,8 @@ class NonPos(Constraint):
     """
     def __init__(self, expr, constr_id=None) -> None:
         super(NonPos, self).__init__([expr], constr_id)
+        if not self.args[0].is_real():
+            raise ValueError("Input to NonPos must be real.")
 
     def name(self) -> str:
         return "%s <= 0" % self.args[0]
@@ -100,6 +102,8 @@ class NonNeg(Constraint):
     """
     def __init__(self, expr, constr_id=None) -> None:
         super(NonNeg, self).__init__([expr], constr_id)
+        if not self.args[0].is_real():
+            raise ValueError("Input to NonNeg must be real.")
 
     def name(self) -> str:
         return "0 <= %s" % self.args[0]

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -81,7 +81,7 @@ class PowCone3D(Constraint):
         return problem.solve(solver='SCS', eps=1e-8)
 
     def get_data(self):
-        return [self.alpha]
+        return [self.alpha, self.id]
 
     def is_imag(self) -> bool:
         return False
@@ -202,7 +202,7 @@ class PowConeND(Constraint):
         return False
 
     def get_data(self):
-        return [self.alpha, self.axis]
+        return [self.alpha, self.axis, self.id]
 
     @property
     def residual(self):

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -117,7 +117,7 @@ class SOC(Constraint):
         -------
         list
         """
-        return [self.axis]
+        return [self.axis, self.id]
 
     def num_cones(self):
         """The number of elementwise cones.

--- a/cvxpy/reductions/complex2real/complex2real.py
+++ b/cvxpy/reductions/complex2real/complex2real.py
@@ -37,7 +37,6 @@ def accepts(problem) -> bool:
 class Complex2Real(Reduction):
     """Lifts complex numbers to a real representation."""
 
-    UNIMPLEMENTED_REAL_DUALS = (OpRelEntrConeQuad, RelEntrConeQuad, PowConeND)
     UNIMPLEMENTED_COMPLEX_DUALS = (SOC, OpRelEntrConeQuad)
 
     def accepts(self, problem) -> None:
@@ -113,8 +112,7 @@ class Complex2Real(Reduction):
                 #
                 for cid, cons in inverse_data.id2cons.items():
                     if cons.is_real():
-                        if not isinstance(cons, self.UNIMPLEMENTED_REAL_DUALS):
-                            dvars[cid] = solution.dual_vars[cid]
+                        dvars[cid] = solution.dual_vars[cid]
                     elif cons.is_imag():
                         imag_id = inverse_data.real2imag[cid]
                         dvars[cid] = 1j*solution.dual_vars[imag_id]

--- a/cvxpy/reductions/complex2real/complex2real.py
+++ b/cvxpy/reductions/complex2real/complex2real.py
@@ -18,8 +18,7 @@ from cvxpy import problems
 from cvxpy import settings as s
 from cvxpy.atoms.affine.upper_tri import vec_to_upper_tri
 from cvxpy.constraints import (PSD, SOC, Equality, Inequality, NonNeg, NonPos,
-                               OpRelEntrConeQuad, PowConeND, RelEntrConeQuad,
-                               Zero,)
+                               OpRelEntrConeQuad, Zero,)
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
 from cvxpy.lin_ops import lin_utils as lu

--- a/cvxpy/reductions/cone2cone/exotic2common.py
+++ b/cvxpy/reductions/cone2cone/exotic2common.py
@@ -41,7 +41,7 @@ def pow_nd_canon(con, args):
     args : tuple of length two
         W,z = args[0], args[1]
     """
-    alpha, axis = con.get_data()
+    alpha, axis, _ = con.get_data()
     alpha = alpha.value
     W, z = args
     if axis == 1:

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -769,3 +769,18 @@ class TestComplex(BaseTest):
         self.assertItemsAlmostEqual(actual_dual_c[0], expect_dual_c[0], places=2)
         self.assertItemsAlmostEqual(actual_dual_c[1], expect_dual_c[1], places=2)
         pass
+
+    def test_illegal_complex_args(self) -> None:
+        x = cp.Variable(shape=(3,), complex=True)
+        with self.assertRaises(ValueError):
+            cp.ExpCone(x[0], x[1], x[2])
+        with self.assertRaises(ValueError):
+            cp.PowCone3D(x[0], x[1], x[2], [0.5])
+        with self.assertRaises(ValueError):
+            cp.PowConeND(x[0], x[:2], [0.5, 0.5])
+        with self.assertRaises(ValueError):
+            cp.RelEntrConeQuad(x[0], x[1], x[2], 1, 1)
+        with self.assertRaises(ValueError):
+            cp.NonNeg(x)
+        with self.assertRaises(ValueError):
+            cp.NonPos(x)

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -745,7 +745,6 @@ class TestComplex(BaseTest):
         #   Run tests
         #
         ####################################
-
         x = cp.Variable(shape=(3,), complex=True)
         actual_objective = cp.Minimize(cp.norm(x - u))
         coupling_con = cp.real(x) == y
@@ -753,7 +752,7 @@ class TestComplex(BaseTest):
         con_a_test = con_a.copy()
         prob_a = cp.Problem(actual_objective, [coupling_con, con_a_test])
         prob_a.solve()
-        actual_dual_a = con_a.dual_value
+        actual_dual_a = con_a_test.dual_value
         self.assertItemsAlmostEqual(actual_dual_a, expect_dual_a, places=2)
 
         con_b_test = con_b.copy()
@@ -768,7 +767,6 @@ class TestComplex(BaseTest):
         actual_dual_c = con_c_test.dual_value
         self.assertItemsAlmostEqual(actual_dual_c[0], expect_dual_c[0], places=2)
         self.assertItemsAlmostEqual(actual_dual_c[1], expect_dual_c[1], places=2)
-        pass
 
     def test_illegal_complex_args(self) -> None:
         x = cp.Variable(shape=(3,), complex=True)

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -710,3 +710,62 @@ class TestComplex(BaseTest):
 
         print(rho_ABC_val)
         assert np.allclose(rho_ABC.value, rho_ABC_val)
+
+    def test_duals(self) -> None:
+        np.random.seed(0)
+        u_real = np.random.rand(3)
+        u_imag = np.random.rand(3)
+        u = u_real + 1j * u_imag
+
+        y = cp.Variable(shape=(3,))
+        helper_objective = cp.Minimize(cp.norm(y - u_real))
+
+        ####################################
+        #
+        #   Compute reference values
+        #
+        ####################################
+        con_a = cp.PowCone3D(y[0], y[1], y[2], [0.25])
+        helper_prob_a = cp.Problem(helper_objective, [con_a])
+        helper_prob_a.solve()
+        expect_dual_a = con_a.dual_value
+
+        con_b = cp.ExpCone(y[0], y[1], y[2])
+        helper_prob_b = cp.Problem(helper_objective, [con_b])
+        helper_prob_b.solve()
+        expect_dual_b = con_b.dual_value
+
+        con_c = cp.SOC(y[2], y[:2])
+        helper_prob_c = cp.Problem(helper_objective, [con_c])
+        helper_prob_c.solve()
+        expect_dual_c = con_c.dual_value
+
+        ####################################
+        #
+        #   Run tests
+        #
+        ####################################
+
+        x = cp.Variable(shape=(3,), complex=True)
+        actual_objective = cp.Minimize(cp.norm(x - u))
+        coupling_con = cp.real(x) == y
+
+        con_a_test = con_a.copy()
+        prob_a = cp.Problem(actual_objective, [coupling_con, con_a_test])
+        prob_a.solve()
+        actual_dual_a = con_a.dual_value
+        self.assertItemsAlmostEqual(actual_dual_a, expect_dual_a, places=2)
+
+        con_b_test = con_b.copy()
+        prob_b = cp.Problem(actual_objective, [coupling_con, con_b_test])
+        prob_b.solve()
+        actual_dual_b = con_b_test.dual_value
+        self.assertItemsAlmostEqual(actual_dual_b, expect_dual_b, places=2)
+
+        con_c_test = con_c.copy()
+        prob_c = cp.Problem(actual_objective, [coupling_con, con_c_test])
+        prob_c.solve()
+        actual_dual_c = con_c_test.dual_value
+        self.assertItemsAlmostEqual(actual_dual_c[0], expect_dual_c[0], places=2)
+        self.assertItemsAlmostEqual(actual_dual_c[1], expect_dual_c[1], places=2)
+        pass

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -78,7 +78,7 @@ class TestConstraints(BaseTest):
         self.assertEqual(copy.args, constr.args)
         self.assertFalse(copy.args is constr.args)
         # Test copy with new args
-        copy = constr.copy(args=[self.A])
+        copy = constr.copy(args=[self.A, self.B])
         self.assertTrue(type(copy) is type(constr))
         self.assertTrue(copy.args[0] is self.A)
 
@@ -122,7 +122,7 @@ class TestConstraints(BaseTest):
         self.assertEqual(copy.args, constr.args)
         self.assertFalse(copy.args is constr.args)
         # Test copy with new args
-        copy = constr.copy(args=[self.A])
+        copy = constr.copy(args=[self.A, self.B])
         self.assertTrue(type(copy) is type(constr))
         self.assertTrue(copy.args[0] is self.A)
 

--- a/cvxpy/utilities/canonical.py
+++ b/cvxpy/utilities/canonical.py
@@ -92,6 +92,8 @@ class Canonical:
             return id_objects[id(self)]
         if args is None:
             args = self.args
+        else:
+            assert len(args) == len(self.args)
         data = self.get_data()
         if data is not None:
             return type(self)(*(args + data))


### PR DESCRIPTION
### Background on this PR

PR #1978 (targeting CVXPY 1.3) included bugfixes for dual variable recovery in problems with complex expressions. The fixes involved adding tuples called ``UNIMPLEMENTED_REAL_DUALS`` and ``UNIMPLEMENTED_COMPLEX_DUALS`` to the ``Complex2Real`` class. These tuples consisted of certain Constraint classes. If the type of a Constraint object belonged to one of these tuples then dual variable recovery for that Constraint would be skipped.

@SteveDiamond started the process of porting this bugfix to CVXPY 1.1 and 1.2 ([link](https://github.com/cvxpy/cvxpy/pull/1955/commits/5be035253739bf6b0a0a76a14a264e7f3831ac62#diff-06ac9467275a4f02950ff75e8cc0f196fae9c2475e68ea88beb0b80606966a5aR38-R39)). It seemed to Steven that _additional_ constraint classes were needed in these new tuples.  At Steven's suggestion I ran some tests and found that the code introduced in PR #1978 could still break. 

This led me to look into this in more detail. The result of my investigation is that changes are needed on both master (for CVXPY 1.3) as well as CVXPY 1.1 and 1.2. This PR is targeting master.

### Changes in this PR

The main change in this PR is to go through all the Constraint classes and make sure that the list returned by ``constr.get_data()`` satisfies ``constr.get_data()[-1] == constr.id``. This has long been the default behavior for the Constraint class, but it was "lost" in subclasses that overrode the ``get_data`` function. Such classes included ExpCone, PowCone3D, PowConeND, SOC, and the quadrature-based approximate cones (to appear in 1.3). After making this change it was possible for me to get rid of the ``UNIMPLEMENTED_REAL_DUALS`` tuple introduced in PR #1978.

Note: the change to the SOC class wasn't strictly necessary, since SOC has a dedicated complex2real canonicalizer that copies the constraint ID ([see here](https://github.com/cvxpy/cvxpy/blob/1c94aad38d961c754c7c097f66d60f7a62fe10ea/cvxpy/reductions/complex2real/canonicalizers/soc_canon.py#L22)). No change was needed to PSD because the PSD class did not override ``Constraint.get_data()``.

I also added input checks for real data to several Constraint classes. This is necessary for CVXPY 1.3 since all Constraint classes are now being exposed in CVXPY's top-level namespace.

### Are these changes really necessary?

This PR includes two new unittests in ``test_complex.py``. These tests will fail if run on master or if run on Steven's pending PR for 1.1 and 1.2 (including if you modify to account for different import structures in these branches). The tests will also fail before either my fix or Steven's version, when the repo was at [this state](https://github.com/cvxpy/cvxpy/tree/f216089ef53a8496b18643211997e00a83cef9d3).