### PR TITLE
Add jquery back to sphinx build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install -e .
-          python -m pip install sphinx
+          python -m pip install sphinx sphinxcontrib-jquery
           cd doc
           make html
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -21,7 +21,6 @@ import sys
 sys.path.insert(0, os.path.abspath('../..'))
 # To import sphinx extensions we've put in the repository:
 sys.path.insert(0, os.path.abspath('../sphinxext'))
-sys.path.append('/home/docs/checkouts/readthedocs.org/user_builds/cvxpy/checkouts/1.0/cvxpy')
 
 import cvxpy
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -33,13 +33,16 @@ __version__ = cvxpy.__version__
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.doctest',
-              'sphinx.ext.todo',
-              'sphinx.ext.coverage',
-              'sphinx.ext.mathjax',
-              'sphinx.ext.viewcode',
-              'sphinx.ext.napoleon']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.todo',
+    'sphinx.ext.coverage',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
+    'sphinxcontrib.jquery',
+]
 
 # To suppress autodoc/numpydoc warning.
 # http://stackoverflow.com/questions/12206334/sphinx-autosummary-toctree-contains-reference-to-nonexisting-document-warnings

--- a/doc/source/related_projects/index.rst
+++ b/doc/source/related_projects/index.rst
@@ -9,6 +9,10 @@ We list here the optimization packages most relevant to CVXPY users.
 Modeling frameworks
 -------------------
 
+- `CVXPYgen <https://github.com/cvxgrp/cvxpygen>`_ is a library that takes a convex optimization problem family modeled with CVXPY and generates a custom solver implementation in C.
+
+- `cvxpylayers <https://github.com/cvxgrp/cvxpylayers/>`_ is a library that converts CVXPY problems into differentiable PyTorch and TensorFlow 2.0 layers.
+
 - `DCCP <https://github.com/cvxgrp/dccp>`_ is a CVXPY extension for modeling and solving difference of convex problems.
 
 - `DMCP <https://github.com/cvxgrp/dmcp>`_ is a CVXPY extension for modeling and solving multi-convex problems.
@@ -16,8 +20,6 @@ Modeling frameworks
 - `NCVX <https://github.com/cvxgrp/ncvx>`_ is a CVXPY extension for modeling and solving problems with convex objectives and decision variables from a nonconvex set.
 
 - `osmm <https://github.com/cvxgrp/osmm>`_ is a Python package for optimization problems that arise in stochastic optimization, which is built on PyTorch and CVXPY.
-
-- `cvxpylayers <https://github.com/cvxgrp/cvxpylayers/>`_ is a library that converts CVXPY problems into differentiable PyTorch and TensorFlow 2.0 layers.
 
 - `SnapVX <http://snap.stanford.edu/snapvx/>`_ is a Python-based convex optimization solver for problems defined on graphs.
 


### PR DESCRIPTION
## Description
Sphinx recently stopped automatically including jQuery, which is required by our site for the version selector. This PR adds jQuery back to the build.

https://www.sphinx-doc.org/en/master/changes.html

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.