### PR TITLE
Fixes for 1.3.0

### DIFF
--- a/cvxpy/atoms/affine/sum.py
+++ b/cvxpy/atoms/affine/sum.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import builtins
 from functools import wraps
 from typing import List, Optional, Tuple
 
@@ -109,6 +110,6 @@ def sum(expr, axis: Optional[int] = None, keepdims: bool = False):
     """Wrapper for Sum class.
     """
     if isinstance(expr, list):
-        return __builtins__['sum'](expr)
+        return builtins.sum(expr)
     else:
         return Sum(expr, axis, keepdims)

--- a/cvxpy/tests/test_perspective.py
+++ b/cvxpy/tests/test_perspective.py
@@ -18,9 +18,8 @@ import numpy as np
 import pytest
 
 import cvxpy as cp
+from cvxpy.atoms.perspective import perspective
 from cvxpy.constraints.exponential import ExpCone
-
-from ..atoms.perspective import perspective
 
 
 def test_monotonicity():


### PR DESCRIPTION
Same fix for PyPy as in #1208; also remove a relative import that makes the test suite fail to run against an out-of-tree `cvxpy`.

From https://github.com/conda-forge/cvxpy-feedstock/pull/75