### PR TITLE
[CI] Build wheels on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,17 +5,17 @@ on:
     push:
         branches:
             - master
+            - 'release/**'
         tags:
           - '*'
 
+# https://docs.github.com/en/enterprise-cloud@latest/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+# Only cancels-in-progress on PRs (head_ref only defined in PR, fallback run_id always unique)
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
-  cleanup-runs:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: rokroskar/workflow-run-cleanup-action@master
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
 
   linters:
     runs-on: ubuntu-latest
@@ -125,7 +125,7 @@ jobs:
           echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
 
       - name: Build wheels
-        if: ${{env.DEPLOY == 'True' && env.USE_OPENMP != 'True'}}
+        if: ${{github.event_name == 'push' && env.USE_OPENMP != 'True'}}
         env:
           CIBW_BUILD: "cp3${{env.PYTHON_SUBVERSION}}-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
@@ -133,20 +133,25 @@ jobs:
         uses: joerick/cibuildwheel@v2.11.2
 
       - name: Build source
-        if: ${{env.DEPLOY == 'True' && env.SINGLE_ACTION_CONFIG == 'True'}}
+        if: ${{github.event_name == 'push' && env.SINGLE_ACTION_CONFIG == 'True'}}
         run: |
           python setup.py sdist --dist-dir=wheelhouse
 
-      - name: Release to pypi
-        if: ${{env.DEPLOY == 'True' &&  env.USE_OPENMP != 'True'}}
+      - name: Check wheels
+        if: ${{github.event_name == 'push' &&  env.USE_OPENMP != 'True'}}
         shell: bash
         run: |
           python -m pip install --upgrade twine
           twine check wheelhouse/*
+
+      - name:  Release to pypi
+        if: ${{env.DEPLOY == 'True' &&  env.USE_OPENMP != 'True'}}
+        shell: bash
+        run: |
           twine upload --skip-existing --repository-url $PYPI_SERVER wheelhouse/* -u $PYPI_USER -p $PYPI_PASSWORD
 
       - name: Upload artifacts to github
-        if: ${{env.DEPLOY == 'True' && env.USE_OPENMP != 'True'}}
+        if: ${{github.event_name == 'push' && env.USE_OPENMP != 'True'}}
         uses: actions/upload-artifact@v1
         with:
           name: wheels
@@ -209,7 +214,7 @@ jobs:
           pytest cvxpy/tests/test_conic_solvers.py -k 'TestCPLEX'
 
       - name: Build wheels
-        if: ${{env.DEPLOY == 'True'}}
+        if: ${{github.event_name == 'push'}}
         env:
           CIBW_BUILD: "cp3${{env.PYTHON_SUBVERSION}}-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
@@ -217,20 +222,25 @@ jobs:
         uses: joerick/cibuildwheel@v2.11.2
 
       - name: Build source
-        if: ${{env.DEPLOY == 'True' && env.SINGLE_ACTION_CONFIG == 'True'}}
+        if: ${{github.event_name == 'push' && env.SINGLE_ACTION_CONFIG == 'True'}}
         run: |
           python setup.py sdist --dist-dir=wheelhouse
+
+      - name: Check wheels
+        shell: bash
+        if: ${{github.event_name == 'push'}}
+        run: |
+          python -m pip install --upgrade twine
+          twine check wheelhouse/*
 
       - name: Release to pypi
         shell: bash
         if: ${{env.DEPLOY == 'True'}}
         run: |
-          python -m pip install --upgrade twine
-          twine check wheelhouse/*
           twine upload --skip-existing --repository-url $PYPI_SERVER wheelhouse/* -u $PYPI_USER -p $PYPI_PASSWORD
 
       - name: Upload artifacts to github
-        if: ${{env.DEPLOY == 'True'}}
+        if: ${{github.event_name == 'push'}}
         uses: actions/upload-artifact@v1
         with:
           name: wheels-base

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,7 +237,7 @@ jobs:
         shell: bash
         if: ${{env.DEPLOY == 'True'}}
         run: |
-          twine upload --skip-existing --repository-url $PYPI_SERVER wheelhouse/* -u $PYPI_USER -p $PYPI_PASSWORD
+          twine upload --skip-existing --repository-url $PYPI_SERVER wheelhouse/* -u $PYPI_USER -p $PYPI_BASE_PASSWORD
 
       - name: Upload artifacts to github
         if: ${{github.event_name == 'push'}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
         tags:
           - '*'
 
-# https://docs.github.com/en/enterprise-cloud@latest/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 # Only cancels-in-progress on PRs (head_ref only defined in PR, fallback run_id always unique)
 concurrency:
   group: ${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Description
Our current build process only builds wheels when we release.
Often, failures of these builds are unrelated to the code changes. When wheels are partially released to PyPI, we have to push a fix in a subsequent release. 

This change builds whenever we merge to master or a release branch (but not on every PR commit).

Regarding changes to the procedures, @h-vetinari you [mentioned](https://github.com/cvxpy/cvxpy/pull/1998#issuecomment-1370662440) that its possible to test pre-releases against your infrastructure. Could you create an example PR on the cvxpy feedstock repo that shows how this is done, then I could add a reference to that in the PROCEDURES document.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.