### PR TITLE
Improved psd check message

### DIFF
--- a/cvxpy/tests/test_constant.py
+++ b/cvxpy/tests/test_constant.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+import scipy.sparse.linalg as sparla
+
+import cvxpy as cp
+from cvxpy import psd_wrap
+
+
+def test_is_psd() -> None:
+
+    n = 50
+
+    # trivial cases
+    psd = np.eye(n)
+    nsd = -np.eye(n)
+
+    assert cp.Constant(psd).is_psd()
+    assert not cp.Constant(psd).is_nsd()
+
+    assert cp.Constant(nsd).is_nsd()
+    assert not cp.Constant(nsd).is_psd()
+
+    np.random.seed(97)
+
+    P = np.random.randn(n, n)
+    P = P.T @ P
+
+    with pytest.raises(sparla.ArpackNoConvergence, match="CVXPY note"):
+        cp.Constant(P).is_psd()
+
+    assert psd_wrap(cp.Constant(P)).is_psd()

--- a/cvxpy/tests/test_constant.py
+++ b/cvxpy/tests/test_constant.py
@@ -1,5 +1,6 @@
 import numpy as np
 import scipy.sparse.linalg as sparla
+from numpy.random import PCG64, Generator
 
 import cvxpy as cp
 from cvxpy import psd_wrap
@@ -20,14 +21,14 @@ def test_is_psd() -> None:
     assert not cp.Constant(nsd).is_psd()
 
     # We simulate a scenario where a matrix is PSD but a ArpackNoConvergence is raised.
-    # With the current numpy random number generator, this happens with seed 97.
+    # With the numpy PCG64-based random number generator, this happens with seed 119.
     # We test a range of seeds to make sure that this scenario is not always triggered.
 
     failures = set()
-    for seed in range(95, 100):
-        np.random.seed(seed)
+    for seed in range(115, 120):
+        rng = Generator(PCG64(seed))
 
-        P = np.random.randn(n, n)
+        P = rng.standard_normal((n, n))
         P = P.T @ P
 
         try:
@@ -35,6 +36,6 @@ def test_is_psd() -> None:
         except sparla.ArpackNoConvergence as e:
             assert "CVXPY note" in str(e)
             failures.add(seed)
-    assert failures == {97}
+    assert failures == {119}
 
     assert psd_wrap(cp.Constant(P)).is_psd()

--- a/cvxpy/tests/test_constant.py
+++ b/cvxpy/tests/test_constant.py
@@ -1,6 +1,5 @@
 import numpy as np
 import scipy.sparse.linalg as sparla
-from numpy.random import PCG64, Generator
 
 import cvxpy as cp
 from cvxpy import psd_wrap
@@ -21,14 +20,14 @@ def test_is_psd() -> None:
     assert not cp.Constant(nsd).is_psd()
 
     # We simulate a scenario where a matrix is PSD but a ArpackNoConvergence is raised.
-    # With the numpy PCG64-based random number generator, this happens with seed 119.
+    # With the current numpy random number generator, this happens with seed 97.
     # We test a range of seeds to make sure that this scenario is not always triggered.
 
     failures = set()
-    for seed in range(115, 120):
-        rng = Generator(PCG64(seed))
+    for seed in range(95, 100):
+        np.random.seed(seed)
 
-        P = rng.standard_normal((n, n))
+        P = np.random.randn(n, n)
         P = P.T @ P
 
         try:
@@ -36,6 +35,6 @@ def test_is_psd() -> None:
         except sparla.ArpackNoConvergence as e:
             assert "CVXPY note" in str(e)
             failures.add(seed)
-    assert failures == {119}
+    assert failures == {97}
 
     assert psd_wrap(cp.Constant(P)).is_psd()

--- a/cvxpy/utilities/linalg.py
+++ b/cvxpy/utilities/linalg.py
@@ -51,7 +51,7 @@ def is_psd_within_tol(A, tol):
 
     Parameters
     ----------
-    A : Union[np.ndarray, spar.spmatrx]
+    A : Union[np.ndarray, spar.spmatrix]
         Symmetric (or Hermitian) NumPy ndarray or SciPy sparse matrix.
 
     tol : float
@@ -76,7 +76,6 @@ def is_psd_within_tol(A, tol):
         # a negative eigenvalue of A. If A - sigma*I is PSD, then we obviously
         # have that the smallest eigenvalue of A is >= sigma.
 
-    ev = np.NaN
     try:
         ev = SA_eigsh(-tol)  # might return np.NaN, or raise exception
     except sparla.ArpackNoConvergence as e:
@@ -84,17 +83,19 @@ def is_psd_within_tol(A, tol):
 
         message = """
         CVXPY note: This failure was encountered while trying to certify
-        that a matrix is positive semidefinite. In rare cases, this method
-        fails for numerical reasons even when the matrix is positive semidefinite.
-        If you know that you're in that situation, you can replace the matrix A by
-        cvxpy.psd_wrap(A).
+        that a matrix is positive semi-definite (see [1] for a definition).
+        In rare cases, this method fails for numerical reasons even when the matrix is
+        positive semi-definite. If you know that you're in that situation, you can
+        replace the matrix A by cvxpy.psd_wrap(A).
+
+        [1] https://en.wikipedia.org/wiki/Definite_matrix
         """
 
         error_with_note = f"{str(e)}\n\n{message}"
 
         raise sparla.ArpackNoConvergence(error_with_note, e.eigenvalues, e.eigenvectors)
 
-    if np.isnan(ev).all():
+    if np.isnan(ev).any():
         # will be NaN if A has an eigenvalue which is exactly -tol
         # (We might also hit this code block for other reasons.)
         temp = tol - np.finfo(A.dtype).eps
@@ -115,7 +116,7 @@ def gershgorin_psd_check(A, tol):
 
     Parameters
     ----------
-    A : Union[np.ndarray, spar.spmatrx]
+    A : Union[np.ndarray, spar.spmatrix]
         Symmetric (or Hermitian) NumPy ndarray or SciPy sparse matrix.
 
     tol : float

--- a/cvxpy/utilities/linalg.py
+++ b/cvxpy/utilities/linalg.py
@@ -4,10 +4,6 @@ import scipy.sparse as spar
 import scipy.sparse.linalg as sparla
 
 
-class CVXPYArpackNoConvergence(sparla.ArpackNoConvergence):
-    pass
-
-
 def orth(V, tol=1e-12):
     """Return a matrix whose columns are an orthonormal basis for range(V)"""
     Q, R, p = la.qr(V, mode='economic', pivoting=True)


### PR DESCRIPTION
## Description
Adding a custom error message to `ArpackNoConvergence` during PSD check.

Issue link (if applicable):  #1995 

cc: @PTNobel

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.