### PR TITLE
SPEC: deepcopy behaviour 

### DIFF
--- a/cvxpy/tests/test_copy.py
+++ b/cvxpy/tests/test_copy.py
@@ -1,3 +1,19 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from copy import copy, deepcopy
 from dataclasses import dataclass
 

--- a/cvxpy/tests/test_copy.py
+++ b/cvxpy/tests/test_copy.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import annotations
 
 from copy import copy, deepcopy
 from dataclasses import dataclass

--- a/cvxpy/tests/test_copy.py
+++ b/cvxpy/tests/test_copy.py
@@ -1,0 +1,90 @@
+from copy import deepcopy, copy
+from dataclasses import dataclass
+
+import pytest
+import cvxpy as cp
+import numpy as np
+
+
+@dataclass
+class MockMutableObject:
+    """
+    A mock mutable object for testing deepcopy.
+    """
+    x: cp.Variable
+    P: list[list[int]]  # requires deepcopy
+
+
+
+def test_valid_deepcopy_example():
+    """
+    Example where deepcopy is required.
+    Even though for the CVXPY expression, deepcopy is not required, it is required for the
+    mutable object.
+    """
+    P = [[1, 0], [0, 1]]
+    x = cp.Variable(2)
+    obj = MockMutableObject(x, P)
+
+    problem1 = cp.Problem(cp.Minimize(cp.quad_form(obj.x, obj.P)), [obj.x == 1])
+    problem1.solve()
+    assert problem1.status == cp.OPTIMAL
+    assert np.isclose(problem1.value, 2)
+
+    # Deepcopy should work.
+    obj_copy = deepcopy(obj)
+    obj_copy.P[0][0] = 2
+
+    problem2 = cp.Problem(cp.Minimize(cp.quad_form(obj_copy.x, obj_copy.P)), [obj_copy.x == 1])
+    problem2.solve()
+    assert problem2.status == cp.OPTIMAL
+    assert np.isclose(problem2.value, 3)
+
+    # Original problem should not be affected.
+    problem1.solve()
+    assert problem1.status == cp.OPTIMAL
+    assert np.isclose(problem1.value, 2)
+
+
+def test_deepcopy_same_identity():
+    x = cp.Variable(nonneg=True, name="x")
+    y = deepcopy(x)
+
+    # Leafs keep their identity (id()), as well as their name and .id
+    assert y.name() == "x"
+    assert y.id == x.id
+    assert id(y) == id(x)
+
+    constraints = [x >= y + 1]
+
+    copied_constraint = deepcopy(constraints[0])
+    # Other expressions change their identity (id()), but their .id stays the same
+    assert copied_constraint.id == constraints[0].id
+    assert id(copied_constraint) != id(constraints[0])
+
+    problem = cp.Problem(cp.Minimize(0), constraints)
+    problem.solve()
+    assert problem.status == cp.INFEASIBLE
+
+
+@pytest.mark.parametrize("copy_func", [copy, deepcopy])
+def test_copy_constraints(copy_func) -> None:
+    """
+    Test copy and deepcopy of constraints.
+    """
+    x = cp.Variable()
+    y = cp.Variable()
+
+    constraints = [
+        x + y == 1,
+        x - y >= 1
+    ]
+    constraints[0].atoms()
+    constraints = copy_func(constraints)
+
+    obj = cp.Minimize((x - y) ** 2)
+    prob = cp.Problem(obj, constraints)
+    prob.solve()
+    assert prob.status == cp.OPTIMAL
+    assert np.allclose(x.value, 1)
+    assert np.allclose(y.value, 0)

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 import builtins
-import copy
 import pickle
 import sys
 import warnings
@@ -25,7 +24,6 @@ from io import StringIO
 import ecos
 import numpy
 import numpy as np
-import pytest
 import scipy.sparse as sp
 # Solvers.
 import scs

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -2061,27 +2061,3 @@ class TestProblem(BaseTest):
             c = cp.sum(a)
             cp.Problem(cp.Maximize(0), [c >= 0])
             assert len(w) == 0
-
-    def test_copy_constraints(self) -> None:
-        """Test copy and deepcopy of constraints.
-        """
-        x = cp.Variable()
-        y = cp.Variable()
-
-        constraints = [
-            x + y == 1,
-            x - y >= 1
-        ]
-        constraints[0].atoms()
-        constraints = copy.copy(constraints)
-
-        obj = cp.Minimize((x - y) ** 2)
-        prob = cp.Problem(obj, constraints)
-        prob.solve()
-        assert prob.status == cp.OPTIMAL
-        assert np.allclose(x.value, 1)
-        assert np.allclose(y.value, 0)
-
-        error_msg = "Creating a deepcopy of a CVXPY expression is not supported"
-        with pytest.raises(NotImplementedError, match=error_msg):
-            copy.deepcopy(constraints)

--- a/cvxpy/utilities/canonical.py
+++ b/cvxpy/utilities/canonical.py
@@ -110,9 +110,8 @@ class Canonical:
         """
         Called by copy.deepcopy()
         """
-        raise NotImplementedError('Creating a deepcopy of a CVXPY expression is not supported. '
-                                  'Use .copy() instead.')
-
+        return self.copy()
+        
     def get_data(self) -> None:
         """Returns info needed to reconstruct the object besides the args.
 

--- a/cvxpy/utilities/canonical.py
+++ b/cvxpy/utilities/canonical.py
@@ -111,7 +111,7 @@ class Canonical:
         Called by copy.deepcopy()
         """
         return self.copy()
-        
+
     def get_data(self) -> None:
         """Returns info needed to reconstruct the object besides the args.
 


### PR DESCRIPTION
## Description
Based on a recent discussion about the behaviour of `deepcopy`, this PR collects examples of how CVXPY expressions might be copied, in an effort to define the **intended** behaviour and **document** it once defined.

Note that as written, this PR **would** restore the `deepcopy` capability, but **would not** treat deepcopied variables as two distinct objects.

Issue link (if applicable): #2012

@michael-123123 @adishavit @rileyjmurray @SteveDiamond 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.