### PR TITLE
Attach Mosek log handler before inputting data

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -225,6 +225,7 @@ class MOSEK(ConicSolver):
             else:
                 env = mosek.Env()
                 task = env.Task(0, 0)
+                save_file = MOSEK.handle_options(env, task, verbose, solver_opts)
                 task = MOSEK._build_dualized_task(task, data)
         else:
             if len(data[s.C]) == 0:
@@ -233,10 +234,10 @@ class MOSEK(ConicSolver):
             else:
                 env = mosek.Env()
                 task = env.Task(0, 0)
+                save_file = MOSEK.handle_options(env, task, verbose, solver_opts)                
                 task = MOSEK._build_slack_task(task, data)
 
-        # Set parameters, optimize the Mosek Task, and return the result.
-        save_file = MOSEK.handle_options(env, task, verbose, solver_opts)
+        # Optimize the Mosek Task, and return the result.
         if save_file:
             task.writedata(save_file)
         task.optimize()

--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -234,7 +234,7 @@ class MOSEK(ConicSolver):
             else:
                 env = mosek.Env()
                 task = env.Task(0, 0)
-                save_file = MOSEK.handle_options(env, task, verbose, solver_opts)                
+                save_file = MOSEK.handle_options(env, task, verbose, solver_opts)
                 task = MOSEK._build_slack_task(task, data)
 
         # Optimize the Mosek Task, and return the result.


### PR DESCRIPTION
Changes the order of operations when initializing the Mosek task: first process options and, in particular, attach the log handler (if verbose), then input data, then optimize.

Attaching the log handler before inputting allows the user to see if Mosek produces any warnings about the magnitude of the data which could be a potential hint in case of numerical issues later in the solver.