### PR TITLE
Enable GLOP 9.5

### DIFF
--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -33,7 +33,7 @@ if [[ "$PYTHON_VERSION" == "3.11" ]]; then
 elif [[ "$RUNNER_OS" == "Windows" ]] && [[ "$PYTHON_VERSION" == "3.8" ]]; then
   python -m pip install gurobipy clarabel osqp
 else
-  python -m pip install "ortools>=9.3,<9.5" coptpy cplex sdpa-python diffcp gurobipy xpress clarabel sdpa-python
+  python -m pip install "ortools>=9.5,<9.6" coptpy cplex sdpa-python diffcp gurobipy xpress clarabel sdpa-python
 fi
 
 # cylp has wheels for all versions 3.7 - 3.10, except for 3.7 on Windows

--- a/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
@@ -48,12 +48,12 @@ class GLOP(ConicSolver):
         """Imports the solver."""
         import google.protobuf
         import ortools
-        if Version(ortools.__version__) < Version('9.3.0'):
+        if Version(ortools.__version__) < Version('9.5.0'):
             raise RuntimeError(f'Version of ortools ({ortools.__version__}) '
-                               f'is too old. Expected >= 9.3.0.')
-        if Version(ortools.__version__) >= Version('9.5.0'):
+                               f'is too old. Expected >= 9.5.0.')
+        if Version(ortools.__version__) >= Version('9.6.0'):
             raise RuntimeError('Unrecognized new version of ortools '
-                               f'({ortools.__version__}). Expected < 9.5.0.'
+                               f'({ortools.__version__}). Expected < 9.6.0.'
                                'Please open a feature request on cvxpy to '
                                'enable support for this version.')
         ortools, google.protobuf  # For flake8

--- a/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
@@ -48,12 +48,12 @@ class PDLP(ConicSolver):
         """Imports the solver."""
         import google.protobuf
         import ortools
-        if Version(ortools.__version__) < Version('9.3.0'):
+        if Version(ortools.__version__) < Version('9.5.0'):
             raise RuntimeError(f'Version of ortools ({ortools.__version__}) '
-                               f'is too old. Expected >= 9.3.0.')
-        if Version(ortools.__version__) >= Version('9.5.0'):
+                               f'is too old. Expected >= 9.5.0.')
+        if Version(ortools.__version__) >= Version('9.6.0'):
             raise RuntimeError('Unrecognized new version of ortools '
-                               f'({ortools.__version__}). Expected < 9.5.0.'
+                               f'({ortools.__version__}). Expected < 9.6.0.'
                                'Please open a feature request on cvxpy to '
                                'enable support for this version.')
         ortools, google.protobuf  # For flake8
@@ -138,9 +138,9 @@ class PDLP(ConicSolver):
             solver_cache: Dict = None,
     ) -> Solution:
         """Returns the result of the call to the solver."""
-        import ortools
         from google.protobuf import text_format
         from ortools.linear_solver import linear_solver_pb2
+        from ortools.model_builder.python import pywrap_model_builder_helper
         from ortools.pdlp import solvers_pb2
 
         # TODO: Switch to a direct numpy interface to PDLP when available.
@@ -166,17 +166,9 @@ class PDLP(ConicSolver):
             request.solver_time_limit_seconds = float(solver_opts["time_limit_sec"])
 
         request.solver_specific_parameters = text_format.MessageToString(parameters)
-        if Version(ortools.__version__) >= Version('9.4.0'):
-            from ortools.model_builder.python import (
-                pywrap_model_builder_helper,)
-            solver = pywrap_model_builder_helper.ModelSolverHelper("pdlp")
-            response_str = solver.solve_serialized_request(request.SerializeToString())
-            response = linear_solver_pb2.MPSolutionResponse.FromString(response_str)
-        else:
-            # Version 9.3
-            from ortools.model_builder.python import model_builder_helper
-            solver = model_builder_helper.ModelSolverHelper()
-            response = solver.Solve(request)
+        solver = pywrap_model_builder_helper.ModelSolverHelper("pdlp")
+        response_str = solver.solve_serialized_request(request.SerializeToString())
+        response = linear_solver_pb2.MPSolutionResponse.FromString(response_str)
 
         solution = {}
         solution["value"] = response.objective_value


### PR DESCRIPTION
## Description
This enables GLOP 9.5 (the latest version) via ortools 9.5.
Issue link (if applicable): #2018

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.