### PR TITLE
P-norm issue with DGP problems

### DIFF
--- a/cvxpy/reductions/dgp2dcp/canonicalizers/__init__.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/__init__.py
@@ -20,7 +20,7 @@ from cvxpy.atoms.norm1 import norm1
 from cvxpy.atoms.norm_inf import norm_inf
 from cvxpy.atoms.one_minus_pos import one_minus_pos
 from cvxpy.atoms.pf_eigenvalue import pf_eigenvalue
-from cvxpy.atoms.pnorm import pnorm
+from cvxpy.atoms.pnorm import Pnorm
 from cvxpy.atoms.prod import Prod
 from cvxpy.atoms.quad_form import quad_form
 from cvxpy.atoms.quad_over_lin import quad_over_lin
@@ -76,7 +76,7 @@ CANON_METHODS = {
     norm_inf : norm_inf_canon,
     one_minus_pos : one_minus_pos_canon,
     pf_eigenvalue : pf_eigenvalue_canon,
-    pnorm : pnorm_canon,
+    Pnorm : pnorm_canon,
     power : power_canon, 
     Prod : prod_canon,
     quad_form : quad_form_canon,

--- a/cvxpy/reductions/dgp2dcp/canonicalizers/pnorm_canon.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/pnorm_canon.py
@@ -12,7 +12,7 @@ def pnorm_canon(expr, args):
         x = promote(p, (1,))
     if expr.axis is None or len(x.shape) == 1:
         x = vec(x)
-        return (1.0/p) * log_sum_exp(hstack([xi ** p for xi in x])), []
+        return (1.0/p) * log_sum_exp(hstack([xi * p for xi in x])), []
 
     if expr.axis == 0:
         x = x.T
@@ -20,5 +20,5 @@ def pnorm_canon(expr, args):
     rows = []
     for i in range(x.shape[0]):
         row = x[i]
-        rows.append((1.0/p) * log_sum_exp(hstack([xi ** p for xi in row])))
+        rows.append((1.0/p) * log_sum_exp(hstack([xi * p for xi in row])))
     return vstack(rows), []

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -624,7 +624,8 @@ class TestDgp2Dcp(BaseTest):
 
     def test_pnorm(self) -> None:
         x = cvxpy.Variable(pos=True)
-        p = cvxpy.Problem(cvxpy.Minimize(cvxpy.norm(cvxpy.Constant([3, 4]), p=2) * x ** 2), [x >= 1])
+        p = cvxpy.Problem(cvxpy.Minimize(cvxpy.norm(cvxpy.Constant([3, 4]), p=2) * x ** 2),
+                          [x >= 1])
         self.assertAlmostEqual(p.solve(gp=True), 5)
         self.assertAlmostEqual(p.solution.opt_val, 5)
         self.assertAlmostEqual(x.value, 1.0)
@@ -648,4 +649,3 @@ class TestDgp2Dcp(BaseTest):
         self.assertAlmostEqual(p.solve(gp=True), l2_norm)
         self.assertAlmostEqual(p.solution.opt_val, l2_norm)
         self.assertAlmostEqual(x.value, 1.0)
-

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -657,4 +657,3 @@ class TestDgp2Dcp(BaseTest):
         self.assertAlmostEqual(p.solve(gp=True), 5)
         self.assertAlmostEqual(p.solution.opt_val, 5)
         self.assertItemsAlmostEqual(x.value, c.value)
-        

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -621,3 +621,31 @@ class TestDgp2Dcp(BaseTest):
                              [x >= b])
         prob.solve(solver=SOLVER, gp=True)
         self.assertItemsAlmostEqual(expr.value, [np.e, 0.5 * np.e**.5])
+
+    def test_pnorm(self) -> None:
+        x = cvxpy.Variable(pos=True)
+        p = cvxpy.Problem(cvxpy.Minimize(cvxpy.norm(cvxpy.Constant([3, 4]), p=2) * x ** 2), [x >= 1])
+        self.assertAlmostEqual(p.solve(gp=True), 5)
+        self.assertAlmostEqual(p.solution.opt_val, 5)
+        self.assertAlmostEqual(x.value, 1.0)
+
+        # Test p = 3
+        x = cvxpy.Variable(pos=True)
+        arr = [1.5, 3, 2]
+        l3_norm = np.linalg.norm(arr, 3)
+        p = cvxpy.Problem(cvxpy.Minimize(cvxpy.norm(cvxpy.Constant(arr), p=3) * x ** 2),
+                          [x >= 1])
+        self.assertAlmostEqual(p.solve(gp=True), l3_norm)
+        self.assertAlmostEqual(p.solution.opt_val, l3_norm)
+        self.assertAlmostEqual(x.value, 1.0)
+
+        # Test fro norm
+        x = cvxpy.Variable(pos=True)
+        mat = [[1, 0.5], [2, 3]]
+        l2_norm = np.linalg.norm(mat, 'fro')
+        p = cvxpy.Problem(cvxpy.Minimize(cvxpy.norm(cvxpy.Constant(mat), p='fro') * x ** 2),
+                          [x >= 1])
+        self.assertAlmostEqual(p.solve(gp=True), l2_norm)
+        self.assertAlmostEqual(p.solution.opt_val, l2_norm)
+        self.assertAlmostEqual(x.value, 1.0)
+

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -649,3 +649,11 @@ class TestDgp2Dcp(BaseTest):
         self.assertAlmostEqual(p.solve(gp=True), l2_norm)
         self.assertAlmostEqual(p.solution.opt_val, l2_norm)
         self.assertAlmostEqual(x.value, 1.0)
+
+        # Test on a variable
+        x = cvxpy.Variable(2, pos=True)
+        c = cvxpy.Constant([3, 4])
+        p = cvxpy.Problem(cvxpy.Minimize(cvxpy.norm(c, p=2)), [x == c])
+        self.assertAlmostEqual(p.solve(gp=True), 5)
+        self.assertAlmostEqual(p.solution.opt_val, 5)
+        self.assertItemsAlmostEqual(x.value, c.value)

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -657,3 +657,4 @@ class TestDgp2Dcp(BaseTest):
         self.assertAlmostEqual(p.solve(gp=True), 5)
         self.assertAlmostEqual(p.solution.opt_val, 5)
         self.assertItemsAlmostEqual(x.value, c.value)
+        


### PR DESCRIPTION
## Description
Ran into the following bug with p-norms in DGP problems.

In particular, the below assertion fails: 

```
x = cp.Variable(pos=True)
norm_expr = cp.norm(cp.Constant([3,4]), p=2)
prob = cp.Problem(cp.Minimize(norm_expr * x ** 2), [x >= 1])
solution = prob.solve(gp=True) # Correctly returns 5 
print(prob.solution.opt_val) # Incorrectly prints 5.8
assert np.isclose(prob.solution.opt_val, solution)
```

Looks like it's due to two issues:
1. In the DGP canon functions dict, the key for pnorms is the pnorm function wrapper, not the Pnorm class. 
2. Should be multiplication instead of exponentiation during the canonicalization process. 

$\ln\(||x||_p\) = \ln\(\(\sum |x_i|^p \)^\frac{1}{p} \) = \frac{1}{p} \ln \(\sum |x_i|^p\)$ 

Since we take the logs of all the leaves first and pass that in as args, we are given $z = \ln (x)$. Then, our expr becomes 
$\frac{1}{p} \ln \(\sum e^{zp} \) = \frac{1}{p} \text{log-sum-exp} (z * p)$. 

Added some tests in `test_dgp2dcp.py` for $p = 2$ and $p = 3$, as well as a matrix fro norm.  

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.
