### PR TITLE
Cleanup in MOSEK parameters setting

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import warnings
 from collections import defaultdict
 
-import warnings
 import numpy as np
 import scipy as sp
 
@@ -28,12 +28,12 @@ from cvxpy.reductions.solution import Solution
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.utilities import expcone_permutor
 
-
 __MSK_ENUM_PARAM_DEPRECATION__ = """
 Using MOSEK constants to specify parameters is deprecated.
 Use generic string names instead.
 For example, replace mosek.iparam.num_threads with 'MSK_IPAR_NUM_THREADS'
 """
+
 
 def vectorized_lower_tri_to_mat(v, dim):
     """

--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 from collections import defaultdict
 
+import warnings
 import numpy as np
 import scipy as sp
 
@@ -27,6 +28,12 @@ from cvxpy.reductions.solution import Solution
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.utilities import expcone_permutor
 
+
+__MSK_ENUM_PARAM_DEPRECATION__ = """
+Using MOSEK constants to specify parameters is deprecated.
+Use generic string names instead.
+For example, replace mosek.iparam.num_threads with 'MSK_IPAR_NUM_THREADS'
+"""
 
 def vectorized_lower_tri_to_mat(v, dim):
     """
@@ -545,7 +552,7 @@ class MOSEK(ConicSolver):
         if verbose:
 
             def streamprinter(text):
-                s.LOGGER.info(text.replace('\n', ''))
+                s.LOGGER.info(text.rstrip('\n'))
 
             print('\n')
             env.set_Stream(mosek.streamtype.log, streamprinter)
@@ -557,18 +564,34 @@ class MOSEK(ConicSolver):
         save_file = None
         bfs = False
         if 'mosek_params' in kwargs:
+            # Issue a warning if Mosek enums are used as parameter names / keys
+            if any(isinstance(param, mosek.iparam) or
+                   isinstance(param, mosek.dparam) or
+                   isinstance(param, mosek.sparam) for param in solver_opts['mosek_params'].keys()):
+                warnings.warn(__MSK_ENUM_PARAM_DEPRECATION__, DeprecationWarning)
+                warnings.warn(__MSK_ENUM_PARAM_DEPRECATION__, UserWarning)
+            # Now set parameters
             for param, value in solver_opts['mosek_params'].items():
                 if isinstance(param, str):
+                    # Parameters are set through generic string names (recommended)
                     param = param.strip()
-                    if param.startswith("MSK_DPAR_"):
-                        task.putnadouparam(param, value)
-                    elif param.startswith("MSK_IPAR_"):
-                        task.putnaintparam(param, value)
-                    elif param.startswith("MSK_SPAR_"):
-                        task.putnastrparam(param, value)
+                    if isinstance(value, str):
+                        # The value is also a string.
+                        # Examples: "MSK_IPAR_INTPNT_SOLVE_FORM": "MSK_SOLVE_DUAL"
+                        #           "MSK_DPAR_CO_TOL_PFEAS": "1.0e-9"
+                        task.putparam(param, value)
                     else:
-                        raise ValueError("Invalid MOSEK parameter '%s'." % param)
+                        # Otherwise we assume the value is of correct type
+                        if param.startswith("MSK_DPAR_"):
+                            task.putnadouparam(param, value)
+                        elif param.startswith("MSK_IPAR_"):
+                            task.putnaintparam(param, value)
+                        elif param.startswith("MSK_SPAR_"):
+                            task.putnastrparam(param, value)
+                        else:
+                            raise ValueError("Invalid MOSEK parameter '%s'." % param)
                 else:
+                    # Parameters are set through Mosek enums (deprecated)
                     if isinstance(param, mosek.dparam):
                         task.putdouparam(param, value)
                     elif isinstance(param, mosek.iparam):

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -562,9 +562,9 @@ class TestMosek(unittest.TestCase):
             problem = cp.Problem(objective, constraints)
 
             invalid_mosek_params = {
-                "dparam.basis_tol_x": "1e-8"
+                "MSK_IPAR_NUM_THREADS": "11.3"
             }
-            with self.assertRaises(ValueError):
+            with self.assertRaises(mosek.Error):
                 problem.solve(solver=cp.MOSEK, mosek_params=invalid_mosek_params)
 
             with self.assertRaises(ValueError):
@@ -572,7 +572,11 @@ class TestMosek(unittest.TestCase):
 
             mosek_params = {
                 mosek.dparam.basis_tol_x: 1e-8,
-                "MSK_IPAR_INTPNT_MAX_ITERATIONS": 20
+                "MSK_IPAR_INTPNT_MAX_ITERATIONS": 20,
+                "MSK_IPAR_NUM_THREADS": "17",
+                "MSK_IPAR_PRESOLVE_USE": "MSK_PRESOLVE_MODE_OFF",
+                "MSK_DPAR_INTPNT_CO_TOL_DFEAS": 1e-9,
+                "MSK_DPAR_INTPNT_CO_TOL_PFEAS": "1e-9"
             }
             problem.solve(solver=cp.MOSEK, mosek_params=mosek_params)
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -578,7 +578,8 @@ class TestMosek(unittest.TestCase):
                 "MSK_DPAR_INTPNT_CO_TOL_DFEAS": 1e-9,
                 "MSK_DPAR_INTPNT_CO_TOL_PFEAS": "1e-9"
             }
-            problem.solve(solver=cp.MOSEK, mosek_params=mosek_params)
+            with pytest.warns():
+                problem.solve(solver=cp.MOSEK, mosek_params=mosek_params)
 
 
 @unittest.skipUnless('CVXOPT' in INSTALLED_SOLVERS, 'CVXOPT is not installed.')

--- a/doc/source/tutorial/advanced/index.rst
+++ b/doc/source/tutorial/advanced/index.rst
@@ -816,11 +816,11 @@ For others see `OSQP documentation <https://osqp.org/docs/interfaces/solver_sett
 `MOSEK`_ options:
 
 ``'mosek_params'``
-    A dictionary of MOSEK parameters. Refer to MOSEK's Python or C API for
-    details. Note that if parameters are given as string-value pairs, parameter
-    names must be of the form ``'MSK_DPAR_BASIS_TOL_X'`` as in the C API.
-    Alternatively, Python enum options like ``'mosek.dparam.basis_tol_x'`` are
-    also supported.
+    A dictionary of MOSEK parameters in the form ``name: value``. Parameter names
+    should be strings, as in the MOSEK C API or command line, for example
+    ``'MSK_DPAR_BASIS_TOL_X'``, ``'MSK_IPAR_NUM_THREADS'`` etc. Values are strings,
+    integers or floats, depending on the parameter.
+    See `example <https://docs.mosek.com/latest/faq/faq.html#cvxpy>`_.
 
 ``'save_file'``
     The name of a file where MOSEK will save the problem just before optimization.
@@ -841,7 +841,7 @@ For others see `OSQP documentation <https://osqp.org/docs/interfaces/solver_sett
     MOSEK interface. If you notice MOSEK solve times are slower for some of your
     problems under CVXPY 1.1.6 or higher, be sure to use the MOSEK solver options
     to tell MOSEK that it should solve the dual; this can be accomplished by
-    adding the ``(key, value)`` pair ``(mosek.iparam.intpnt_solve_form, mosek.solveform.dual)``
+    adding the ``(key, value)`` pair ``('MSK_IPAR_INTPNT_SOLVE_FORM', 'MSK_SOLVE_DUAL')``
     to the ``mosek_params`` argument.
     
 `CVXOPT`_ options:

--- a/examples/notebooks/WWW/Gini Portfolio.ipynb
+++ b/examples/notebooks/WWW/Gini Portfolio.ipynb
@@ -175,7 +175,7 @@
     "\n",
     "    try:\n",
     "        prob.solve(solver=cp.MOSEK,\n",
-    "                   mosek_params={mosek.iparam.num_threads: 2},\n",
+    "                   mosek_params={'MSK_IPAR_NUM_THREADS': 2},\n",
     "                   verbose=False,)\n",
     "        w = pd.DataFrame(w.value)\n",
     "        w.index = assets\n",

--- a/examples/notebooks/WWW/Kurtosis Portfolio.ipynb
+++ b/examples/notebooks/WWW/Kurtosis Portfolio.ipynb
@@ -466,7 +466,7 @@
     "obj = cp.Minimize(risk * 1000)\n",
     "prob = cp.Problem(obj, constraints)\n",
     "\n",
-    "#prob.solve(solver='MOSEK', mosek_params= {mosek.iparam.num_threads: 2})\n",
+    "#prob.solve(solver='MOSEK', mosek_params= {'MSK_IPAR_NUM_THREADS': 2})\n",
     "prob.solve()\n",
     "w = pd.DataFrame(x.value, index=assets, columns=['weights'])\n",
     "display(w)"


### PR DESCRIPTION
## Description
Tries to make Mosek parameters systematic. See https://github.com/cvxpy/cvxpy/issues/2023

Adds proper handling of the case where both parameter name and value are strings. Deprecates the use of constants from the Python API. Adapts the documentation and test accordingly.

Documentation mentions https://docs.mosek.com/latest/faq/faq.html#cvxpy  That link will be separately updated in the same style next time new Mosek docs are uploaded.

