### PR TITLE
MI DGP support

### DIFF
--- a/cvxpy/constraints/finite_set.py
+++ b/cvxpy/constraints/finite_set.py
@@ -60,9 +60,9 @@ class FiniteSet(Constraint):
         if isinstance(vec, set):
             vec = list(vec)
         vec = Expression.cast_to_const(vec).flatten()
-        if not expre.is_affine():
+        if not expre.is_affine() and not expre.is_log_log_affine():
             msg = """
-            Provided Expression must be affine, but had curvature %s.
+            Provided Expression must be affine or log-log affine, but had curvature %s.
             """ % expre.curvature
             raise ValueError(msg)
         # Note: we use the term "expre" rather than "expr" since
@@ -88,7 +88,13 @@ class FiniteSet(Constraint):
         return self.args[0].is_affine()
 
     def is_dgp(self, dpp: bool = False) -> bool:
-        return False
+        # TODO expand to parameterized sets.
+        if self.vec.parameters():
+            return False
+        # Not a parameter, so value is fixed.
+        vec_val = self.vec.value
+        # DGP if expr is monomial and all values in set are positive.
+        return self.expre.is_log_log_affine() and np.all(vec_val > 0)
 
     def is_dqcp(self) -> bool:
         return self.is_dcp()

--- a/cvxpy/constraints/finite_set.py
+++ b/cvxpy/constraints/finite_set.py
@@ -94,7 +94,11 @@ class FiniteSet(Constraint):
         # Not a parameter, so value is fixed.
         vec_val = self.vec.value
         # DGP if expr is monomial and all values in set are positive.
-        return self.expre.is_log_log_affine() and np.all(vec_val > 0)
+        if dpp:
+            with scopes.dpp_scope():
+                return self.expre.is_log_log_affine() and np.all(vec_val > 0)
+        else:
+            return self.expre.is_log_log_affine() and np.all(vec_val > 0)
 
     def is_dqcp(self) -> bool:
         return self.is_dcp()

--- a/cvxpy/reductions/dgp2dcp/canonicalizers/__init__.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/__init__.py
@@ -24,6 +24,7 @@ from cvxpy.atoms.pnorm import Pnorm
 from cvxpy.atoms.prod import Prod
 from cvxpy.atoms.quad_form import quad_form
 from cvxpy.atoms.quad_over_lin import quad_over_lin
+from cvxpy.constraints.finite_set import FiniteSet
 from cvxpy.expressions.constants.constant import Constant
 from cvxpy.expressions.constants.parameter import Parameter
 from cvxpy.expressions.variable import Variable
@@ -34,6 +35,8 @@ from cvxpy.reductions.dgp2dcp.canonicalizers.div_canon import div_canon
 from cvxpy.reductions.dgp2dcp.canonicalizers.exp_canon import exp_canon
 from cvxpy.reductions.dgp2dcp.canonicalizers.eye_minus_inv_canon import (
     eye_minus_inv_canon,)
+from cvxpy.reductions.dgp2dcp.canonicalizers.finite_set_canon import (
+    finite_set_canon,)
 from cvxpy.reductions.dgp2dcp.canonicalizers.geo_mean_canon import (
     geo_mean_canon,)
 from cvxpy.reductions.dgp2dcp.canonicalizers.gmatmul_canon import gmatmul_canon
@@ -67,6 +70,7 @@ CANON_METHODS = {
     DivExpression : div_canon,
     exp : exp_canon,
     eye_minus_inv : eye_minus_inv_canon,
+    FiniteSet : finite_set_canon,
     geo_mean : geo_mean_canon,
     gmatmul : gmatmul_canon,
     log : log_canon,

--- a/cvxpy/reductions/dgp2dcp/canonicalizers/finite_set_canon.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/finite_set_canon.py
@@ -1,0 +1,7 @@
+from cvxpy.constraints.finite_set import FiniteSet
+
+
+def finite_set_canon(expr, args):
+    ineq_form, id = expr.get_data()
+    # Log applied already to set of values (i.e., args[1]).
+    return FiniteSet(args[0], args[1], ineq_form, id), []


### PR DESCRIPTION
## Description
Adds support for mixed-integer geometric programs, via the FiniteSet constraint.
Issue link (if applicable): #1590

@adishavit

The canonicalization is straightforward. I am not allowing the values of the finite set to be parameterized right now, because ``is_pos`` is only supported for leafs but it's needed here for more complex expressions, since theoretically the set values could be something like param1 + param2. I could hack around this though if the functionality is desired.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.