### PR TITLE
Fix Mosek power cone

### DIFF
--- a/cvxpy/reductions/cone2cone/affine2direct.py
+++ b/cvxpy/reductions/cone2cone/affine2direct.py
@@ -197,6 +197,7 @@ class Dualize:
                 dv = direct_prims[DUAL_EXP][i:i + con.size]
                 dual_vars[con.id] = dv
                 i += con.size
+            i = 0
             for con in constr_map[PowCone_obj]:
                 dv = direct_prims[DUAL_POW3D][i:i + con.size]
                 dual_vars[con.id] = dv

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -20,6 +20,7 @@ import unittest
 import numpy as np
 import pytest
 import scipy.linalg as la
+import scipy.stats as st
 
 import cvxpy as cp
 import cvxpy.tests.solver_test_helpers as sths
@@ -580,6 +581,55 @@ class TestMosek(unittest.TestCase):
             }
             with pytest.warns():
                 problem.solve(solver=cp.MOSEK, mosek_params=mosek_params)
+
+    def test_power_portfolio(self) -> None:
+        """Test the portfolio problem in issue #2042"""
+        T, N = 200, 10
+
+        rs = np.random.RandomState(123)
+        mean = np.zeros(N) + 1/1000
+        cov = rs.rand(N, N) * 1.5 - 0.5
+        cov = cov @ cov.T/1000 + np.diag(rs.rand(N) * 0.7 + 0.3)/1000
+
+        Y = st.multivariate_normal.rvs(
+            mean=mean,
+            cov=cov,
+            size=T,
+            random_state=rs
+        )
+
+        w = cp.Variable((N, 1))
+        t = cp.Variable((1, 1))
+        z = cp.Variable((1, 1))
+        omega = cp.Variable((T, 1))
+        psi = cp.Variable((T, 1))
+        nu = cp.Variable((T, 1))
+        epsilon = cp.Variable((T, 1))
+        k = cp.Variable((1, 1))
+        b = np.ones((1, N))/N
+
+        X = Y @ w
+
+        h = 0.2
+        ones = np.ones((T, 1))
+        constraints = [
+            cp.constraints.power.PowCone3D(z * (1+h)/(2*h) * ones, psi * (1+h)/h, epsilon, 1/(1+h)),
+            cp.constraints.power.PowCone3D(omega/(1-h), nu/h, -z/(2*h) * ones, (1-h)),
+            -X - t + epsilon + omega <= 0,
+            w >= 0,
+            z >= 0,
+            ]
+
+        obj = t + z + cp.sum(psi + nu)
+
+        constraints += [cp.sum(w) == k,
+                        k >= 0,
+                        b @ cp.log(w) >= 1,
+                        ]
+        objective = cp.Minimize(obj)
+        prob = cp.Problem(objective, constraints)
+        prob.solve(solver=cp.MOSEK)
+        assert prob.status is cp.OPTIMAL
 
 
 @unittest.skipUnless('CVXOPT' in INSTALLED_SOLVERS, 'CVXOPT is not installed.')


### PR DESCRIPTION
## Description
There was a bug in the canonicalization chain with mosek that failed when both power cones and exponential cones were present.
Issue link (if applicable): #2042

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.