### PR TITLE
fixing typo in documentation

### DIFF
--- a/doc/source/examples/derivatives/fundamentals.rst
+++ b/doc/source/examples/derivatives/fundamentals.rst
@@ -4,7 +4,7 @@ Derivatives fundamentals
 
 This notebook will introduce you to the fundamentals of computing the
 derivative of the solution map to optimization problems. The derivative
-can be used for **sensitvity analysis**, to see how a solution would
+can be used for **sensitivity analysis**, to see how a solution would
 change given small changes to the parameters, and to compute
 **gradients** of scalar-valued functions of the solution.
 

--- a/examples/notebooks/derivatives/fundamentals.ipynb
+++ b/examples/notebooks/derivatives/fundamentals.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Derivatives fundamentals\n",
     "\n",
-    "This notebook will introduce you to the fundamentals of computing the derivative of the solution map to optimization problems. The derivative can be used for **sensitvity analysis**, to see how a solution would change given small changes to the parameters, and to compute **gradients** of scalar-valued functions of the solution.\n",
+    "This notebook will introduce you to the fundamentals of computing the derivative of the solution map to optimization problems. The derivative can be used for **sensitivity analysis**, to see how a solution would change given small changes to the parameters, and to compute **gradients** of scalar-valued functions of the solution.\n",
     "\n",
     "In this notebook, we will consider a simple disciplined geometric program. The geometric program under consideration is\n",
     "\n",


### PR DESCRIPTION
## Description
I found a small typo in the documentation. 
It is in the "derivative fundamental" sub-section. 
"sensitvity" -> "sensitivity"

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.