### PR TITLE
Add compilation time property

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -409,7 +409,7 @@ class Problem(u.Canonical):
     @property
     def compilation_time(self) -> float | None:
         """float : The number of seconds it took to compile the problem the
-                   last time it was solved.
+                   last time it was compiled.
         """
         return self._compilation_time
 

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -405,14 +405,13 @@ class Problem(u.Canonical):
         """:class:`~cvxpy.problems.problem.SolverStats` : Information returned by the solver.
         """
         return self._solver_stats
-    
+
     @property
     def compilation_time(self) -> float:
         """float : The number of seconds it took to compile the problem the
                    last time it was solved
         """
         return self._compilation_time
-
 
     def solve(self, *args, **kwargs):
         """Compiles and solves the problem using the specified method.

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -405,6 +405,14 @@ class Problem(u.Canonical):
         """:class:`~cvxpy.problems.problem.SolverStats` : Information returned by the solver.
         """
         return self._solver_stats
+    
+    @property
+    def compilation_time(self) -> float:
+        """float : The number of seconds it took to compile the problem the
+                   last time it was solved
+        """
+        return self._compilation_time
+
 
     def solve(self, *args, **kwargs):
         """Compiles and solves the problem using the specified method.

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -407,7 +407,7 @@ class Problem(u.Canonical):
         return self._solver_stats
 
     @property
-    def compilation_time(self) -> float:
+    def compilation_time(self) -> float | None:
         """float : The number of seconds it took to compile the problem the
                    last time it was solved.
         """

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -409,7 +409,7 @@ class Problem(u.Canonical):
     @property
     def compilation_time(self) -> float:
         """float : The number of seconds it took to compile the problem the
-                   last time it was solved
+                   last time it was solved.
         """
         return self._compilation_time
 

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -213,6 +213,11 @@ class TestProblem(BaseTest):
         self.assertGreater(stats.num_iters, 0)
         self.assertTrue(hasattr(stats.extra_stats, 'info'))
 
+    def test_compilation_time(self) -> None:
+        prob = Problem(cp.Minimize(cp.norm(self.x)), [self.x == 0])
+        prob.solve()
+        assert isinstance(prob.compilation_time, float)
+
     def test_get_problem_data(self) -> None:
         """Test get_problem_data method.
         """

--- a/doc/source/api_reference/cvxpy.problems.rst
+++ b/doc/source/api_reference/cvxpy.problems.rst
@@ -44,9 +44,8 @@ Information about the size of a problem instance and statistics about the most
 recent solve invocation are captured by the
 :class:`~cvxpy.problems.problem.SizeMetrics` and
 :class:`~cvxpy.problems.problem.SolverStats` classes, respectively, and can be
-accessed via the :meth:`~cvxpy.problems.problem.Problem.size_metrics`, 
-:meth:`~cvxpy.problems.problem.Problem.solver_stats` and
-:meth:`~cvxpy.problems.problem.Problem.compilation_time` properties of the
+accessed via the :meth:`~cvxpy.problems.problem.Problem.size_metrics` and
+:meth:`~cvxpy.problems.problem.Problem.solver_stats` properties of the
 :class:`~cvxpy.problems.problem.Problem` class.
 
 .. contents:: :local:

--- a/doc/source/api_reference/cvxpy.problems.rst
+++ b/doc/source/api_reference/cvxpy.problems.rst
@@ -44,8 +44,9 @@ Information about the size of a problem instance and statistics about the most
 recent solve invocation are captured by the
 :class:`~cvxpy.problems.problem.SizeMetrics` and
 :class:`~cvxpy.problems.problem.SolverStats` classes, respectively, and can be
-accessed via the :meth:`~cvxpy.problems.problem.Problem.size_metrics` and
-:meth:`~cvxpy.problems.problem.Problem.solver_stats` properties of the
+accessed via the :meth:`~cvxpy.problems.problem.Problem.size_metrics`, 
+:meth:`~cvxpy.problems.problem.Problem.solver_stats` and
+:meth:`~cvxpy.problems.problem.Problem.compilation_time` properties of the
 :class:`~cvxpy.problems.problem.Problem` class.
 
 .. contents:: :local:
@@ -69,7 +70,7 @@ Problem
 .. autoclass:: cvxpy.Problem
     :members: value, status, objective, constraints, is_dcp, is_dgp, is_dqcp,
               is_qp, is_dpp, variables, parameters, constants,
-              backward, derivative, atoms, size_metrics, solver_stats, solve,
+              backward, derivative, atoms, size_metrics, solver_stats, compilation_time, solve,
               register_solve, get_problem_data, unpack_results
     :undoc-members:
     :member-order: groupwise


### PR DESCRIPTION
## Description
Exposes the `compilation_time` attribute as a property of the `Problem`. I wanted to be able to access this programmatically in a project I was working on.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.