### PR TITLE
Introduce ruff linter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: isort
-        uses: jamescurtin/isort-action@master
-      - name: flake8
-        uses: py-actions/flake8@v1
+      - uses: pre-commit/action@v3.0.0
 
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           python-version: 3.8
       - uses: pre-commit/action@v3.0.0
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Run Ruff
+        run: ruff check --format=github .
 
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - uses: pre-commit/action@v3.0.0
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,30 +1,7 @@
 repos:
-  # remove unused import and variable using autoflake
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v1.4
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    # Ruff version.
+    rev: 'v0.0.251'
     hooks:
-      - id: autoflake
-        args: [
-          '--in-place',
-          '--recursive',
-          '--remove-all-unused-imports',
-          '--ignore-init-module-imports',
-          '--remove-unused-variables',
-          '--exclude',
-          'test_*',
-          '--'
-        ]
-
-  # import sorting with isort
-  - repo: https://github.com/pycqa/isort
-    rev: 5.8.0
-    hooks:
-      - id: isort
-
-  # linting and code analysis with flake8
-  - repo: https://github.com/pycqa/flake8
-    rev: 3.8.3
-    hooks:
-      - id: flake8
-        args: ['--config=setup.cfg']
-        files: ^(cvxpy|continuous_integration)/
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -34,8 +34,10 @@ from cvxpy.atoms.affine.reshape import deep_flatten
 from cvxpy.atoms.affine.sum import sum as cvxpy_sum
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.error import DCPError
-from cvxpy.expressions.constants.parameter import (is_param_affine,
-                                                   is_param_free,)
+from cvxpy.expressions.constants.parameter import (
+    is_param_affine,
+    is_param_free,
+)
 
 
 class BinaryOperator(AffAtom):

--- a/cvxpy/atoms/affine/partial_trace.py
+++ b/cvxpy/atoms/affine/partial_trace.py
@@ -54,7 +54,7 @@ def _term(expr, j: int, dims: Tuple[int], axis: Optional[int] = 0):
     return a @ expr @ b
 
 
-# flake8: noqa: E501
+# ruff: noqa: E501
 def partial_trace(expr, dims: Tuple[int], axis: Optional[int] = 0):
     """
     Assumes :math:`\\texttt{expr} = X_1 \\otimes \\cdots \\otimes X_n` is a 2D Kronecker

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -39,9 +39,6 @@ class Atom(Expression):
     # args are the expressions passed into the Atom constructor.
 
     def __init__(self, *args) -> None:
-
-        UNUSED_VARIABLE = 0  # TODO: remove this
-
         self.id = lu.get_id()
         # Throws error if args is empty.
         if len(args) == 0:

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -39,6 +39,9 @@ class Atom(Expression):
     # args are the expressions passed into the Atom constructor.
 
     def __init__(self, *args) -> None:
+
+        UNUSED_VARIABLE = 0  # TODO: remove this
+
         self.id = lu.get_id()
         # Throws error if args is empty.
         if len(args) == 0:

--- a/cvxpy/atoms/elementwise/log_normcdf.py
+++ b/cvxpy/atoms/elementwise/log_normcdf.py
@@ -20,8 +20,8 @@ from cvxpy.atoms.elementwise.maximum import maximum
 from cvxpy.expressions.expression import Expression
 
 
-# flake8: noqa: E501
-def log_normcdf(x):  # noqa: E501
+# ruff: noqa: E501
+def log_normcdf(x):
     """Elementwise log of the cumulative distribution function of a standard normal random variable.
 
     The implementation is a quadratic approximation with modest accuracy over [-4, 4].

--- a/cvxpy/atoms/elementwise/loggamma.py
+++ b/cvxpy/atoms/elementwise/loggamma.py
@@ -16,7 +16,7 @@ from cvxpy.atoms.elementwise.log import log
 from cvxpy.atoms.elementwise.maximum import maximum
 
 
-# flake8: noqa: E501
+# ruff: noqa: E501
 def loggamma(x):
     """Elementwise log of the gamma function.
 

--- a/cvxpy/atoms/geo_mean.py
+++ b/cvxpy/atoms/geo_mean.py
@@ -22,8 +22,14 @@ import scipy.sparse as sp
 from cvxpy.atoms.atom import Atom
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
-from cvxpy.utilities.power_tools import (approx_error, decompose, fracify,
-                                         lower_bound, over_bound, prettydict,)
+from cvxpy.utilities.power_tools import (
+    approx_error,
+    decompose,
+    fracify,
+    lower_bound,
+    over_bound,
+    prettydict,
+)
 
 
 class geo_mean(Atom):

--- a/cvxpy/cvxcore/README.md
+++ b/cvxpy/cvxcore/README.md
@@ -31,7 +31,7 @@ bash rebuild_cvxcore.sh
 ```
 
 Rebuilding cvxcore will automatically generate ``cvxpy/cvxcore/python/cvxpy.py``.
-That generated file will probably have flake8 style errors.
+That generated file will probably have linter errors.
 If you use ``pre-commit`` as part of development then it will
 automatically fix those, but you'll need to add the modified
 file again before attempting to commit.

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -31,8 +31,11 @@ import scipy.sparse as sp
 import cvxpy.interface as intf
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import expression
-from cvxpy.settings import (GENERAL_PROJECTION_TOL, PSD_NSD_PROJECTION_TOL,
-                            SPARSE_PROJECTION_TOL,)
+from cvxpy.settings import (
+    GENERAL_PROJECTION_TOL,
+    PSD_NSD_PROJECTION_TOL,
+    SPARSE_PROJECTION_TOL,
+)
 
 
 class Leaf(expression.Expression):

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -47,8 +47,10 @@ from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.defines import SOLVER_MAP_CONIC, SOLVER_MAP_QP
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 from cvxpy.reductions.solvers.solver import Solver
-from cvxpy.reductions.solvers.solving_chain import (SolvingChain,
-                                                    construct_solving_chain,)
+from cvxpy.reductions.solvers.solving_chain import (
+    SolvingChain,
+    construct_solving_chain,
+)
 from cvxpy.settings import SOLVERS
 from cvxpy.utilities import debug_tools
 from cvxpy.utilities.deterministic import unique_list

--- a/cvxpy/reductions/complex2real/canonicalizers/matrix_canon.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/matrix_canon.py
@@ -18,8 +18,15 @@ from typing import List, Optional, Union
 
 import numpy as np
 
-from cvxpy.atoms import (bmat, lambda_sum_largest, normNuc, reshape,
-                         symmetric_wrap, von_neumann_entr, vstack,)
+from cvxpy.atoms import (
+    bmat,
+    lambda_sum_largest,
+    normNuc,
+    reshape,
+    symmetric_wrap,
+    von_neumann_entr,
+    vstack,
+)
 from cvxpy.atoms.affine.wraps import psd_wrap
 from cvxpy.constraints.exponential import OpRelEntrConeQuad
 from cvxpy.expressions.constants.constant import Constant

--- a/cvxpy/reductions/complex2real/complex2real.py
+++ b/cvxpy/reductions/complex2real/complex2real.py
@@ -17,14 +17,21 @@ limitations under the License.
 from cvxpy import problems
 from cvxpy import settings as s
 from cvxpy.atoms.affine.upper_tri import vec_to_upper_tri
-from cvxpy.constraints import (PSD, SOC, Equality, Inequality, NonNeg, NonPos,
-                               OpRelEntrConeQuad, Zero,)
+from cvxpy.constraints import (
+    PSD,
+    SOC,
+    Equality,
+    Inequality,
+    NonNeg,
+    NonPos,
+    OpRelEntrConeQuad,
+    Zero,
+)
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
 from cvxpy.lin_ops import lin_utils as lu
 from cvxpy.reductions import InverseData, Solution
-from cvxpy.reductions.complex2real.canonicalizers import (
-    CANON_METHODS as elim_cplx_methods,)
+from cvxpy.reductions.complex2real.canonicalizers import CANON_METHODS as elim_cplx_methods
 from cvxpy.reductions.reduction import Reduction
 
 

--- a/cvxpy/reductions/cone2cone/approximations.py
+++ b/cvxpy/reductions/cone2cone/approximations.py
@@ -21,13 +21,17 @@ import numpy as np
 import cvxpy as cp
 from cvxpy.atoms.affine.upper_tri import upper_tri
 from cvxpy.constraints.constraint import Constraint
-from cvxpy.constraints.exponential import (ExpCone, OpRelEntrConeQuad,
-                                           RelEntrConeQuad,)
+from cvxpy.constraints.exponential import (
+    ExpCone,
+    OpRelEntrConeQuad,
+    RelEntrConeQuad,
+)
 from cvxpy.constraints.zero import Zero
 from cvxpy.expressions.variable import Variable
 from cvxpy.reductions.canonicalization import Canonicalization
 from cvxpy.reductions.dcp2cone.canonicalizers.von_neumann_entr_canon import (
-    von_neumann_entr_canon,)
+    von_neumann_entr_canon,
+)
 
 APPROX_CONES = {
     RelEntrConeQuad: {cp.SOC},

--- a/cvxpy/reductions/dcp2cone/canonicalizers/lambda_sum_largest_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/lambda_sum_largest_canon.py
@@ -17,7 +17,8 @@ limitations under the License.
 from cvxpy.atoms import trace
 from cvxpy.expressions.variable import Variable
 from cvxpy.reductions.dcp2cone.canonicalizers.lambda_max_canon import (
-    lambda_max_canon,)
+    lambda_max_canon,
+)
 
 
 def lambda_sum_largest_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/canonicalizers/quad_form_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/quad_form_canon.py
@@ -18,7 +18,8 @@ from cvxpy.atoms import sum_squares
 from cvxpy.atoms.quad_form import decomp_quad
 from cvxpy.expressions.constants import Constant
 from cvxpy.reductions.dcp2cone.canonicalizers.quad_over_lin_canon import (
-    quad_over_lin_canon,)
+    quad_over_lin_canon,
+)
 
 
 def quad_form_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/canonicalizers/suppfunc_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/suppfunc_canon.py
@@ -3,7 +3,8 @@ import numpy as np
 from cvxpy import SOC, Variable, hstack
 from cvxpy.constraints.exponential import ExpCone
 from cvxpy.reductions.solvers.conic_solvers.scs_conif import (
-    scs_psdvec_to_psdmat,)
+    scs_psdvec_to_psdmat,
+)
 
 
 def suppfunc_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/canonicalizers/von_neumann_entr_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/von_neumann_entr_canon.py
@@ -19,7 +19,8 @@ from cvxpy.constraints.nonpos import NonPos
 from cvxpy.constraints.zero import Zero
 from cvxpy.reductions.dcp2cone.canonicalizers.entr_canon import entr_canon
 from cvxpy.reductions.dcp2cone.canonicalizers.lambda_sum_largest_canon import (
-    lambda_sum_largest_canon,)
+    lambda_sum_largest_canon,
+)
 
 
 def von_neumann_entr_canon(expr, args):

--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -19,17 +19,31 @@ import numpy as np
 import scipy.sparse as sp
 
 import cvxpy.settings as s
-from cvxpy.constraints import (PSD, SOC, Equality, ExpCone, Inequality, NonNeg,
-                               NonPos, PowCone3D, Zero,)
+from cvxpy.constraints import (
+    PSD,
+    SOC,
+    Equality,
+    ExpCone,
+    Inequality,
+    NonNeg,
+    NonPos,
+    PowCone3D,
+    Zero,
+)
 from cvxpy.cvxcore.python import canonInterface
 from cvxpy.expressions.variable import Variable
 from cvxpy.problems.objective import Minimize
 from cvxpy.problems.param_prob import ParamProb
 from cvxpy.reductions import InverseData, Solution, cvx_attr2constr
 from cvxpy.reductions.matrix_stuffing import MatrixStuffing, extract_mip_idx
-from cvxpy.reductions.utilities import (ReducedMat, are_args_affine,
-                                        group_constraints, lower_equality,
-                                        lower_ineq_to_nonneg, nonpos2nonneg,)
+from cvxpy.reductions.utilities import (
+    ReducedMat,
+    are_args_affine,
+    group_constraints,
+    lower_equality,
+    lower_ineq_to_nonneg,
+    nonpos2nonneg,
+)
 from cvxpy.utilities.coeff_extractor import CoeffExtractor
 
 

--- a/cvxpy/reductions/dcp2cone/dcp2cone.py
+++ b/cvxpy/reductions/dcp2cone/dcp2cone.py
@@ -21,11 +21,9 @@ from cvxpy.expressions import cvxtypes
 from cvxpy.expressions.expression import Expression
 from cvxpy.problems.objective import Minimize
 from cvxpy.reductions.canonicalization import Canonicalization
-from cvxpy.reductions.dcp2cone.canonicalizers import (
-    CANON_METHODS as cone_canon_methods,)
+from cvxpy.reductions.dcp2cone.canonicalizers import CANON_METHODS as cone_canon_methods
 from cvxpy.reductions.inverse_data import InverseData
-from cvxpy.reductions.qp2quad_form.canonicalizers import (
-    QUAD_CANON_METHODS as quad_canon_methods,)
+from cvxpy.reductions.qp2quad_form.canonicalizers import QUAD_CANON_METHODS as quad_canon_methods
 
 
 class Dcp2Cone(Canonicalization):

--- a/cvxpy/reductions/dgp2dcp/canonicalizers/eye_minus_inv_canon.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/eye_minus_inv_canon.py
@@ -3,9 +3,11 @@ from cvxpy.atoms.affine.diag import diag
 from cvxpy.atoms.one_minus_pos import one_minus_pos
 from cvxpy.expressions.variable import Variable
 from cvxpy.reductions.dgp2dcp.canonicalizers.mulexpression_canon import (
-    mulexpression_canon,)
+    mulexpression_canon,
+)
 from cvxpy.reductions.dgp2dcp.canonicalizers.one_minus_pos_canon import (
-    one_minus_pos_canon,)
+    one_minus_pos_canon,
+)
 
 
 def eye_minus_inv_canon(expr, args):

--- a/cvxpy/reductions/dgp2dcp/canonicalizers/pf_eigenvalue_canon.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/pf_eigenvalue_canon.py
@@ -2,7 +2,8 @@ from cvxpy.atoms.affine.binary_operators import matmul
 from cvxpy.expressions.variable import Variable
 from cvxpy.reductions.dgp2dcp.canonicalizers.mul_canon import mul_canon
 from cvxpy.reductions.dgp2dcp.canonicalizers.mulexpression_canon import (
-    mulexpression_canon,)
+    mulexpression_canon,
+)
 
 
 def pf_eigenvalue_canon(expr, args):

--- a/cvxpy/reductions/eliminate_pwl/canonicalizers/minimum_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/canonicalizers/minimum_canon.py
@@ -16,7 +16,8 @@ limitations under the License.
 
 from cvxpy.atoms.elementwise.maximum import maximum
 from cvxpy.reductions.eliminate_pwl.canonicalizers.maximum_canon import (
-    maximum_canon,)
+    maximum_canon,
+)
 
 
 def minimum_canon(expr, args):

--- a/cvxpy/reductions/eliminate_pwl/eliminate_pwl.py
+++ b/cvxpy/reductions/eliminate_pwl/eliminate_pwl.py
@@ -16,8 +16,7 @@ limitations under the License.
 
 from cvxpy.atoms import abs, max, maximum, norm1, norm_inf, sum_largest
 from cvxpy.reductions.canonicalization import Canonicalization
-from cvxpy.reductions.eliminate_pwl.canonicalizers import (
-    CANON_METHODS as elim_pwl_methods,)
+from cvxpy.reductions.eliminate_pwl.canonicalizers import CANON_METHODS as elim_pwl_methods
 
 
 class EliminatePwl(Canonicalization):

--- a/cvxpy/reductions/qp2quad_form/canonicalizers/huber_canon.py
+++ b/cvxpy/reductions/qp2quad_form/canonicalizers/huber_canon.py
@@ -19,7 +19,8 @@ from cvxpy.atoms.elementwise.power import power
 from cvxpy.expressions.variable import Variable
 from cvxpy.reductions.eliminate_pwl.canonicalizers.abs_canon import abs_canon
 from cvxpy.reductions.qp2quad_form.canonicalizers.power_canon import (
-    power_canon,)
+    power_canon,
+)
 
 
 def huber_canon(expr, args):

--- a/cvxpy/reductions/qp2quad_form/qp2symbolic_qp.py
+++ b/cvxpy/reductions/qp2quad_form/qp2symbolic_qp.py
@@ -17,8 +17,7 @@ limitations under the License.
 from cvxpy.constraints import Equality, Inequality, NonNeg, NonPos, Zero
 from cvxpy.reductions.canonicalization import Canonicalization
 from cvxpy.reductions.cvx_attr2constr import convex_attributes
-from cvxpy.reductions.qp2quad_form.canonicalizers import (
-    CANON_METHODS as qp_canon_methods,)
+from cvxpy.reductions.qp2quad_form.canonicalizers import CANON_METHODS as qp_canon_methods
 from cvxpy.reductions.utilities import are_args_affine
 
 

--- a/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
+++ b/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
@@ -18,8 +18,15 @@ from __future__ import annotations
 import numpy as np
 
 import cvxpy.settings as s
-from cvxpy.constraints import (PSD, SOC, Equality, ExpCone, Inequality, NonPos,
-                               Zero,)
+from cvxpy.constraints import (
+    PSD,
+    SOC,
+    Equality,
+    ExpCone,
+    Inequality,
+    NonPos,
+    Zero,
+)
 from cvxpy.cvxcore.python import canonInterface
 from cvxpy.expressions.variable import Variable
 from cvxpy.problems.objective import Minimize
@@ -27,9 +34,13 @@ from cvxpy.problems.param_prob import ParamProb
 from cvxpy.reductions import InverseData, Solution
 from cvxpy.reductions.cvx_attr2constr import convex_attributes
 from cvxpy.reductions.matrix_stuffing import MatrixStuffing, extract_mip_idx
-from cvxpy.reductions.utilities import (ReducedMat, are_args_affine,
-                                        group_constraints, lower_equality,
-                                        lower_ineq_to_nonpos,)
+from cvxpy.reductions.utilities import (
+    ReducedMat,
+    are_args_affine,
+    group_constraints,
+    lower_equality,
+    lower_ineq_to_nonpos,
+)
 from cvxpy.utilities.coeff_extractor import CoeffExtractor
 
 

--- a/cvxpy/reductions/solvers/conic_solvers/cbc_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cbc_conif.py
@@ -61,8 +61,7 @@ class CBC(ConicSolver):
     def import_solver(self) -> None:
         """Imports the solver.
         """
-        from cylp.cy import CyClpSimplex
-        CyClpSimplex  # noqa F401
+        from cylp.cy import CyClpSimplex  # noqa F401
 
     def accepts(self, problem) -> bool:
         """Can Cbc solve the problem?

--- a/cvxpy/reductions/solvers/conic_solvers/cbc_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cbc_conif.py
@@ -19,7 +19,9 @@ import numpy as np
 import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import (
-    ConicSolver, dims_to_solver_dict,)
+    ConicSolver,
+    dims_to_solver_dict,
+)
 
 
 class CBC(ConicSolver):

--- a/cvxpy/reductions/solvers/conic_solvers/cbc_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cbc_conif.py
@@ -62,7 +62,7 @@ class CBC(ConicSolver):
         """Imports the solver.
         """
         from cylp.cy import CyClpSimplex
-        CyClpSimplex  # For flake8
+        CyClpSimplex  # noqa F401
 
     def accepts(self, problem) -> bool:
         """Can Cbc solve the problem?

--- a/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
@@ -88,7 +88,7 @@ class CLARABEL(ConicSolver):
         """Imports the solver.
         """
         import clarabel
-        clarabel  # For flake8
+        clarabel  # noqa F401
 
     def supports_quad_obj(self) -> bool:
         """Clarabel supports quadratic objective with any combination of conic constraints.

--- a/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
@@ -87,8 +87,7 @@ class CLARABEL(ConicSolver):
     def import_solver(self) -> None:
         """Imports the solver.
         """
-        import clarabel
-        clarabel  # noqa F401
+        import clarabel  # noqa F401
 
     def supports_quad_obj(self) -> bool:
         """Clarabel supports quadratic objective with any combination of conic constraints.

--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -76,7 +76,7 @@ class COPT(ConicSolver):
         Imports the solver.
         """
         import coptpy
-        coptpy  # For flake8
+        coptpy  # noqa F401
 
     def accepts(self, problem):
         """

--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -75,8 +75,7 @@ class COPT(ConicSolver):
         """
         Imports the solver.
         """
-        import coptpy
-        coptpy  # noqa F401
+        import coptpy  # noqa F401
 
     def accepts(self, problem):
         """

--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -9,7 +9,9 @@ from cvxpy.constraints import PSD, SOC
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import (
-    ConicSolver, dims_to_solver_dict,)
+    ConicSolver,
+    dims_to_solver_dict,
+)
 
 
 def tri_to_full(lower_tri, n):

--- a/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
@@ -218,8 +218,7 @@ class CPLEX(ConicSolver):
 
     def import_solver(self) -> None:
         """Imports the solver."""
-        import cplex
-        cplex  # noqa F401
+        import cplex  # noqa F401
 
     def accepts(self, problem) -> bool:
         """Can CPLEX solve the problem?

--- a/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
@@ -25,7 +25,9 @@ from cvxpy.constraints import SOC
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import (
-    ConicSolver, dims_to_solver_dict,)
+    ConicSolver,
+    dims_to_solver_dict,
+)
 
 # Values used to distinguish between linear and quadratic constraints.
 _LIN, _QUAD = 0, 1

--- a/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
@@ -219,7 +219,7 @@ class CPLEX(ConicSolver):
     def import_solver(self) -> None:
         """Imports the solver."""
         import cplex
-        cplex  # For flake8
+        cplex  # noqa F401
 
     def accepts(self, problem) -> bool:
         """Can CPLEX solve the problem?

--- a/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
@@ -73,8 +73,7 @@ class CVXOPT(ConicSolver):
     def import_solver(self) -> None:
         """Imports the solver.
         """
-        import cvxopt
-        cvxopt  # noqa F401
+        import cvxopt  # noqa F401
 
     def accepts(self, problem) -> bool:
         """Can CVXOPT solve the problem?

--- a/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
@@ -74,7 +74,7 @@ class CVXOPT(ConicSolver):
         """Imports the solver.
         """
         import cvxopt
-        cvxopt  # For flake8
+        cvxopt  # noqa F401
 
     def accepts(self, problem) -> bool:
         """Can CVXOPT solve the problem?

--- a/cvxpy/reductions/solvers/conic_solvers/ecos_bb_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/ecos_bb_conif.py
@@ -22,7 +22,9 @@ from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.conic_solvers.ecos_conif import (
-    ECOS, dims_to_solver_dict,)
+    ECOS,
+    dims_to_solver_dict,
+)
 
 
 class ECOS_BB(ECOS):

--- a/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
@@ -73,8 +73,7 @@ class ECOS(ConicSolver):
     def import_solver(self) -> None:
         """Imports the solver.
         """
-        import ecos
-        ecos  # noqa F401
+        import ecos  # noqa F401
 
     def name(self):
         """The name of the solver.

--- a/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
@@ -74,7 +74,7 @@ class ECOS(ConicSolver):
         """Imports the solver.
         """
         import ecos
-        ecos  # For flake8
+        ecos  # noqa F401
 
     def name(self):
         """The name of the solver.

--- a/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
@@ -56,7 +56,7 @@ class GLOP(ConicSolver):
                                f'({ortools.__version__}). Expected < 9.5.0.'
                                'Please open a feature request on cvxpy to '
                                'enable support for this version.')
-        ortools, google.protobuf  # For flake8
+        ortools, google.protobuf  # noqa F401
 
     def apply(self, problem: ParamConeProg) -> Tuple[Dict, Dict]:
         """Returns a new problem and data for inverting the new solution."""

--- a/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
@@ -46,8 +46,8 @@ class GLOP(ConicSolver):
 
     def import_solver(self) -> None:
         """Imports the solver."""
-        import google.protobuf
-        import ortools
+        import google.protobuf  # noqa F401
+        import ortools  # noqa F401
         if Version(ortools.__version__) < Version('9.3.0'):
             raise RuntimeError(f'Version of ortools ({ortools.__version__}) '
                                f'is too old. Expected >= 9.3.0.')
@@ -56,7 +56,6 @@ class GLOP(ConicSolver):
                                f'({ortools.__version__}). Expected < 9.5.0.'
                                'Please open a feature request on cvxpy to '
                                'enable support for this version.')
-        ortools, google.protobuf  # noqa F401
 
     def apply(self, problem: ParamConeProg) -> Tuple[Dict, Dict]:
         """Returns a new problem and data for inverting the new solution."""

--- a/cvxpy/reductions/solvers/conic_solvers/glpk_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glpk_conif.py
@@ -39,7 +39,7 @@ class GLPK(CVXOPT):
         """Imports the solver.
         """
         from cvxopt import glpk
-        glpk  # For flake8
+        glpk  # noqa F401
 
     def invert(self, solution, inverse_data):
         """Returns the solution to the original problem given the inverse_data.

--- a/cvxpy/reductions/solvers/conic_solvers/glpk_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glpk_conif.py
@@ -38,8 +38,7 @@ class GLPK(CVXOPT):
     def import_solver(self) -> None:
         """Imports the solver.
         """
-        from cvxopt import glpk
-        glpk  # noqa F401
+        from cvxopt import glpk  # noqa F401
 
     def invert(self, solution, inverse_data):
         """Returns the solution to the original problem given the inverse_data.

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -61,8 +61,7 @@ class GUROBI(ConicSolver):
     def import_solver(self) -> None:
         """Imports the solver.
         """
-        import gurobipy
-        gurobipy  # noqa F401
+        import gurobipy  # noqa F401
 
     def accepts(self, problem) -> bool:
         """Can Gurobi solve the problem?

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -62,7 +62,7 @@ class GUROBI(ConicSolver):
         """Imports the solver.
         """
         import gurobipy
-        gurobipy  # For flake8
+        gurobipy  # noqa F401
 
     def accepts(self, problem) -> bool:
         """Can Gurobi solve the problem?

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -22,7 +22,9 @@ from cvxpy.constraints import SOC
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import (
-    ConicSolver, dims_to_solver_dict,)
+    ConicSolver,
+    dims_to_solver_dict,
+)
 
 
 class GUROBI(ConicSolver):

--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -89,7 +89,7 @@ class MOSEK(ConicSolver):
         """Imports the solver (updates the set of supported constraints, if applicable).
         """
         import mosek
-        mosek  # For flake8
+        mosek  # noqa F401
         if hasattr(mosek.conetype, 'pexp') and ExpCone not in MOSEK.SUPPORTED_CONSTRAINTS:
             MOSEK.SUPPORTED_CONSTRAINTS.append(ExpCone)
             MOSEK.SUPPORTED_CONSTRAINTS.append(PowCone3D)

--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -88,8 +88,8 @@ class MOSEK(ConicSolver):
     def import_solver(self) -> None:
         """Imports the solver (updates the set of supported constraints, if applicable).
         """
-        import mosek
-        mosek  # noqa F401
+        import mosek  # noqa F401
+
         if hasattr(mosek.conetype, 'pexp') and ExpCone not in MOSEK.SUPPORTED_CONSTRAINTS:
             MOSEK.SUPPORTED_CONSTRAINTS.append(ExpCone)
             MOSEK.SUPPORTED_CONSTRAINTS.append(PowCone3D)

--- a/cvxpy/reductions/solvers/conic_solvers/nag_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/nag_conif.py
@@ -46,7 +46,7 @@ class NAG(ConicSolver):
         """Imports the solver.
         """
         from naginterfaces.library import opt
-        opt  # For flake8
+        opt  # noqa F401
 
     def name(self):
         """The name of the solver.

--- a/cvxpy/reductions/solvers/conic_solvers/nag_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/nag_conif.py
@@ -45,8 +45,7 @@ class NAG(ConicSolver):
     def import_solver(self) -> None:
         """Imports the solver.
         """
-        from naginterfaces.library import opt
-        opt  # noqa F401
+        from naginterfaces.library import opt  # noqa F401
 
     def name(self):
         """The name of the solver.

--- a/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
@@ -168,7 +168,8 @@ class PDLP(ConicSolver):
         request.solver_specific_parameters = text_format.MessageToString(parameters)
         if Version(ortools.__version__) >= Version('9.4.0'):
             from ortools.model_builder.python import (
-                pywrap_model_builder_helper,)
+                pywrap_model_builder_helper,
+            )
             solver = pywrap_model_builder_helper.ModelSolverHelper("pdlp")
             response_str = solver.solve_serialized_request(request.SerializeToString())
             response = linear_solver_pb2.MPSolutionResponse.FromString(response_str)

--- a/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
@@ -46,8 +46,8 @@ class PDLP(ConicSolver):
 
     def import_solver(self) -> None:
         """Imports the solver."""
-        import google.protobuf
-        import ortools
+        import google.protobuf  # noqa F401
+        import ortools  # noqa F401
         if Version(ortools.__version__) < Version('9.3.0'):
             raise RuntimeError(f'Version of ortools ({ortools.__version__}) '
                                f'is too old. Expected >= 9.3.0.')
@@ -56,7 +56,6 @@ class PDLP(ConicSolver):
                                f'({ortools.__version__}). Expected < 9.5.0.'
                                'Please open a feature request on cvxpy to '
                                'enable support for this version.')
-        ortools, google.protobuf  # noqa F401
 
     def apply(self, problem: ParamConeProg) -> Tuple[Dict, Dict]:
         """Returns a new problem and data for inverting the new solution."""

--- a/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
@@ -56,7 +56,7 @@ class PDLP(ConicSolver):
                                f'({ortools.__version__}). Expected < 9.5.0.'
                                'Please open a feature request on cvxpy to '
                                'enable support for this version.')
-        ortools, google.protobuf  # For flake8
+        ortools, google.protobuf  # noqa F401
 
     def apply(self, problem: ParamConeProg) -> Tuple[Dict, Dict]:
         """Returns a new problem and data for inverting the new solution."""

--- a/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
@@ -27,7 +27,9 @@ from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ParamConeProg
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import (
-    ConicSolver, dims_to_solver_dict,)
+    ConicSolver,
+    dims_to_solver_dict,
+)
 
 log = logging.getLogger(__name__)
 

--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -52,7 +52,7 @@ class SCIPY(ConicSolver):
         """Imports the solver.
         """
         from scipy import optimize as opt
-        opt  # For flake8
+        opt  # noqa F401
 
     def name(self):
         """The name of the solver.

--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -51,8 +51,7 @@ class SCIPY(ConicSolver):
     def import_solver(self) -> None:
         """Imports the solver.
         """
-        from scipy import optimize as opt
-        opt  # noqa F401
+        from scipy import optimize as opt  # noqa F401
 
     def name(self):
         """The name of the solver.

--- a/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
@@ -159,7 +159,7 @@ class SCS(ConicSolver):
         """Imports the solver.
         """
         import scs
-        scs  # For flake8
+        scs  # noqa F401
 
     def supports_quad_obj(self) -> bool:
         """SCS >= 3.0.0 supports a quadratic objective.

--- a/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
@@ -158,8 +158,7 @@ class SCS(ConicSolver):
     def import_solver(self) -> None:
         """Imports the solver.
         """
-        import scs
-        scs  # noqa F401
+        import scs  # noqa F401
 
     def supports_quad_obj(self) -> bool:
         """SCS >= 3.0.0 supports a quadratic objective.

--- a/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
@@ -22,9 +22,12 @@ from cvxpy.constraints import PSD, SOC, ExpCone, PowCone3D
 from cvxpy.expressions.expression import Expression
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
-from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import (
-    dims_to_solver_dict as dims_to_solver_dict_default,)
+    ConicSolver,
+)
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import (
+    dims_to_solver_dict as dims_to_solver_dict_default,
+)
 from cvxpy.utilities.versioning import Version
 
 

--- a/cvxpy/reductions/solvers/conic_solvers/sdpa_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/sdpa_conif.py
@@ -62,7 +62,7 @@ class SDPA(ConicSolver):
         """Imports the solver.
         """
         import sdpap
-        sdpap  # For flake8
+        sdpap  # noqa F401
 
     def accepts(self, problem) -> bool:
         """Can SDPA solve the problem?

--- a/cvxpy/reductions/solvers/conic_solvers/sdpa_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/sdpa_conif.py
@@ -61,8 +61,7 @@ class SDPA(ConicSolver):
     def import_solver(self) -> None:
         """Imports the solver.
         """
-        import sdpap
-        sdpap  # noqa F401
+        import sdpap  # noqa F401
 
     def accepts(self, problem) -> bool:
         """Can SDPA solve the problem?

--- a/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
@@ -21,7 +21,9 @@ from cvxpy.constraints import SOC
 from cvxpy.reductions.solution import Solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import (
-    ConicSolver, dims_to_solver_dict,)
+    ConicSolver,
+    dims_to_solver_dict,
+)
 
 
 def makeMstart(A, n, ifCol: int = 1):

--- a/cvxpy/reductions/solvers/defines.py
+++ b/cvxpy/reductions/solvers/defines.py
@@ -19,39 +19,31 @@ import scipy  # For version checks
 
 import cvxpy.settings as s
 from cvxpy.reductions.solvers.conic_solvers.cbc_conif import CBC as CBC_con
-from cvxpy.reductions.solvers.conic_solvers.clarabel_conif import (
-    CLARABEL as CLARABEL_con,)
+from cvxpy.reductions.solvers.conic_solvers.clarabel_conif import CLARABEL as CLARABEL_con
 from cvxpy.reductions.solvers.conic_solvers.copt_conif import COPT as COPT_con
-from cvxpy.reductions.solvers.conic_solvers.cplex_conif import (
-    CPLEX as CPLEX_con,)
-from cvxpy.reductions.solvers.conic_solvers.cvxopt_conif import (
-    CVXOPT as CVXOPT_con,)
+from cvxpy.reductions.solvers.conic_solvers.cplex_conif import CPLEX as CPLEX_con
+from cvxpy.reductions.solvers.conic_solvers.cvxopt_conif import CVXOPT as CVXOPT_con
+
 # Conic interfaces
-from cvxpy.reductions.solvers.conic_solvers.diffcp_conif import (
-    DIFFCP as DIFFCP_con,)
-from cvxpy.reductions.solvers.conic_solvers.ecos_bb_conif import (
-    ECOS_BB as ECOS_BB_con,)
+from cvxpy.reductions.solvers.conic_solvers.diffcp_conif import DIFFCP as DIFFCP_con
+from cvxpy.reductions.solvers.conic_solvers.ecos_bb_conif import ECOS_BB as ECOS_BB_con
 from cvxpy.reductions.solvers.conic_solvers.ecos_conif import ECOS as ECOS_con
 from cvxpy.reductions.solvers.conic_solvers.glop_conif import GLOP as GLOP_con
 from cvxpy.reductions.solvers.conic_solvers.glpk_conif import GLPK as GLPK_con
-from cvxpy.reductions.solvers.conic_solvers.glpk_mi_conif import (
-    GLPK_MI as GLPK_MI_con,)
-from cvxpy.reductions.solvers.conic_solvers.gurobi_conif import (
-    GUROBI as GUROBI_con,)
-from cvxpy.reductions.solvers.conic_solvers.mosek_conif import (
-    MOSEK as MOSEK_con,)
+from cvxpy.reductions.solvers.conic_solvers.glpk_mi_conif import GLPK_MI as GLPK_MI_con
+from cvxpy.reductions.solvers.conic_solvers.gurobi_conif import GUROBI as GUROBI_con
+from cvxpy.reductions.solvers.conic_solvers.mosek_conif import MOSEK as MOSEK_con
 from cvxpy.reductions.solvers.conic_solvers.nag_conif import NAG as NAG_con
 from cvxpy.reductions.solvers.conic_solvers.pdlp_conif import PDLP as PDLP_con
 from cvxpy.reductions.solvers.conic_solvers.scip_conif import SCIP as SCIP_con
-from cvxpy.reductions.solvers.conic_solvers.scipy_conif import (
-    SCIPY as SCIPY_con,)
+from cvxpy.reductions.solvers.conic_solvers.scipy_conif import SCIPY as SCIPY_con
 from cvxpy.reductions.solvers.conic_solvers.scs_conif import SCS as SCS_con
 from cvxpy.reductions.solvers.conic_solvers.sdpa_conif import SDPA as SDPA_con
-from cvxpy.reductions.solvers.conic_solvers.xpress_conif import (
-    XPRESS as XPRESS_con,)
+from cvxpy.reductions.solvers.conic_solvers.xpress_conif import XPRESS as XPRESS_con
 from cvxpy.reductions.solvers.qp_solvers.copt_qpif import COPT as COPT_qp
 from cvxpy.reductions.solvers.qp_solvers.cplex_qpif import CPLEX as CPLEX_qp
 from cvxpy.reductions.solvers.qp_solvers.gurobi_qpif import GUROBI as GUROBI_qp
+
 # QP interfaces
 from cvxpy.reductions.solvers.qp_solvers.osqp_qpif import OSQP as OSQP_qp
 from cvxpy.reductions.solvers.qp_solvers.proxqp_qpif import PROXQP as PROXQP_qp

--- a/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
@@ -40,8 +40,7 @@ class COPT(QpSolver):
         """
         Imports the solver.
         """
-        import coptpy
-        coptpy  # For flake8
+        import coptpy  # noqa F401
 
     def invert(self, solution, inverse_data):
         """

--- a/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/cplex_qpif.py
@@ -4,7 +4,10 @@ import cvxpy.interface as intf
 import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.conic_solvers.cplex_conif import (
-    get_status, hide_solver_output, set_parameters,)
+    get_status,
+    hide_solver_output,
+    set_parameters,
+)
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 
 

--- a/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
+++ b/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
@@ -20,8 +20,10 @@ import scipy.sparse as sp
 import cvxpy.settings as s
 from cvxpy.constraints import NonPos, Zero
 from cvxpy.reductions.cvx_attr2constr import convex_attributes
-from cvxpy.reductions.qp2quad_form.qp_matrix_stuffing import (ConeDims,
-                                                              ParamQuadProg,)
+from cvxpy.reductions.qp2quad_form.qp_matrix_stuffing import (
+    ConeDims,
+    ParamQuadProg,
+)
 from cvxpy.reductions.solvers.solver import Solver
 from cvxpy.reductions.utilities import group_constraints
 

--- a/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
@@ -4,7 +4,9 @@ import cvxpy.interface as intf
 import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.conic_solvers.xpress_conif import (
-    get_status_maps, makeMstart,)
+    get_status_maps,
+    makeMstart,
+)
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 
 

--- a/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
@@ -24,8 +24,7 @@ class XPRESS(QpSolver):
 
     def import_solver(self) -> None:
 
-        import xpress
-        xpress  # Prevents flake8 warning
+        import xpress  # noqa F401
 
     def apply(self, problem):
         """Returns a new problem and data for inverting the new solution.

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -6,22 +6,35 @@ from typing import List, Optional
 import numpy as np
 
 from cvxpy.atoms import EXP_ATOMS, NONPOS_ATOMS, PSD_ATOMS, SOC_ATOMS
-from cvxpy.constraints import (PSD, SOC, Equality, ExpCone, FiniteSet,
-                               Inequality, NonNeg, NonPos, PowCone3D, Zero,)
+from cvxpy.constraints import (
+    PSD,
+    SOC,
+    Equality,
+    ExpCone,
+    FiniteSet,
+    Inequality,
+    NonNeg,
+    NonPos,
+    PowCone3D,
+    Zero,
+)
 from cvxpy.constraints.exponential import OpRelEntrConeQuad, RelEntrConeQuad
 from cvxpy.error import DCPError, DGPError, DPPError, SolverError
 from cvxpy.problems.objective import Maximize
 from cvxpy.reductions.chain import Chain
 from cvxpy.reductions.complex2real import complex2real
 from cvxpy.reductions.cone2cone.approximations import APPROX_CONES, QuadApprox
-from cvxpy.reductions.cone2cone.exotic2common import (EXOTIC_CONES,
-                                                      Exotic2Common,)
+from cvxpy.reductions.cone2cone.exotic2common import (
+    EXOTIC_CONES,
+    Exotic2Common,
+)
 from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
 from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
 from cvxpy.reductions.dcp2cone.dcp2cone import Dcp2Cone
 from cvxpy.reductions.dgp2dcp.dgp2dcp import Dgp2Dcp
 from cvxpy.reductions.discrete2mixedint.valinvec2mixedint import (
-    Valinvec2mixedint,)
+    Valinvec2mixedint,
+)
 from cvxpy.reductions.eval_params import EvalParams
 from cvxpy.reductions.flip_objective import FlipObjective
 from cvxpy.reductions.qp2quad_form import qp2symbolic_qp

--- a/cvxpy/reductions/solvers/utilities.py
+++ b/cvxpy/reductions/solvers/utilities.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict
-
 """
 Copyright 2013 Steven Diamond
 
@@ -17,6 +15,7 @@ limitations under the License.
 """
 
 import numpy as np
+from typing import Any, Dict
 
 import cvxpy.interface as intf
 

--- a/cvxpy/reductions/solvers/utilities.py
+++ b/cvxpy/reductions/solvers/utilities.py
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import numpy as np
 from typing import Any, Dict
+
+import numpy as np
 
 import cvxpy.interface as intf
 

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -31,8 +31,7 @@ from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
 from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
 from cvxpy.reductions.dcp2cone.dcp2cone import Dcp2Cone
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
-from cvxpy.reductions.solvers.defines import (
-    INSTALLED_MI_SOLVERS as INSTALLED_MI,)
+from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS as INSTALLED_MI
 from cvxpy.reductions.solvers.defines import MI_SOCP_SOLVERS as MI_SOCP
 from cvxpy.tests import solver_test_helpers as STH
 from cvxpy.tests.base_test import BaseTest

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -24,14 +24,20 @@ import scipy.stats as st
 
 import cvxpy as cp
 import cvxpy.tests.solver_test_helpers as sths
-from cvxpy.reductions.solvers.defines import (INSTALLED_MI_SOLVERS,
-                                              INSTALLED_SOLVERS,)
+from cvxpy.reductions.solvers.defines import (
+    INSTALLED_MI_SOLVERS,
+    INSTALLED_SOLVERS,
+)
 from cvxpy.tests.base_test import BaseTest
-from cvxpy.tests.solver_test_helpers import (StandardTestECPs, StandardTestLPs,
-                                             StandardTestMixedCPs,
-                                             StandardTestPCPs, StandardTestQPs,
-                                             StandardTestSDPs,
-                                             StandardTestSOCPs,)
+from cvxpy.tests.solver_test_helpers import (
+    StandardTestECPs,
+    StandardTestLPs,
+    StandardTestMixedCPs,
+    StandardTestPCPs,
+    StandardTestQPs,
+    StandardTestSDPs,
+    StandardTestSOCPs,
+)
 from cvxpy.utilities.versioning import Version
 
 
@@ -1807,9 +1813,11 @@ class TestAllSolvers(BaseTest):
     def test_installed_solvers(self) -> None:
         """Test the list of installed solvers.
         """
-        from cvxpy.reductions.solvers.defines import (INSTALLED_SOLVERS,
-                                                      SOLVER_MAP_CONIC,
-                                                      SOLVER_MAP_QP,)
+        from cvxpy.reductions.solvers.defines import (
+            INSTALLED_SOLVERS,
+            SOLVER_MAP_CONIC,
+            SOLVER_MAP_QP,
+        )
         prob = cp.Problem(cp.Minimize(cp.norm(self.x, 1) + 1.0), [self.x == 0])
         for solver in SOLVER_MAP_CONIC.keys():
             if solver in INSTALLED_SOLVERS:

--- a/cvxpy/tests/test_lin_ops.py
+++ b/cvxpy/tests/test_lin_ops.py
@@ -17,11 +17,26 @@ limitations under the License.
 import numpy as np
 import scipy.sparse as sp
 
-from cvxpy.lin_ops.lin_op import (DENSE_CONST, NEG, PARAM, SCALAR_CONST,
-                                  SPARSE_CONST, SUM_ENTRIES, VARIABLE,)
-from cvxpy.lin_ops.lin_utils import (create_const, create_eq, create_leq,
-                                     create_param, create_var, get_expr_vars,
-                                     neg_expr, sum_entries, sum_expr,)
+from cvxpy.lin_ops.lin_op import (
+    DENSE_CONST,
+    NEG,
+    PARAM,
+    SCALAR_CONST,
+    SPARSE_CONST,
+    SUM_ENTRIES,
+    VARIABLE,
+)
+from cvxpy.lin_ops.lin_utils import (
+    create_const,
+    create_eq,
+    create_leq,
+    create_param,
+    create_var,
+    get_expr_vars,
+    neg_expr,
+    sum_entries,
+    sum_expr,
+)
 from cvxpy.tests.base_test import BaseTest
 
 

--- a/cvxpy/tests/test_mip_vars.py
+++ b/cvxpy/tests/test_mip_vars.py
@@ -19,8 +19,7 @@ import numpy as np
 
 import cvxpy as cp
 import cvxpy.settings as s
-from cvxpy.reductions.solvers.defines import (
-    INSTALLED_MI_SOLVERS as MIP_SOLVERS,)
+from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS as MIP_SOLVERS
 from cvxpy.tests.base_test import BaseTest
 
 

--- a/cvxpy/tests/test_numpy.py
+++ b/cvxpy/tests/test_numpy.py
@@ -19,8 +19,10 @@ import numpy as np
 import pytest
 
 import cvxpy as cp
-from cvxpy.expressions.expression import (__BINARY_EXPRESSION_UFUNCS__,
-                                          __NUMPY_UFUNC_ERROR__,)
+from cvxpy.expressions.expression import (
+    __BINARY_EXPRESSION_UFUNCS__,
+    __NUMPY_UFUNC_ERROR__,
+)
 from cvxpy.tests.base_test import BaseTest
 
 

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -27,6 +27,7 @@ import numpy
 import numpy as np
 import pytest
 import scipy.sparse as sp
+
 # Solvers.
 import scs
 from numpy import linalg as LA
@@ -41,8 +42,10 @@ from cvxpy.expressions.variable import Variable
 from cvxpy.problems.problem import Problem
 from cvxpy.reductions.solvers.conic_solvers import ecos_conif, scs_conif
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
-from cvxpy.reductions.solvers.defines import (INSTALLED_SOLVERS,
-                                              SOLVER_MAP_CONIC,)
+from cvxpy.reductions.solvers.defines import (
+    INSTALLED_SOLVERS,
+    SOLVER_MAP_CONIC,
+)
 from cvxpy.tests.base_test import BaseTest
 
 

--- a/cvxpy/tests/test_python_backends.py
+++ b/cvxpy/tests/test_python_backends.py
@@ -9,7 +9,11 @@ import scipy.sparse as sp
 
 import cvxpy.settings as s
 from cvxpy.lin_ops.canon_backend import (
-    CanonBackend, ScipyCanonBackend, ScipyTensorView, TensorRepresentation,)
+    CanonBackend,
+    ScipyCanonBackend,
+    ScipyTensorView,
+    TensorRepresentation,
+)
 
 
 @dataclass

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -21,8 +21,17 @@ from scipy.linalg import lstsq
 
 import cvxpy as cp
 from cvxpy import Maximize, Minimize, Parameter, Problem
-from cvxpy.atoms import (QuadForm, abs, huber, matrix_frac, norm, power,
-                         quad_over_lin, sum, sum_squares,)
+from cvxpy.atoms import (
+    QuadForm,
+    abs,
+    huber,
+    matrix_frac,
+    norm,
+    power,
+    quad_over_lin,
+    sum,
+    sum_squares,
+)
 from cvxpy.expressions.variable import Variable
 from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS, QP_SOLVERS
 from cvxpy.tests.base_test import BaseTest

--- a/cvxpy/transforms/partial_optimize.py
+++ b/cvxpy/transforms/partial_optimize.py
@@ -77,11 +77,11 @@ def partial_optimize(
     # If opt_vars is not specified, it's the complement of dont_opt_vars.
     elif opt_vars is None:
         ids = [id(var) for var in dont_opt_vars]
-        opt_vars = [var for var in prob.variables() if not id(var) in ids]
+        opt_vars = [var for var in prob.variables() if id(var) not in ids]
     # If dont_opt_vars is not specified, it's the complement of opt_vars.
     elif dont_opt_vars is None:
         ids = [id(var) for var in opt_vars]
-        dont_opt_vars = [var for var in prob.variables() if not id(var) in ids]
+        dont_opt_vars = [var for var in prob.variables() if id(var) not in ids]
     elif opt_vars is not None and dont_opt_vars is not None:
         ids = [id(var) for var in opt_vars + dont_opt_vars]
         for var in prob.variables():

--- a/cvxpy/transforms/suppfunc.py
+++ b/cvxpy/transforms/suppfunc.py
@@ -94,7 +94,6 @@ def scs_cone_selectors(K):
     return selectors
 
 
-# flake8: noqa: E501
 class SuppFunc:
     """
     Given a list of CVXPY Constraint objects :math:`\\texttt{constraints}`

--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -25,8 +25,10 @@ import scipy.sparse as sp
 from cvxpy.cvxcore.python import canonInterface
 from cvxpy.lin_ops.lin_op import NO_OP, LinOp
 from cvxpy.reductions.inverse_data import InverseData
-from cvxpy.utilities.replace_quad_forms import (replace_quad_forms,
-                                                restore_quad_forms,)
+from cvxpy.utilities.replace_quad_forms import (
+    replace_quad_forms,
+    restore_quad_forms,
+)
 
 
 # TODO find best format for sparse matrices: csr, csc, dok, lil, ...

--- a/cvxpy/utilities/scopes.py
+++ b/cvxpy/utilities/scopes.py
@@ -1,5 +1,3 @@
-from typing import Generator
-
 """
 Copyright, the CVXPY authors
 
@@ -16,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import contextlib
+from typing import Generator
+
 
 _dpp_scope_active = False
 

--- a/cvxpy/utilities/scopes.py
+++ b/cvxpy/utilities/scopes.py
@@ -16,7 +16,6 @@ limitations under the License.
 import contextlib
 from typing import Generator
 
-
 _dpp_scope_active = False
 
 

--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -154,15 +154,13 @@ Please add the following license to new files:
 
 Code style
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-We use `flake8 <https://flake8.pycqa.org/en/latest/>`_ and
-`isort <https://pycqa.github.io/isort/>`_ to enforce our Python coding
+We use `ruff <https://beta.ruff.rs/docs/>`_ to enforce our Python coding
 style. Before sending us a pull request, navigate to the project root
 and run
 
   ::
-
-    flake8 cvxpy/
-    isort .
+    pip install ruff
+    ruff check cvxpy
 
 to make sure that your changes abide by our style conventions. Please fix any
 errors that are reported before sending the pull request.

--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -159,6 +159,7 @@ style. Before sending us a pull request, navigate to the project root
 and run
 
   ::
+
     pip install ruff
     ruff check cvxpy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ exclude = [
     "cvxpy/cvxcore/*",
     "*__init__.py"
 ]
-# Assume Python 3.8.
-target-version = "py38"
+# The minimum Python version that should be supported
+target-version = "py37"
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.ruff]
+select = ["E", "F", "I"]
 line-length = 100
 exclude = [
     "build",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,13 @@
-[tool.isort]
-include_trailing_comma = true
-use_parentheses = true
-extend_skip = [
-    "cvxpy/__init__.py",
-    "cvxpy/reductions/__init__.py",
-    "cvxpy/reductions/dcp2cone/canonicalizers/__init__.py"
+[tool.ruff]
+line-length = 100
+exclude = [
+    "build",
+    "examples",
+    "doc",
+    "cvxpy/cvxcore/*",
+    "*__init__.py"
 ]
+
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ exclude = [
     "cvxpy/cvxcore/*",
     "*__init__.py"
 ]
+# Assume Python 3.8.
+target-version = "py38"
 
 
 [tool.pytest.ini_options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,3 @@ SCIP = PySCIPOpt
 SCIPY = scipy
 SCS = setuptools>65.5.1
 XPRESS = xpress
-
-[flake8]
-max-line-length=100
-exclude=build,examples,doc,cvxpy/cvxcore/*,*__init__.py


### PR DESCRIPTION
## Description
This PR adds configuration for [ruff](https://github.com/charliermarsh/ruff), an extremely fast linter for Python projects and is used by SciPy, pandas, and many others. It includes the relevant rules from flake8 and isort.
Currently, the `isort` pre-commit hook needs an upgrade and I used this as an opportunity to unify all of our linting under one umbrella.
You can run
```
pip install ruff
ruff check cvxpy
```
to try it out (yes, it actually did execute). 

To update you're pre-commit hooks in this branch, run
```
pre-commit clean
pre-commit install
```
Mostly put this together out of curiosity and so other people can try it out easily to see if they like it. 

Seems to work nicely with the GitHub inline errors:
![image](https://user-images.githubusercontent.com/44360364/220686879-38c8ea67-1ed4-4a39-9fb4-200c2393d8a8.png)



Tasks:
- [x] Configuration
- [x] Documentation
- [x] Linter action

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.