### PR TITLE
New deepcopy semantics

### DIFF
--- a/cvxpy/constraints/constraint.py
+++ b/cvxpy/constraints/constraint.py
@@ -195,6 +195,10 @@ class Constraint(u.Canonical):
         """
         return self.constr_id
 
+    @id.setter
+    def id(self, value):
+        self.constr_id = value
+
     def get_data(self):
         """Data needed to copy.
         """

--- a/cvxpy/tests/test_copy.py
+++ b/cvxpy/tests/test_copy.py
@@ -27,10 +27,6 @@ def test_leaf():
     b = copy.copy(a)
     c = copy.deepcopy(a)
 
-    assert a is b
-    assert a is not c
-    assert b is not c
-
     assert a.id == b.id
     assert a.id != c.id
 
@@ -44,10 +40,6 @@ def test_constraint():
     a = Equality(x, 0)
     b = copy.copy(a)
     c = copy.deepcopy(a)
-
-    assert a is not b
-    assert a is not c
-    assert b is not c
 
     assert a.id == b.id
     assert a.id != c.id
@@ -63,10 +55,6 @@ def test_expression():
     a = x + 1
     b = copy.copy(a)
     c = copy.deepcopy(a)
-
-    assert a is not b
-    assert a is not c
-    assert b is not c
 
     assert a.id != b.id
     assert a.id != c.id

--- a/cvxpy/tests/test_copy.py
+++ b/cvxpy/tests/test_copy.py
@@ -1,0 +1,134 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import copy
+
+import numpy as np
+
+import cvxpy as cp
+from cvxpy.constraints import Equality
+
+
+def test_leaf():
+    a = cp.Variable()
+    b = copy.copy(a)
+    c = copy.deepcopy(a)
+
+    assert a is b
+    assert a is not c
+    assert b is not c
+
+    assert a.id == b.id
+    assert a.id != c.id
+
+    assert id(a) == id(b)
+    assert id(a) != id(c)
+
+
+def test_constraint():
+    x = cp.Variable()
+
+    a = Equality(x, 0)
+    b = copy.copy(a)
+    c = copy.deepcopy(a)
+
+    assert a is not b
+    assert a is not c
+    assert b is not c
+
+    assert a.id == b.id
+    assert a.id != c.id
+
+    assert id(a) != id(b)
+    assert id(a) != id(c)
+    assert id(b) != id(c)
+
+
+def test_expression():
+    x = cp.Variable()
+
+    a = x + 1
+    b = copy.copy(a)
+    c = copy.deepcopy(a)
+
+    assert a is not b
+    assert a is not c
+    assert b is not c
+
+    assert a.id != b.id
+    assert a.id != c.id
+
+    assert id(a) != id(b)
+    assert id(a) != id(c)
+    assert id(b) != id(c)
+
+
+def test_problem():
+    x = cp.Variable()
+    y = cp.Variable()
+    obj = cp.Minimize((x + y) ** 2)
+    constraints = [x + y == 1]
+    prob = cp.Problem(obj, constraints)
+    prob_copy = prob.copy()
+    prob_deepcopy = copy.deepcopy(prob)
+
+    assert id(prob) != id(prob_copy)
+    assert id(prob) != id(prob_deepcopy)
+    assert id(prob_copy) != id(prob_deepcopy)
+
+    prob.solve()
+    assert prob.status == cp.OPTIMAL
+
+    prob_copy.solve()
+    assert prob_copy.status == cp.OPTIMAL
+
+    prob_deepcopy.solve()
+    assert prob_deepcopy.status == cp.OPTIMAL
+
+
+def test_constraints_in_problem():
+
+    x = cp.Variable(name='x', nonneg=True)
+    y = cp.Variable(name='y', nonneg=True)
+
+    original_constraints = [
+        x + y == 1
+    ]
+    shallow_constraints = copy.copy(original_constraints)
+
+    obj = cp.Maximize((x + 2 * y))
+    prob = cp.Problem(obj, shallow_constraints)
+    prob.solve()
+    assert prob.status == cp.OPTIMAL
+    assert np.allclose(x.value, 0)
+    assert np.allclose(y.value, 1)
+
+    deep_constraints = copy.deepcopy(original_constraints)
+    prob = cp.Problem(obj, deep_constraints)
+    prob.solve()
+    # The constraints refer to the original variables, so the problem is unbounded
+    assert prob.status == cp.UNBOUNDED
+
+    x_copied = deep_constraints[0].variables()[0]
+    y_copied = deep_constraints[0].variables()[1]
+
+    deep_obj = cp.Maximize((x_copied + 2 * y_copied))
+    prob = cp.Problem(deep_obj, deep_constraints)
+    prob.solve()
+    # Can get back the same solution by using copied variables
+    assert prob.status == cp.OPTIMAL
+    assert np.allclose(x_copied.value, 0)
+    assert np.allclose(y_copied.value, 1)

--- a/cvxpy/tests/test_copy.py
+++ b/cvxpy/tests/test_copy.py
@@ -70,7 +70,7 @@ def test_problem():
     obj = cp.Minimize((x + y) ** 2)
     constraints = [x + y == 1]
     prob = cp.Problem(obj, constraints)
-    prob_copy = prob.copy()
+    prob_copy = copy.copy(prob)
     prob_deepcopy = copy.deepcopy(prob)
 
     assert id(prob) != id(prob_copy)

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 import builtins
-import copy
 import pickle
 import sys
 import warnings
@@ -25,7 +24,6 @@ from io import StringIO
 import ecos
 import numpy
 import numpy as np
-import pytest
 import scipy.sparse as sp
 # Solvers.
 import scs
@@ -2061,27 +2059,3 @@ class TestProblem(BaseTest):
             c = cp.sum(a)
             cp.Problem(cp.Maximize(0), [c >= 0])
             assert len(w) == 0
-
-    def test_copy_constraints(self) -> None:
-        """Test copy and deepcopy of constraints.
-        """
-        x = cp.Variable()
-        y = cp.Variable()
-
-        constraints = [
-            x + y == 1,
-            x - y >= 1
-        ]
-        constraints[0].atoms()
-        constraints = copy.copy(constraints)
-
-        obj = cp.Minimize((x - y) ** 2)
-        prob = cp.Problem(obj, constraints)
-        prob.solve()
-        assert prob.status == cp.OPTIMAL
-        assert np.allclose(x.value, 1)
-        assert np.allclose(y.value, 0)
-
-        error_msg = "Creating a deepcopy of a CVXPY expression is not supported"
-        with pytest.raises(NotImplementedError, match=error_msg):
-            copy.deepcopy(constraints)

--- a/cvxpy/utilities/canonical.py
+++ b/cvxpy/utilities/canonical.py
@@ -15,7 +15,9 @@ limitations under the License.
 """
 
 import abc
+import copy
 
+import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.utilities import performance_utils as pu
 from cvxpy.utilities.deterministic import unique_list
 
@@ -110,8 +112,17 @@ class Canonical:
         """
         Called by copy.deepcopy()
         """
-        raise NotImplementedError('Creating a deepcopy of a CVXPY expression is not supported. '
-                                  'Use .copy() instead.')
+        cvxpy_id = getattr(self, 'id', None)
+        if cvxpy_id is not None and cvxpy_id in memo:
+            return memo[cvxpy_id]
+        else:
+            with DefaultDeepCopyContextManager(self):  # Avoid infinite recursion
+                new = copy.deepcopy(self, memo)
+            if getattr(self, 'id', None) is not None:
+                new_id = lu.get_id()
+                new.id = new_id
+            memo[cvxpy_id] = new
+            return new
 
     def get_data(self) -> None:
         """Returns info needed to reconstruct the object besides the args.
@@ -131,3 +142,26 @@ class Canonical:
         """
         # Remove duplicates.
         return unique_list(atom for arg in self.args for atom in arg.atoms())
+
+
+_MISSING = object()
+
+
+class DefaultDeepCopyContextManager:
+    """
+    override custom __deepcopy__ implementation and call copy.deepcopy's implementation instead
+    """
+
+    def __init__(self, item):
+        self.item = item
+        self.deepcopy = None
+
+    def __enter__(self):
+        self.deepcopy = getattr(self.item, '__deepcopy__', _MISSING)
+        if self.deepcopy is not _MISSING:
+            self.item.__deepcopy__ = None
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.deepcopy is not _MISSING:
+            self.item.__deepcopy__ = self.deepcopy
+            self.deepcopy = _MISSING

--- a/cvxpy/utilities/canonical.py
+++ b/cvxpy/utilities/canonical.py
@@ -105,12 +105,23 @@ class Canonical:
     def __copy__(self):
         """
         Called by copy.copy()
+        Creates a shallow copy of the object, that is, the copied object refers to the same
+        leaf nodes as the original object. Non-leaf nodes are recreated.
+        Constraints keep their .id attribute, as it is used to propagate dual variables.
+
+        Summary:
+        ========
+        Leafs:              Same object
+        Constraints:        New object with same .id
+        Other expressions:  New object with new .id
         """
         return self.copy()
 
     def __deepcopy__(self, memo):
         """
         Called by copy.deepcopy()
+        Creates an independent copy of the object while maintaining the relationship between the
+        nodes in the expression tree.
         """
         cvxpy_id = getattr(self, 'id', None)
         if cvxpy_id is not None and cvxpy_id in memo:

--- a/doc/source/faq/index.rst
+++ b/doc/source/faq/index.rst
@@ -96,6 +96,18 @@ How do I create variables with more than 2 dimensions?
 You must mimic the extra dimensions using a dict,
 as described in `this Github issue <https://github.com/cvxpy/cvxpy/issues/198>`__.
 
+Can I copy CVXPY expressions?
+-----------------------------
+Yes, CVXPY supports shallow and deep copying using the ``copy`` and ``deepcopy`` functions from the ``copy`` module.
+
+A (shallow) copy refers to the same leaf nodes (Variables, Constants, and Parameters) as the original object.
+Non-leaf nodes are recreated. Constraints keep their ``.id`` attribute, as it is used to propagate dual variables.
+
+A deepcopy creates an independent copy of the object while maintaining the relationship between the
+nodes in the expression tree.
+
+
+
 Why does it take so long to compile my Problem?
 -----------------------------------------------
 In general, you should vectorize CVXPY expressions whenever possible if you


### PR DESCRIPTION
## Description
Resumes #2014. This PR can be used to work on the new semantics, and we can still decide which version to backport to 1.1, 1.2, 1.3, respectively. 

Implementation based on a suggestion by @michael-123123.

TODO: Documentation for new behaviour. 

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.