### PR TITLE
add a cvxpy_shape type (fix #2026)

### DIFF
--- a/cvxpy/atoms/affine/add_expr.py
+++ b/cvxpy/atoms/affine/add_expr.py
@@ -22,6 +22,7 @@ import cvxpy.lin_ops.lin_utils as lu
 import cvxpy.utilities as u
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class AddExpression(AffAtom):
@@ -36,7 +37,7 @@ class AddExpression(AffAtom):
         for group in arg_groups:
             self.args += self.expand_args(group)
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return u.shape.sum_shapes([arg.shape for arg in self.args])
@@ -103,7 +104,7 @@ class AddExpression(AffAtom):
         return copy
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Sum the linear expressions.
 

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -36,6 +36,7 @@ from cvxpy.constraints.constraint import Constraint
 from cvxpy.error import DCPError
 from cvxpy.expressions.constants.parameter import (is_param_affine,
                                                    is_param_free,)
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class BinaryOperator(AffAtom):
@@ -114,7 +115,7 @@ class MulExpression(BinaryOperator):
         else:
             return np.matmul(values[0], values[1])
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return u.shape.mul_shapes(self.args[0].shape, self.args[1].shape)
@@ -202,7 +203,7 @@ class MulExpression(BinaryOperator):
         return [DX, DY]
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Multiply the linear expressions.
 
@@ -272,7 +273,7 @@ class multiply(MulExpression):
         else:
             return np.multiply(values[0], values[1])
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """The sum of the argument dimensions - 1.
         """
         return u.shape.sum_shapes([arg.shape for arg in self.args])
@@ -290,7 +291,7 @@ class multiply(MulExpression):
                (self.args[0].is_nsd() and self.args[1].is_psd())
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Multiply the expressions elementwise.
 
@@ -351,7 +352,7 @@ class DivExpression(BinaryOperator):
     def is_qpwa(self) -> bool:
         return self.args[0].is_qpwa() and self.args[1].is_constant()
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return self.args[0].shape
@@ -398,7 +399,7 @@ class DivExpression(BinaryOperator):
             return self.args[0].is_nonneg()
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Multiply the linear expressions.
 

--- a/cvxpy/atoms/affine/conj.py
+++ b/cvxpy/atoms/affine/conj.py
@@ -21,6 +21,7 @@ import numpy as np
 import cvxpy.lin_ops.lin_op as lo
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class conj(AffAtom):
@@ -34,7 +35,7 @@ class conj(AffAtom):
         """
         return np.conj(values[0])
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the shape of the expression.
         """
         return self.args[0].shape
@@ -60,7 +61,7 @@ class conj(AffAtom):
         return self.args[0].is_hermitian()
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Multiply the linear expressions.
 

--- a/cvxpy/atoms/affine/conv.py
+++ b/cvxpy/atoms/affine/conv.py
@@ -24,6 +24,7 @@ import cvxpy.lin_ops.lin_utils as lu
 import cvxpy.utilities as u
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class conv(AffAtom):
@@ -89,7 +90,7 @@ class conv(AffAtom):
         return self.args[0].is_nonpos()
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Convolve two vectors.
 

--- a/cvxpy/atoms/affine/cumsum.py
+++ b/cvxpy/atoms/affine/cumsum.py
@@ -26,6 +26,7 @@ from cvxpy.atoms.axis_atom import AxisAtom
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.expression import Expression
 from cvxpy.expressions.variable import Variable
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 def get_diff_mat(dim: int, axis: int) -> sp.csc_matrix:
@@ -83,7 +84,7 @@ class cumsum(AffAtom, AxisAtom):
         """
         return np.cumsum(values[0], axis=self.axis)
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """The same as the input.
         """
         return self.args[0].shape
@@ -118,7 +119,7 @@ class cumsum(AffAtom, AxisAtom):
         return [self.axis]
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Cumulative sum via difference matrix.
 

--- a/cvxpy/atoms/affine/diag.py
+++ b/cvxpy/atoms/affine/diag.py
@@ -22,6 +22,7 @@ import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.atoms.affine.vec import vec
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 def diag(expr) -> Union["diag_mat", "diag_vec"]:
@@ -95,7 +96,7 @@ class diag_vec(AffAtom):
         return self.is_nonpos()
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Convolve two vectors.
 
@@ -152,7 +153,7 @@ class diag_mat(AffAtom):
         return self.args[0].is_nonneg() or self.args[0].is_psd()
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Extracts the diagonal of a matrix.
 

--- a/cvxpy/atoms/affine/hstack.py
+++ b/cvxpy/atoms/affine/hstack.py
@@ -21,6 +21,7 @@ import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 def hstack(arg_list) -> "Hstack":
@@ -51,7 +52,7 @@ class Hstack(AffAtom):
         return np.hstack(values)
 
     # The shape is the common width and the sum of the heights.
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         if self.args[0].ndim == 1:
             return (sum(arg.size for arg in self.args),)
         else:
@@ -72,7 +73,7 @@ class Hstack(AffAtom):
                         raise error
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Stack the expressions horizontally.
 

--- a/cvxpy/atoms/affine/imag.py
+++ b/cvxpy/atoms/affine/imag.py
@@ -18,6 +18,7 @@ from typing import Tuple
 import numpy as np
 
 from cvxpy.atoms.affine.affine_atom import AffAtom
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class imag(AffAtom):
@@ -31,7 +32,7 @@ class imag(AffAtom):
         """
         return np.imag(values[0])
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the shape of the expression.
         """
         return self.args[0].shape

--- a/cvxpy/atoms/affine/index.py
+++ b/cvxpy/atoms/affine/index.py
@@ -26,6 +26,7 @@ from cvxpy.atoms.affine.vec import vec
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.expression import Expression
 from cvxpy.utilities import key_utils as ku
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class index(AffAtom):
@@ -74,7 +75,7 @@ class index(AffAtom):
         """
         return values[0][self._orig_key]
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the shape of the index expression.
         """
         return ku.shape(self.key, self._orig_key, self.args[0].shape)
@@ -85,7 +86,7 @@ class index(AffAtom):
         return [self.key, self._orig_key]
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Index/slice into the expression.
 
@@ -147,7 +148,7 @@ class special_index(AffAtom):
         """
         return values[0][self.key]
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the shape of the index expression.
         """
         return self._shape
@@ -175,7 +176,7 @@ class special_index(AffAtom):
         return lowered.grad
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Index/slice into the expression.
 

--- a/cvxpy/atoms/affine/kron.py
+++ b/cvxpy/atoms/affine/kron.py
@@ -23,6 +23,7 @@ import cvxpy.utilities as u
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.constants.parameter import is_param_free
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class kron(AffAtom):
@@ -103,7 +104,7 @@ class kron(AffAtom):
         return case1 or case2
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Kronecker product of two matrices.
 

--- a/cvxpy/atoms/affine/promote.py
+++ b/cvxpy/atoms/affine/promote.py
@@ -22,9 +22,10 @@ import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.expression import Expression
+from cvxpy.utilities.shape import cvxpy_shape
 
 
-def promote(expr: Expression, shape: Tuple[int, ...]):
+def promote(expr: Expression, shape: cvxpy_shape):
     """ Promote a scalar expression to a vector/matrix.
 
     Parameters
@@ -60,7 +61,7 @@ class Promote(AffAtom):
         The shape to promote to.
     """
 
-    def __init__(self, expr, shape: Tuple[int, ...]) -> None:
+    def __init__(self, expr, shape: cvxpy_shape) -> None:
         self.promoted_shape = shape
         super(Promote, self).__init__(expr)
 
@@ -83,7 +84,7 @@ class Promote(AffAtom):
         """Is the atom log-log concave?"""
         return True
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return self.promoted_shape
@@ -94,7 +95,7 @@ class Promote(AffAtom):
         return [self.promoted_shape]
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Promote scalar to vector/matrix
 

--- a/cvxpy/atoms/affine/real.py
+++ b/cvxpy/atoms/affine/real.py
@@ -18,6 +18,7 @@ from typing import Tuple
 import numpy as np
 
 from cvxpy.atoms.affine.affine_atom import AffAtom
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class real(AffAtom):
@@ -32,7 +33,7 @@ class real(AffAtom):
         # Convert values to 1D.
         return np.real(values[0])
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the shape of the expression.
         """
         return self.args[0].shape

--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import numbers
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 import numpy as np
 
@@ -24,7 +24,7 @@ from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.atoms.affine.hstack import hstack
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.expression import Expression
-from cvxpy.utilities.shape import size_from_shape
+from cvxpy.utilities.shape import cvxpy_shape, size_from_shape
 
 
 class reshape(AffAtom):
@@ -43,7 +43,7 @@ class reshape(AffAtom):
     order : F(ortran) or C
     """
 
-    def __init__(self, expr, shape: Tuple[int, int], order: str = 'F') -> None:
+    def __init__(self, expr, shape: Union[int, cvxpy_shape], order: str = 'F') -> None:
         if isinstance(shape, numbers.Integral):
             shape = (int(shape),)
         if len(shape) > 2:
@@ -80,7 +80,7 @@ class reshape(AffAtom):
                 "Invalid reshape dimensions %s." % (self._shape,)
             )
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the shape from the rows, cols arguments.
         """
         return self._shape
@@ -91,7 +91,7 @@ class reshape(AffAtom):
         return [self._shape, self.order]
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Reshape
 

--- a/cvxpy/atoms/affine/sum.py
+++ b/cvxpy/atoms/affine/sum.py
@@ -24,6 +24,7 @@ import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.atoms.axis_atom import AxisAtom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class Sum(AxisAtom, AffAtom):
@@ -64,7 +65,7 @@ class Sum(AxisAtom, AffAtom):
         return result
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Sum the linear expression's entries.
 

--- a/cvxpy/atoms/affine/trace.py
+++ b/cvxpy/atoms/affine/trace.py
@@ -21,6 +21,7 @@ import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class trace(AffAtom):
@@ -57,7 +58,7 @@ class trace(AffAtom):
         if self.args[0].ndim != 2 or shape[0] != shape[1]:
             raise ValueError("Argument to trace must be a square matrix.")
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Always scalar.
         """
         return tuple()
@@ -73,7 +74,7 @@ class trace(AffAtom):
         return False
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Sum the diagonal entries of the linear expression.
 

--- a/cvxpy/atoms/affine/transpose.py
+++ b/cvxpy/atoms/affine/transpose.py
@@ -21,6 +21,7 @@ import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class transpose(AffAtom):
@@ -60,7 +61,7 @@ class transpose(AffAtom):
         """
         return self.args[0].is_hermitian()
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the shape of the transpose expression.
         """
         return self.args[0].shape[::-1]
@@ -71,7 +72,7 @@ class transpose(AffAtom):
         return [self.axes]
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Create a new variable equal to the argument transposed.
 

--- a/cvxpy/atoms/affine/unary_operators.py
+++ b/cvxpy/atoms/affine/unary_operators.py
@@ -20,6 +20,7 @@ import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class UnaryOperator(AffAtom):
@@ -44,7 +45,7 @@ class NegExpression(UnaryOperator):
     OP_NAME = "-"
     OP_FUNC = op.neg
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return self.args[0].shape
@@ -75,7 +76,7 @@ class NegExpression(UnaryOperator):
         return self.args[0].is_hermitian()
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Negate the affine objective.
 

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -24,6 +24,7 @@ from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.atoms.affine.reshape import reshape
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.expression import Expression
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class upper_tri(AffAtom):
@@ -88,7 +89,7 @@ class upper_tri(AffAtom):
         return True
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Vectorized strictly upper triagonal entries.
 

--- a/cvxpy/atoms/affine/vstack.py
+++ b/cvxpy/atoms/affine/vstack.py
@@ -21,6 +21,7 @@ import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 def vstack(arg_list) -> "Vstack":
@@ -47,7 +48,7 @@ class Vstack(AffAtom):
         return np.vstack(values)
 
     # The shape is the common width and the sum of the heights.
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         self.args[0].shape
         if self.args[0].ndim == 0:
             return (len(self.args), 1)
@@ -75,7 +76,7 @@ class Vstack(AffAtom):
                                   " for axis 0 must match exactly."))
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Stack the expressions vertically.
 

--- a/cvxpy/atoms/affine/wraps.py
+++ b/cvxpy/atoms/affine/wraps.py
@@ -18,6 +18,7 @@ from typing import List, Tuple
 import cvxpy.lin_ops.lin_op as lo
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class Wrap(AffAtom):
@@ -37,13 +38,13 @@ class Wrap(AffAtom):
         """
         return values[0]
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Shape of input.
         """
         return self.args[0].shape
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List[Constraint]]:
         """Stack the expressions horizontally.
 

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -16,6 +16,8 @@ limitations under the License.
 import abc
 from typing import TYPE_CHECKING, List, Tuple
 
+from cvxpy.utilities.shape import cvxpy_shape
+
 if TYPE_CHECKING:
     from cvxpy.constraints.constraint import Constraint
 
@@ -71,13 +73,13 @@ class Atom(Expression):
             )
 
     @abc.abstractmethod
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the shape of the expression.
         """
         raise NotImplementedError()
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> cvxpy_shape:
         return self._shape
 
     @abc.abstractmethod
@@ -330,7 +332,7 @@ class Atom(Expression):
             return graph_obj, constraints + graph_constr
 
     def graph_implementation(
-        self, arg_objs, shape: Tuple[int, ...], data=None
+        self, arg_objs, shape: cvxpy_shape, data=None
     ) -> Tuple[lo.LinOp, List['Constraint']]:
         """Reduces the atom to an affine expression and list of constraints.
 

--- a/cvxpy/atoms/axis_atom.py
+++ b/cvxpy/atoms/axis_atom.py
@@ -21,6 +21,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from cvxpy.atoms.atom import Atom
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class AxisAtom(Atom):
@@ -35,7 +36,7 @@ class AxisAtom(Atom):
         self.keepdims = keepdims
         super(AxisAtom, self).__init__(expr)
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Depends on axis.
         """
         shape = list(self.args[0].shape)

--- a/cvxpy/atoms/condition_number.py
+++ b/cvxpy/atoms/condition_number.py
@@ -19,6 +19,7 @@ from scipy import linalg as LA
 
 from cvxpy.atoms.atom import Atom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class condition_number(Atom):
@@ -64,7 +65,7 @@ class condition_number(Atom):
                 f"The argument {self.args[0].name()} to condition_number must be a square matrix."
             )
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/cummax.py
+++ b/cvxpy/atoms/cummax.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from cvxpy.atoms.atom import Atom
 from cvxpy.atoms.axis_atom import AxisAtom
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class cummax(AxisAtom):
@@ -34,7 +35,7 @@ class cummax(AxisAtom):
         """
         return np.maximum.accumulate(values[0], axis=self.axis)
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """The same as the input.
         """
         return self.args[0].shape

--- a/cvxpy/atoms/dist_ratio.py
+++ b/cvxpy/atoms/dist_ratio.py
@@ -18,6 +18,7 @@ from typing import Tuple
 import numpy as np
 
 from cvxpy.atoms.atom import Atom
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class dist_ratio(Atom):
@@ -40,7 +41,7 @@ class dist_ratio(Atom):
         return np.linalg.norm(
             values[0] - self.a) / np.linalg.norm(values[0] - self.b)
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/dotsort.py
+++ b/cvxpy/atoms/dotsort.py
@@ -22,6 +22,7 @@ import scipy.sparse as sp
 import cvxpy.utilities as u
 from cvxpy.atoms.atom import Atom
 from cvxpy.expressions.constants.parameter import is_param_affine
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class dotsort(Atom):
@@ -82,7 +83,7 @@ class dotsort(Atom):
         sorted_w = np.sort(w_padded)
         return [sp.csc_matrix((sorted_w, (indices, np.zeros(n))), shape=(n, 1))]
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/elementwise/elementwise.py
+++ b/cvxpy/atoms/elementwise/elementwise.py
@@ -23,13 +23,14 @@ import scipy.sparse as sp
 import cvxpy.lin_ops.lin_utils as lu
 import cvxpy.utilities as u
 from cvxpy.atoms.atom import Atom
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class Elementwise(Atom):
     """ Abstract base class for elementwise atoms. """
     __metaclass__ = abc.ABCMeta
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Shape is the same as the sum of the arguments.
         """
         return u.shape.sum_shapes([arg.shape for arg in self.args])
@@ -63,7 +64,7 @@ class Elementwise(Atom):
         return sp.dia_matrix((np.atleast_1d(value), [0]), shape=(rows, cols)).tocsc()
 
     @staticmethod
-    def _promote(arg, shape: Tuple[int, ...]):
+    def _promote(arg, shape: cvxpy_shape):
         """Promotes the lin op if necessary.
 
         Parameters

--- a/cvxpy/atoms/eye_minus_inv.py
+++ b/cvxpy/atoms/eye_minus_inv.py
@@ -19,6 +19,7 @@ from typing import Tuple
 import numpy as np
 
 from cvxpy.atoms.atom import Atom
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 def resolvent(X, s: float):
@@ -78,7 +79,7 @@ class eye_minus_inv(Atom):
     def name(self) -> str:
         return "%s(%s)" % (self.__class__.__name__, self.args[0])
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return self.args[0].shape

--- a/cvxpy/atoms/gen_lambda_max.py
+++ b/cvxpy/atoms/gen_lambda_max.py
@@ -19,6 +19,7 @@ from scipy import linalg as LA
 
 from cvxpy.atoms.atom import Atom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class gen_lambda_max(Atom):
@@ -70,7 +71,7 @@ class gen_lambda_max(Atom):
                 "be square and have the same dimensions." % (
                  self.args[0].name(), self.args[1].name()))
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/geo_mean.py
+++ b/cvxpy/atoms/geo_mean.py
@@ -24,6 +24,7 @@ from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
 from cvxpy.utilities.power_tools import (approx_error, decompose, fracify,
                                          lower_bound, over_bound, prettydict,)
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class geo_mean(Atom):
@@ -282,7 +283,7 @@ class geo_mean(Atom):
     def pretty_tree(self) -> None:
         print(prettydict(self.tree))
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/gmatmul.py
+++ b/cvxpy/atoms/gmatmul.py
@@ -21,6 +21,7 @@ import numpy as np
 import cvxpy.utilities as u
 from cvxpy.atoms.atom import Atom
 from cvxpy.expressions import cvxtypes
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class gmatmul(Atom):
@@ -81,7 +82,7 @@ class gmatmul(Atom):
                 "gmatmul(A, X) requires that X be positive."
             )
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return u.shape.mul_shapes(self.A.shape, self.args[0].shape)

--- a/cvxpy/atoms/lambda_max.py
+++ b/cvxpy/atoms/lambda_max.py
@@ -21,6 +21,7 @@ from scipy import linalg as LA
 
 from cvxpy.atoms.atom import Atom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class lambda_max(Atom):
@@ -68,7 +69,7 @@ class lambda_max(Atom):
             raise ValueError("The argument '%s' to lambda_max must resolve to a square matrix."
                              % self.args[0].name())
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/length.py
+++ b/cvxpy/atoms/length.py
@@ -19,6 +19,7 @@ import numpy as np
 
 import cvxpy.settings as s
 from cvxpy.atoms.atom import Atom
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class length(Atom):
@@ -37,7 +38,7 @@ class length(Atom):
         outside_tol = np.abs(values[0]) > s.ATOM_EVAL_TOL
         return np.max(np.nonzero(outside_tol)) + 1
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/log_det.py
+++ b/cvxpy/atoms/log_det.py
@@ -23,6 +23,7 @@ from numpy import linalg as LA
 import cvxpy.settings as s
 from cvxpy.atoms.atom import Atom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class log_det(Atom):
@@ -53,7 +54,7 @@ class log_det(Atom):
         if len(X.shape) == 1 or X.shape[0] != X.shape[1]:
             raise TypeError("The argument to log_det must be a square matrix.")
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/matrix_frac.py
+++ b/cvxpy/atoms/matrix_frac.py
@@ -24,6 +24,7 @@ from numpy import linalg as LA
 from cvxpy.atoms.atom import Atom
 from cvxpy.atoms.quad_form import QuadForm
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class MatrixFrac(Atom):
@@ -98,7 +99,7 @@ class MatrixFrac(Atom):
                 "The arguments to matrix_frac have incompatible dimensions."
             )
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/norm_nuc.py
+++ b/cvxpy/atoms/norm_nuc.py
@@ -20,6 +20,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from cvxpy.atoms.atom import Atom
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class normNuc(Atom):
@@ -51,7 +52,7 @@ class normNuc(Atom):
         D = U.dot(V)
         return [sp.csc_matrix(D.ravel(order='F')).T]
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/one_minus_pos.py
+++ b/cvxpy/atoms/one_minus_pos.py
@@ -21,6 +21,7 @@ import scipy.sparse as sp
 
 from cvxpy.atoms.affine.binary_operators import multiply
 from cvxpy.atoms.atom import Atom
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 def diff_pos(x, y):
@@ -63,7 +64,7 @@ class one_minus_pos(Atom):
     def name(self) -> str:
         return "%s(%s)" % (self.__class__.__name__, self.args[0])
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return self.args[0].shape

--- a/cvxpy/atoms/perspective.py
+++ b/cvxpy/atoms/perspective.py
@@ -123,7 +123,7 @@ class perspective(Atom):
         """
         return False
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return self.f.shape

--- a/cvxpy/atoms/pf_eigenvalue.py
+++ b/cvxpy/atoms/pf_eigenvalue.py
@@ -19,6 +19,7 @@ from typing import Tuple
 import numpy as np
 
 from cvxpy.atoms.atom import Atom
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class pf_eigenvalue(Atom):
@@ -49,7 +50,7 @@ class pf_eigenvalue(Atom):
     def name(self) -> str:
         return "%s(%s)" % (self.__class__.__name__, self.args[0])
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -27,6 +27,7 @@ from cvxpy.atoms.affine.wraps import psd_wrap
 from cvxpy.atoms.atom import Atom
 from cvxpy.expressions.expression import Expression
 from cvxpy.interface.matrix_utilities import is_sparse
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class CvxPyDomainError(Exception):
@@ -121,7 +122,7 @@ class QuadForm(Atom):
         D = (P + np.conj(P.T)) @ x
         return [sp.csc_matrix(D.ravel(order="F")).T]
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         return tuple() if self.args[0].ndim == 0 else (1, 1)
 
 
@@ -152,7 +153,7 @@ class SymbolicQuadForm(Atom):
     def is_incr(self, idx) -> bool:
         return self.original_expression.is_incr(idx)
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         return self.original_expression.shape_from_args()
 
     def sign_from_args(self) -> Tuple[bool, bool]:

--- a/cvxpy/atoms/quad_over_lin.py
+++ b/cvxpy/atoms/quad_over_lin.py
@@ -22,6 +22,7 @@ import scipy.sparse as sp
 
 from cvxpy.atoms.atom import Atom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class quad_over_lin(Atom):
@@ -75,7 +76,7 @@ class quad_over_lin(Atom):
             DX = scipy.sparse.csc_matrix(DX)
             return [DX, Dy]
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/sigma_max.py
+++ b/cvxpy/atoms/sigma_max.py
@@ -21,6 +21,7 @@ import scipy.sparse as sp
 from numpy import linalg as LA
 
 from cvxpy.atoms.atom import Atom
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class sigma_max(Atom):
@@ -54,7 +55,7 @@ class sigma_max(Atom):
         D = U.dot(np.diag(ds)).dot(V)
         return [sp.csc_matrix(D.ravel(order='F')).T]
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/sign.py
+++ b/cvxpy/atoms/sign.py
@@ -16,6 +16,7 @@ limitations under the License.
 from typing import Tuple
 
 from cvxpy.atoms.atom import Atom
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class sign(Atom):
@@ -33,7 +34,7 @@ class sign(Atom):
         x[x <= 0] = -1.0
         return x
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/sum_largest.py
+++ b/cvxpy/atoms/sum_largest.py
@@ -21,6 +21,7 @@ import scipy.sparse as sp
 
 import cvxpy.interface as intf
 from cvxpy.atoms.atom import Atom
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class sum_largest(Atom):
@@ -63,7 +64,7 @@ class sum_largest(Atom):
         D[indices] = 1
         return [sp.csc_matrix(D)]
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/suppfunc.py
+++ b/cvxpy/atoms/suppfunc.py
@@ -6,6 +6,7 @@ import scipy.sparse as sp
 import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.atom import Atom
 from cvxpy.expressions.variable import Variable
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class SuppFuncAtom(Atom):
@@ -24,7 +25,7 @@ class SuppFuncAtom(Atom):
         self.args = [Atom.cast_to_const(y)]
         self._parent = parent
         self._eta = None  # store for debugging purposes
-        self._shape: Tuple[int, ...] = tuple()
+        self._shape: cvxpy_shape = tuple()
         self.validate_arguments()
 
     def validate_arguments(self) -> None:
@@ -43,7 +44,7 @@ class SuppFuncAtom(Atom):
     def constants(self):
         return []
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         return self._shape
 
     def sign_from_args(self) -> Tuple[bool, bool]:

--- a/cvxpy/atoms/tr_inv.py
+++ b/cvxpy/atoms/tr_inv.py
@@ -23,6 +23,7 @@ from numpy import linalg as LA
 import cvxpy.settings as s
 from cvxpy.atoms.atom import Atom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class tr_inv(Atom):
@@ -55,7 +56,7 @@ class tr_inv(Atom):
         if len(X.shape) == 1 or X.shape[0] != X.shape[1]:
             raise TypeError("The argument to tr_inv must be a square matrix.")
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the (row, col) shape of the expression.
         """
         return tuple()

--- a/cvxpy/atoms/von_neumann_entr.py
+++ b/cvxpy/atoms/von_neumann_entr.py
@@ -21,6 +21,7 @@ from scipy.special import entr
 
 from cvxpy.atoms.atom import Atom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class von_neumann_entr(Atom):
@@ -80,7 +81,7 @@ class von_neumann_entr(Atom):
         """
         return False
 
-    def shape_from_args(self) -> Tuple[int, ...]:
+    def shape_from_args(self) -> cvxpy_shape:
         """Returns the shape of the expression.
         """
         return tuple()

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -128,7 +128,7 @@ class ExpCone(Constraint):
         return self.is_dcp()
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> cvxpy_shape:
         s = (3,) + self.x.shape
         return s
 
@@ -245,7 +245,7 @@ class RelEntrQuad(Constraint):
         return self.is_dcp()
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> cvxpy_shape:
         s = (3,) + self.x.shape
         return s
 
@@ -357,7 +357,7 @@ class OpRelConeQuad(Constraint):
         return self.is_dcp()
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> cvxpy_shape:
         s = (3,) + self.X.shape
         return s
 

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -21,6 +21,7 @@ import numpy as np
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
 from cvxpy.utilities import scopes
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class PowCone3D(Constraint):
@@ -114,7 +115,7 @@ class PowCone3D(Constraint):
         return self.is_dcp()
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> cvxpy_shape:
         s = (3,) + self.x.shape
         # Note: this can be a 3-tuple of x.ndim == 2.
         return s

--- a/cvxpy/constraints/utilities.py
+++ b/cvxpy/constraints/utilities.py
@@ -95,7 +95,7 @@ def format_elemwise(vars_):
     return [lu.create_geq(lu.sum_expr(terms))]
 
 
-def get_spacing_matrix(shape: Tuple[int, ...], spacing, offset):
+def get_spacing_matrix(shape: cvxpy_shape, spacing, offset):
     """Returns a sparse matrix LinOp that spaces out an expression.
 
     Parameters

--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -25,6 +25,7 @@ import cvxpy.utilities.eigvals as eig_util
 from cvxpy.expressions.leaf import Leaf
 from cvxpy.settings import EIGVAL_TOL
 from cvxpy.utilities import performance_utils as perf
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class Constant(Leaf):
@@ -100,7 +101,7 @@ class Constant(Leaf):
         return {}
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> cvxpy_shape:
         """Returns the (row, col) dimensions of the expression.
         """
         return self._shape

--- a/cvxpy/expressions/constants/parameter.py
+++ b/cvxpy/expressions/constants/parameter.py
@@ -44,7 +44,7 @@ class Parameter(Leaf):
     PARAM_COUNT = 0
 
     def __init__(
-        self, shape: int | tuple[int, ...] = (), name: str | None = None, value=None,
+        self, shape: int | cvxpy_shape = (), name: str | None = None, value=None,
         id=None, **kwargs
     ) -> None:
         if id is None:

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -29,7 +29,7 @@ from cvxpy import error
 from cvxpy.constraints import PSD, Equality, Inequality
 from cvxpy.expressions import cvxtypes
 from cvxpy.utilities import scopes
-from cvxpy.utilities.shape import size_from_shape
+from cvxpy.utilities.shape import cvxpy_shape, size_from_shape
 
 
 def _cast_other(binary_op):
@@ -397,7 +397,7 @@ class Expression(u.Canonical):
         raise NotImplementedError()
 
     @abc.abstractproperty
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> cvxpy_shape:
         """tuple : The expression dimensions.
         """
         raise NotImplementedError()

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -183,7 +183,7 @@ class Leaf(expression.Expression):
         """
 
     @property
-    def shape(self) -> tuple[int, ...]:
+    def shape(self) -> cvxpy_shape:
         """ tuple : The dimensions of the expression.
         """
         return self._shape

--- a/cvxpy/interface/base_matrix_interface.py
+++ b/cvxpy/interface/base_matrix_interface.py
@@ -19,6 +19,7 @@ from typing import Tuple
 import numpy as np
 
 import cvxpy.interface.matrix_utilities
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class BaseMatrixInterface:
@@ -71,16 +72,16 @@ class BaseMatrixInterface:
         raise NotImplementedError()
 
     # Return a matrix with all 0's.
-    def zeros(self, shape: Tuple[int, ...]):
+    def zeros(self, shape: cvxpy_shape):
         return self.scalar_matrix(0, shape)
 
     # Return a matrix with all 1's.
-    def ones(self, shape: Tuple[int, ...]):
+    def ones(self, shape: cvxpy_shape):
         return self.scalar_matrix(1, shape)
 
     # A matrix with all entries equal to the given scalar value.
     @abc.abstractmethod
-    def scalar_matrix(self, value, shape: Tuple[int, ...]):
+    def scalar_matrix(self, value, shape: cvxpy_shape):
         raise NotImplementedError()
 
     # Return the value at the given index in the matrix.
@@ -94,7 +95,7 @@ class BaseMatrixInterface:
 
     # Coerce the matrix into the given shape.
     @abc.abstractmethod
-    def reshape(self, matrix, shape: Tuple[int, ...]):
+    def reshape(self, matrix, shape: cvxpy_shape):
         raise NotImplementedError()
 
     def block_add(self, matrix, block, vert_offset, horiz_offset, rows, cols,

--- a/cvxpy/interface/numpy_interface/matrix_interface.py
+++ b/cvxpy/interface/numpy_interface/matrix_interface.py
@@ -19,6 +19,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from cvxpy.interface.numpy_interface.ndarray_interface import NDArrayInterface
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class MatrixInterface(NDArrayInterface):
@@ -52,7 +53,7 @@ class MatrixInterface(NDArrayInterface):
         return np.asmatrix(np.eye(size))
 
     # A matrix with all entries equal to the given scalar value.
-    def scalar_matrix(self, value, shape: Tuple[int, ...]):
+    def scalar_matrix(self, value, shape: cvxpy_shape):
         mat = np.zeros(shape, dtype='float64') + value
         return np.asmatrix(mat)
 

--- a/cvxpy/interface/numpy_interface/ndarray_interface.py
+++ b/cvxpy/interface/numpy_interface/ndarray_interface.py
@@ -21,6 +21,7 @@ import numpy
 import scipy.sparse
 
 from .. import base_matrix_interface as base
+from ...utilities.shape import cvxpy_shape
 
 
 class NDArrayInterface(base.BaseMatrixInterface):
@@ -57,7 +58,7 @@ class NDArrayInterface(base.BaseMatrixInterface):
         return numpy.eye(size)
 
     # Return the dimensions of the matrix.
-    def shape(self, matrix) -> Tuple[int, ...]:
+    def shape(self, matrix) -> cvxpy_shape:
         return tuple(int(d) for d in matrix.shape)
 
     def size(self, matrix):
@@ -70,7 +71,7 @@ class NDArrayInterface(base.BaseMatrixInterface):
         return matrix.item()
 
     # A matrix with all entries equal to the given scalar value.
-    def scalar_matrix(self, value, shape: Tuple[int, ...]):
+    def scalar_matrix(self, value, shape: cvxpy_shape):
         return numpy.zeros(shape, dtype='float64') + value
 
     def reshape(self, matrix, size):

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -215,7 +215,7 @@ class PythonCanonBackend(CanonBackend):
 
     @staticmethod
     @abstractmethod
-    def reshape_constant_data(constant_data: Any, new_shape: tuple[int, ...]) -> Any:
+    def reshape_constant_data(constant_data: Any, new_shape: cvxpy_shape) -> Any:
         """
         Reshape constant data from column format to the required shape for operations that
         do not require column format
@@ -493,7 +493,7 @@ class PythonCanonBackend(CanonBackend):
         pass  # noqa
 
     @abstractmethod
-    def get_variable_tensor(self, shape: tuple[int, ...], variable_id: int) -> Any:
+    def get_variable_tensor(self, shape: cvxpy_shape, variable_id: int) -> Any:
         """
         Returns tensor of a variable node, i.e., eye(n) across axes 0 and 1, where n i the number of
         entries of the variable.
@@ -508,7 +508,7 @@ class PythonCanonBackend(CanonBackend):
         pass  # noqa
 
     @abstractmethod
-    def get_param_tensor(self, shape: tuple[int, ...], parameter_id: int) -> Any:
+    def get_param_tensor(self, shape: cvxpy_shape, parameter_id: int) -> Any:
         """
         Returns tensor of a parameter node, i.e., eye(n) across axes 0 and 2, where n i the number
         of entries of the parameter.
@@ -533,7 +533,7 @@ class RustCanonBackend(CanonBackend):
 class ScipyCanonBackend(PythonCanonBackend):
 
     @staticmethod
-    def reshape_constant_data(constant_data: dict[int, sp.csr_matrix], new_shape: tuple[int, ...]) \
+    def reshape_constant_data(constant_data: dict[int, sp.csr_matrix], new_shape: cvxpy_shape) \
             -> dict[int, sp.csr_matrix]:
         return {k: [v_i.reshape(new_shape[:-1], order="F").tocsr()
                     for v_i in v] for k, v in constant_data.items()}
@@ -787,7 +787,7 @@ class ScipyCanonBackend(PythonCanonBackend):
 
         return view.accumulate_over_variables(func, is_param_free_function=is_param_free_rhs)
 
-    def get_variable_tensor(self, shape: tuple[int, ...], variable_id: int) -> \
+    def get_variable_tensor(self, shape: cvxpy_shape, variable_id: int) -> \
             dict[int, dict[int, list[sp.csr_matrix]]]:
         assert variable_id != Constant.ID
         n = int(np.prod(shape))
@@ -802,7 +802,7 @@ class ScipyCanonBackend(PythonCanonBackend):
             tensor = sp.coo_matrix(data).reshape((-1, 1), order="F").tocsr()
         return {Constant.ID.value: {Constant.ID.value: [tensor]}}
 
-    def get_param_tensor(self, shape: tuple[int, ...], parameter_id: int) \
+    def get_param_tensor(self, shape: cvxpy_shape, parameter_id: int) \
             -> dict[int, dict[int, list[sp.csr_matrix]]]:
         assert parameter_id != Constant.ID
         shape = int(np.prod(shape))

--- a/cvxpy/lin_ops/lin_op.py
+++ b/cvxpy/lin_ops/lin_op.py
@@ -18,11 +18,13 @@ DO NOT CALL THESE FUNCTIONS IN YOUR CODE!
 """
 from typing import Tuple
 
+from cvxpy.utilities.shape import cvxpy_shape
+
 
 # A linear operator applied to a variable
 # or a constant or function of parameters.
 class LinOp:
-    def __init__(self, type, shape: Tuple[int, ...], args, data) -> None:
+    def __init__(self, type, shape: cvxpy_shape, args, data) -> None:
         self.type = type
         self.shape = shape
         self.args = args

--- a/cvxpy/lin_ops/lin_utils.py
+++ b/cvxpy/lin_ops/lin_utils.py
@@ -23,6 +23,8 @@ import numpy as np
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.utilities as u
 from cvxpy.lin_ops.lin_constraints import LinEqConstr, LinLeqConstr
+from cvxpy.utilities.shape import cvxpy_shape
+
 
 # Utility functions for dealing with LinOp.
 
@@ -56,7 +58,7 @@ def get_id() -> int:
     return new_id
 
 
-def create_var(shape: Tuple[int, ...], var_id=None):
+def create_var(shape: cvxpy_shape, var_id=None):
     """Creates a new internal variable.
 
     Parameters
@@ -76,7 +78,7 @@ def create_var(shape: Tuple[int, ...], var_id=None):
     return lo.LinOp(lo.VARIABLE, shape, [], var_id)
 
 
-def create_param(shape: Tuple[int, ...], param_id=None):
+def create_param(shape: cvxpy_shape, param_id=None):
     """Wraps a parameter.
 
     Parameters
@@ -94,7 +96,7 @@ def create_param(shape: Tuple[int, ...], param_id=None):
     return lo.LinOp(lo.PARAM, shape, [], param_id)
 
 
-def create_const(value, shape: Tuple[int, ...], sparse: bool = False):
+def create_const(value, shape: cvxpy_shape, sparse: bool = False):
     """Wraps a constant.
 
     Parameters
@@ -235,7 +237,7 @@ def promote_lin_ops_for_mul(lh_op, rh_op):
     return lh_op, rh_op, shape
 
 
-def mul_expr(lh_op, rh_op, shape: Tuple[int, ...]):
+def mul_expr(lh_op, rh_op, shape: cvxpy_shape):
     """Multiply two linear operators, with the constant on the left.
 
     Parameters
@@ -253,7 +255,7 @@ def mul_expr(lh_op, rh_op, shape: Tuple[int, ...]):
     return lo.LinOp(lo.MUL, shape, [rh_op], lh_op)
 
 
-def rmul_expr(lh_op, rh_op, shape: Tuple[int, ...]):
+def rmul_expr(lh_op, rh_op, shape: cvxpy_shape):
     """Multiply two linear operators, with the constant on the right.
 
     Parameters
@@ -292,7 +294,7 @@ def multiply(lh_op, rh_op):
     return lo.LinOp(lo.MUL_ELEM, shape, [rh_op], lh_op)
 
 
-def kron_r(lh_op, rh_op, shape: Tuple[int, ...]):
+def kron_r(lh_op, rh_op, shape: cvxpy_shape):
     """Kronecker product of two matrices, where the right operand is a Variable
 
     Parameters
@@ -310,7 +312,7 @@ def kron_r(lh_op, rh_op, shape: Tuple[int, ...]):
     return lo.LinOp(lo.KRON_R, shape, [rh_op], lh_op)
 
 
-def kron_l(lh_op, rh_op, shape: Tuple[int, ...]):
+def kron_l(lh_op, rh_op, shape: cvxpy_shape):
     """Kronecker product of two matrices, where the left operand is a Variable
 
     Parameters
@@ -350,7 +352,7 @@ def div_expr(lh_op, rh_op):
     return lo.LinOp(lo.DIV, lh_op.shape, [lh_op], rh_op)
 
 
-def promote(operator, shape: Tuple[int, ...]):
+def promote(operator, shape: cvxpy_shape):
     """Promotes a scalar operator to the given shape.
 
     Parameters
@@ -368,7 +370,7 @@ def promote(operator, shape: Tuple[int, ...]):
     return lo.LinOp(lo.PROMOTE, shape, [operator], None)
 
 
-def sum_entries(operator, shape: Tuple[int, ...]):
+def sum_entries(operator, shape: cvxpy_shape):
     """Sum the entries of an operator.
 
     Parameters
@@ -402,7 +404,7 @@ def trace(operator):
     return lo.LinOp(lo.TRACE, (1, 1), [operator], None)
 
 
-def index(operator, shape: Tuple[int, ...], keys):
+def index(operator, shape: cvxpy_shape, keys):
     """Indexes/slices an operator.
 
     Parameters
@@ -422,7 +424,7 @@ def index(operator, shape: Tuple[int, ...], keys):
     return lo.LinOp(lo.INDEX, shape, [operator], keys)
 
 
-def conv(lh_op, rh_op, shape: Tuple[int, ...]):
+def conv(lh_op, rh_op, shape: cvxpy_shape):
     """1D discrete convolution of two vectors.
 
     Parameters
@@ -464,7 +466,7 @@ def transpose(operator):
         return lo.LinOp(lo.TRANSPOSE, shape, [operator], None)
 
 
-def reshape(operator, shape: Tuple[int, ...]):
+def reshape(operator, shape: cvxpy_shape):
     """Reshapes an operator.
 
     Parameters
@@ -534,7 +536,7 @@ def upper_tri(operator):
     return lo.LinOp(lo.UPPER_TRI, shape, [operator], None)
 
 
-def hstack(operators, shape: Tuple[int, ...]):
+def hstack(operators, shape: cvxpy_shape):
     """Concatenates operators horizontally.
 
     Parameters
@@ -552,7 +554,7 @@ def hstack(operators, shape: Tuple[int, ...]):
     return lo.LinOp(lo.HSTACK, shape, operators, None)
 
 
-def vstack(operators, shape: Tuple[int, ...]):
+def vstack(operators, shape: cvxpy_shape):
     """Concatenates operators vertically.
 
     Parameters

--- a/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
+++ b/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
@@ -25,6 +25,8 @@ from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ParamConeProg
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.solver import Solver
+from cvxpy.utilities.shape import cvxpy_shape
+
 
 # NOTE(akshayka): Small changes to this file can lead to drastic
 # performance regressions. If you are making a change to this file,
@@ -34,7 +36,7 @@ from cvxpy.reductions.solvers.solver import Solver
 
 class LinearOperator:
     """A wrapper for linear operators."""
-    def __init__(self, linear_op, shape: Tuple[int, ...]) -> None:
+    def __init__(self, linear_op, shape: cvxpy_shape) -> None:
         if sp.issparse(linear_op):
             self._matmul = lambda X: linear_op @ X
         else:
@@ -116,7 +118,7 @@ class ConicSolver(Solver):
                         problem.constraints))
 
     @staticmethod
-    def get_spacing_matrix(shape: Tuple[int, ...], spacing, streak, num_blocks, offset):
+    def get_spacing_matrix(shape: cvxpy_shape, spacing, streak, num_blocks, offset):
         """Returns a sparse matrix that spaces out an expression.
 
         Parameters

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -202,7 +202,16 @@ class GUROBI(ConicSolver):
 
         leq_start = dims[s.EQ_DIM]
         leq_end = dims[s.EQ_DIM] + dims[s.LEQ_DIM]
-        if hasattr(model, 'addMConstrs'):
+        if hasattr(model, 'addMConstr'):
+            # Code path for Gurobi v10.0-
+            eq_constrs = model.addMConstr(
+                A[:leq_start, :], None, gurobipy.GRB.EQUAL, b[:leq_start]
+            ).tolist()
+            ineq_constrs = model.addMConstr(
+                A[leq_start:leq_end, :], None, gurobipy.GRB.LESS_EQUAL,
+                b[leq_start:leq_end]).tolist()
+        elif hasattr(model, 'addMConstrs'):
+            # Code path for Gurobi v9.0-v9.5
             eq_constrs = model.addMConstrs(
                 A[:leq_start, :], None, gurobipy.GRB.EQUAL, b[:leq_start])
             ineq_constrs = model.addMConstrs(

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -178,16 +178,14 @@ class GUROBI(QpSolver):
         x = np.array(model.getVars(), copy=False)
 
         if A.shape[0] > 0:
-            if hasattr(model, 'addMConstrs'):
+            if hasattr(model, 'addMConstr'):
                 # We can pass all of A @ x == b at once, use stable API
-                # introduced with Gurobi v9
+                # introduced with Gurobi v9.5
+                model.addMConstr(A, None, grb.GRB.EQUAL, b)
+            elif hasattr(model, 'addMConstrs'):
+                # We can pass all of A @ x == b at once, use (now) deprecated
+                # API introduced with Gurobi v9.0
                 model.addMConstrs(A, None, grb.GRB.EQUAL, b)
-            elif hasattr(model, '_v811_addMConstrs'):
-                # We can pass all of A @ x == b at once, API only for Gurobi
-                # v811
-                A.eliminate_zeros()  # Work around bug in gurobipy v811
-                sense = np.repeat(grb.GRB.EQUAL, A.shape[0])
-                model._v811_addMConstrs(A, sense, b)
             else:
                 # Add equality constraints: iterate over the rows of A
                 # adding each row into the model
@@ -201,16 +199,14 @@ class GUROBI(QpSolver):
         model.update()
 
         if F.shape[0] > 0:
-            if hasattr(model, 'addMConstrs'):
-                # We can pass all of F @ x <= g at once, use stable API
-                # introduced with Gurobi v9
+            if hasattr(model, 'addMConstr'):
+                # We can pass all of A @ x == b at once, use stable API
+                # introduced with Gurobi v9.5
+                model.addMConstr(F, None, grb.GRB.LESS_EQUAL, g)
+            elif hasattr(model, 'addMConstrs'):
+                # We can pass all of A @ x == b at once, use (now) deprecated
+                # API introduced with Gurobi v9.0
                 model.addMConstrs(F, None, grb.GRB.LESS_EQUAL, g)
-            elif hasattr(model, '_v811_addMConstrs'):
-                # We can pass all of F @ x <= g at once, API only for Gurobi
-                # v811.
-                F.eliminate_zeros()  # Work around bug in gurobipy v811
-                sense = np.repeat(grb.GRB.LESS_EQUAL, F.shape[0])
-                model._v811_addMConstrs(F, sense, g)
             else:
                 # Add inequality constraints: iterate over the rows of F
                 # adding each row into the model

--- a/cvxpy/tests/test_matrices.py
+++ b/cvxpy/tests/test_matrices.py
@@ -24,6 +24,7 @@ import cvxpy.interface.matrix_utilities as intf
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.expression import Expression
 from cvxpy.expressions.variable import Variable
+from cvxpy.utilities.shape import cvxpy_shape
 
 PY35 = sys.version_info >= (3, 5)
 
@@ -31,7 +32,7 @@ PY35 = sys.version_info >= (3, 5)
 class TestMatrices(unittest.TestCase):
     """ Unit tests for testing different forms of matrices as constants. """
 
-    def assertExpression(self, expr, shape: Tuple[int, ...]) -> None:
+    def assertExpression(self, expr, shape: cvxpy_shape) -> None:
         """Asserts that expr is an Expression with dimension shape.
         """
         assert isinstance(expr, Expression) or isinstance(expr, Constraint)

--- a/cvxpy/tests/test_python_backends.py
+++ b/cvxpy/tests/test_python_backends.py
@@ -18,7 +18,7 @@ class linOpHelper:
     Helper class that allows to access properties of linOps without
     needing to create a full linOps instance
     """
-    shape: None | tuple[int, ...] = None
+    shape: None | cvxpy_shape = None
     type: None | str = None
     data: None | int | np.ndarray | list[slice] = None
     args: None | list[linOpHelper] = None

--- a/cvxpy/transforms/indicator.py
+++ b/cvxpy/transforms/indicator.py
@@ -21,6 +21,7 @@ import numpy as np
 import cvxpy.utilities.performance_utils as perf
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.expression import Expression
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 class indicator(Expression):
@@ -89,7 +90,7 @@ class indicator(Expression):
         return [self.err_tol]
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> cvxpy_shape:
         """Returns the (row, col) dimensions of the expression.
         """
         return ()

--- a/cvxpy/transforms/partial_optimize.py
+++ b/cvxpy/transforms/partial_optimize.py
@@ -24,6 +24,7 @@ from cvxpy.expressions.expression import Expression
 from cvxpy.expressions.variable import Variable
 from cvxpy.problems.objective import Maximize, Minimize
 from cvxpy.problems.problem import Problem
+from cvxpy.utilities.shape import cvxpy_shape
 
 
 def partial_optimize(
@@ -183,7 +184,7 @@ class PartialProblem(Expression):
         return False
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> cvxpy_shape:
         """Returns the (row, col) dimensions of the expression.
         """
         return tuple()

--- a/cvxpy/utilities/key_utils.py
+++ b/cvxpy/utilities/key_utils.py
@@ -23,10 +23,12 @@ from typing import Optional, Tuple
 
 import numpy as np
 
+from cvxpy.utilities.shape import cvxpy_shape
+
 
 # TODO(akshayka): This module needs to be updated in order to handle
 # NumPy 0/1D arrays.
-def validate_key(key, shape: Tuple[int, ...]):
+def validate_key(key, shape: cvxpy_shape):
     """Check if the key is a valid index.
 
     Args:
@@ -169,7 +171,7 @@ def is_single_index(slc) -> bool:
         slc.start + step >= slc.stop
 
 
-def shape(key, orig_key, shape: Tuple[int, ...]) -> Tuple[int, ...]:
+def shape(key, orig_key, shape: cvxpy_shape) -> cvxpy_shape:
     """Finds the dimensions of a sliced expression.
 
     Args:

--- a/cvxpy/utilities/shape.py
+++ b/cvxpy/utilities/shape.py
@@ -15,14 +15,15 @@ limitations under the License.
 """
 from functools import reduce
 from operator import mul
-from typing import List, Tuple
+from typing import List, NewType, Tuple, Union
 
+cvxpy_shape = NewType("cvxpy_shape", Tuple[int, ...])
 
-def squeezed(shape: Tuple[int, ...]) -> Tuple[int, ...]:
+def squeezed(shape: cvxpy_shape) -> cvxpy_shape:
     return tuple(dim for dim in shape if dim != 1)
 
 
-def sum_shapes(shapes: List[Tuple[int, ...]]) -> Tuple[int, ...]:
+def sum_shapes(shapes: List[cvxpy_shape]) -> cvxpy_shape:
     """Give the shape resulting from summing a list of shapes.
 
     Summation semantics are exactly the same as NumPy's, including
@@ -68,8 +69,8 @@ def sum_shapes(shapes: List[Tuple[int, ...]]) -> Tuple[int, ...]:
 
 
 def mul_shapes_promote(
-    lh_shape: Tuple[int, ...], rh_shape: Tuple[int, ...]
-) -> Tuple[Tuple[int, ...], Tuple[int, ...], Tuple[int, ...]]:
+    lh_shape: cvxpy_shape, rh_shape: cvxpy_shape
+) -> Tuple[cvxpy_shape, cvxpy_shape, cvxpy_shape]:
     """Promotes shapes as necessary and returns promoted shape of product.
 
     If lh_shape is of length one, prepend a one to it.
@@ -116,7 +117,7 @@ def mul_shapes_promote(
             tuple(list(lh_shape[:-2]) + [lh_mat_shape[0]] + [rh_mat_shape[1]]))
 
 
-def mul_shapes(lh_shape: Tuple[int, ...], rh_shape: Tuple[int, ...]) -> Tuple[int, ...]:
+def mul_shapes(lh_shape: cvxpy_shape, rh_shape: cvxpy_shape) -> cvxpy_shape:
     """Give the shape resulting from multiplying two shapes.
 
     Adheres the semantics of np.matmul and additionally permits multiplication
@@ -166,3 +167,5 @@ def size_from_shape(shape) -> int:
         The size of an object corresponding to shape.
     """
     return reduce(mul, shape, 1)
+
+


### PR DESCRIPTION
## Description
Add a new type cvxpy_shape ~ Tuple[int, ...] and use it acress the code base + fix #2026 by changing the signature of reshape.

## Type of change
- [X] Bug fix

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Check that your code adheres to our coding style.
- [x] Run the unittests and check that they’re passing.