### PR TITLE
Added the diag_offset parameter to the diag atom

### DIFF
--- a/cvxpy/cvxcore/src/LinOp.hpp
+++ b/cvxpy/cvxcore/src/LinOp.hpp
@@ -57,7 +57,7 @@ typedef operatortype OperatorType;
 /* LinOp Class mirrors the CVXPY linOp class. Data fields are determined
          by the TYPE of LinOp. No error checking is performed on the data
    fields,
-         and the semantics of SIZE, ARGS, and DATA depends on the linop TYPE. */
+         and the semantics of SIZE, ARGS, and DATA depends on the linOp TYPE. */
 class LinOp {
 public:
   LinOp(OperatorType type, const std::vector<int> &shape,

--- a/cvxpy/cvxcore/src/LinOpOperations.cpp
+++ b/cvxpy/cvxcore/src/LinOpOperations.cpp
@@ -582,16 +582,28 @@ Tensor get_upper_tri_mat(const LinOp &lin, int arg_idx) {
  */
 Tensor get_diag_matrix_mat(const LinOp &lin, int arg_idx) {
   assert(lin.get_type() == DIAG_MAT);
-  int rows = lin.get_shape()[0];
 
-  Matrix coeffs(rows, rows * rows);
+  int k = lin.get_dense_data()(0, 0);
+  int rows = lin.get_shape()[0];
+  int original_rows = rows + abs(k);
+
+  Matrix coeffs(rows, original_rows * original_rows);
   std::vector<Triplet> tripletList;
   tripletList.reserve(rows);
   for (int i = 0; i < rows; ++i) {
     // index in the extracted vector
     int row_idx = i;
     // index in the original matrix
-    int col_idx = i * rows + i;
+    int col_idx;
+
+    if (k == 0) {
+      col_idx = i + i * original_rows;
+    } else if (k > 0){
+      col_idx = i + i * original_rows + (original_rows * k);
+    } else {
+      col_idx = i + i * original_rows - k;
+    }
+
     tripletList.push_back(Triplet(row_idx, col_idx, 1.0));
   }
 
@@ -612,16 +624,27 @@ Tensor get_diag_matrix_mat(const LinOp &lin, int arg_idx) {
  */
 Tensor get_diag_vec_mat(const LinOp &lin, int arg_idx) {
   assert(lin.get_type() == DIAG_VEC);
-  int rows = lin.get_shape()[0];
 
-  Matrix coeffs(rows * rows, rows);
+  int k = lin.get_dense_data()(0, 0);
+  int rows = lin.get_shape()[0];
+  int original_rows = rows - abs(k);
+
+  Matrix coeffs(rows*rows, original_rows);
   std::vector<Triplet> tripletList;
-  tripletList.reserve(rows);
-  for (int i = 0; i < rows; ++i) {
+  tripletList.reserve(original_rows);
+  for (int i = 0; i < original_rows; ++i) {
     // index in the diagonal matrix
-    int row_idx = i * rows + i;
+    int row_idx;
     // index in the original vector
     int col_idx = i;
+
+    if (k == 0) {
+      row_idx = i + i * rows;
+    } else if (k > 0) {
+      row_idx = i + i * rows + rows * k;
+    } else {
+      row_idx = i + i * rows - k;
+    }
     tripletList.push_back(Triplet(row_idx, col_idx, 1.0));
   }
   coeffs.setFromTriplets(tripletList.begin(), tripletList.end());

--- a/cvxpy/lin_ops/lin_op.py
+++ b/cvxpy/lin_ops/lin_op.py
@@ -72,13 +72,13 @@ TRACE = "trace"
 # Data: None
 RESHAPE = "reshape"
 # Converts a vector to a diagonal matrix.
-# Data: None
+# Data: int, diagonal offset
 DIAG_VEC = "diag_vec"
 # Converts the diagonal of a matrix to a vector.
-# Data: float
+# Data: int, diagonal offset
 DIAG_MAT = "diag_mat"
 # Vectorized upper triangular portion of a matrix.
-# Data: float
+# Data: None
 UPPER_TRI = "upper_tri"
 # The 1D discrete convolution of two vectors.
 # Data: LinOp evaluating to the left hand term.

--- a/cvxpy/lin_ops/lin_op.py
+++ b/cvxpy/lin_ops/lin_op.py
@@ -75,10 +75,10 @@ RESHAPE = "reshape"
 # Data: None
 DIAG_VEC = "diag_vec"
 # Converts the diagonal of a matrix to a vector.
-# Data: None
+# Data: float
 DIAG_MAT = "diag_mat"
 # Vectorized upper triangular portion of a matrix.
-# Data: None
+# Data: float
 UPPER_TRI = "upper_tri"
 # The 1D discrete convolution of two vectors.
 # Data: LinOp evaluating to the left hand term.

--- a/cvxpy/lin_ops/lin_utils.py
+++ b/cvxpy/lin_ops/lin_utils.py
@@ -482,38 +482,43 @@ def reshape(operator, shape: Tuple[int, ...]):
     return lo.LinOp(lo.RESHAPE, shape, [operator], None)
 
 
-def diag_vec(operator):
+def diag_vec(operator, k: int = 0):
     """Converts a vector to a diagonal matrix.
 
     Parameters
     ----------
     operator : LinOp
         The operator to convert to a diagonal matrix.
+    k : int
+        The offset of the diagonal.
 
     Returns
     -------
     LinOp
        LinOp representing the diagonal matrix.
     """
-    shape = (operator.shape[0], operator.shape[0])
-    return lo.LinOp(lo.DIAG_VEC, shape, [operator], None)
+    rows = operator.shape[0] + abs(k)
+    shape = (rows, rows)
+    return lo.LinOp(lo.DIAG_VEC, shape, [operator], k)
 
 
-def diag_mat(operator):
+def diag_mat(operator, k: int = 0):
     """Converts the diagonal of a matrix to a vector.
 
     Parameters
     ----------
     operator : LinOp
         The operator to convert to a vector.
+    k : int
+        The offset of the diagonal.
 
     Returns
     -------
     LinOp
        LinOp representing the matrix diagonal.
     """
-    shape = (operator.shape[0], 1)
-    return lo.LinOp(lo.DIAG_MAT, shape, [operator], None)
+    shape = (operator.shape[0] - abs(k), 1)
+    return lo.LinOp(lo.DIAG_MAT, shape, [operator], k)
 
 
 def upper_tri(operator):

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -643,6 +643,50 @@ class TestAtoms(BaseTest):
         self.assertFalse(expr.is_psd())
         self.assertFalse(expr.is_nsd())
 
+    def test_diag_offset(self) -> None:
+        """Test matrix to vector on scalar matrices"""
+        A1 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        a1 = cp.diag(A1, 1)
+        a2 = cp.diag(A1, -1)
+        a3 = cp.diag(A1, 2)
+        self.assertEqual(a1.size, 2)
+        self.assertEqual(a2.size, 2)
+        self.assertEqual(a3.size, 1)
+        self.assertItemsAlmostEqual(a1.value, [2, 6])
+        self.assertItemsAlmostEqual(a2.value, [4, 8])
+        self.assertItemsAlmostEqual(a3.value, [3])
+
+        """Test vector to matrix on scalar matrices"""
+        A1 = cp.diag(np.array([1, 2, 3]), 1)
+        A2 = cp.diag(np.array([1, 2, 3]), -1)
+        A3 = cp.diag(np.array([1, 2, 3]), 3)
+        B1 = np.array([
+            [0, 1, 0, 0],
+            [0, 0, 2, 0],
+            [0, 0, 0, 3],
+            [0, 0, 0, 0]])
+        B2 = np.array([
+            [0, 0, 0, 0],
+            [1, 0, 0, 0],
+            [0, 2, 0, 0],
+            [0, 0, 3, 0]])
+        B3 = np.array([
+            [0, 0, 0, 1, 0, 0],
+            [0, 0, 0, 0, 2, 0],
+            [0, 0, 0, 0, 0, 3],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0]])
+        self.assertEqual(A1.shape, (4, 4))
+        self.assertEqual(A2.shape, (4, 4))
+        self.assertEqual(A3.shape, (6, 6))
+        self.assertItemsAlmostEqual(A1.value, B1)
+        self.assertItemsAlmostEqual(A2.value, B2)
+        self.assertItemsAlmostEqual(A3.value, B3)
+
+        X = cp.diag(Variable(5), 1)
+        self.assertEqual(X.size, 36)
+
     def test_trace(self) -> None:
         """Test the trace atom.
         """

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -645,44 +645,16 @@ class TestAtoms(BaseTest):
 
     def test_diag_offset(self) -> None:
         """Test matrix to vector on scalar matrices"""
-        A1 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-        a1 = cp.diag(A1, 1)
-        a2 = cp.diag(A1, -1)
-        a3 = cp.diag(A1, 2)
-        self.assertEqual(a1.size, 2)
-        self.assertEqual(a2.size, 2)
-        self.assertEqual(a3.size, 1)
-        self.assertItemsAlmostEqual(a1.value, [2, 6])
-        self.assertItemsAlmostEqual(a2.value, [4, 8])
-        self.assertItemsAlmostEqual(a3.value, [3])
-
-        """Test vector to matrix on scalar matrices"""
-        A1 = cp.diag(np.array([1, 2, 3]), 1)
-        A2 = cp.diag(np.array([1, 2, 3]), -1)
-        A3 = cp.diag(np.array([1, 2, 3]), 3)
-        B1 = np.array([
-            [0, 1, 0, 0],
-            [0, 0, 2, 0],
-            [0, 0, 0, 3],
-            [0, 0, 0, 0]])
-        B2 = np.array([
-            [0, 0, 0, 0],
-            [1, 0, 0, 0],
-            [0, 2, 0, 0],
-            [0, 0, 3, 0]])
-        B3 = np.array([
-            [0, 0, 0, 1, 0, 0],
-            [0, 0, 0, 0, 2, 0],
-            [0, 0, 0, 0, 0, 3],
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0]])
-        self.assertEqual(A1.shape, (4, 4))
-        self.assertEqual(A2.shape, (4, 4))
-        self.assertEqual(A3.shape, (6, 6))
-        self.assertItemsAlmostEqual(A1.value, B1)
-        self.assertItemsAlmostEqual(A2.value, B2)
-        self.assertItemsAlmostEqual(A3.value, B3)
+        test_matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        test_vector = np.array([1, 2, 3])
+        offsets = [0, 1, -1, 2]
+        for offset in offsets:
+            a_cp = cp.diag(test_matrix, k=offset)
+            a_np = np.diag(test_matrix, k=offset)
+            A_cp = cp.diag(test_vector, k=offset)
+            A_np = np.diag(test_vector, k=offset)
+            self.assertItemsAlmostEqual(a_cp.value, a_np)
+            self.assertItemsAlmostEqual(A_cp.value, A_np)
 
         X = cp.diag(Variable(5), 1)
         self.assertEqual(X.size, 36)

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1437,7 +1437,7 @@ class TestProblem(BaseTest):
             obj = cp.Minimize(cp.sum(x))
             constraints = [cp.diag(x, k) == np.diag(np.diag(A, k), k)]
             prob = cp.Problem(obj, constraints)
-            result = prob.solve(solver=cp.SCS, canon_backend=cp.CPP_CANON_BACKEND, eps=1e-6)
+            result = prob.solve(solver=cp.SCS, eps=1e-6)
             self.assertAlmostEqual(result, np.sum(np.diag(A, k)))
             assert np.allclose(x.value, np.diag(A, k), atol=1e-4)
 
@@ -1447,7 +1447,7 @@ class TestProblem(BaseTest):
             obj = cp.Minimize(cp.sum(X))
             constraints = [cp.diag(X, k) == np.diag(A, k)]
             prob = cp.Problem(obj, constraints)
-            result = prob.solve(solver=cp.SCS, canon_backend=cp.CPP_CANON_BACKEND, eps=1e-6)
+            result = prob.solve(solver=cp.SCS, eps=1e-6)
             self.assertAlmostEqual(result, np.sum(np.diag(A, k)))
             assert np.allclose(X.value, np.diag(np.diag(A, k), k), atol=1e-4)
 

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1437,7 +1437,7 @@ class TestProblem(BaseTest):
             obj = cp.Minimize(cp.sum(x))
             constraints = [cp.diag(x, k) == np.diag(np.diag(A, k), k)]
             prob = cp.Problem(obj, constraints)
-            result = prob.solve(solver=cp.SCS, canon_backend=cp.SCIPY_CANON_BACKEND, eps=1e-6)
+            result = prob.solve(solver=cp.SCS, canon_backend=cp.CPP_CANON_BACKEND, eps=1e-6)
             self.assertAlmostEqual(result, np.sum(np.diag(A, k)))
             assert np.allclose(x.value, np.diag(A, k), atol=1e-4)
 
@@ -1447,7 +1447,7 @@ class TestProblem(BaseTest):
             obj = cp.Minimize(cp.sum(X))
             constraints = [cp.diag(X, k) == np.diag(A, k)]
             prob = cp.Problem(obj, constraints)
-            result = prob.solve(solver=cp.SCS, canon_backend=cp.SCIPY_CANON_BACKEND, eps=1e-6)
+            result = prob.solve(solver=cp.SCS, canon_backend=cp.CPP_CANON_BACKEND, eps=1e-6)
             self.assertAlmostEqual(result, np.sum(np.diag(A, k)))
             assert np.allclose(X.value, np.diag(np.diag(A, k), k), atol=1e-4)
 

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1425,6 +1425,50 @@ class TestProblem(BaseTest):
         result = prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 0.583151, places=2)
 
+    def test_diag_offset(self) -> None:
+        """Test matrix to vector on scalar matrices"""
+        A1 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        a1 = cp.diag(A1, 1)
+        a2 = cp.diag(A1, -1)
+        a3 = cp.diag(A1, 2)
+        self.assertEqual(a1.size, 2)
+        self.assertEqual(a2.size, 2)
+        self.assertEqual(a3.size, 1)
+        self.assertItemsAlmostEqual(a1.value, [2, 6])
+        self.assertItemsAlmostEqual(a2.value, [4, 8])
+        self.assertItemsAlmostEqual(a3.value, [3])
+
+        """Test vector to matrix on scalar matrices"""
+        A1 = cp.diag(np.array([1, 2, 3]), 1)
+        A2 = cp.diag(np.array([1, 2, 3]), -1)
+        A3 = cp.diag(np.array([1, 2, 3]), 3)
+        B1 = np.array([
+            [0, 1, 0, 0],
+            [0, 0, 2, 0],
+            [0, 0, 0, 3],
+            [0, 0, 0, 0]])
+        B2 = np.array([
+            [0, 0, 0, 0],
+            [1, 0, 0, 0],
+            [0, 2, 0, 0],
+            [0, 0, 3, 0]])
+        B3 = np.array([
+            [0, 0, 0, 1, 0, 0],
+            [0, 0, 0, 0, 2, 0],
+            [0, 0, 0, 0, 0, 3],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0]])
+        self.assertEqual(A1.shape, (4, 4))
+        self.assertEqual(A2.shape, (4, 4))
+        self.assertEqual(A3.shape, (6, 6))
+        self.assertItemsAlmostEqual(A1.value, B1)
+        self.assertItemsAlmostEqual(A2.value, B2)
+        self.assertItemsAlmostEqual(A3.value, B3)
+
+        X = cp.diag(Variable(5), 1)
+        self.assertEqual(X.size, 36)
+
     def test_presolve_parameters(self) -> None:
         """Test presolve with parameters.
         """

--- a/cvxpy/tests/test_python_backends.py
+++ b/cvxpy/tests/test_python_backends.py
@@ -389,6 +389,56 @@ class TestScipyBackend:
         # Note: view is edited in-place:
         assert out_view.get_tensor_representation(0) == view.get_tensor_representation(0)
 
+    def test_diag_mat_with_offset(self, backend):
+        """
+        define x = Variable((2,2)) with
+        [[x11, x12],
+         [x21, x22]]
+
+        x is represented as eye(4) in the A matrix (in column-major order), i.e.,
+
+         x11 x21 x12 x22
+        [[1   0   0   0],
+         [0   1   0   0],
+         [0   0   1   0],
+         [0   0   0   1]]
+
+        diag_mat(x, k=1) means we select only the 1-(super)diagonal, i.e., x12.
+
+        which, when using the same columns as before, now maps to
+
+         x11 x21 x12 x22
+        [[0   0   1   0]]
+
+        -> It reduces to selecting a subset of the rows of A.
+        """
+
+        variable_lin_op = linOpHelper((2, 2), type='variable', data=1)
+        empty_view = ScipyTensorView.get_empty_view(self.param_size_plus_one, self.id_to_col,
+                                                    self.param_to_size, self.param_to_col,
+                                                    self.var_length)
+        view = backend.process_constraint(variable_lin_op, empty_view)
+
+        # cast to numpy
+        view_A = view.get_tensor_representation(0)
+        view_A = sp.coo_matrix((view_A.data, (view_A.row, view_A.col)), shape=(4, 4)).toarray()
+        assert np.all(view_A == np.eye(4))
+
+        k = 1
+        diag_mat_lin_op = linOpHelper(shape=(2, 2), data=k)
+        out_view = backend.diag_mat(diag_mat_lin_op, view)
+        A = out_view.get_tensor_representation(0)
+
+        # cast to numpy
+        A = sp.coo_matrix((A.data, (A.row, A.col)), shape=(1, 4)).toarray()
+        expected = np.array(
+            [[0, 0, 1, 0]]
+        )
+        assert np.all(A == expected)
+
+        # Note: view is edited in-place:
+        assert out_view.get_tensor_representation(0) == view.get_tensor_representation(0)
+
     def test_diag_vec(self, backend):
         """
         define x = Variable((2,)) with
@@ -434,6 +484,72 @@ class TestScipyBackend:
              [0, 0],
              [0, 0],
              [0, 1]]
+        )
+        assert np.all(A == expected)
+
+        # Note: view is edited in-place:
+        assert out_view.get_tensor_representation(0) == view.get_tensor_representation(0)
+
+    def test_diag_vec_with_offset(self, backend):
+        """
+        define x = Variable((2,)) with
+        [x1, x2]
+
+        x is represented as eye(2) in the A matrix, i.e.,
+
+         x1  x2
+        [[1  0],
+         [0  1]]
+
+        diag_vec(x, k) means we introduce zero rows as if the vector was the k-diagonal
+        of an n+|k| x n+|k| matrix, with n the length of x.
+
+        Thus, for k=1 and using the same columns as before, want to represent
+        [[0  x1 0],
+        [ 0  0  x2],
+        [[0  0  0]]
+        i.e., unrolled in column-major order:
+
+         x1  x2
+        [[0  0],
+        [0  0],
+        [0  0],
+        [1  0],
+        [0  0],
+        [0  0],
+        [0  0],
+        [0  1],
+        [0  0]]
+        """
+
+        variable_lin_op = linOpHelper((2,), type='variable', data=1)
+        empty_view = ScipyTensorView.get_empty_view(self.param_size_plus_one, self.id_to_col,
+                                                    self.param_to_size, self.param_to_col,
+                                                    self.var_length)
+        view = backend.process_constraint(variable_lin_op, empty_view)
+
+        # cast to numpy
+        view_A = view.get_tensor_representation(0)
+        view_A = sp.coo_matrix((view_A.data, (view_A.row, view_A.col)), shape=(2, 2)).toarray()
+        assert np.all(view_A == np.eye(2))
+
+        k = 1
+        diag_vec_lin_op = linOpHelper(shape=(2, 2), data=k)
+        out_view = backend.diag_vec(diag_vec_lin_op, view)
+        A = out_view.get_tensor_representation(0)
+
+        # cast to numpy
+        A = sp.coo_matrix((A.data, (A.row, A.col)), shape=(9, 2)).toarray()
+        expected = np.array(
+            [[0, 0],
+             [0, 0],
+             [0, 0],
+             [1, 0],
+             [0, 0],
+             [0, 0],
+             [0, 0],
+             [0, 1],
+             [0, 0]]
         )
         assert np.all(A == expected)
 

--- a/cvxpy/tests/test_python_backends.py
+++ b/cvxpy/tests/test_python_backends.py
@@ -374,7 +374,7 @@ class TestScipyBackend:
         view_A = sp.coo_matrix((view_A.data, (view_A.row, view_A.col)), shape=(4, 4)).toarray()
         assert np.all(view_A == np.eye(4))
 
-        diag_mat_lin_op = linOpHelper(shape=(2, 2))
+        diag_mat_lin_op = linOpHelper(shape=(2, 2), data=0)
         out_view = backend.diag_mat(diag_mat_lin_op, view)
         A = out_view.get_tensor_representation(0)
 
@@ -425,7 +425,7 @@ class TestScipyBackend:
         assert np.all(view_A == np.eye(4))
 
         k = 1
-        diag_mat_lin_op = linOpHelper(shape=(2, 2), data=k)
+        diag_mat_lin_op = linOpHelper(shape=(1, 1), data=k)
         out_view = backend.diag_mat(diag_mat_lin_op, view)
         A = out_view.get_tensor_representation(0)
 
@@ -473,7 +473,7 @@ class TestScipyBackend:
         view_A = sp.coo_matrix((view_A.data, (view_A.row, view_A.col)), shape=(2, 2)).toarray()
         assert np.all(view_A == np.eye(2))
 
-        diag_vec_lin_op = linOpHelper(shape=(2, 2))
+        diag_vec_lin_op = linOpHelper(shape=(2, 2), data=0)
         out_view = backend.diag_vec(diag_vec_lin_op, view)
         A = out_view.get_tensor_representation(0)
 
@@ -534,7 +534,7 @@ class TestScipyBackend:
         assert np.all(view_A == np.eye(2))
 
         k = 1
-        diag_vec_lin_op = linOpHelper(shape=(2, 2), data=k)
+        diag_vec_lin_op = linOpHelper(shape=(3, 3), data=k)
         out_view = backend.diag_vec(diag_vec_lin_op, view)
         A = out_view.get_tensor_representation(0)
 


### PR DESCRIPTION
## Description
Added an offset parameter to the diag atom. Now it is possible to extract an off-diagonal vector from a square matrix and make a square matrix with a vector on the off-diagonal. 

I had some questions regarding the `graph_implementation` method of the `diag_vec` and `diag_mat` classes. It is yet unclear to me what the graph_implementation is doing and I are not sure where I should add the offset parameter. Currently the code will fail if `diag_offset != 0`.

I was also wondering if I should add assert statements to ensure that the value of `diag_offset` is no more than the dimension of the input matrix or vector and would like to know where the best place to add it is.   

Issue link (if applicable): #808 

## Type of change
- [x] New feature (backwards compatible)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Check that your code adheres to our coding style.
- [x] Make modifications to C++ backend
- [x] Add tests comparing the behaviour of cvxpy and python
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.