### PR TITLE
Initial cut at adding error on raw float keys and tuples of floats

### DIFF
--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1062,7 +1062,8 @@ class TestExpressions(BaseTest):
 
         with self.assertRaises(IndexError) as cm:
             self.x[np.array([1.0, 2.0])]
-        self.assertEqual(str(cm.exception), "float is an invalid index type.")
+        self.assertEqual(str(cm.exception),
+                         "arrays used as indices must be of integer (or boolean) type")
 
     def test_neg_indices(self) -> None:
         """Test negative indices.

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1050,15 +1050,19 @@ class TestExpressions(BaseTest):
     def test_float_is_invalid_index(self) -> None:
         with self.assertRaises(IndexError) as cm:
             self.x[1.0]
+        self.assertEqual(str(cm.exception), "float is an invalid index type.")
 
         with self.assertRaises(IndexError) as cm:
             self.x[(1.0,)]
+        self.assertEqual(str(cm.exception), "float is an invalid index type.")
 
         with self.assertRaises(IndexError) as cm:
             self.C[: 2.:40]
-        
+        self.assertEqual(str(cm.exception), "float is an invalid index type.")
+
         with self.assertRaises(IndexError) as cm:
             self.x[np.array([1.0, 2.0])]
+        self.assertEqual(str(cm.exception), "float is an invalid index type.")
 
     def test_neg_indices(self) -> None:
         """Test negative indices.

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1047,6 +1047,19 @@ class TestExpressions(BaseTest):
         exp = self.C[:, -199:-3]
         self.assertEqual(exp.shape, (3, 0))
 
+    def test_float_is_invalid_index(self) -> None:
+        with self.assertRaises(IndexError) as cm:
+            self.x[1.0]
+
+        with self.assertRaises(IndexError) as cm:
+            self.x[(1.0,)]
+
+        with self.assertRaises(IndexError) as cm:
+            self.C[: 2.:40]
+        
+        with self.assertRaises(IndexError) as cm:
+            self.x[np.array([1.0, 2.0])]
+
     def test_neg_indices(self) -> None:
         """Test negative indices.
         """

--- a/cvxpy/utilities/key_utils.py
+++ b/cvxpy/utilities/key_utils.py
@@ -40,6 +40,8 @@ def validate_key(key, shape: Tuple[int, ...]):
         Error: Index/slice out of bounds.
     """
     key = to_tuple(key)
+    if any(isinstance(k, float) for k in key):
+        raise IndexError("float is an invalid index type.")
     if len(key) == 0:
         raise IndexError("An index cannot be empty.")
     # Change single indices for vectors into double indices.

--- a/cvxpy/utilities/key_utils.py
+++ b/cvxpy/utilities/key_utils.py
@@ -40,7 +40,12 @@ def validate_key(key, shape: Tuple[int, ...]):
         Error: Index/slice out of bounds.
     """
     key = to_tuple(key)
-    if any(isinstance(k, float) for k in key):
+    if any(
+        isinstance(k, float) or (isinstance(k, slice) and (
+            isinstance(k.start, float) or
+            isinstance(k.stop, float) or
+            isinstance(k.step, float)
+    )) for k in key):
         raise IndexError("float is an invalid index type.")
     if len(key) == 0:
         raise IndexError("An index cannot be empty.")

--- a/cvxpy/utilities/key_utils.py
+++ b/cvxpy/utilities/key_utils.py
@@ -40,12 +40,10 @@ def validate_key(key, shape: Tuple[int, ...]):
         Error: Index/slice out of bounds.
     """
     key = to_tuple(key)
-    if any(
-        isinstance(k, float) or (isinstance(k, slice) and (
+    if any(isinstance(k, float) or (isinstance(k, slice) and (
             isinstance(k.start, float) or
             isinstance(k.stop, float) or
-            isinstance(k.step, float)
-    )) for k in key):
+            isinstance(k.step, float))) for k in key):
         raise IndexError("float is an invalid index type.")
     if len(key) == 0:
         raise IndexError("An index cannot be empty.")


### PR DESCRIPTION
## Description

Per the chat, we decided that `cp.Variable(4)[2.5]` should be an error. This is my first cut at making it one.

I wasn't exactly sure where to put the source of the error or how to structure it. My preference would be to whitelist certain types ala NumPy and validate them that way, but I figured I'd start by banning floats since that occurs the most (in code like `x[5/2]`).

It is worth noting we already have this error for arrays of floats:
```python
ipdb> cp.Variable(5)[2:][np.array([1.5])]
*** IndexError: arrays used as indices must be of integer (or boolean) type

```

Let me know if we should move it and how many unit tests this needs!

## Type of change
- [ ] New feature (backwards compatible)
- [x] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.