### PR TITLE
Allow -1 in reshape

### DIFF
--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -58,7 +58,7 @@ class reshape(AffAtom):
         super(reshape, self).__init__(expr)
 
     @staticmethod
-    def _infer_shape(shape: Tuple[int, ...], size: Expression) -> Tuple[int, ...]:
+    def _infer_shape(shape: Tuple[int, ...], size: int) -> Tuple[int, ...]:
         assert shape.count(-1) == 1, "Only one dimension can be -1."
         if len(shape) == 1:
             shape = (size,)

--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -49,10 +49,30 @@ class reshape(AffAtom):
         if len(shape) > 2:
             raise ValueError("Expressions of dimension greater than 2 "
                              "are not supported.")
+        if any(d == -1 for d in shape):
+            shape = self._infer_shape(shape, expr.size)
+
         self._shape = tuple(shape)
         assert order in ['F', 'C']
         self.order = order
         super(reshape, self).__init__(expr)
+
+    @staticmethod
+    def _infer_shape(shape: Tuple[int, ...], size: Expression) -> Tuple[int, ...]:
+        assert shape.count(-1) == 1, "Only one dimension can be -1."
+        if len(shape) == 1:
+            shape = (size,)
+        else:
+            unspecified_index = shape.index(-1)
+            specified = shape[1 - unspecified_index]
+            assert specified >= 0, "Specified dimension must be nonnegative."
+            unspecified, remainder = divmod(size, shape[1 - unspecified_index])
+            if remainder != 0:
+                raise ValueError(
+                    f"Cannot reshape expression of size {size} into shape {shape}."
+                )
+            shape = tuple(unspecified if d == -1 else specified for d in shape)
+        return shape
 
     def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -605,7 +605,7 @@ class TestAtoms(BaseTest):
         expr_reshaped = cp.reshape(expr, -1)
         self.assertEqual(expr_reshaped.shape, (6,))
 
-        expr_reshaped = cp.reshape(expr, -1)
+        expr_reshaped = cp.reshape(expr, (-1,))
         self.assertEqual(expr_reshaped.shape, (6,))
 
         with pytest.raises(ValueError, match="Cannot reshape expression"):

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -592,21 +592,18 @@ class TestAtoms(BaseTest):
         """
         Test the reshape class with -1 in the shape.
         """
+
         expr = cp.Variable((2, 3))
-        expr_reshaped = cp.reshape(expr, (-1, 1))
-        self.assertEqual(expr_reshaped.shape, (6, 1))
+        numpy_expr = np.ones((2, 3))
+        shapes = [(-1, 1), (1, -1), (-1, 2), -1, (-1,)]
+        expected_shapes = [(6, 1), (1, 6), (3, 2), (6,), (6,)]
 
-        expr_reshaped = cp.reshape(expr, (1, -1))
-        self.assertEqual(expr_reshaped.shape, (1, 6))
+        for shape, expected_shape in zip(shapes, expected_shapes):
+            expr_reshaped = cp.reshape(expr, shape)
+            self.assertEqual(expr_reshaped.shape, expected_shape)
 
-        expr_reshaped = cp.reshape(expr, (-1, 2))
-        self.assertEqual(expr_reshaped.shape, (3, 2))
-
-        expr_reshaped = cp.reshape(expr, -1)
-        self.assertEqual(expr_reshaped.shape, (6,))
-
-        expr_reshaped = cp.reshape(expr, (-1,))
-        self.assertEqual(expr_reshaped.shape, (6,))
+            numpy_expr_reshaped = np.reshape(numpy_expr, shape)
+            self.assertEqual(numpy_expr_reshaped.shape, expected_shape)
 
         with pytest.raises(ValueError, match="Cannot reshape expression"):
             cp.reshape(expr, (8, -1))

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -588,6 +588,44 @@ class TestAtoms(BaseTest):
         self.assertItemsAlmostEqual(b_reshaped, X_reshaped.value)
         self.assertItemsAlmostEqual(b, X.value)
 
+    def test_reshape_negative_one(self) -> None:
+        """
+        Test the reshape class with -1 in the shape.
+        """
+        expr = cp.Variable((2, 3))
+        expr_reshaped = cp.reshape(expr, (-1, 1))
+        self.assertEqual(expr_reshaped.shape, (6, 1))
+
+        expr_reshaped = cp.reshape(expr, (1, -1))
+        self.assertEqual(expr_reshaped.shape, (1, 6))
+
+        expr_reshaped = cp.reshape(expr, (-1, 2))
+        self.assertEqual(expr_reshaped.shape, (3, 2))
+
+        expr_reshaped = cp.reshape(expr, -1)
+        self.assertEqual(expr_reshaped.shape, (6,))
+
+        expr_reshaped = cp.reshape(expr, -1)
+        self.assertEqual(expr_reshaped.shape, (6,))
+
+        with pytest.raises(ValueError, match="Cannot reshape expression"):
+            cp.reshape(expr, (8, -1))
+
+        with pytest.raises(AssertionError, match="Only one"):
+            cp.reshape(expr, (-1, -1))
+
+        with pytest.raises(ValueError, match="Invalid reshape dimensions"):
+            cp.reshape(expr, (-1, 0))
+
+        with pytest.raises(AssertionError, match="Specified dimension must be nonnegative"):
+            cp.reshape(expr, (-1, -2))
+
+        A = np.array([[1, 2, 3], [4, 5, 6]])
+        A_reshaped = cp.reshape(A, -1, order='C')
+        assert np.allclose(A_reshaped.value, A.reshape(-1, order='C'))
+        A_reshaped = cp.reshape(A, -1, order='F')
+        assert np.allclose(A_reshaped.value, A.reshape(-1, order='F'))
+
     def test_vec(self) -> None:
         """Test the vec atom.
         """


### PR DESCRIPTION
## Description
Allows replacing one dimension by -1 in reshape.
Issue link (if applicable): #1723 

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.