### PR TITLE
Mosek Interface: Keep sparsity for PSD constraints

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import annotations
 
 import warnings
 from collections import defaultdict
@@ -49,11 +50,31 @@ def vectorized_lower_tri_to_mat(v, dim):
     return A
 
 
-def vectorized_lower_tri_to_triples(A: sp.sparse.coo_array, dim):
+def vectorized_lower_tri_to_triples(A: sp.sparse.coo_array, dim: int) \
+        -> tuple[list[int], list[int], list[float]]:
+    """
+    Attributes
+    ----------
+    A : scipy.sparse.coo_array
+        Contains the lower triangular entries of a symmetric matrix, flattened into a 1D array in
+        column-major order.
+    dim : int
+        The number of rows (equivalently, columns) in the original matrix.
+
+    Returns
+    -------
+    rows : list[int]
+        The row indices of the entries in the original matrix.
+    cols : list[int]
+        The column indices of the entries in the original matrix.
+    vals : list[float]
+        The values of the entries in the original matrix.
+    """
 
     vals = A.data
     flattened_cols = A.col
 
+    # Ensure that the columns are sorted.
     if not np.all(flattened_cols[:-1] < flattened_cols[1:]):
         sort_idx = np.argsort(flattened_cols)
         vals = vals[sort_idx]

--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -43,19 +43,19 @@ def vectorized_lower_tri_to_mat(v, dim):
     :return: Return the symmetric 2D array defined by taking "v" to
       specify its lower triangular entries.
     """
-    rows, cols, vals = vectorized_lower_tri_to_triples(sp.sparse.coo_array(v), dim)
+    rows, cols, vals = vectorized_lower_tri_to_triples(sp.sparse.coo_matrix(v), dim)
     A = sp.sparse.coo_matrix((vals, (rows, cols)), shape=(dim, dim)).toarray()
     d = np.diag(np.diag(A))
     A = A + A.T - d
     return A
 
 
-def vectorized_lower_tri_to_triples(A: sp.sparse.coo_array, dim: int) \
+def vectorized_lower_tri_to_triples(A: sp.sparse.coo_matrix, dim: int) \
         -> tuple[list[int], list[int], list[float]]:
     """
     Attributes
     ----------
-    A : scipy.sparse.coo_array
+    A : scipy.sparse.coo_matrix
         Contains the lower triangular entries of a symmetric matrix, flattened into a 1D array in
         column-major order.
     dim : int
@@ -215,7 +215,7 @@ class MOSEK(ConicSolver):
                 rows, cols, vals = vectorized_lower_tri_to_triples(A_row_coo, dim)
                 A_bar_data.append((i, j, (rows, cols, vals)))
 
-            c_block = sp.sparse.coo_array(c_psd[idx:idx + vec_len])
+            c_block = sp.sparse.coo_matrix(c_psd[idx:idx + vec_len])
             rows, cols, vals = vectorized_lower_tri_to_triples(c_block, dim)
             c_bar_data.append((j, (rows, cols, vals)))
             idx += vec_len

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1440,7 +1440,7 @@ class TestAtoms(BaseTest):
             cp.trace(X) == 1
         ]
         prob = cp.Problem(cp.Minimize(cp.tr_inv(X)), constraints)
-        prob.solve(verbose=True)
+        prob.solve()
         # Check result. The best value is T^2.
         self.assertAlmostEqual(prob.value, T**2)
         X_actual = X.value


### PR DESCRIPTION
## Description
The current implementation casts PSD constraints to a dense array before passing them to mosek. This PR keeps the sparsity.
Issue link (if applicable):  #2051 

For reference, here is the script from the to reproduce the issue:

```py
import numpy as np
import cvxpy

n = 130
np.random.seed(43)
Q = np.random.normal(loc=0, scale=1, size=(n, n))

X = cvxpy.Variable((n, n), symmetric=True)
constraints = [X[i, i] == 1 for i in range(n)] + [X >> 0]
objective = cvxpy.Minimize(cvxpy.trace(Q @ X))
problem = cvxpy.Problem(objective, constraints)
problem.get_problem_data(verbose=True, solver=cvxpy.MOSEK)
```

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.