### PR TITLE
Fix issue with matrix multiplication involving quad

### DIFF
--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -108,7 +108,7 @@ class MulExpression(BinaryOperator):
     def numeric(self, values):
         """Matrix multiplication.
         """
-        if self.args[0].shape == () or self.args[1].shape == () or \
+        if values[0].shape == () or values[1].shape == () or \
            intf.is_sparse(values[0]) or intf.is_sparse(values[1]):
             return values[0] * values[1]
         else:

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1429,3 +1429,16 @@ class TestExpressions(BaseTest):
         M = Variable(shape=(2, 2))
         expr = x.T.__matmul__(M).__matmul__(x)
         assert not isinstance(expr, cp.QuadForm)
+
+    def test_matmul_scalars(self) -> None:
+        """Test evaluating a matmul that reduces one argument inernally to a scalar.
+
+        See https://github.com/cvxpy/cvxpy/issues/2065
+        """
+        x = cp.Variable((2,))
+        quad = cp.quad_form(x, np.eye(2))
+        a = np.array([2])
+        # NOTE quad has dimensions (1, 1) which is a bug.
+        expr = a @ quad
+        x.value = np.array([1, 2])
+        self.assertAlmostEqual(expr.value, 10)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1431,7 +1431,7 @@ class TestExpressions(BaseTest):
         assert not isinstance(expr, cp.QuadForm)
 
     def test_matmul_scalars(self) -> None:
-        """Test evaluating a matmul that reduces one argument inernally to a scalar.
+        """Test evaluating a matmul that reduces one argument internally to a scalar.
 
         See https://github.com/cvxpy/cvxpy/issues/2065
         """


### PR DESCRIPTION
## Description
Right now the dimensions of quad_form are usually (1, 1). This is not right at all, and leads to errors such as #2065. However changing the dimension of quad_form probably needs to wait for the 1.4 release. This is a hotfix that resolves #2065 more narrowly.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.