### PR TITLE
Change shape quadratic form 

### DIFF
--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -122,7 +122,7 @@ class QuadForm(Atom):
         return [sp.csc_matrix(D.ravel(order="F")).T]
 
     def shape_from_args(self) -> Tuple[int, ...]:
-        return tuple() if self.args[0].ndim == 0 else ()
+        return tuple()
 
 
 class SymbolicQuadForm(Atom):

--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -122,7 +122,7 @@ class QuadForm(Atom):
         return [sp.csc_matrix(D.ravel(order="F")).T]
 
     def shape_from_args(self) -> Tuple[int, ...]:
-        return tuple() if self.args[0].ndim == 0 else (1, 1)
+        return tuple() if self.args[0].ndim == 0 else ()
 
 
 class SymbolicQuadForm(Atom):

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1450,13 +1450,13 @@ class TestExpressions(BaseTest):
 
     def test_matmul_scalars(self) -> None:
         """Test evaluating a matmul that reduces one argument internally to a scalar.
-
-        See https://github.com/cvxpy/cvxpy/issues/2065
         """
         x = cp.Variable((2,))
         quad = cp.quad_form(x, np.eye(2))
         a = np.array([2])
-        # NOTE quad has dimensions (1, 1) which is a bug.
-        expr = a @ quad
+        expr = quad * a
         x.value = np.array([1, 2])
-        self.assertAlmostEqual(expr.value, 10)
+        X = np.eye(2)
+        true_val = (np.transpose(x.value) @ X @ x.value) * a
+        self.assertEqual(expr.value, true_val)
+

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1456,7 +1456,7 @@ class TestExpressions(BaseTest):
         a = np.array([2])
         expr = quad * a
         x.value = np.array([1, 2])
-        X = np.eye(2)
-        true_val = (np.transpose(x.value) @ X @ x.value) * a
+        P = np.eye(2)
+        true_val = (np.transpose(x.value) @ P @ x.value) * a
         assert quad.shape == ()
         self.assertEqual(expr.value, true_val)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1458,5 +1458,5 @@ class TestExpressions(BaseTest):
         x.value = np.array([1, 2])
         X = np.eye(2)
         true_val = (np.transpose(x.value) @ X @ x.value) * a
+        assert quad.shape == ()
         self.assertEqual(expr.value, true_val)
-


### PR DESCRIPTION
## Description
Please include a short summary of the change.
I adjusted the returned shape for 1-dimensional quadratic form and adjusted test_matmul_scalars. 
Issue link (if applicable):
Found issue on this page: https://github.com/cvxpy/cvxpy/issues/2070

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.
![bench_without](https://user-images.githubusercontent.com/93285862/226441033-452bb700-9128-4d80-a48d-6963d739ebcf.png)
![Screenshot 2023-03-20 at 20 05 53](https://user-images.githubusercontent.com/93285862/226441038-034dabe7-9a09-489f-9557-c008a6fcaa8f.png)