### PR TITLE
Change scalar_product to function in api

### DIFF
--- a/doc/source/api_reference/cvxpy.atoms.affine.rst
+++ b/doc/source/api_reference/cvxpy.atoms.affine.rst
@@ -165,9 +165,7 @@ reshape
 scalar_product
 --------------
 
-.. autoclass:: cvxpy.scalar_product
-    :show-inheritance:
-
+.. autofunction:: cvxpy.scalar_product
 
 .. _sum:
 


### PR DESCRIPTION
## Description
Please include a short summary of the change.
Issue link (if applicable):
Currently in the function scalar_product in https://www.cvxpy.org/api_reference/cvxpy.atoms.affine.html#scalar-product is mentioned as a class although, it is implemented as a function in binary_operators.py

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.