### PR TITLE
fix: scipy time limit raises SolverError

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -42,7 +42,7 @@ class SCIPY(ConicSolver):
 
     # Map of SciPy linprog status
     STATUS_MAP = {0: s.OPTIMAL,  # Optimal
-                  1: s.SOLVER_ERROR,  # Iteration limit reached
+                  1: s.OPTIMAL_INACCURATE,  # Iteration limit reached
                   2: s.INFEASIBLE,  # Infeasible
                   3: s.UNBOUNDED,  # Unbounded
                   4: s.SOLVER_ERROR  # Numerical difficulties encountered

--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -219,8 +219,8 @@ class SCIPY(ConicSolver):
         """
         status = self.STATUS_MAP[solution["status"]]
 
-        # Sometimes when the solver's time limit is reached, the solver doesn't return a solution. In these situations
-        # we correct the problem status from s.OPTIMAL_INACCURATE to s.SOLVER_ERROR
+        # Sometimes when the solver's time limit is reached, the solver doesn't return a solution.
+        # In these situations we correct the status from s.OPTIMAL_INACCURATE to s.SOLVER_ERROR
         if (status == s.OPTIMAL_INACCURATE) and (solution.x is None):
             status = s.SOLVER_ERROR
 

--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -42,7 +42,7 @@ class SCIPY(ConicSolver):
 
     # Map of SciPy linprog status
     STATUS_MAP = {0: s.OPTIMAL,  # Optimal
-                  1: s.OPTIMAL_INACCURATE,  # Iteration limit reached
+                  1: s.OPTIMAL_INACCURATE,  # Iteration/time limit reached
                   2: s.INFEASIBLE,  # Infeasible
                   3: s.UNBOUNDED,  # Unbounded
                   4: s.SOLVER_ERROR  # Numerical difficulties encountered
@@ -217,7 +217,12 @@ class SCIPY(ConicSolver):
     def invert(self, solution, inverse_data):
         """Returns the solution to the original problem given the inverse_data.
         """
-        status = self.STATUS_MAP[solution['status']]
+        status = self.STATUS_MAP[solution["status"]]
+
+        # Sometimes when the solver's time limit is reached, the solver doesn't return a solution. In these situations
+        # we correct the problem status from s.OPTIMAL_INACCURATE to s.SOLVER_ERROR
+        if (status == s.OPTIMAL_INACCURATE) and (solution.x is None):
+            status = s.SOLVER_ERROR
 
         primal_vars = None
         dual_vars = None

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -753,6 +753,32 @@ def mi_lp_5() -> SolverTestHelper:
     return sth
 
 
+def mi_lp_7() -> SolverTestHelper:
+    """Problem that takes significant time to solve - for testing time/iteration limits"""
+    np.random.seed(0)
+    n = 24 * 8
+    c = cp.Variable((n,), pos=True)
+    d = cp.Variable((n,), pos=True)
+    c_or_d = cp.Variable((n,), boolean=True)
+    big = 1e3
+    s = cp.cumsum(c * 0.9 - d)
+    p = np.random.random(n)
+    objective = cp.Maximize(p @ (d - c))
+    constraints = [
+        d <= 1,
+        c <= 1,
+        s >= 0,
+        s <= 1,
+        c <= c_or_d * big,
+        d <= (1 - c_or_d) * big,
+    ]
+    return SolverTestHelper(
+        (objective, None),
+        [(c, None,), (d, None), (c_or_d, None)],
+        [(con, None) for con in constraints]
+    )
+
+
 def mi_socp_1() -> SolverTestHelper:
     """
     Formulate the following mixed-integer SOCP with cvxpy

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -24,6 +24,7 @@ import scipy.stats as st
 
 import cvxpy as cp
 import cvxpy.tests.solver_test_helpers as sths
+from cvxpy import SolverError
 from cvxpy.reductions.solvers.defines import (
     INSTALLED_MI_SOLVERS,
     INSTALLED_SOLVERS,
@@ -1993,6 +1994,19 @@ class TestSCIPY(unittest.TestCase):
     @unittest.skipUnless('SCIPY' in INSTALLED_MI_SOLVERS, 'SCIPY version cannot solve MILPs')
     def test_scipy_mi_lp_5(self) -> None:
         StandardTestLPs.test_mi_lp_5(solver='SCIPY')
+
+    @unittest.skipUnless('SCIPY' in INSTALLED_MI_SOLVERS, 'SCIPY version cannot solve MILPs')
+    def test_scipy_mi_time_limit_reached(self) -> None:
+        sth = sths.mi_lp_7()
+
+        # run without enough time to find optimum
+        sth.solve(solver='SCIPY', scipy_options={"time_limit": 0.01})
+        assert sth.prob.status == cp.OPTIMAL_INACCURATE
+        assert sth.objective.value > 0
+
+        # run without enough time to do anything
+        with pytest.raises(SolverError):
+            sth.solve(solver='SCIPY', scipy_options={"time_limit": 0.})
 
 
 @unittest.skipUnless('COPT' in INSTALLED_SOLVERS, 'COPT is not installed.')


### PR DESCRIPTION
## Description
When using SciPy, if the solver reaches it's set time limit, a `SolverError` is raised. This change makes it so these instances are instead reported as `OPTIMAL_INACCURATE`. I think this behavior is more consistent with other solvers - this is at least how GLPK works currently.

I haven't added a unit test for this. Let me know if this seems necessary.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.