### PR TITLE
Adds an error message on `builtins.abs(cp.Variable())`

### DIFF
--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -67,6 +67,12 @@ You're calling a NumPy function on a CVXPY expression. This is prone to causing
 errors or code that doesn't behave as expected. Consider using one of the
 functions documented here: https://www.cvxpy.org/tutorial/functions/index.html
 """
+
+__ABS_ERROR__ = """
+You're calling the builtin abs function on a CVXPY expression. This is not
+supported. Consider using the abs function provided by CVXPY.
+"""
+
 __BINARY_EXPRESSION_UFUNCS__ = {
         np.add: lambda self, a: self.__radd__(a),
         np.subtract: lambda self, a: self.__rsub__(a),
@@ -747,3 +753,6 @@ class Expression(u.Canonical):
             pass
 
         raise RuntimeError(__NUMPY_UFUNC_ERROR__)
+
+    def __abs__(self):
+        raise RuntimeError(__ABS_ERROR__)

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -69,7 +69,7 @@ functions documented here: https://www.cvxpy.org/tutorial/functions/index.html
 """
 
 __ABS_ERROR__ = """
-You're calling the builtin abs function on a CVXPY expression. This is not
+You're calling the built-in abs function on a CVXPY expression. This is not
 supported. Consider using the abs function provided by CVXPY.
 """
 

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -755,4 +755,4 @@ class Expression(u.Canonical):
         raise RuntimeError(__NUMPY_UFUNC_ERROR__)
 
     def __abs__(self):
-        raise RuntimeError(__ABS_ERROR__)
+        raise TypeError(__ABS_ERROR__)

--- a/cvxpy/tests/test_errors.py
+++ b/cvxpy/tests/test_errors.py
@@ -109,5 +109,5 @@ class TestErrors(BaseTest):
             np.linalg.norm(self.x)
 
     def test_abs_error(self) -> None:
-        with pytest.raises(RuntimeError, match=__ABS_ERROR__):
+        with pytest.raises(TypeError, match=__ABS_ERROR__):
             builtins.abs(self.x)

--- a/cvxpy/tests/test_errors.py
+++ b/cvxpy/tests/test_errors.py
@@ -68,7 +68,8 @@ class TestErrors(BaseTest):
                     ufunc is np.less or \
                     ufunc is np.greater:
                 continue
-            self.assertItemsAlmostEqual(ufunc(a, self.x).value, ufunc(a, self.x.value))
+            self.assertItemsAlmostEqual(
+                ufunc(a, self.x).value, ufunc(a, self.x.value))
 
         for ufunc in __BINARY_EXPRESSION_UFUNCS__:
             if ufunc is np.matmul:
@@ -91,7 +92,8 @@ class TestErrors(BaseTest):
                     ufunc is np.greater:
                 continue
 
-            self.assertItemsAlmostEqual(ufunc(b, self.x).value, ufunc(b, self.x.value))
+            self.assertItemsAlmostEqual(
+                ufunc(b, self.x).value, ufunc(b, self.x.value))
 
     def test_working_numpy_functions(self) -> None:
         hstack = np.hstack([self.x])
@@ -104,7 +106,7 @@ class TestErrors(BaseTest):
     def test_broken_numpy_functions(self) -> None:
         with pytest.raises(RuntimeError, match=__NUMPY_UFUNC_ERROR__):
             np.linalg.norm(self.x)
-    
+
     def test_abs_error(self) -> None:
         with pytest.raises(RuntimeError, match=__ABS_ERROR__):
             builtins.abs(self.x)

--- a/cvxpy/tests/test_errors.py
+++ b/cvxpy/tests/test_errors.py
@@ -21,9 +21,11 @@ import numpy as np
 import pytest
 
 import cvxpy as cp
-from cvxpy.expressions.expression import (__ABS_ERROR__,
-                                          __BINARY_EXPRESSION_UFUNCS__,
-                                          __NUMPY_UFUNC_ERROR__)
+from cvxpy.expressions.expression import (
+    __ABS_ERROR__,
+    __BINARY_EXPRESSION_UFUNCS__,
+    __NUMPY_UFUNC_ERROR__,
+)
 from cvxpy.tests.base_test import BaseTest
 
 

--- a/cvxpy/tests/test_errors.py
+++ b/cvxpy/tests/test_errors.py
@@ -15,16 +15,15 @@ limitations under the License.
 """
 
 
-import numpy as np
-import pytest
 import builtins
 
+import numpy as np
+import pytest
+
 import cvxpy as cp
-from cvxpy.expressions.expression import (
-    __BINARY_EXPRESSION_UFUNCS__,
-    __NUMPY_UFUNC_ERROR__,
-    __ABS_ERROR__,
-)
+from cvxpy.expressions.expression import (__ABS_ERROR__,
+                                          __BINARY_EXPRESSION_UFUNCS__,
+                                          __NUMPY_UFUNC_ERROR__)
 from cvxpy.tests.base_test import BaseTest
 
 

--- a/cvxpy/tests/test_errors.py
+++ b/cvxpy/tests/test_errors.py
@@ -17,17 +17,21 @@ limitations under the License.
 
 import numpy as np
 import pytest
+import builtins
 
 import cvxpy as cp
 from cvxpy.expressions.expression import (
     __BINARY_EXPRESSION_UFUNCS__,
     __NUMPY_UFUNC_ERROR__,
+    __ABS_ERROR__,
 )
 from cvxpy.tests.base_test import BaseTest
 
 
-class TestNumpy(BaseTest):
-    """ Unit tests for using NumPy ufuncs on CVXPY objects should cause errors. """
+class TestErrors(BaseTest):
+    """
+    Unit tests for custom error messages to explain why code is broken
+    """
 
     def setUp(self) -> None:
 
@@ -100,3 +104,7 @@ class TestNumpy(BaseTest):
     def test_broken_numpy_functions(self) -> None:
         with pytest.raises(RuntimeError, match=__NUMPY_UFUNC_ERROR__):
             np.linalg.norm(self.x)
+    
+    def test_abs_error(self) -> None:
+        with pytest.raises(RuntimeError, match=__ABS_ERROR__):
+            builtins.abs(self.x)


### PR DESCRIPTION
## Description
This PR changes the text of the error that occurs when people run `builtins.abs(cp.Variable())` to explain what is wrong.

Since the text of error messages is not part of our backward compatibility guarantees, but their type is, this is backwards compatible.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.