### PR TITLE
improve string representation, especially shortening expression.tostring

### DIFF
--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -61,6 +61,9 @@ class Constant(Leaf):
     def name(self) -> str:
         """The value as a string.
         """
+        if len(self.shape) == 2 and "\n" in str(self.value):
+            return np.array2string(self.value, edgeitems=2, threshold=5,
+                                    formatter={'float': lambda x: f'{x:.2f}'})
         return str(self.value)
 
     def constants(self) -> List["Constant"]:

--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -21,9 +21,9 @@ import scipy.sparse as sp
 
 import cvxpy.interface as intf
 import cvxpy.lin_ops.lin_utils as lu
+import cvxpy.settings as s
 import cvxpy.utilities.linalg as eig_util
 from cvxpy.expressions.leaf import Leaf
-from cvxpy.settings import EIGVAL_TOL
 from cvxpy.utilities import performance_utils as perf
 
 
@@ -62,8 +62,10 @@ class Constant(Leaf):
         """The value as a string.
         """
         if len(self.shape) == 2 and "\n" in str(self.value):
-            return np.array2string(self.value, edgeitems=2, threshold=5,
-                                    formatter={'float': lambda x: f'{x:.2f}'})
+            return np.array2string(self.value,
+                                   edgeitems=s.PRINT_EDGEITEMS,
+                                   threshold=s.PRINT_THRESHOLD,
+                                   formatter={'float': lambda x: f'{x:.2f}'})
         return str(self.value)
 
     def constants(self) -> List["Constant"]:
@@ -222,7 +224,7 @@ class Constant(Leaf):
 
         # Compute sign of bottom eigenvalue if absent.
         if self._psd_test is None:
-            self._psd_test = eig_util.is_psd_within_tol(self.value, EIGVAL_TOL)
+            self._psd_test = eig_util.is_psd_within_tol(self.value, s.EIGVAL_TOL)
 
         return self._psd_test
 
@@ -244,6 +246,6 @@ class Constant(Leaf):
 
         # Compute sign of top eigenvalue if absent.
         if self._nsd_test is None:
-            self._nsd_test = eig_util.is_psd_within_tol(-self.value, EIGVAL_TOL)
+            self._nsd_test = eig_util.is_psd_within_tol(-self.value, s.EIGVAL_TOL)
 
         return self._nsd_test

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -133,7 +133,11 @@ class Expression(u.Canonical):
     def __str__(self) -> str:
         """Returns a string showing the mathematical expression.
         """
-        return self.name()
+        name = self.name()
+        if len(self.shape) == 2 and self.value is not None and "\n" in name:
+            name = np.array2string(self.value, edgeitems=2, threshold=5,
+                                   formatter={'float': lambda x: f'{x:.2f}'})
+        return name
 
     def __repr__(self) -> str:
         """Returns a string with information about the expression.

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -133,11 +133,7 @@ class Expression(u.Canonical):
     def __str__(self) -> str:
         """Returns a string showing the mathematical expression.
         """
-        name = self.name()
-        if len(self.shape) == 2 and self.value is not None and "\n" in name:
-            name = np.array2string(self.value, edgeitems=2, threshold=5,
-                                   formatter={'float': lambda x: f'{x:.2f}'})
-        return name
+        return self.name()
 
     def __repr__(self) -> str:
         """Returns a string with information about the expression.

--- a/cvxpy/expressions/variable.py
+++ b/cvxpy/expressions/variable.py
@@ -137,7 +137,4 @@ class Variable(Leaf):
         """String to recreate the object.
         """
         attr_str = self._get_attr_str()
-        if len(attr_str) > 0:
-            return "Variable(%s%s)" % (self.shape, attr_str)
-        else:
-            return f"Variable({self.shape}, {self.__str__()})"
+        return f"Variable({self.shape}, {self.__str__()}{attr_str})"

--- a/cvxpy/expressions/variable.py
+++ b/cvxpy/expressions/variable.py
@@ -140,4 +140,4 @@ class Variable(Leaf):
         if len(attr_str) > 0:
             return "Variable(%s%s)" % (self.shape, attr_str)
         else:
-            return "Variable(%s)" % (self.shape,)
+            return "Variable(%s, %s)" % (self.shape, self.__str__())

--- a/cvxpy/expressions/variable.py
+++ b/cvxpy/expressions/variable.py
@@ -140,4 +140,4 @@ class Variable(Leaf):
         if len(attr_str) > 0:
             return "Variable(%s%s)" % (self.shape, attr_str)
         else:
-            return "Variable(%s, %s)" % (self.shape, self.__str__())
+            return f"Variable({self.shape}, {self.__str__()})"

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -195,6 +195,9 @@ PARAM_THRESHOLD = 1e4
 # environment variable)
 NUM_THREADS = -1
 
+PRINT_EDGEITEMS = 2
+PRINT_THRESHOLD = 5
+
 
 def set_num_threads(num_threads: int) -> None:
     global NUM_THREADS

--- a/cvxpy/tests/test_constant.py
+++ b/cvxpy/tests/test_constant.py
@@ -2,6 +2,7 @@ import numpy as np
 import scipy.sparse.linalg as sparla
 
 import cvxpy as cp
+import cvxpy.settings as s
 from cvxpy import psd_wrap
 
 
@@ -38,3 +39,16 @@ def test_is_psd() -> None:
     assert failures == {97}
 
     assert psd_wrap(cp.Constant(P)).is_psd()
+
+
+def test_print():
+    A = cp.Constant(np.ones((3, 3)))
+    assert str(A) == '[[1.00 1.00 1.00]\n [1.00 1.00 1.00]\n [1.00 1.00 1.00]]'
+    B = cp.Constant(np.ones((5, 2)))
+    assert str(
+        B) == '[[1.00 1.00]\n [1.00 1.00]\n ...\n [1.00 1.00]\n [1.00 1.00]]'
+    default = s.PRINT_EDGEITEMS
+    s.PRINT_EDGEITEMS = 10
+    assert str(
+        B) == '[[1.00 1.00]\n [1.00 1.00]\n [1.00 1.00]\n [1.00 1.00]\n [1.00 1.00]]'
+    s.PRINT_EDGEITEMS = default

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -63,6 +63,8 @@ class TestExpressions(BaseTest):
 
         self.assertEqual(repr(self.x), "Variable((2,), x)")
         self.assertEqual(repr(self.A), "Variable((2, 2), A)")
+        self.assertEqual(repr(cp.Variable(name='x', nonneg=True)), "Variable((), x, nonneg=True)")
+        self.assertTrue(repr(cp.Variable()).startswith("Variable((), var"))
 
         # Test shape provided as list instead of tuple
         self.assertEqual(cp.Variable(shape=[2], integer=True).shape, (2,))

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -61,8 +61,8 @@ class TestExpressions(BaseTest):
         # self.assertEqual(x.canonical_form[0].shape, (2, 1))
         # self.assertEqual(x.canonical_form[1], [])
 
-        self.assertEqual(repr(self.x), "Variable((2,))")
-        self.assertEqual(repr(self.A), "Variable((2, 2))")
+        self.assertEqual(repr(self.x), "Variable((2,), x)")
+        self.assertEqual(repr(self.A), "Variable((2, 2), A)")
 
         # Test shape provided as list instead of tuple
         self.assertEqual(cp.Variable(shape=[2], integer=True).shape, (2,))


### PR DESCRIPTION
## Description
I made changes to three files:

<b>expression.py</b>: here I changed the expression toString method, by using [numpy.array2string](https://numpy.org/doc/stable/reference/generated/numpy.array2string.html) we are able to take advantage of formatting (floating point numbers with 2 decimals), and hiding additional elements (using edgeitems=2).

The last part of the if statement was added to bypass some tests that weren't passing for test_transpose.
```
self.value is not None and "\n" in name
```
This ensures that we only use numpy.array2string on expressions whose name are arrays. (For example, x.T.T wouldn't be affected as it's name doesn't contain a newline).

<b>variable.py</b>: expanded variable representation by including the variable name in addition to the variable shape.

<b>test_expression.py</b>: made changes to two asserts that verified the representation of the expressions.

Here is an example of the changes made in this PR
```
print(cp.Constant(np.ones((5,5))).__str__())
[[1.00 1.00 ... 1.00 1.00]
 [1.00 1.00 ... 1.00 1.00]
 ...
 [1.00 1.00 ... 1.00 1.00]
 [1.00 1.00 ... 1.00 1.00]]
```

Issue link (if applicable): #2089 

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.