### PR TITLE
feat: retrieve mip gap from SCIPY solution

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -245,7 +245,9 @@ class SCIPY(ConicSolver):
                     inverse_data[self.NEQ_CONSTR])
                 eq_dual.update(leq_dual)
                 dual_vars = eq_dual
-
-            return Solution(status, opt_val, primal_vars, dual_vars, {})
+            attr = {}
+            if inverse_data['is_mip']:
+                attr[s.EXTRA_STATS] = {"mip_gap": solution['mip_gap']}
+            return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
             return failure_solution(status)

--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -246,7 +246,7 @@ class SCIPY(ConicSolver):
                 eq_dual.update(leq_dual)
                 dual_vars = eq_dual
             attr = {}
-            if inverse_data['is_mip']:
+            if "mip_gap" in solution:
                 attr[s.EXTRA_STATS] = {"mip_gap": solution['mip_gap']}
             return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2018,6 +2018,7 @@ class TestSCIPY(unittest.TestCase):
         sth.solve(solver='SCIPY', scipy_options={"time_limit": 0.01})
         assert sth.prob.status == cp.OPTIMAL_INACCURATE
         assert sth.objective.value > 0
+        assert sth.prob.solver_stats.extra_stats["mip_gap"] > 0
 
         # run without enough time to do anything
         with pytest.raises(cp.error.SolverError):


### PR DESCRIPTION
## Description
When using scipy to solve a MIP, this change makes the solution's relative mip gap available in `Problem.solver_stats.extra_stats["mip_gap"]`

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.