### PR TITLE
fix: remove reductions import in top-level __init__.py

### DIFF
--- a/cvxpy/__init__.py
+++ b/cvxpy/__init__.py
@@ -28,7 +28,6 @@ from cvxpy.expressions.variable import Variable
 from cvxpy.problems.objective import Maximize, Minimize
 from cvxpy.problems.problem import Problem
 from cvxpy.transforms import linearize, partial_optimize, suppfunc
-from cvxpy.reductions import *
 from cvxpy.reductions.solvers.defines import installed_solvers
 from cvxpy.settings import (CBC, CLARABEL, COPT, CPLEX, CPP_CANON_BACKEND,
                             CVXOPT, DIFFCP, ECOS, ECOS_BB, GLOP, GLPK, GLPK_MI,

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -30,6 +30,7 @@ from cvxpy.reductions.cone2cone import affine2direct as a2d
 from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
 from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
 from cvxpy.reductions.dcp2cone.dcp2cone import Dcp2Cone
+from cvxpy.reductions.solution import Solution
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS as INSTALLED_MI
 from cvxpy.reductions.solvers.defines import MI_SOCP_SOLVERS as MI_SOCP
@@ -88,7 +89,7 @@ class TestDualize(BaseTest):
         if K_dir[a2d.DUAL_POW3D]:
             dual_prims[a2d.DUAL_POW3D] = dual_prims[a2d.DUAL_POW3D].value
         dual_duals = {s.EQ_DUAL: constraints[0].dual_value}
-        dual_sol = cp.Solution(dual_prob.status, dual_prob.value, dual_prims, dual_duals, dict())
+        dual_sol = Solution(dual_prob.status, dual_prob.value, dual_prims, dual_duals, dict())
         cone_sol = a2d.Dualize.invert(dual_sol, inv_data)
 
         # Pass the solution back up the solving chain.
@@ -217,7 +218,7 @@ class TestSlacks(BaseTest):
         slack_prob = cp.Problem(objective, constraints)
         slack_prob.solve(**solve_kwargs)
         slack_prims = {a2d.FREE: y[:cone_prog.x.size].value}  # nothing else need be populated.
-        slack_sol = cp.Solution(slack_prob.status, slack_prob.value, slack_prims, None, dict())
+        slack_sol = Solution(slack_prob.status, slack_prob.value, slack_prims, None, dict())
         cone_sol = a2d.Slacks.invert(slack_sol, inv_data)
 
         # pass solution up the solving chain

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -17,6 +17,7 @@ import numpy as np
 
 import cvxpy as cp
 import cvxpy.settings as s
+from cvxpy.reductions.dqcp2dcp.dqcp2dcp import Dqcp2Dcp
 from cvxpy.reductions.solvers import bisection
 from cvxpy.tests import base_test
 
@@ -41,7 +42,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(problem.is_dcp())
         self.assertFalse(problem.is_dgp())
 
-        red = cp.Dqcp2Dcp(problem)
+        red = Dqcp2Dcp(problem)
         reduced = red.reduce()
         self.assertTrue(reduced.is_dcp())
         self.assertEqual(len(reduced.parameters()), 1)
@@ -69,7 +70,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(problem.is_dcp())
         self.assertFalse(problem.is_dgp())
 
-        red = cp.Dqcp2Dcp(problem)
+        red = Dqcp2Dcp(problem)
         reduced = red.reduce()
         self.assertTrue(reduced.is_dcp())
         self.assertEqual(len(reduced.parameters()), 1)


### PR DESCRIPTION
## Description

Reductions are stated to not be in the public API
(https://www.cvxpy.org/api_reference/cvxpy.reductions.html#disclaimer, https://github.com/cvxpy/cvxpy/pull/2104#issuecomment-1509886345), but they are imported in the top-level `__init__.py`.

This change removes that import.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)