### PR TITLE
Revert "feat: retrieve mip gap from SCIPY solution"

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -245,9 +245,7 @@ class SCIPY(ConicSolver):
                     inverse_data[self.NEQ_CONSTR])
                 eq_dual.update(leq_dual)
                 dual_vars = eq_dual
-            attr = {}
-            if "mip_gap" in solution:
-                attr[s.EXTRA_STATS] = {"mip_gap": solution['mip_gap']}
-            return Solution(status, opt_val, primal_vars, dual_vars, attr)
+
+            return Solution(status, opt_val, primal_vars, dual_vars, {})
         else:
             return failure_solution(status)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2018,7 +2018,6 @@ class TestSCIPY(unittest.TestCase):
         sth.solve(solver='SCIPY', scipy_options={"time_limit": 0.01})
         assert sth.prob.status == cp.OPTIMAL_INACCURATE
         assert sth.objective.value > 0
-        assert sth.prob.solver_stats.extra_stats["mip_gap"] > 0
 
         # run without enough time to do anything
         with pytest.raises(cp.error.SolverError):


### PR DESCRIPTION
This reverts commit 6eb5466ab0a90be20d74839dc993d489b96dcd19.

## Description
The MIP gap is not available with the interface we are using. Consequently the added tests fail. We didn't notice the regression because of unrelated failures in the CI.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.