### PR TITLE
SciPy MIP gap

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -245,7 +245,9 @@ class SCIPY(ConicSolver):
                     inverse_data[self.NEQ_CONSTR])
                 eq_dual.update(leq_dual)
                 dual_vars = eq_dual
-
-            return Solution(status, opt_val, primal_vars, dual_vars, {})
+            attr = {}
+            if "mip_gap" in solution:
+                attr[s.EXTRA_STATS] = {"mip_gap": solution['mip_gap']}
+            return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
             return failure_solution(status)

--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -17,6 +17,7 @@ limitations under the License.
 
 import warnings
 
+import numpy as np
 import scipy  # For version checks
 
 import cvxpy.settings as s
@@ -187,10 +188,23 @@ class SCIPY(ConicSolver):
                 self._log_scipy_method_warning(meth)
 
         if problem_is_a_mip:
-            solution = opt.linprog(data[s.C], A_ub=data[s.G], b_ub=data[s.H],
-                                   A_eq=data[s.A], b_eq=data[s.B], method=meth,
-                                   options=solver_opts['scipy_options'],
-                                   integrality=integrality, bounds=bounds)
+            constraints = []
+            G = data[s.G]
+            if G is not None:
+                ineq = scipy.optimize.LinearConstraint(G, ub=data[s.H])
+                constraints.append(ineq)
+            A = data[s.A]
+            if A is not None:
+                eq = scipy.optimize.LinearConstraint(A,data[s.B], data[s.B])
+                constraints.append(eq)
+            lb = [t[0] if t[0] is not None else -np.inf for t in bounds]
+            ub = [t[1] if t[1] is not None else np.inf for t in bounds]
+            bounds = scipy.optimize.Bounds(lb, ub)
+            solution = opt.milp(data[s.C], 
+                                constraints=constraints,
+                                options=solver_opts['scipy_options'],
+                                integrality=integrality,
+                                bounds=bounds)
         else:
             solution = opt.linprog(data[s.C], A_ub=data[s.G], b_ub=data[s.H],
                                    A_eq=data[s.A], b_eq=data[s.B], method=meth,

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2018,6 +2018,7 @@ class TestSCIPY(unittest.TestCase):
         sth.solve(solver='SCIPY', scipy_options={"time_limit": 0.01})
         assert sth.prob.status == cp.OPTIMAL_INACCURATE
         assert sth.objective.value > 0
+        assert sth.prob.solver_stats.extra_stats["mip_gap"] > 0
 
         # run without enough time to do anything
         with pytest.raises(cp.error.SolverError):

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2015,7 +2015,7 @@ class TestSCIPY(unittest.TestCase):
         sth = sths.mi_lp_7()
 
         # run without enough time to find optimum
-        sth.solve(solver='SCIPY', scipy_options={"time_limit": 0.01})
+        sth.solve(solver='SCIPY', scipy_options={"time_limit": 0.02})
         assert sth.prob.status == cp.OPTIMAL_INACCURATE
         assert sth.objective.value > 0
         assert sth.prob.solver_stats.extra_stats["mip_gap"] > 0


### PR DESCRIPTION
## Description
Slight adaption of #2103 using `milp` instead of `linprog` which also provides the mip gap for problems with time limits.
Issue link (if applicable): #2112 

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.