### PR TITLE
`setup.py`: Remove `setup_requires`, remove setuptools from `install_requires'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -231,7 +231,5 @@ setup(
         "scs >= 1.1.6",
         "numpy >= 1.15",
         "scipy >= 1.1.0",
-        "setuptools > 65.5.1",
     ],
-    setup_requires=["numpy >= 1.15"],
 )


### PR DESCRIPTION
## Description
Please include a short summary of the change.
Issue link (if applicable):

`setup_requires` is outdated; the build dependencies are declared in `pyproject.toml`.
Also `setuptools` should not appear in `install_requires`; these are the runtime dependencies.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.