### PR TITLE
Correct categorization of ``tr_inv`` atom.

### DIFF
--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -116,7 +116,6 @@ SOC_ATOMS = [
 EXP_ATOMS = [
     log_sum_exp,
     log_det,
-    tr_inv,
     entr,
     exp,
     kl_div,
@@ -136,6 +135,7 @@ PSD_ATOMS = [
     MatrixFrac,
     normNuc,
     sigma_max,
+    tr_inv,
 ]
 
 NONPOS_ATOMS = [


### PR DESCRIPTION
This resolves GitHub Issue #2092.

No new unit tests should be needed for this change. It's the kind of error that could happen with any atom whenever it's first contributed (although it's an unusual mistake and this is the first I've seen something like it).
