### PR TITLE
Fix bug with calling Mosek simplex solver

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
@@ -140,7 +140,7 @@ class CLARABEL(ConicSolver):
         import clarabel
         if Version(clarabel.__version__) >= Version('0.5.0'):
             SUPPORTED_CONSTRAINTS.append(PSD)
-    except (ModuleNotFoundError, TypeError):
+    except ModuleNotFoundError:
         pass
     
 

--- a/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
@@ -140,7 +140,7 @@ class CLARABEL(ConicSolver):
         import clarabel
         if Version(clarabel.__version__) >= Version('0.5.0'):
             SUPPORTED_CONSTRAINTS.append(PSD)
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, TypeError):
         pass
     
 

--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -485,10 +485,17 @@ class MOSEK(ConicSolver):
 
         env = solver_output['env']
         task = solver_output['task']
+        solver_opts = solver_output['solver_options']
+        simplex_algs = [
+            mosek.optimizertype.primal_simplex,
+            mosek.optimizertype.dual_simplex,
+        ]
+        current_optimizer = task.getintparam(mosek.iparam.optimizer)
+        bfs_active = "bfs" in solver_opts and solver_opts["bfs"] and task.getnumcone() == 0
 
         if task.getnumintvar() > 0:
             sol_type = mosek.soltype.itg
-        elif 'bfs' in solver_opts and solver_opts['bfs'] and task.getnumcone() == 0:
+        elif current_optimizer in simplex_algs or bfs_active:
             sol_type = mosek.soltype.bas  # the basic feasible solution
         else:
             sol_type = mosek.soltype.itr  # the solution found via interior point method

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -622,6 +622,24 @@ class TestMosek(unittest.TestCase):
             with pytest.warns():
                 problem.solve(solver=cp.MOSEK, mosek_params=mosek_params)
 
+    def test_mosek_simplex(self) -> None:
+        n = 10
+        m = 4
+        np.random.seed(0)
+        A = np.random.randn(m, n)
+        x = np.random.randn(n)
+        y = A.dot(x)
+
+        # Solve a simple basis pursuit problem for testing purposes.
+        z = cp.Variable(n)
+        objective = cp.Minimize(cp.norm1(z))
+        constraints = [A @ z == y]
+        problem = cp.Problem(objective, constraints)
+        problem.solve(
+            solver=cp.MOSEK, 
+            mosek_params={"MSK_IPAR_OPTIMIZER": "MSK_OPTIMIZER_DUAL_SIMPLEX"}
+        )
+
     def test_power_portfolio(self) -> None:
         """Test the portfolio problem in issue #2042"""
         T, N = 200, 10


### PR DESCRIPTION
## Description
The Mosek simplex and dual simplex solver cannot be used right now due to a simple interface bug, fixed here. I also made the Clarabel interface a bit more robust because it was failing on my old Clarabel version.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.