### PR TITLE
Follow-up Mosek accept unknown

### DIFF
--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -677,7 +677,7 @@ class TestMosek(unittest.TestCase):
         }
         sth = sths.lp_5()
         sth.solve(solver=cp.MOSEK, accept_unknown=True, mosek_params=mosek_param)
-        assert sth.prob.status == cp.OPTIMAL_INACCURATE
+        assert sth.prob.status in {cp.OPTIMAL_INACCURATE, cp.OPTIMAL}
 
         with pytest.raises(cp.error.SolverError, match="Solver 'MOSEK' failed"):
             sth.solve(solver=cp.MOSEK, mosek_params=mosek_param)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -681,16 +681,13 @@ class TestMosek(unittest.TestCase):
                        cp.sum(x) >= 0.1,
                        x >= 0,
                        cone_con]
-        obj = cp.Minimize(3 * x[0] + 2 * x[1] + x[2])
+        obj = cp.Minimize(3 * x[0] + 2 * x[1] + x[2] + cp.exp(x[0]))
         prob = cp.Problem(obj, constraints)
         prob.solve(solver=cp.MOSEK, accept_unknown=True, mosek_params=mosek_param)
-        assert prob.status is cp.OPTIMAL_INACCURATE
-        with pytest.raises(cp.error.SolverError) as se:
+        assert prob.status == cp.OPTIMAL_INACCURATE
+
+        with pytest.raises(cp.error.SolverError, match="Solver 'MOSEK' failed"):
             prob.solve(solver=cp.MOSEK, mosek_params=mosek_param)
-            exc = " Solver 'MOSEK' failed. " \
-                  "Try another solver, or solve with verbose=True " \
-                  "for more information."
-            assert str(se.value) == exc
 
 
 @unittest.skipUnless('CVXOPT' in INSTALLED_SOLVERS, 'CVXOPT is not installed.')

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -673,7 +673,7 @@ class TestMosek(unittest.TestCase):
 
     def test_mosek_accept_unknown(self) -> None:
         mosek_param = {
-            "MSK_DPAR_OPTIMIZER_MAX_TIME": 0
+            "MSK_IPAR_INTPNT_MAX_ITERATIONS": 0
         }
         sth = sths.lp_5()
         sth.solve(solver=cp.MOSEK, accept_unknown=True, mosek_params=mosek_param)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -681,10 +681,10 @@ class TestMosek(unittest.TestCase):
                        cp.sum(x) >= 0.1,
                        x >= 0,
                        cone_con]
-        obj = cp.Minimize(3 * x[0] + 2 * x[1] + x[2] + cp.exp(x[0]))
+        obj = cp.Minimize(3 * x[0] + 2 * x[1] + x[2])
         prob = cp.Problem(obj, constraints)
         prob.solve(solver=cp.MOSEK, accept_unknown=True, mosek_params=mosek_param)
-        assert prob.status == cp.OPTIMAL_INACCURATE
+        assert prob.status == cp.OPTIMAL_INACCURATE, x.value
 
         with pytest.raises(cp.error.SolverError, match="Solver 'MOSEK' failed"):
             prob.solve(solver=cp.MOSEK, mosek_params=mosek_param)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -675,19 +675,12 @@ class TestMosek(unittest.TestCase):
         mosek_param = {
             "MSK_DPAR_OPTIMIZER_MAX_TIME": 0
         }
-        x = cp.Variable(shape=(3, 1))
-        cone_con = cp.constraints.ExpCone(x[2], x[1], x[0])
-        constraints = [cp.sum(x) <= 1.0,
-                       cp.sum(x) >= 0.1,
-                       x >= 0,
-                       cone_con]
-        obj = cp.Minimize(3 * x[0] + 2 * x[1] + x[2])
-        prob = cp.Problem(obj, constraints)
-        prob.solve(solver=cp.MOSEK, accept_unknown=True, mosek_params=mosek_param)
-        assert prob.status == cp.OPTIMAL_INACCURATE, x.value
+        sth = sths.lp_5()
+        sth.solve(solver=cp.MOSEK, accept_unknown=True, mosek_params=mosek_param)
+        assert sth.prob.status == cp.OPTIMAL_INACCURATE
 
         with pytest.raises(cp.error.SolverError, match="Solver 'MOSEK' failed"):
-            prob.solve(solver=cp.MOSEK, mosek_params=mosek_param)
+            sth.solve(solver=cp.MOSEK, mosek_params=mosek_param)
 
 
 @unittest.skipUnless('CVXOPT' in INSTALLED_SOLVERS, 'CVXOPT is not installed.')


### PR DESCRIPTION
## Description
Trying to fix the CI after merging #2117.
Under windows, the test gives `cp.optimal` instead of `cp.optimal_inaccuracte`.

Looks like @rileyjmurray called it?
https://github.com/cvxpy/cvxpy/pull/2117#issuecomment-1530464403

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.