### PR TITLE
Stop cvxpy from crashing when using an old version of clarabel

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
@@ -140,7 +140,7 @@ class CLARABEL(ConicSolver):
         import clarabel
         if Version(clarabel.__version__) >= Version('0.5.0'):
             SUPPORTED_CONSTRAINTS.append(PSD)
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, TypeError):
         pass
     
 


### PR DESCRIPTION
## Description
Clarabel would crash in the try/except block when using an old version.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.