### PR TITLE
Human-readable SolverStats

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -1517,10 +1517,10 @@ class SolverStats:
         """
         return cls(
             solver_name,
-            solve_time=attr.get('solve_time'),
-            setup_time=attr.get('setup_time'),
-            num_iters=attr.get('num_iters'),
-            extra_stats=attr.get('extra_stats'),
+            solve_time=attr.get(s.SOLVE_TIME),
+            setup_time=attr.get(s.SETUP_TIME),
+            num_iters=attr.get(s.NUM_ITERS),
+            extra_stats=attr.get(s.EXTRA_STATS),
         )
 
 class SizeMetrics:

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import time
 import warnings
 from collections import namedtuple
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
 
 import numpy as np
@@ -1405,7 +1406,7 @@ class Problem(u.Canonical):
                     "information.")
 
         self.unpack(solution)
-        self._solver_stats = SolverStats(self._solution.attr,
+        self._solver_stats = SolverStats.from_dict(self._solution.attr,
                                          chain.solver.name())
 
     def __str__(self) -> str:
@@ -1470,6 +1471,7 @@ class Problem(u.Canonical):
     __truediv__ = __div__
 
 
+@dataclass
 class SolverStats:
     """Reports some of the miscellaneous information that is returned
     by the solver after solving but that is not captured directly by
@@ -1490,22 +1492,36 @@ class SolverStats:
         returned directly from the solver, without modification by CVXPY.
         This object may be a dict, or a custom Python object.
     """
-    def __init__(self, results_dict, solver_name: str) -> None:
-        self.solver_name = solver_name
-        self.solve_time = None
-        self.setup_time = None
-        self.num_iters = None
-        self.extra_stats = None
 
-        if s.SOLVE_TIME in results_dict:
-            self.solve_time = results_dict[s.SOLVE_TIME]
-        if s.SETUP_TIME in results_dict:
-            self.setup_time = results_dict[s.SETUP_TIME]
-        if s.NUM_ITERS in results_dict:
-            self.num_iters = results_dict[s.NUM_ITERS]
-        if s.EXTRA_STATS in results_dict:
-            self.extra_stats = results_dict[s.EXTRA_STATS]
+    solver_name: str
+    solve_time: Optional[float] = None
+    setup_time: Optional[float] = None
+    num_iters: Optional[int] = None
+    extra_stats: Optional[dict] = None
 
+    @classmethod
+    def from_dict(cls, attr: dict, solver_name: str) -> "SolverStats":
+        """Construct a SolverStats object from a dictionary of attributes.
+
+        Parameters
+        ----------
+        attr : dict
+            A dictionary of attributes returned by the solver.
+        solver_name : str
+            The name of the solver.
+
+        Returns
+        -------
+        SolverStats
+            A SolverStats object.
+        """
+        return cls(
+            solver_name,
+            solve_time=attr.get('solve_time'),
+            setup_time=attr.get('setup_time'),
+            num_iters=attr.get('num_iters'),
+            extra_stats=attr.get('extra_stats'),
+        )
 
 class SizeMetrics:
     """Reports various metrics regarding the problem.

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -213,6 +213,7 @@ class TestProblem(BaseTest):
         # into setup, solve, and polish; these are summed to obtain solve_time)
         self.assertGreater(stats.num_iters, 0)
         self.assertTrue(hasattr(stats.extra_stats, 'info'))
+        self.assertTrue(str(stats).startswith("SolverStats(solver_name="))
 
     def test_compilation_time(self) -> None:
         prob = Problem(cp.Minimize(cp.norm(self.x)), [self.x == 0])


### PR DESCRIPTION
## Description
I wanted to add a human-readable string representation to `SolverStats`. Using a `dataclass`, this comes for free.

The output for `extra_stats` depends on the solver. For example, ECOS and SCS give quite detailed information, other solvers point to the solution object or provide no further information.  If you think it is too unwieldy, we can remove `extra_stats` from the string. 

Before:
![image](https://github.com/cvxpy/cvxpy/assets/44360364/85ea54c8-1705-4cb0-8ac7-01ffddb5a366)

After:
![image](https://github.com/cvxpy/cvxpy/assets/44360364/1b1d71bc-be5b-49e9-9e0d-9ef330332b4e)


## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.