### PR TITLE
Improves monotonicity logic for cp.length

### DIFF
--- a/cvxpy/atoms/length.py
+++ b/cvxpy/atoms/length.py
@@ -71,12 +71,12 @@ class length(Atom):
     def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
-        return False
+        return self.args[idx].is_nonneg()
 
     def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
-        return False
+        return self.args[idx].is_nonpos()
 
     def _grad(self, values) -> None:
         return None

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -403,12 +403,12 @@ class TestDqcp(base_test.BaseTest):
     def test_length_monototicity(self) -> None:
         n = 5
         x = cp.Variable(n)
-        self.assertTrue(cp.length(cp.exp(x)).is_incr(0))
-        self.assertFalse(cp.length(cp.exp(x)-1).is_incr(0))
-        self.assertTrue(cp.length(cp.exp(x)).is_dqcp())
-        self.assertFalse(cp.length(cp.exp(x)-1).is_dqcp())
-        self.assertTrue(cp.length(-cp.exp(x)).is_decr(0))
-        self.assertFalse(cp.length(-cp.exp(x)+1).is_decr(0))
+        self.assertTrue(cp.length(cp.abs(x)).is_incr(0))
+        self.assertFalse(cp.length(cp.abs(x)-1).is_incr(0))
+        self.assertTrue(cp.length(cp.abs(x)).is_dqcp())
+        self.assertFalse(cp.length(cp.abs(x)-1).is_dqcp())
+        self.assertTrue(cp.length(-cp.abs(x)).is_decr(0))
+        self.assertFalse(cp.length(-cp.abs(x)+1).is_decr(0))
 
     def test_infeasible(self) -> None:
         x = cp.Variable(2)

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -400,6 +400,18 @@ class TestDqcp(base_test.BaseTest):
         problem.solve(qcp=True)
         assert np.isclose(problem.value, 8)
 
+    def test_length_monototicity(self) -> None:
+        n = 5
+        x = cp.Variable(n)
+        self.assertTrue(cp.length(cp.exp(x)).is_incr(0))
+        self.assertFalse(cp.length(cp.exp(x)-1).is_incr(0))
+        self.assertTrue(cp.length(cp.exp(x)).is_dqcp())
+        self.assertFalse(cp.length(cp.exp(x)-1).is_dqcp())
+        self.assertTrue(cp.length(-cp.exp(x)).is_decr(0))
+        self.assertFalse(cp.length(-cp.exp(x)+1).is_decr(0))
+
+
+
     def test_infeasible(self) -> None:
         x = cp.Variable(2)
         problem = cp.Problem(

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -410,8 +410,6 @@ class TestDqcp(base_test.BaseTest):
         self.assertTrue(cp.length(-cp.exp(x)).is_decr(0))
         self.assertFalse(cp.length(-cp.exp(x)+1).is_decr(0))
 
-
-
     def test_infeasible(self) -> None:
         x = cp.Variable(2)
         problem = cp.Problem(


### PR DESCRIPTION
## Description
`cp.length` is nondecreasing for nonnegative arguments, and nonincreasing for nonpositive arguments.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.