### PR TITLE
Correctly handle solver failure in SOC2PSD reduction

### DIFF
--- a/cvxpy/reductions/cone2cone/soc2psd.py
+++ b/cvxpy/reductions/cone2cone/soc2psd.py
@@ -132,6 +132,10 @@ class SOC2PSD(Reduction):
         The dual variables that we return in `solution` should correspond to the original
         SOC constraints, and not their PSD equivalents. To this end, inversion is required.
         """
+        if solution.dual_vars=={}:
+            # in case the solver fails
+            return solution
+
         soc_id_from_psd, soc_constraint_ids = inverse_data
         psd_constraint_ids = soc_id_from_psd.keys()
 


### PR DESCRIPTION
## Description

Besides avoiding unnecessary computation, this change will also correctly handle the case when the solver fails and returns an empty dual variables list (otherwise `np.hstack` complains about being provided an empty list).

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.