### PR TITLE
Makes vec_to_upper_tri top level import

### DIFF
--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -33,7 +33,7 @@ from cvxpy.atoms.affine.reshape import deep_flatten, reshape
 from cvxpy.atoms.affine.sum import sum
 from cvxpy.atoms.affine.trace import trace
 from cvxpy.atoms.affine.transpose import transpose
-from cvxpy.atoms.affine.upper_tri import upper_tri
+from cvxpy.atoms.affine.upper_tri import upper_tri, vec_to_upper_tri
 from cvxpy.atoms.affine.vec import vec
 from cvxpy.atoms.affine.vstack import vstack
 from cvxpy.atoms.affine.wraps import (hermitian_wrap, psd_wrap,

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -137,15 +137,9 @@ def vec_to_upper_tri(expr, strict: bool = False):
     # compute expr3 = reshape(expr2, shape=(n, n)).T
     #   expr3 is the matrix formed by reading length-n blocks of expr2,
     #   and letting each block form a row of expr3.
-    P_rows = []
-    P_row = 0
-    for mat_row in range(n):
-        entries_in_row = n - mat_row
-        if strict:
-            entries_in_row -= 1
-        P_row += n - entries_in_row  # these are zeros
-        P_rows.extend(range(P_row, P_row + entries_in_row))
-        P_row += entries_in_row
+    k = 1 if strict else 0
+    row_idx, col_idx = np.triu_indices(n, k=k)
+    P_rows = n*row_idx + col_idx
     P_cols = np.arange(ell)
     P_vals = np.ones(P_cols.size)
     P = csc_matrix((P_vals, (P_rows, P_cols)), shape=(n**2, ell))

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -22,9 +22,11 @@ import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.atoms.affine.reshape import reshape
+from cvxpy.atoms.affine.vec import vec
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.expression import Expression
 
+vec
 
 class upper_tri(AffAtom):
     """The vectorized strictly upper-triagonal entries.
@@ -111,6 +113,12 @@ class upper_tri(AffAtom):
 
 def vec_to_upper_tri(expr, strict: bool = False):
     expr = Expression.cast_to_const(expr)
+
+    if not expr.is_vector():
+        raise ValueError("The input must be a vector.")
+    if expr.ndim != 1:
+        expr = vec(expr)
+
     ell = expr.shape[0]
     if strict:
         # n * (n-1)/2 == ell
@@ -119,6 +127,9 @@ def vec_to_upper_tri(expr, strict: bool = False):
         # n * (n+1)/2 == ell
         n = ((8 * ell + 1) ** 0.5 - 1) // 2
     n = int(n)
+    if not (n * (n + 1) // 2 == ell or n * (n - 1) // 2 == ell):
+        raise ValueError("The size of the vector must be a triangular number.")
+
     # form a matrix P, of shape (n**2, ell).
     #       the i-th block of n rows of P gives the entries of the i-th row
     #       of the upper-triangular matrix associated with expr.

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -26,7 +26,6 @@ from cvxpy.atoms.affine.vec import vec
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.expression import Expression
 
-vec
 
 class upper_tri(AffAtom):
     """The vectorized strictly upper-triagonal entries.

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -736,16 +736,15 @@ class TestAtoms(BaseTest):
                          "Argument to upper_tri must be a square matrix.")
 
     def test_vec_to_upper_tri(self) -> None:
-        from cvxpy.atoms.affine.upper_tri import vec_to_upper_tri
         x = Variable(shape=(3,))
-        X = vec_to_upper_tri(x)
+        X = cp.vec_to_upper_tri(x)
         x.value = np.array([1, 2, 3])
         actual = X.value
         expect = np.array([[1, 2], [0, 3]])
         assert np.allclose(actual, expect)
         y = Variable(shape=(1,))
         y.value = np.array([4])
-        Y = vec_to_upper_tri(y, strict=True)
+        Y = cp.vec_to_upper_tri(y, strict=True)
         actual = Y.value
         expect = np.array([[0, 4], [0, 0]])
         assert np.allclose(actual, expect)
@@ -754,26 +753,26 @@ class TestAtoms(BaseTest):
                              [0, 0, 0, 21],
                              [0, 0, 0, 0]])
         a = np.array([11, 12, 13, 16, 17, 21])
-        A_actual = vec_to_upper_tri(a, strict=True).value
+        A_actual = cp.vec_to_upper_tri(a, strict=True).value
         assert np.allclose(A_actual, A_expect)
 
         with pytest.raises(ValueError, match="must be a triangular number"):
-            vec_to_upper_tri(cp.Variable(shape=(4)))
+            cp.vec_to_upper_tri(cp.Variable(shape=(4)))
 
         with pytest.raises(ValueError, match="must be a triangular number"):
-            vec_to_upper_tri(cp.Variable(shape=(4)), strict=True)
+            cp.vec_to_upper_tri(cp.Variable(shape=(4)), strict=True)
 
         with pytest.raises(ValueError, match="must be a vector"):
-            vec_to_upper_tri(cp.Variable(shape=(2, 2)))
+            cp.vec_to_upper_tri(cp.Variable(shape=(2, 2)))
 
         # works with row vectors
         assert np.allclose(
-            vec_to_upper_tri(np.arange(6)).value, 
-            vec_to_upper_tri(np.arange(6).reshape(1, 6)).value
+            cp.vec_to_upper_tri(np.arange(6)).value, 
+            cp.vec_to_upper_tri(np.arange(6).reshape(1, 6)).value
         )
 
         # works with scalars
-        assert np.allclose(vec_to_upper_tri(1, strict=True).value, np.array([[0, 1], [0, 0]]))
+        assert np.allclose(cp.vec_to_upper_tri(1, strict=True).value, np.array([[0, 1], [0, 0]]))
 
 
     def test_huber(self) -> None:

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -757,6 +757,25 @@ class TestAtoms(BaseTest):
         A_actual = vec_to_upper_tri(a, strict=True).value
         assert np.allclose(A_actual, A_expect)
 
+        with pytest.raises(ValueError, match="must be a triangular number"):
+            vec_to_upper_tri(cp.Variable(shape=(4)))
+
+        with pytest.raises(ValueError, match="must be a triangular number"):
+            vec_to_upper_tri(cp.Variable(shape=(4)), strict=True)
+
+        with pytest.raises(ValueError, match="must be a vector"):
+            vec_to_upper_tri(cp.Variable(shape=(2, 2)))
+
+        # works with row vectors
+        assert np.allclose(
+            vec_to_upper_tri(np.arange(6)).value, 
+            vec_to_upper_tri(np.arange(6).reshape(1, 6)).value
+        )
+
+        # works with scalars
+        assert np.allclose(vec_to_upper_tri(1, strict=True).value, np.array([[0, 1], [0, 0]]))
+
+
     def test_huber(self) -> None:
         # Valid.
         cp.huber(self.x, 1)


### PR DESCRIPTION
## Description
This PR makes `vec_to_upper_tri` an atom accessible as a top-level import, i.e., part of our public API.

TODO: Add docs (Inline and web)

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.