### PR TITLE
Deprecate NonPos in favor of NonNeg

### DIFF
--- a/cvxpy/constraints/nonpos.py
+++ b/cvxpy/constraints/nonpos.py
@@ -54,7 +54,7 @@ class NonPos(Constraint):
     """
 
     def __init__(self, expr, constr_id=None) -> None:
-        warnings.warn(NonPos.DEPRECATION_MESSAGE)
+        warnings.warn(NonPos.DEPRECATION_MESSAGE, DeprecationWarning)
         super(NonPos, self).__init__([expr], constr_id)
         if not self.args[0].is_real():
             raise ValueError("Input to NonPos must be real.")

--- a/cvxpy/constraints/nonpos.py
+++ b/cvxpy/constraints/nonpos.py
@@ -19,18 +19,22 @@ import numpy as np
 # Only need Variable from expressions, but that would create a circular import.
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.utilities import scopes
+import warnings
 
 
 class NonPos(Constraint):
-    """A constraint of the form :math:`x \\leq 0`.
+    """An inequality constraint of the form :math:`x \\leq 0`.
 
-    The preferred way of creating a ``NonPos`` constraint is through
-    operator overloading. To constrain an expression ``x`` to be non-positive,
-    simply write ``x <= 0``; to constrain ``x`` to be non-negative, write
-    ``x >= 0``. The former creates a ``NonPos`` constraint with ``x``
-    as its argument, while the latter creates one with ``-x`` as its argument.
-    Strict inequalities are not supported, as they do not make sense in a
-    numerical setting.
+    The preferred way of creating an inequality constraint is through
+    operator overloading. To constrain an expression ``x`` to be nonpositive,
+    write ``x <= 0``; to constrain ``x`` to be nonnegative, write ``x >= 0``.
+
+    Dual variables associated with this constraint are nonnegative, rather
+    than nonpositive. As such, dual variables to this constraint belong to the
+    polar cone rather than the dual cone.
+
+    Note: strict inequalities are not supported, as they do not make sense in
+    a numerical setting.
 
     Parameters
     ----------
@@ -39,7 +43,17 @@ class NonPos(Constraint):
     constr_id : int
         A unique id for the constraint.
     """
+
+    DEPRECATION_MESSAGE = """
+    Explicitly invoking NonPos(expr) to a create a constraint is deprecated.
+    Please use operator overloading or NonNeg(-expr) instead.
+    
+    Sign conventions on dual variables associated with these constraints may
+    change in the future.
+    """
+
     def __init__(self, expr, constr_id=None) -> None:
+        warnings.warn(NonPos.DEPRECATION_MESSAGE)
         super(NonPos, self).__init__([expr], constr_id)
         if not self.args[0].is_real():
             raise ValueError("Input to NonPos must be real.")
@@ -48,7 +62,7 @@ class NonPos(Constraint):
         return "%s <= 0" % self.args[0]
 
     def is_dcp(self, dpp: bool = False) -> bool:
-        """A non-positive constraint is DCP if its argument is convex."""
+        """A NonPos constraint is DCP if its argument is convex."""
         if dpp:
             with scopes.dpp_scope():
                 return self.args[0].is_convex()
@@ -84,14 +98,12 @@ class NonPos(Constraint):
 class NonNeg(Constraint):
     """A constraint of the form :math:`x \\geq 0`.
 
-    This class was created to account for the fact that the
-    ConicSolver interface returns matrix data stated with respect
-    to the nonnegative orthant, rather than the nonpositive orthant.
+    The preferred way of creating an inequality constraint is through
+    operator overloading. To constrain an expression ``x`` to be nonnegative,
+    write ``x >= 0``; to constrain ``x`` to be nonpositive, write ``x <= 0``.
 
-    This class can be removed if the behavior of ConicSolver is
-    changed. However the current behavior of ConicSolver means
-    CVXPY's dual variable and Lagrangian convention follows the
-    most common convention in the literature.
+    Dual variables for these constraints are nonnegative. As such, they
+    actually belong to this constraint class' corresponding dual cone.
 
     Parameters
     ----------
@@ -145,6 +157,17 @@ class NonNeg(Constraint):
 class Inequality(Constraint):
     """A constraint of the form :math:`x \\leq y`.
 
+    Dual variables to these constraints are always nonnegative.
+    A constraint of this type affects the Lagrangian :math:`L` of a
+    minimization problem by
+
+        :math:`L += (x - y)^{T}(\\texttt{con.dual\\_value})`.
+
+    The preferred way of creating one of these constraints is via
+    operator overloading. The expression ``x <= y`` evaluates to
+    ``Inequality(x, y)``, and the expression ``x >= y`` evaluates
+    to ``Inequality(y, x)``.
+
     Parameters
     ----------
     lhs : Expression
@@ -156,7 +179,6 @@ class Inequality(Constraint):
     """
     def __init__(self, lhs, rhs, constr_id=None) -> None:
         self._expr = lhs - rhs
-        # TODO remove this restriction.
         if self._expr.is_complex():
             raise ValueError("Inequality constraints cannot be complex.")
         super(Inequality, self).__init__([lhs, rhs], constr_id)

--- a/cvxpy/constraints/nonpos.py
+++ b/cvxpy/constraints/nonpos.py
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import warnings
+
 import numpy as np
 
 # Only need Variable from expressions, but that would create a circular import.
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.utilities import scopes
-import warnings
 
 
 class NonPos(Constraint):

--- a/cvxpy/constraints/nonpos.py
+++ b/cvxpy/constraints/nonpos.py
@@ -45,10 +45,10 @@ class NonPos(Constraint):
     """
 
     DEPRECATION_MESSAGE = """
-    Explicitly invoking NonPos(expr) to a create a constraint is deprecated.
-    Please use operator overloading or NonNeg(-expr) instead.
+    Explicitly invoking "NonPos(expr)" to a create a constraint is deprecated.
+    Please use operator overloading or "NonNeg(-expr)" instead.
     
-    Sign conventions on dual variables associated with these constraints may
+    Sign conventions on dual variables associated with NonPos constraints may
     change in the future.
     """
 
@@ -118,7 +118,7 @@ class NonNeg(Constraint):
             raise ValueError("Input to NonNeg must be real.")
 
     def name(self) -> str:
-        return "0 <= %s" % self.args[0]
+        return "%s >= 0" % self.args[0]
 
     def is_dcp(self, dpp: bool = False) -> bool:
         """A non-negative constraint is DCP if its argument is concave."""

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -727,19 +727,13 @@ class Expression(u.Canonical):
         return Inequality(self, other)
 
     def __lt__(self, other: "Expression"):
-        """Unsupported.
-        """
         raise NotImplementedError("Strict inequalities are not allowed.")
 
     @_cast_other
     def __ge__(self, other: "Expression"):
-        """NonPos : Creates an inequality constraint.
-        """
-        return other.__le__(self)
+        return Inequality(other, self)
 
     def __gt__(self, other: "Expression"):
-        """Unsupported.
-        """
         raise NotImplementedError("Strict inequalities are not allowed.")
 
     def __array_ufunc__(self, ufunc, method, *args, **kwargs):

--- a/cvxpy/reductions/complex2real/canonicalizers/__init__.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/__init__.py
@@ -32,7 +32,7 @@ from cvxpy.atoms.affine.unary_operators import NegExpression
 from cvxpy.atoms.affine.vstack import Vstack
 from cvxpy.atoms.affine.wraps import hermitian_wrap
 from cvxpy.atoms.norm_nuc import normNuc
-from cvxpy.constraints import (PSD, SOC, Equality, Inequality, NonNeg, NonPos,
+from cvxpy.constraints import (PSD, SOC, Equality, Inequality,
                                OpRelEntrConeQuad, Zero,)
 from cvxpy.expressions.constants import Constant, Parameter
 from cvxpy.expressions.variable import Variable
@@ -45,7 +45,7 @@ from cvxpy.reductions.complex2real.canonicalizers.constant_canon import (
 from cvxpy.reductions.complex2real.canonicalizers.equality_canon import (
     equality_canon, zero_canon,)
 from cvxpy.reductions.complex2real.canonicalizers.inequality_canon import (
-    inequality_canon, nonneg_canon, nonpos_canon,)
+    inequality_canon,)
 from cvxpy.reductions.complex2real.canonicalizers.matrix_canon import (
     hermitian_canon, lambda_sum_largest_canon, matrix_frac_canon,
     norm_nuc_canon, op_rel_entr_cone_canon, quad_canon, quad_over_lin_canon,

--- a/cvxpy/reductions/complex2real/canonicalizers/__init__.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/__init__.py
@@ -91,8 +91,6 @@ CANON_METHODS = {
     Constant: constant_canon,
     Parameter: param_canon,
     Inequality: inequality_canon,
-    NonPos: inequality_canon,
-    NonNeg: inequality_canon,
     PSD: psd_canon,
     SOC: soc_canon,
     Equality: equality_canon,

--- a/cvxpy/reductions/complex2real/canonicalizers/inequality_canon.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/inequality_canon.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 import numpy as np
 
-from cvxpy.constraints import Inequality, NonNeg, NonPos
+from cvxpy.constraints import Inequality
 from cvxpy.expressions.constants import Constant
 
 
@@ -38,28 +38,4 @@ def inequality_canon(expr, real_args, imag_args, real2imag):
         for i in range(len(real_args)):
             if real_args[i] is None:
                 real_args[i] = Constant(np.zeros(imag_args[i].shape))
-        return [expr.copy(real_args)], imag_cons
-
-
-def nonpos_canon(expr, real_args, imag_args, real2imag):
-    if imag_args[0] is None:
-        return [expr.copy(real_args)], None
-
-    imag_cons = [NonPos(imag_args[0], constr_id=real2imag[expr.id])]
-    if real_args[0] is None:
-        return None, imag_cons
-    else:
-        return [expr.copy(real_args)], imag_cons
-
-
-def nonneg_canon(expr, real_args, imag_args, real2imag):
-    # Created by Riley; copied nonpos_canon code, and replaced imag_cons'
-    # call to "NonPos" with a call to "NonNeg".
-    if imag_args[0] is None:
-        return [expr.copy(real_args)], None
-
-    imag_cons = [NonNeg(imag_args[0], constr_id=real2imag[expr.id])]
-    if real_args[0] is None:
-        return None, imag_cons
-    else:
         return [expr.copy(real_args)], imag_cons

--- a/cvxpy/reductions/complex2real/complex2real.py
+++ b/cvxpy/reductions/complex2real/complex2real.py
@@ -21,9 +21,6 @@ from cvxpy.constraints import (
     PSD,
     SOC,
     Equality,
-    Inequality,
-    NonNeg,
-    NonPos,
     OpRelEntrConeQuad,
     Zero,
 )

--- a/cvxpy/reductions/complex2real/complex2real.py
+++ b/cvxpy/reductions/complex2real/complex2real.py
@@ -123,11 +123,11 @@ class Complex2Real(Reduction):
                         imag_id = inverse_data.real2imag[cid]
                         dvars[cid] = 1j*solution.dual_vars[imag_id]
                     # All cases that follow are for complex-valued constraints:
-                    #   1. check inequality / equality constraints.
+                    #   1. check equality constraints.
                     #   2. check PSD constraints.
                     #   3. check if a constraint is known to lack a complex dual implementation
                     #   4. raise an error
-                    elif isinstance(cons, (Equality, Zero, Inequality, NonNeg, NonPos)):
+                    elif isinstance(cons, (Equality, Zero)):
                         imag_id = inverse_data.real2imag[cid]
                         if imag_id in solution.dual_vars:
                             dvars[cid] = solution.dual_vars[cid] + \

--- a/cvxpy/reductions/dcp2cone/canonicalizers/von_neumann_entr_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/von_neumann_entr_canon.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 from cvxpy import Variable, lambda_sum_largest, trace
 from cvxpy.atoms.affine.sum import sum
-from cvxpy.constraints.nonpos import NonPos
+from cvxpy.constraints.nonpos import NonNeg
 from cvxpy.constraints.zero import Zero
 from cvxpy.reductions.dcp2cone.canonicalizers.entr_canon import entr_canon
 from cvxpy.reductions.dcp2cone.canonicalizers.lambda_sum_largest_canon import (
@@ -37,7 +37,7 @@ def von_neumann_entr_canon(expr, args):
         expr_r = lambda_sum_largest(N, r)
         epi, cons = lambda_sum_largest_canon(expr_r, expr_r.args)
         constrs.extend(cons)
-        con = NonPos(epi - sum(x[:r]))
+        con = NonNeg(sum(x[:r]) - epi)
         constrs.append(con)
 
     # trace(N) \leq sum(x)
@@ -50,7 +50,7 @@ def von_neumann_entr_canon(expr, args):
 
     # x[:(n-1)] >= x[1:]
     #   x[0] >= x[1],  x[1] >= x[2], ...
-    con = NonPos(x[1:] - x[:(n - 1)])
+    con = NonNeg(x[:(n - 1)] - x[1:])
     constrs.append(con)
 
     # END code that applies to all spectral functions #
@@ -58,7 +58,7 @@ def von_neumann_entr_canon(expr, args):
     # sum(entr(x)) >= t
     hypos, entr_cons = entr_canon(x, [x])
     constrs.extend(entr_cons)
-    con = NonPos(t - sum(hypos))
+    con = NonNeg(sum(hypos) - t)
     constrs.append(con)
 
     return t, constrs

--- a/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
+++ b/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
@@ -34,14 +34,14 @@ from cvxpy.problems.objective import Minimize
 from cvxpy.problems.param_prob import ParamProb
 from cvxpy.reductions import InverseData, Solution
 from cvxpy.reductions.cvx_attr2constr import convex_attributes
-from cvxpy.reductions.matrix_stuffing import MatrixStuffing, extract_mip_idx
 from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import nonpos2nonneg
+from cvxpy.reductions.matrix_stuffing import MatrixStuffing, extract_mip_idx
 from cvxpy.reductions.utilities import (
     ReducedMat,
     are_args_affine,
     group_constraints,
     lower_equality,
-    lower_ineq_to_nonneg
+    lower_ineq_to_nonneg,
 )
 from cvxpy.utilities.coeff_extractor import CoeffExtractor
 

--- a/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
+++ b/cvxpy/reductions/qp2quad_form/qp_matrix_stuffing.py
@@ -25,6 +25,7 @@ from cvxpy.constraints import (
     ExpCone,
     Inequality,
     NonNeg,
+    NonPos,
     Zero,
 )
 from cvxpy.cvxcore.python import canonInterface
@@ -34,6 +35,7 @@ from cvxpy.problems.param_prob import ParamProb
 from cvxpy.reductions import InverseData, Solution
 from cvxpy.reductions.cvx_attr2constr import convex_attributes
 from cvxpy.reductions.matrix_stuffing import MatrixStuffing, extract_mip_idx
+from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import nonpos2nonneg
 from cvxpy.reductions.utilities import (
     ReducedMat,
     are_args_affine,
@@ -251,6 +253,8 @@ class QpMatrixStuffing(MatrixStuffing):
                 con = lower_equality(con)
             elif isinstance(con, Inequality):
                 con = lower_ineq_to_nonneg(con)
+            elif isinstance(con, NonPos):
+                con = nonpos2nonneg(con)
             cons.append(con)
 
         # Reorder constraints to Zero, NonNeg.

--- a/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
+++ b/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
@@ -18,7 +18,7 @@ import numpy as np
 import scipy.sparse as sp
 
 import cvxpy.settings as s
-from cvxpy.constraints import NonPos, Zero
+from cvxpy.constraints import NonNeg, Zero
 from cvxpy.reductions.cvx_attr2constr import convex_attributes
 from cvxpy.reductions.qp2quad_form.qp_matrix_stuffing import (
     ConeDims,
@@ -32,8 +32,8 @@ class QpSolver(Solver):
     """
     A QP solver interface.
     """
-    # Every QP solver supports Zero and NonPos constraints.
-    SUPPORTED_CONSTRAINTS = [Zero, NonPos]
+    # Every QP solver supports Zero and NonNeg constraints.
+    SUPPORTED_CONSTRAINTS = [Zero, NonNeg]
 
     # Some solvers cannot solve problems that do not have constraints.
     # For such solvers, REQUIRES_CONSTR should be set to True.
@@ -81,7 +81,7 @@ class QpSolver(Solver):
         # Get number of variables
         n = problem.x.size
         len_eq = data[QpSolver.DIMS].zero
-        len_leq = data[QpSolver.DIMS].nonpos
+        len_leq = data[QpSolver.DIMS].nonneg
 
         if len_eq > 0:
             A = AF[:len_eq, :]
@@ -90,8 +90,8 @@ class QpSolver(Solver):
             A, b = sp.csr_matrix((0, n)), -np.array([])
 
         if len_leq > 0:
-            F = AF[len_eq:, :]
-            g = -bg[len_eq:]
+            F = -AF[len_eq:, :]
+            g = bg[len_eq:]
         else:
             F, g = sp.csr_matrix((0, n)), -np.array([])
 

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -116,7 +116,7 @@ class SolverTestHelper:
                 comp = cp.scalar_product(pv, dv).value
             elif isinstance(con, (cp.constraints.ExpCone,
                                   cp.constraints.SOC,
-                                  cp.constraints.NonPos,
+                                  cp.constraints.NonNeg,
                                   cp.constraints.Zero)):
                 comp = cp.scalar_product(con.args, con.dual_value).value
             elif isinstance(con, cp.constraints.PowCone3D):

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -353,7 +353,7 @@ class TestConstraints(BaseTest):
         self.assertItemsAlmostEqual(x.value, c)
 
         # Solve through QP path.
-        prob.solve(solver=cp.OSQP)
+        prob.solve(solver=cp.OSQP, verbose=True)
         self.assertItemsAlmostEqual(x.value, c)
 
     def test_nonpos_dual(self) -> None:

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -340,38 +340,43 @@ class TestConstraints(BaseTest):
             (self.z <= self.x).__bool__()
         self.assertEqual(str(cm.exception), error_str)
 
-    def test_nonpos(self) -> None:
-        """Tests the NonPos constraint for correctness.
+    def test_nonneg(self) -> None:
+        """Solve a trivial NonNeg-constrained problem through
+        the conic and QP code paths.
         """
-        n = 3
-        x = cp.Variable(n)
-        c = np.arange(n)
-        prob = cp.Problem(cp.Maximize(cp.sum(x)),
-                          [cp.NonPos(x - c)])
-        # Solve through cone program path.
+        x = cp.Variable(3)
+        c = np.arange(3)
+        prob = cp.Problem(cp.Minimize(cp.sum(x)),
+                          [cp.NonNeg(x - c)])
         prob.solve(solver=cp.ECOS)
         self.assertItemsAlmostEqual(x.value, c)
-
-        # Solve through QP path.
-        prob.solve(solver=cp.OSQP, verbose=True)
+        prob.solve(solver=cp.OSQP)
         self.assertItemsAlmostEqual(x.value, c)
 
-    def test_nonpos_dual(self) -> None:
-        """Test dual variables work for NonPos.
+    def test_nonpos(self) -> None:
+        """Tests the NonPos constraint for correctness with conic and
+        QP code paths.
         """
-        n = 3
-        x = cp.Variable(n)
-        c = np.arange(n)
-        prob = cp.Problem(cp.Maximize(cp.sum(x)),
-                          [(x - c) <= 0])
+        x = cp.Variable(3)
+        c = np.arange(3)
+        prob = cp.Problem(cp.Maximize(cp.sum(x)), [cp.NonPos(x - c)])
+        prob.solve(solver=cp.ECOS)
+        self.assertItemsAlmostEqual(x.value, c)
+        prob.solve(solver=cp.OSQP)
+        self.assertItemsAlmostEqual(x.value, c)
+
+    def test_nonneg_dual(self) -> None:
+        # Compute reference solution with an Inequality constraint.
+        x = cp.Variable(3)
+        c = np.arange(3)
+        objective = cp.Minimize(cp.sum(x))
+        prob = cp.Problem(objective, [c - x <= 0])
         prob.solve(solver=cp.ECOS)
         dual = prob.constraints[0].dual_value
-        prob = cp.Problem(cp.Maximize(cp.sum(x)),
-                          [cp.NonPos(x - c)])
-        # Solve through cone program path.
+        # reported dual variables are the same with NonNeg, even though
+        # the convention for how they add to the Lagrangian differs by sign.
+        prob = cp.Problem(objective, [cp.NonNeg(x - c)])
         prob.solve(solver=cp.ECOS)
         self.assertItemsAlmostEqual(prob.constraints[0].dual_value, dual)
-
-        # Solve through QP path.
         prob.solve(solver=cp.OSQP)
         self.assertItemsAlmostEqual(prob.constraints[0].dual_value, dual)

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -33,7 +33,7 @@ from numpy import linalg as LA
 import cvxpy as cp
 import cvxpy.interface as intf
 import cvxpy.settings as s
-from cvxpy.constraints import PSD, ExpCone, NonPos, Zero
+from cvxpy.constraints import PSD, ExpCone, NonNeg, Zero
 from cvxpy.error import DCPError, ParameterError, SolverError
 from cvxpy.expressions.constants import Constant, Parameter
 from cvxpy.expressions.variable import Variable
@@ -76,11 +76,11 @@ class TestProblem(BaseTest):
 
         # Test str.
         result = (
-            "minimize %(name)s\nsubject to %(name)s == 0\n           %(name)s <= 0" % {
+            "minimize %(name)s\nsubject to %(name)s == 0\n           %(name)s >= 0" % {
                 "name": self.a.name()
             }
         )
-        prob = Problem(cp.Minimize(self.a), [Zero(self.a), NonPos(self.a)])
+        prob = Problem(cp.Minimize(self.a), [Zero(self.a), NonNeg(self.a)])
         self.assertEqual(str(prob), result)
 
     def test_variables(self) -> None:


### PR DESCRIPTION
I recently opened a GitHub Discussion about awkwardness with the NonPos constraint class: https://github.com/cvxpy/cvxpy/discussions/2153. This PR offers the solution where we deprecate NonPos in favor of NonNeg. It includes a deprecation warning, updates to tests, and changes to canonicalization code paths. NonPos constraints are still supported, but we never construct those constraints outside of our testing code.
