### PR TITLE
Support for s=0 in perspective functions

### DIFF
--- a/cvxpy/atoms/perspective.py
+++ b/cvxpy/atoms/perspective.py
@@ -48,8 +48,9 @@ class perspective(Atom):
     :math:`p(z,s) = sf(z/s)` is the perpective transform of :math:`f`.
     """
 
-    def __init__(self, f: Expression, s: Variable) -> None:
+    def __init__(self, f: Expression, s: Variable, f_recession: Expression = None) -> None:
         self.f = f
+        self.f_recession = f_recession
         super(perspective, self).__init__(s, *f.variables())
 
     def validate_arguments(self) -> None:
@@ -65,11 +66,17 @@ class perspective(Atom):
         """
 
         assert values[0] >= 0
-        assert not np.isclose(values[0], 0.0), \
-            "There are valid cases where s = 0, but we do not handle this yet, e.g., f(x) = x + 1."
-
         s_val = np.array(values[0])
+
+        # Normal scenario: compute the perspective transform of the given function f
         f = self.f
+        if np.isclose(values[0], 0.0):
+            # Handle s = 0 with the recession function by swapping f with f_recession
+            # Since we just swap the two functions, we end up with s * f_recession(x / s) when we just want f_recession(x)
+            # Thus we set s=1 to ignore s.
+            assert self.f_recession is not None, "To handle s = 0, pass in a recession function f_recession"
+            f = self.f_recession
+            values[0] = 1 
 
         old_x_vals = [var.value for var in f.variables()]
 

--- a/cvxpy/atoms/perspective.py
+++ b/cvxpy/atoms/perspective.py
@@ -72,9 +72,11 @@ class perspective(Atom):
         f = self.f
         if np.isclose(values[0], 0.0):
             # Handle s = 0 with the recession function by swapping f with f_recession
-            # Since we just swap the two functions, we end up with s * f_recession(x / s) when we just want f_recession(x)
-            # Thus we set s=1 to ignore s.
-            assert self.f_recession is not None, "To handle s = 0, pass in a recession function f_recession"
+            # Since we just swap the two functions, we end up with s * f_recession(x / s) 
+            # when we actually just want f_recession(x). Thus we set s=1 to ignore s.
+            assert self.f_recession is not None, (
+                "To handle s = 0, pass in a recession function f_recession"
+            )
             f = self.f_recession
             values[0] = 1 
 

--- a/cvxpy/tests/test_perspective.py
+++ b/cvxpy/tests/test_perspective.py
@@ -418,7 +418,7 @@ def test_assert_s_nonzero():
     obj = perspective(x+1, s)
 
     prob = cp.Problem(cp.Minimize(obj), [x >= 3.14])
-    with pytest.raises(AssertionError, match="There are valid cases"):
+    with pytest.raises(AssertionError, match="To handle s = 0, pass in a recession function"):
         prob.solve()
 
 

--- a/cvxpy/tests/test_perspective.py
+++ b/cvxpy/tests/test_perspective.py
@@ -457,3 +457,19 @@ def test_dpp():
     obj = cp.perspective(cp.log(a+x), s)
 
     assert not obj.is_dpp()
+
+def test_boolean_s():
+    # Problem where the optimal s is s = 0
+    # s also happens to be boolean (where this arises more)
+    x = cp.Variable(1)
+    s = cp.Variable(1, boolean=True)
+    f = x + 1
+    f_recession = x
+    obj = cp.perspective(f, s, f_recession=f_recession)
+    constr = [-cp.square(x) + 1 >= 0]
+    
+    prob = cp.Problem(cp.Minimize(obj), constr)
+    prob.solve(solver=cp.SCIP)
+
+    assert np.isclose(x.value, -1)
+    assert np.isclose(s.value, 0)

--- a/cvxpy/tests/test_perspective.py
+++ b/cvxpy/tests/test_perspective.py
@@ -413,12 +413,13 @@ def test_scalar_x():
 
 
 def test_assert_s_nonzero():
+    # If s=0 arises, make sure we ask for a recession function
     x = cp.Variable()
     s = cp.Variable(nonneg=True)
     obj = perspective(x+1, s)
 
     prob = cp.Problem(cp.Minimize(obj), [x >= 3.14])
-    with pytest.raises(AssertionError, match="To handle s = 0, pass in a recession function"):
+    with pytest.raises(AssertionError, match="pass in a recession function"):
         prob.solve()
 
 
@@ -458,18 +459,18 @@ def test_dpp():
 
     assert not obj.is_dpp()
 
-def test_boolean_s():
+def test_s_eq_0():
     # Problem where the optimal s is s = 0
-    # s also happens to be boolean (where this arises more)
+    # Proves that we can support integer / boolean s, where s=0 is more common
     x = cp.Variable(1)
-    s = cp.Variable(1, boolean=True)
+    s = cp.Variable(1, nonneg=True)
     f = x + 1
     f_recession = x
     obj = cp.perspective(f, s, f_recession=f_recession)
     constr = [-cp.square(x) + 1 >= 0]
     
     prob = cp.Problem(cp.Minimize(obj), constr)
-    prob.solve(solver=cp.SCIP)
+    prob.solve()
 
     assert np.isclose(x.value, -1)
     assert np.isclose(s.value, 0)


### PR DESCRIPTION
## Description Summary
**Summary:** Implementing support for s=0 in perspective functions by allowing users to pass in a recession function.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.

## Full Description
Currently, for the perspective transform $f_p$ of a function $f$, defined as $f_p(s, x) = sf(x/s)$, the [CVXPY list of atomic functions](https://www.cvxpy.org/tutorial/functions/index.html#:~:text=None-,perspective(f(x)%2Cs),-sf( ) says that it supports any $s$ where $s \geq 0$. However, actual support for the case where $s=0$ is not implemented, and would instead trigger an assertion error. One use case for motivating support for $s=0$ is when using perspective transforms in MILP problems with boolean $s$ - for example, a convex formulation of solving shortest paths over mixed discrete-continuous graphs [1].

The problem with the $s=0$ case is that the general perspective function $f_p(s,x)$ is only well behaved at $s=0$ for certain $f(x)$, and it is difficult to implement a general solution where given an arbitrary $f(x)$, we both verify that $f_p(s,x)$ is well behaved at $s=0$, and we can find what the $f_p(s,x)$ approaches as s approaches zero. Consider these examples:
- For $f(x) = x+1$, the perspective transform $f_p(s,x) = sf(x/s) = s (x/s + 1) = x + s$, so when $s=0$ we clearly see that $f_p(0,x) = x$.
- However, for $f(x) = x^2$, the perspective transform is $f_p(s,x) = sf(x/s) = s(x/s)^2 = x^2/s$ which is undefined at $s=0$. 

A full solution could expand $f_p(s,x)$ to see if it is well-behaved at zero, and handle it appropriately. However, I was working with CVXPY for a final project and instead implemented a simpler solution: simply have users pass a recession function $f_\infty(x)$ to act as $f(0, x)$ if they want to handle cases where $s=0$. This is in fact consistent with the approach in [1], where the perspective function $\tilde{f}(x, \lambda)$ at $\lambda=0$ is defined as a separate function $f_\infty(x)$. 

Mathematically, this separate function is consistent with the notion of the recession cone or recession function of a perspective transform. If we consider the epigraph of $f(x)$ as a convex set, then the epigraph of $f_p(s,x)$ is a perspective cone, and the recession function $f_p(0, x)$ corresponds to the recession cone of this perspective cone. For more on perspective cones see section IV.2.2 of [2] and chapter 8 of [3].

Please let me know what you all think of this change! I simply did what was fastest and easiest for me to do at the time - if we want a more general solution for `s=0` I can also see if I have time to work on that. 

## Testing:
I have created one additional unit test, where we consider the perspective transform of the function $f(x)=x+1$.

Running `python3 -m pytest` in the tests directory passes. 

The results from running `python3 -m pytest test_benchmark.py` on both `master` and this feature branch are in the attached txt file:
[benchmark_comparison.txt](https://github.com/cvxpy/cvxpy/files/11860769/benchmark_comparison.txt)

## References:
[1] Marcucci et al, 2021. _Shortest Paths in Graphs of Convex Sets_ https://arxiv.org/pdf/2101.11565.pdf__
[2] Hiriart-Urruty and Lemarechal. _Convex Analysis and Minimization Algorithms 1_. Section IV. 2.2
[3] Rockefeller. _Convex Analysis_. Chapter 8 