### PR TITLE
Remove github banner

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -151,7 +151,7 @@ html_sidebars = {
 html_theme_options = {
    'github_user': 'cvxpy',
    'github_repo': 'cvxpy',
-   'github_banner': True,
+   'github_banner': False,
    'github_type': 'star',
    'travis_button': False,
    'analytics_id': 'UA-50248335-1',


### PR DESCRIPTION
## Description
The github fork banner has not been showing up properly for a while. This PR removes the banner.

I ran ``make html`` with this change and verified the banner is removed.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.