### PR TITLE
[CI] PR benchmark against base branch

### DIFF
--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -36,8 +36,8 @@ jobs:
         run: |
           cd benchmark/
           asv machine --config asv_pr.conf.json --yes
-          asv continuous origin/master HEAD --config asv_pr.conf.json --quick
-          asv compare origin/master HEAD --config asv_pr.conf.json --split --sort ratio | tee -a asv_compare.log
+          asv continuous origin/${{github.base_ref}} HEAD --config asv_pr.conf.json --quick
+          asv compare origin/${{github.base_ref}} HEAD --config asv_pr.conf.json --split --sort ratio | tee -a asv_compare.log
           mkdir comment_log
           mv asv_compare.log comment_log/
       


### PR DESCRIPTION
## Description
Currently, all PRs are benchmarked against `master`, which does not make sense for release PRs like #2151.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.