### PR TITLE
Update to support or-tools 9.5 and 9.6

### DIFF
--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -41,7 +41,7 @@ if [[ "$PYTHON_VERSION" == "3.11" ]]; then
 elif [[ "$PYTHON_VERSION" == "3.8" ]] && [[ "$RUNNER_OS" != "macos-11" ]]; then
   python -m pip install gurobipy clarabel piqp
 else
-  python -m pip install "ortools>=9.3,<9.5" coptpy cplex diffcp gurobipy xpress clarabel piqp
+  python -m pip install "ortools>=9.4,<9.7" coptpy cplex diffcp gurobipy xpress clarabel piqp
   if [[ "$RUNNER_OS" == "Windows" ]]; then
     python -m pip install sdpa-multiprecision
   else

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -30,7 +30,7 @@ elif [[ "$PYTHON_VERSION" == "3.11" ]]; then
 fi
 
 if [[ "$PYTHON_VERSION" == "3.11" ]]; then
-  python -m pip install gurobipy clarabel osqp piqp
+  python -m pip install "ortools>=9.4,<9.7" gurobipy clarabel osqp piqp
   if [[ "$RUNNER_OS" == "Windows" ]]; then
     # SDPA with OpenBLAS backend does not pass LP5 on Windows
     python -m pip install sdpa-multiprecision
@@ -41,7 +41,7 @@ if [[ "$PYTHON_VERSION" == "3.11" ]]; then
 elif [[ "$PYTHON_VERSION" == "3.8" ]] && [[ "$RUNNER_OS" != "macos-11" ]]; then
   python -m pip install gurobipy clarabel piqp
 else
-  python -m pip install "ortools>=9.4,<9.7" coptpy cplex diffcp gurobipy xpress clarabel piqp
+  python -m pip install coptpy cplex diffcp gurobipy xpress clarabel piqp
   if [[ "$RUNNER_OS" == "Windows" ]]; then
     python -m pip install sdpa-multiprecision
   else

--- a/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
@@ -48,12 +48,12 @@ class GLOP(ConicSolver):
         """Imports the solver."""
         import google.protobuf  # noqa F401
         import ortools  # noqa F401
-        if Version(ortools.__version__) < Version('9.3.0'):
+        if Version(ortools.__version__) < Version('9.4.0'):
             raise RuntimeError(f'Version of ortools ({ortools.__version__}) '
-                               f'is too old. Expected >= 9.3.0.')
-        if Version(ortools.__version__) >= Version('9.5.0'):
+                               f'is too old. Expected >= 9.4.0.')
+        if Version(ortools.__version__) >= Version('9.7.0'):
             raise RuntimeError('Unrecognized new version of ortools '
-                               f'({ortools.__version__}). Expected < 9.5.0.'
+                               f'({ortools.__version__}). Expected < 9.7.0.'
                                'Please open a feature request on cvxpy to '
                                'enable support for this version.')
 

--- a/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
@@ -48,12 +48,12 @@ class PDLP(ConicSolver):
         """Imports the solver."""
         import google.protobuf  # noqa F401
         import ortools  # noqa F401
-        if Version(ortools.__version__) < Version('9.3.0'):
+        if Version(ortools.__version__) < Version('9.4.0'):
             raise RuntimeError(f'Version of ortools ({ortools.__version__}) '
-                               f'is too old. Expected >= 9.3.0.')
-        if Version(ortools.__version__) >= Version('9.5.0'):
+                               f'is too old. Expected >= 9.4.0.')
+        if Version(ortools.__version__) >= Version('9.7.0'):
             raise RuntimeError('Unrecognized new version of ortools '
-                               f'({ortools.__version__}). Expected < 9.5.0.'
+                               f'({ortools.__version__}). Expected < 9.7.0.'
                                'Please open a feature request on cvxpy to '
                                'enable support for this version.')
 
@@ -165,18 +165,19 @@ class PDLP(ConicSolver):
             request.solver_time_limit_seconds = float(solver_opts["time_limit_sec"])
 
         request.solver_specific_parameters = text_format.MessageToString(parameters)
-        if Version(ortools.__version__) >= Version('9.4.0'):
+        if Version(ortools.__version__) < Version('9.5.0'):
+            # Version 9.4
             from ortools.model_builder.python import (
                 pywrap_model_builder_helper,
             )
-            solver = pywrap_model_builder_helper.ModelSolverHelper("pdlp")
-            response_str = solver.solve_serialized_request(request.SerializeToString())
-            response = linear_solver_pb2.MPSolutionResponse.FromString(response_str)
         else:
-            # Version 9.3
-            from ortools.model_builder.python import model_builder_helper
-            solver = model_builder_helper.ModelSolverHelper()
-            response = solver.Solve(request)
+            # Version 9.5+
+            from ortools.linear_solver.python import (
+                pywrap_model_builder_helper,
+            )
+        solver = pywrap_model_builder_helper.ModelSolverHelper("pdlp")
+        response_str = solver.solve_serialized_request(request.SerializeToString())
+        response = linear_solver_pb2.MPSolutionResponse.FromString(response_str)
 
         solution = {}
         solution["value"] = response.objective_value

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,14 +6,14 @@ CVXOPT = cvxopt
 DIFFCP = diffcp
 ECOS =
 ECOS_BB =
-GLOP = ortools>=9.3,<9.5
+GLOP = ortools>=9.4,<9.7
 GLPK = cvxopt
 GLPK_MI = cvxopt
 GUROBI = gurobipy
 HIGHS = scipy>=1.6.1
 MOSEK = Mosek
 OSQP =
-PDLP = ortools>=9.3,<9.5
+PDLP = ortools>=9.4,<9.7
 PIQP = piqp
 PROXQP = proxsuite
 SCIP = PySCIPOpt


### PR DESCRIPTION
## Description
Updated glop and pdlp interfaces to work with or-tools 9.5 and 9.6.

Drops support for or-tools 9.3.

I tested both 9.5 and 9.6 locally.

Closes #2135
Closes #2052
Closes #2019

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)
