### PR TITLE
Deprecates `scipy_wrapper.py`

### DIFF
--- a/cvxpy/interface/scipy_wrapper.py
+++ b/cvxpy/interface/scipy_wrapper.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import warnings
+
 from scipy import sparse
 
 from cvxpy.expressions import expression as exp
@@ -30,15 +32,25 @@ SPARSE_MATRIX_CLASSES = [
 BIN_OPS = ["__div__", "__mul__", "__add__", "__sub__",
            "__le__", "__eq__", "__lt__", "__gt__"]
 
+SCIPY_WRAPPER_DEPRECATION_MESSAGE = """
+Your CVXPY program is using a deprecated feature of our SciPy interface.
+
+We believed it was impossible to hit this warning; please inform us of how you
+reached this warning at https://github.com/cvxpy/cvxpy/discussions/XXX so we can
+ensure that we correct this issue without causing breakage.
+"""
 
 def wrap_bin_op(method):
     """Factory for wrapping binary operators.
     """
     def new_method(self, other):
-        if isinstance(other, exp.Expression):
+        output = method(self, other)
+        if isinstance(other, exp.Expression) and output is not NotImplemented:
+            warnings.warn(SCIPY_WRAPPER_DEPRECATION_MESSAGE,
+                          category=DeprecationWarning)
             return NotImplemented
         else:
-            return method(self, other)
+            return output
     return new_method
 
 for cls in SPARSE_MATRIX_CLASSES:


### PR DESCRIPTION
## Description

We automatically detect when `scipy_wrapper.py` actually does something and then raises a warning telling people to contact us. The hope is we will hear if there are cases not covered by our test suite that require scipy_wrapper to do something.

This might have a slight performance regression in cases where SciPy does expensive compute that we throw away, but those cases will result in warnings so we should hear about them and can correct them.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.