### PR TITLE
Fixed bug in incidence_matrix example

### DIFF
--- a/examples/flows/incidence_matrix.py
+++ b/examples/flows/incidence_matrix.py
@@ -15,12 +15,12 @@ limitations under the License.
 """
 
 # Incidence matrix approach.
-import numpy as np
 import pickle
 
-import create_graph as g
-
+import numpy as np
 from cvxpy import Maximize, Parameter, Problem, Variable, vstack
+
+import create_graph as g
 
 # Read a graph from a file.
 f = open(g.FILE, 'rb')

--- a/examples/flows/incidence_matrix.py
+++ b/examples/flows/incidence_matrix.py
@@ -15,41 +15,44 @@ limitations under the License.
 """
 
 # Incidence matrix approach.
+import numpy as np
 import pickle
 
 import create_graph as g
-import cvxopt
 
-from cvxpy import Maximize, Problem, Variable, vstack
+from cvxpy import Maximize, Parameter, Problem, Variable, vstack
 
 # Read a graph from a file.
-f = open(g.FILE, 'r')
+f = open(g.FILE, 'rb')
 data = pickle.load(f)
 f.close()
 
 # Construct incidence matrix and capacities vector.
 node_count = data[g.NODE_COUNT_KEY]
 edges = data[g.EDGES_KEY]
-E = 2*len(edges)
-A = cvxopt.matrix(0,(node_count, E+2), tc='d')
-c = cvxopt.matrix(1000,(E,1), tc='d')
-for i,(n1,n2,capacity) in enumerate(edges):
-    A[n1,2*i] = -1
-    A[n2,2*i] = 1
-    A[n1,2*i+1] = 1
-    A[n2,2*i+1] = -1
-    c[2*i] = capacity
-    c[2*i+1] = capacity
+E = 2 * len(edges)
+
+A = Parameter((node_count, E + 2))
+A.value = np.zeros((node_count, E + 2))
+c = Parameter((E))
+c.value = np.full((E), 1000)
+for i, (n1, n2, capacity) in enumerate(edges):
+    A.value[n1, 2 * i] = -1
+    A.value[n2, 2 * i] = 1
+    A.value[n1, 2 * i + 1] = 1
+    A.value[n2, 2 * i + 1] = -1
+    c.value[2 * i] = capacity
+    c.value[2 * i + 1] = capacity
 # Add source.
-A[0,E] = 1
+A.value[0, E] = 1
 # Add sink.
-A[-1,E+1] = -1
+A.value[-1, E + 1] = -1
 # Construct the problem.
 flows = Variable(E)
 source = Variable()
 sink = Variable()
 p = Problem(Maximize(source),
-            [A*vstack([flows,source,sink]) == 0,
+            [A @ vstack([f for f in flows] + [source, sink]) == 0,
              0 <= flows,
              flows <= c])
 result = p.solve()

--- a/examples/flows/incidence_matrix.py
+++ b/examples/flows/incidence_matrix.py
@@ -31,7 +31,6 @@ f.close()
 node_count = data[g.NODE_COUNT_KEY]
 edges = data[g.EDGES_KEY]
 E = 2 * len(edges)
-
 A = Parameter((node_count, E + 2))
 A.value = np.zeros((node_count, E + 2))
 c = Parameter((E))


### PR DESCRIPTION
## Description
Fixed bug in examples/flows/incidence_matrix described in #1609.  Basically, there were 3 bugs when running the example:

1. When loading a file using pickle the following error was raised: TypeError: a bytes-like object is required, not 'str'" 
2. When stacking variables  the following error was raised: "ValueError: All the input dimensions except for axis 0 must match exactly."
3. When subtracting the variable "flows" and the cvxopt.matrix "c"  the following error was raised:  "ValueError: Cannot broadcast dimensions  (378,) (378, 1)"

Moreover, I removed the dependency on cvxopt, and fixed minor style issues.

Issue link (if applicable): #1609 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.