### PR TITLE
Fixed bugs in multiple flow examples

### DIFF
--- a/examples/flows/commodity_flow.py
+++ b/examples/flows/commodity_flow.py
@@ -16,45 +16,56 @@ limitations under the License.
 import pickle
 import random as r
 
+import numpy as np
+from cvxpy import Maximize, Parameter, Problem, Variable
+from cvxpy.atoms.affine.sum import sum as sum_
+from cvxpy.atoms.elementwise.abs import abs as abs_
+
 import create_graph as g
-import cvxopt
 from max_flow import Edge, Node
 
-from cvxpy import Maximize, Problem, Variable
-
 # Multi-commodity flow.
-COMMODITIES = 5 # Number of commodities.
+COMMODITIES = 5  # Number of commodities.
 r.seed(1)
+
 
 class MultiEdge(Edge):
     """ An undirected, capacity limited edge with multiple commodities. """
+
     def __init__(self, capacity) -> None:
         self.capacity = capacity
         self.in_flow = Variable(COMMODITIES)
         self.out_flow = Variable(COMMODITIES)
 
+    # Connects two nodes via the edge.
+    def connect(self, in_node, out_node):
+        in_node.edge_flows.append(-self.in_flow)
+        out_node.edge_flows.append(self.out_flow)
+
     # Returns the edge's internal constraints.
     def constraints(self):
         return [self.in_flow + self.out_flow == 0,
-                sum(abs(self.in_flow)) <= self.capacity]
+                sum_(abs_(self.in_flow)) <= self.capacity]
+
 
 class MultiNode(Node):
     """ A node with a target flow accumulation and a capacity. """
+
     def __init__(self, capacity: float = 0.0) -> None:
-        self.capacity = capacity
+        self.capacity = np.array(capacity)
         self.edge_flows = []
 
     # The total accumulation of flow.
     def accumulation(self):
-        return sum(f for f in self.edge_flows)
+        return sum_([f for f in self.edge_flows])
 
     def constraints(self):
-        return [abs(self.accumulation()) <= self.capacity]
+        return [abs_(self.accumulation()) <= self.capacity.flatten()]
 
 
 if __name__ == "__main__":
     # Read a graph from a file.
-    f = open(g.FILE, 'r')
+    f = open(g.FILE, 'rb')
     data = pickle.load(f)
     f.close()
 
@@ -65,20 +76,21 @@ if __name__ == "__main__":
     sources = []
     sinks = []
     for i in range(COMMODITIES):
-        source,sink = r.sample(nodes, 2)
+        source, sink = r.sample(nodes, 2)
         # Only count accumulation of a single commodity.
-        commodity_vec = cvxopt.matrix(0,(COMMODITIES,1))
-        commodity_vec[i] = 1
+        commodity_vec = Parameter((COMMODITIES, 1))
+        commodity_vec.value = np.zeros((COMMODITIES, 1))
+        commodity_vec.value[i] = 1
         # Initialize the source.
-        source.capacity = commodity_vec*Variable()
+        source.capacity = commodity_vec * Variable()
         sources.append(source)
         # Initialize the sink.
-        sink.capacity = commodity_vec*Variable()
+        sink.capacity = commodity_vec * Variable()
         sinks.append(sink)
 
     # Construct edges.
     edges = []
-    for n1,n2,capacity in data[g.EDGES_KEY]:
+    for n1, n2, capacity in data[g.EDGES_KEY]:
         edges.append(MultiEdge(capacity))
         edges[-1].connect(nodes[n1], nodes[n2])
 
@@ -87,10 +99,11 @@ if __name__ == "__main__":
     constraints = []
     for o in nodes + edges:
         constraints += o.constraints()
+
     p = Problem(objective, constraints)
     result = p.solve()
     print("Objective value = %s" % result)
     # Show how the flow for each commodity.
-    for i,s in enumerate(sinks):
+    for i, s in enumerate(sinks):
         accumulation = sum(f.value[i] for f in s.edge_flows)
         print("Accumulation of commodity %s = %s" % (i, accumulation))

--- a/examples/flows/create_graph.py
+++ b/examples/flows/create_graph.py
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import pickle
 # Construct a random connected graph and stores it as tuples of
 # (start node #, end node #, capacity).
+import pickle
 from random import random, sample
 
 # Constants

--- a/examples/flows/create_graph.py
+++ b/examples/flows/create_graph.py
@@ -26,19 +26,19 @@ EDGES_KEY = "edges"
 
 if __name__ == "__main__":
     N = 20
-    E = N*(N-1)/2
+    E = N * (N - 1) / 2
     c = 10
     edges = []
     # Start with a line.
-    for i in range(1,N):
-        edges.append( (i-1,i,c*random()) )
+    for i in range(1, N):
+        edges.append((i - 1, i, c * random()))
     # Add additional edges.
-    for i in range(N,E):
-        n1,n2 = sample(range(N), 2)
-        edges.append( (n1,n2,c) )
+    for i in range(N, int(E)):
+        n1, n2 = sample(range(N), 2)
+        edges.append((n1, n2, c))
     # Pickle the graph data.
     data = {NODE_COUNT_KEY: N,
             EDGES_KEY: edges}
-    f = open(FILE, 'w')
+    f = open(FILE, 'wb')
     pickle.dump(data, f)
     f.close()

--- a/examples/flows/incidence_matrix.py
+++ b/examples/flows/incidence_matrix.py
@@ -17,23 +17,23 @@ limitations under the License.
 # Incidence matrix approach.
 import pickle
 
+from create_graph import FILE, NODE_COUNT_KEY, EDGES_KEY
 import numpy as np
-from cvxpy import Maximize, Parameter, Problem, Variable, vstack
 
-import create_graph as g
+import cvxpy as cp
 
 # Read a graph from a file.
-f = open(g.FILE, 'rb')
+f = open(FILE, 'rb')
 data = pickle.load(f)
 f.close()
 
 # Construct incidence matrix and capacities vector.
-node_count = data[g.NODE_COUNT_KEY]
-edges = data[g.EDGES_KEY]
+node_count = data[NODE_COUNT_KEY]
+edges = data[EDGES_KEY]
 E = 2 * len(edges)
-A = Parameter((node_count, E + 2))
+A = cp.Parameter((node_count, E + 2))
 A.value = np.zeros((node_count, E + 2))
-c = Parameter((E))
+c = cp.Parameter((E))
 c.value = np.full((E), 1000)
 for i, (n1, n2, capacity) in enumerate(edges):
     A.value[n1, 2 * i] = -1
@@ -47,12 +47,12 @@ A.value[0, E] = 1
 # Add sink.
 A.value[-1, E + 1] = -1
 # Construct the problem.
-flows = Variable(E)
-source = Variable()
-sink = Variable()
-p = Problem(Maximize(source),
-            [A @ vstack([f for f in flows] + [source, sink]) == 0,
-             0 <= flows,
-             flows <= c])
+flows = cp.Variable(E)
+source = cp.Variable()
+sink = cp.Variable()
+p = cp.Problem(cp.Maximize(source),
+               [A @ cp.vstack([f for f in flows] + [source, sink]) == 0,
+                0 <= flows,
+                flows <= c])
 result = p.solve()
 print(result)

--- a/examples/flows/leaky_edges.py
+++ b/examples/flows/leaky_edges.py
@@ -18,27 +18,32 @@ import pickle
 
 from cvxpy import Maximize, Problem, Variable
 
-from .create_graph import EDGES_KEY, FILE, NODE_COUNT_KEY
-from .max_flow import Edge, Node
+from create_graph import EDGES_KEY, FILE, NODE_COUNT_KEY
+from max_flow import Edge, Node
 
 
 # Max-flow with different kinds of edges.
 class Directed(Edge):
     """ A directed, capacity limited edge """
+
     # Returns the edge's internal constraints.
     def constraints(self):
         return [self.flow >= 0, self.flow <= self.capacity]
 
+
 class LeakyDirected(Directed):
     """ A directed edge that leaks flow. """
     EFFICIENCY = .95
+
     # Connects two nodes via the edge.
     def connect(self, in_node, out_node):
         in_node.edge_flows.append(-self.flow)
-        out_node.edge_flows.append(self.EFFICIENCY*self.flow)
+        out_node.edge_flows.append(self.EFFICIENCY * self.flow)
+
 
 class LeakyUndirected(Edge):
     """ An undirected edge that leaks flow. """
+
     # Model a leaky undirected edge as two leaky directed
     # edges pointing in opposite directions.
     def __init__(self, capacity) -> None:
@@ -53,9 +58,10 @@ class LeakyUndirected(Edge):
     def constraints(self):
         return self.forward.constraints() + self.backward.constraints()
 
+
 if __name__ == "__main__":
     # Read a graph from a file.
-    f = open(FILE, 'r')
+    f = open(FILE, 'rb')
     data = pickle.load(f)
     f.close()
 
@@ -69,7 +75,7 @@ if __name__ == "__main__":
 
     # Construct edges.
     edges = []
-    for n1,n2,capacity in data[EDGES_KEY]:
+    for n1, n2, capacity in data[EDGES_KEY]:
         edges.append(LeakyUndirected(capacity))
         edges[-1].connect(nodes[n1], nodes[n2])
 

--- a/examples/flows/leaky_edges.py
+++ b/examples/flows/leaky_edges.py
@@ -16,10 +16,10 @@ limitations under the License.
 
 import pickle
 
-from cvxpy import Maximize, Problem, Variable
-
 from create_graph import EDGES_KEY, FILE, NODE_COUNT_KEY
 from max_flow import Edge, Node
+
+import cvxpy as cp
 
 
 # Max-flow with different kinds of edges.
@@ -69,9 +69,9 @@ if __name__ == "__main__":
     node_count = data[NODE_COUNT_KEY]
     nodes = [Node() for i in range(node_count)]
     # Add source.
-    nodes[0].accumulation = Variable()
+    nodes[0].accumulation = cp.Variable()
     # Add sink.
-    nodes[-1].accumulation = Variable()
+    nodes[-1].accumulation = cp.Variable()
 
     # Construct edges.
     edges = []
@@ -83,6 +83,6 @@ if __name__ == "__main__":
     constraints = []
     for o in nodes + edges:
         constraints += o.constraints()
-    p = Problem(Maximize(nodes[-1].accumulation), constraints)
+    p = cp.Problem(cp.Maximize(nodes[-1].accumulation), constraints)
     result = p.solve()
     print(result)

--- a/examples/flows/max_flow.py
+++ b/examples/flows/max_flow.py
@@ -17,6 +17,8 @@ limitations under the License.
 import pickle
 
 from cvxpy import Maximize, Problem, Variable
+from cvxpy.atoms.affine.sum import sum as sum_
+from cvxpy.atoms.elementwise.abs import abs as abs_
 
 from create_graph import EDGES_KEY, FILE, NODE_COUNT_KEY
 
@@ -24,6 +26,7 @@ from create_graph import EDGES_KEY, FILE, NODE_COUNT_KEY
 # An object oriented max-flow problem.
 class Edge:
     """ An undirected, capacity limited edge. """
+
     def __init__(self, capacity) -> None:
         self.capacity = capacity
         self.flow = Variable()
@@ -35,21 +38,24 @@ class Edge:
 
     # Returns the edge's internal constraints.
     def constraints(self):
-        return [abs(self.flow) <= self.capacity]
+        return [abs_(self.flow) <= self.capacity]
+
 
 class Node:
     """ A node with accumulation. """
+
     def __init__(self, accumulation: float = 0.0) -> None:
         self.accumulation = accumulation
         self.edge_flows = []
 
     # Returns the node's internal constraints.
     def constraints(self):
-        return [sum(f for f in self.edge_flows) == self.accumulation]
+        return [sum_([f for f in self.edge_flows]) == self.accumulation]
+
 
 if __name__ == "__main__":
     # Read a graph from a file.
-    f = open(FILE, 'r')
+    f = open(FILE, 'rb')
     data = pickle.load(f)
     f.close()
 
@@ -63,7 +69,7 @@ if __name__ == "__main__":
 
     # Construct edges.
     edges = []
-    for n1,n2,capacity in data[EDGES_KEY]:
+    for n1, n2, capacity in data[EDGES_KEY]:
         edges.append(Edge(capacity))
         edges[-1].connect(nodes[n1], nodes[n2])
     # Construct the problem.

--- a/examples/flows/max_flow.py
+++ b/examples/flows/max_flow.py
@@ -18,7 +18,7 @@ import pickle
 
 from cvxpy import Maximize, Problem, Variable
 
-from .create_graph import EDGES_KEY, FILE, NODE_COUNT_KEY
+from create_graph import EDGES_KEY, FILE, NODE_COUNT_KEY
 
 
 # An object oriented max-flow problem.

--- a/examples/flows/max_flow.py
+++ b/examples/flows/max_flow.py
@@ -16,11 +16,9 @@ limitations under the License.
 
 import pickle
 
-from cvxpy import Maximize, Problem, Variable
-from cvxpy.atoms.affine.sum import sum as sum_
-from cvxpy.atoms.elementwise.abs import abs as abs_
-
 from create_graph import EDGES_KEY, FILE, NODE_COUNT_KEY
+
+import cvxpy as cp
 
 
 # An object oriented max-flow problem.
@@ -29,7 +27,7 @@ class Edge:
 
     def __init__(self, capacity) -> None:
         self.capacity = capacity
-        self.flow = Variable()
+        self.flow = cp.Variable()
 
     # Connects two nodes via the edge.
     def connect(self, in_node, out_node):
@@ -38,7 +36,7 @@ class Edge:
 
     # Returns the edge's internal constraints.
     def constraints(self):
-        return [abs_(self.flow) <= self.capacity]
+        return [cp.abs(self.flow) <= self.capacity]
 
 
 class Node:
@@ -50,7 +48,7 @@ class Node:
 
     # Returns the node's internal constraints.
     def constraints(self):
-        return [sum_([f for f in self.edge_flows]) == self.accumulation]
+        return [cp.sum([f for f in self.edge_flows]) == self.accumulation]
 
 
 if __name__ == "__main__":
@@ -63,9 +61,9 @@ if __name__ == "__main__":
     node_count = data[NODE_COUNT_KEY]
     nodes = [Node() for i in range(node_count)]
     # Add source.
-    nodes[0].accumulation = Variable()
+    nodes[0].accumulation = cp.Variable()
     # Add sink.
-    nodes[-1].accumulation = Variable()
+    nodes[-1].accumulation = cp.Variable()
 
     # Construct edges.
     edges = []
@@ -76,6 +74,6 @@ if __name__ == "__main__":
     constraints = []
     for o in nodes + edges:
         constraints += o.constraints()
-    p = Problem(Maximize(nodes[-1].accumulation), constraints)
+    p = cp.Problem(cp.Maximize(nodes[-1].accumulation), constraints)
     result = p.solve()
     print(result)


### PR DESCRIPTION
## Description
Fixed bugs, style issues, and removed the dependency on cvxopt in multiple flow examples (commodity_flow, create_graph, max_flow,  and leaky_edges).  This includes the changes suggested by [choltz95](https://github.com/choltz95) and [mmusallam19](https://github.com/mmusallam19) in #1926.

Please include a short summary of the change.
Issue link (if applicable): #1926 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.