### PR TITLE
Don't cast complex numpy dtypes to float64

### DIFF
--- a/cvxpy/interface/numpy_interface/ndarray_interface.py
+++ b/cvxpy/interface/numpy_interface/ndarray_interface.py
@@ -22,6 +22,9 @@ import scipy.sparse
 
 from .. import base_matrix_interface as base
 
+# Possible types for complex data.
+COMPLEX_TYPES = [complex, numpy.complex64, numpy.complex128]
+
 
 class NDArrayInterface(base.BaseMatrixInterface):
     """
@@ -47,7 +50,7 @@ class NDArrayInterface(base.BaseMatrixInterface):
             result = numpy.asarray(value).T
         else:
             result = numpy.asarray(value)
-        if result.dtype in [complex, numpy.float64]:
+        if result.dtype in [numpy.float64] + COMPLEX_TYPES:
             return result
         else:
             return result.astype(numpy.float64)

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -238,6 +238,19 @@ class TestComplex(BaseTest):
         val = np.ones(2)*np.sqrt(2)
         self.assertItemsAlmostEqual(x.value, val + 1j*val)
 
+    def test_complex_ndarray(self) -> None:
+        """Test ndarray of type complex64 and complex128.
+        """
+        x = Variable()
+        z = np.full(1, 1j, dtype=np.complex64)
+        x.value = 0
+        expr = x + z
+        assert np.isclose(expr.value, z)
+
+        z = np.full(1, 1j, dtype=np.complex128)
+        expr = x + z
+        assert np.isclose(expr.value, z)
+
     def test_missing_imag(self) -> None:
         """Test problems where imaginary is missing.
         """

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -697,3 +697,17 @@ class TestDqcp(base_test.BaseTest):
         problem = cp.Problem(cp.Minimize(cp.cumsum(1/x)))
         problem.solve(SOLVER, qcp=True)
         self.assertAlmostEqual(problem.value, 0, places=3)
+
+    def test_hypersonic_shape_design(self) -> None:
+        """Test hypersonic shape design example."""
+        x = cp.Variable(pos=True)
+        obj = cp.sqrt(cp.inv_pos(cp.square(x))-1)
+
+        a = .05
+        b = .65
+        constraint = [a*cp.inv_pos(x)-(1-b)*cp.sqrt(1-cp.square(x))<=0]
+        prob = cp.Problem(cp.Minimize(obj), constraint)
+        prob.solve(SOLVER, qcp=True)
+
+        assert np.isclose(constraint[0].violation(), 0)
+        assert np.isclose(obj.value, 1/6.8541076)


### PR DESCRIPTION
## Description
An oversight in the code and testing led to conversion of np.complex64 and np.complex128 dtypes to float64.

Issue link (if applicable): #2182 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.