### PR TITLE
Update test for OSQP 1

### DIFF
--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -217,5 +217,5 @@ class TestNonOptimal(BaseTest):
         prob = cp.Problem(cp.Minimize(expr))
         # Transform to a SolverError.
         with pytest.raises(cp.SolverError,
-                           match="Workspace allocation error!"):
+                           match=r"(Workspace allocation error!)|(Setup Error \(Error Code 4\))"):
             prob.solve(solver=cp.OSQP)


### PR DESCRIPTION
## Description
Following the discussion in https://github.com/cvxpy/cvxpy/discussions/2166#discussioncomment-6312195, I have created a new action that checks pre-releases once a week. 
Interestingly, it immediately caught a (small) test failure we would have encountered after the OSQP 1.0 release.
https://github.com/cvxpy/actions/actions/runs/5558476612/jobs/10153621071

This PR update the test to allow both versions of the error message.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.