### PR TITLE
`PowCone3D` fix

### DIFF
--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -302,22 +302,14 @@ class TestConstraints(BaseTest):
         Simple test case with scalar AND vector `alpha`
         inputs to `PowCone3D`
         """""
+        x_0 = cp.Variable(shape=(3,))
         x = cp.Variable(shape=(3,))
-        y_square = cp.Variable()
-        epis = cp.Variable(shape=(3,))
-        cons = [PowCone3D(x[0], x[1], x[2], 0.25),
-                PowCone3D(np.ones(3), epis, x, cp.Constant([0.5, 0.5, 0.5])),
-                        cp.sum(epis) <= y_square,
-                        x[0] + x[1] + 3 * x[2] >= 1.0,
-                        y_square <= 25]
-        obj = cp.Minimize(3 * x[0] + 2 * x[1] + x[2])
+        cons = [cp.PowCone3D(x_0[0], x_0[1], x_0[2], 0.25),
+                x <= -10]
+        obj = cp.Minimize(cp.norm(x - x_0))
         prob = cp.Problem(obj, cons)
         prob.solve()
-        self.assertLessEqual(cons[0].residual, 1e-6)
-        self.assertLessEqual(cons[1].residual, 1e-6)
-        self.assertItemsAlmostEqual(cons[0].dual_value,
-                                    [np.array(1.98202141),
-                                     np.array(0.98202142), np.array(-2.05393575)])
+        self.assertAlmostEqual(prob.value, 17.320508075380552)
 
     def test_pownd_constraint(self) -> None:
         n = 4

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -312,8 +312,8 @@ class TestConstraints(BaseTest):
                         y_square <= 25]
         obj = cp.Minimize(3 * x[0] + 2 * x[1] + x[2])
         prob = cp.Problem(obj, cons)
-        prob.solve(solver='MOSEK')
-        self.assertAlmostEqual(prob.value, 1.0179785846849545)
+        prob.solve()
+        self.assertAlmostEqual(prob.value, 1.017)
         self.assertLessEqual(cons[0].residual, 1e-6)
         self.assertLessEqual(cons[1].residual, 1e-6)
         self.assertItemsAlmostEqual(cons[0].dual_value,

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -313,7 +313,6 @@ class TestConstraints(BaseTest):
         obj = cp.Minimize(3 * x[0] + 2 * x[1] + x[2])
         prob = cp.Problem(obj, cons)
         prob.solve()
-        self.assertAlmostEqual(prob.value, 1.0179727538139272)
         self.assertLessEqual(cons[0].residual, 1e-6)
         self.assertLessEqual(cons[1].residual, 1e-6)
         self.assertItemsAlmostEqual(cons[0].dual_value,

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -313,7 +313,7 @@ class TestConstraints(BaseTest):
         obj = cp.Minimize(3 * x[0] + 2 * x[1] + x[2])
         prob = cp.Problem(obj, cons)
         prob.solve()
-        self.assertAlmostEqual(prob.value, 1.017)
+        self.assertAlmostEqual(prob.value, 1.0179727538139272)
         self.assertLessEqual(cons[0].residual, 1e-6)
         self.assertLessEqual(cons[1].residual, 1e-6)
         self.assertItemsAlmostEqual(cons[0].dual_value,


### PR DESCRIPTION
## Description
Fixes small issue with `PowCone3D` when passing in naked floats as `alpha`.
Issue link (if applicable): [#2191](https://github.com/cvxpy/cvxpy/issues/2191)

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.