### PR TITLE
Adding functionality to cvxpy/tests: verifying dual feasibility for `Constraint` classes as part of the KKT conditions

### DIFF
--- a/cvxpy/__init__.py
+++ b/cvxpy/__init__.py
@@ -17,7 +17,7 @@ from cvxpy.version import (
     version as __version__,)  # cvxpy/version.py is auto-generated
 import cvxpy.interface.scipy_wrapper
 from cvxpy.atoms import *
-from cvxpy.constraints import (Constraint, PSD, SOC, NonPos, NonNeg, Zero, 
+from cvxpy.constraints import (Constraint, Cone, PSD, SOC, NonPos, NonNeg, Zero,
                                PowCone3D, PowConeND, ExpCone, 
                                OpRelEntrConeQuad, RelEntrConeQuad, FiniteSet,)
 from cvxpy.error import (DCPError, DGPError, DPPError, SolverError,

--- a/cvxpy/constraints/__init__.py
+++ b/cvxpy/constraints/__init__.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.constraints.cones import Cone
 from cvxpy.constraints.exponential import (ExpCone, OpRelEntrConeQuad,
                                            RelEntrConeQuad,)
 from cvxpy.constraints.finite_set import FiniteSet

--- a/cvxpy/constraints/cones.py
+++ b/cvxpy/constraints/cones.py
@@ -18,6 +18,7 @@ import abc
 import typing
 
 from cvxpy.constraints.constraint import Constraint
+import cvxpy as cp
 
 
 class Cone(Constraint):
@@ -46,9 +47,27 @@ class Cone(Constraint):
     def __init__(self, args, constr_id=None) -> None:
         super(Cone, self).__init__(args, constr_id)
 
-    def dual_cone(self) -> typing.Type['Cone']:
+    def dual_cone(self, args: list['cp.Expression'] | None = None) -> typing.Type['Cone']:
+    # def dual_cone(self, args) -> typing.Type['Cone']:
+        """Method for modelling problems with the dual cone of `Cone`
+
+        If the user simply calls the method without any arguments, then
+        the dual cone to the current instance of `Cone` will be returned, else,
+        the user can also choose to freely model with the dual cone of `Cone`
+        by constraining aribitrary expressions in the same.
+
+        Will typically not be used stand-alone, and would be
+        indirectly accessed via `dual_residual` which will return
+        the violation of CVXPY's computed dual variables w.r.t. `Cone`'s
+        dual-cone"""
         raise NotImplementedError
 
     @property
     def dual_residual(self) -> float:
-        return self.dual_cone().residual
+        """Computes the residual (see Constraint.violation for a
+        more formal definition) for the dual cone of the current instance
+        of `Cone` w.r.t. the recovered dual variables
+
+        Primarily intended to be used for full-fledged KKT checks
+        """
+        return self.dual_cone(*self.dual_variables).residual

--- a/cvxpy/constraints/cones.py
+++ b/cvxpy/constraints/cones.py
@@ -1,0 +1,54 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import abc
+import typing
+
+from cvxpy.constraints.constraint import Constraint
+
+
+class Cone(Constraint):
+    """A base class for all conic constraints in CVXPY
+
+    These are special constraints imposing set membership in convex cones
+    CVXPY supports modelling using the following cones as of today:
+    - ExpCone
+    - SOC (Second Order Cone)
+    - PowCone3D
+    - PowConeND
+    - RelEntrConeQuad
+    - OpRelEntrConeQuad
+    - PSD/NSD
+
+    Parameters
+    ----------
+    args : list
+        A list of expression trees.
+    constr_id : int
+        A unique id for the constraint.
+    """
+
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, args, constr_id=None) -> None:
+        super(Cone, self).__init__(args, constr_id)
+
+    def dual_cone(self) -> typing.Type['Cone']:
+        raise NotImplementedError
+
+    @property
+    def dual_residual(self) -> float:
+        return self.dual_cone().residual

--- a/cvxpy/constraints/cones.py
+++ b/cvxpy/constraints/cones.py
@@ -17,8 +17,8 @@ limitations under the License.
 import abc
 import typing
 
-from cvxpy.constraints.constraint import Constraint
 import cvxpy as cp
+from cvxpy.constraints.constraint import Constraint
 
 
 class Cone(Constraint):

--- a/cvxpy/constraints/cones.py
+++ b/cvxpy/constraints/cones.py
@@ -15,9 +15,7 @@ limitations under the License.
 """
 
 import abc
-import typing
 
-import cvxpy as cp
 from cvxpy.constraints.constraint import Constraint
 
 
@@ -47,7 +45,7 @@ class Cone(Constraint):
     def __init__(self, args, constr_id=None) -> None:
         super(Cone, self).__init__(args, constr_id)
 
-    def _dual_cone(self, args: list['cp.Expression'] | None = None) -> typing.Type['Cone']:
+    def _dual_cone(self, args):
         """Method for modelling problems with the dual cone of `Cone`
 
         If the user simply calls the method without any arguments, then

--- a/cvxpy/constraints/cones.py
+++ b/cvxpy/constraints/cones.py
@@ -47,8 +47,7 @@ class Cone(Constraint):
     def __init__(self, args, constr_id=None) -> None:
         super(Cone, self).__init__(args, constr_id)
 
-    def dual_cone(self, args: list['cp.Expression'] | None = None) -> typing.Type['Cone']:
-    # def dual_cone(self, args) -> typing.Type['Cone']:
+    def _dual_cone(self, args: list['cp.Expression'] | None = None) -> typing.Type['Cone']:
         """Method for modelling problems with the dual cone of `Cone`
 
         If the user simply calls the method without any arguments, then
@@ -68,6 +67,6 @@ class Cone(Constraint):
         more formal definition) for the dual cone of the current instance
         of `Cone` w.r.t. the recovered dual variables
 
-        Primarily intended to be used for full-fledged KKT checks
+        Primarily intended to be used for KKT checks
         """
-        return self.dual_cone(*self.dual_variables).residual
+        return self._dual_cone(*self.dual_variables).residual

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -150,7 +150,8 @@ class ExpCone(Constraint):
     def dual_cone(x, y, z):
         return ExpCone(-y, -x, np.exp(1)*z)
 
-    def dual_violation(self):
+    @property
+    def dual_residual(self):
         return ExpCone.dual_cone(*self.dual_variables).residual
 
 class RelEntrConeQuad(Constraint):

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -146,9 +146,21 @@ class ExpCone(Cone):
         self.dual_variables[1].save_value(dv1)
         self.dual_variables[2].save_value(dv2)
 
-    def dual_cone(self):
-        return ExpCone(-self.dual_variables[1], -self.dual_variables[0],
-                       np.exp(1)*self.dual_variables[2])
+    def dual_cone(self, *args):
+        """Implements the dual cone of the exponential cone
+        See Pg 85 of the MOSEK modelling cookbook for more information"""
+        if args is ():
+            return ExpCone(-self.dual_variables[1], -self.dual_variables[0],
+                           np.exp(1) * self.dual_variables[2])
+        else:
+            # some assertions for verifying `args`
+            f = lambda x: x.shape
+            args_shapes = list(map(f, args))
+            instance_args_shapes = list(map(f, self.args))
+            assert len(args) == len(self.args)
+            assert args_shapes == instance_args_shapes
+            return ExpCone(-args[1], -args[0],
+                           np.exp(1)*args[2])
 
 
 class RelEntrConeQuad(Cone):

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -20,14 +20,14 @@ from typing import List, Tuple, TypeVar
 
 import numpy as np
 
-from cvxpy.constraints.constraint import Constraint
+from cvxpy.constraints.cones import Cone
 from cvxpy.expressions import cvxtypes
 from cvxpy.utilities import scopes
 
 Expression = TypeVar('Expression')
 
 
-class ExpCone(Constraint):
+class ExpCone(Cone):
     """A reformulated exponential cone constraint.
 
     Operates elementwise on :math:`x, y, z`.
@@ -146,15 +146,12 @@ class ExpCone(Constraint):
         self.dual_variables[1].save_value(dv1)
         self.dual_variables[2].save_value(dv2)
 
-    @staticmethod
-    def dual_cone(x, y, z):
-        return ExpCone(-y, -x, np.exp(1)*z)
+    def dual_cone(self):
+        return ExpCone(-self.dual_variables[1], -self.dual_variables[0],
+                       np.exp(1)*self.dual_variables[2])
 
-    @property
-    def dual_residual(self):
-        return ExpCone.dual_cone(*self.dual_variables).residual
 
-class RelEntrConeQuad(Constraint):
+class RelEntrConeQuad(Cone):
     """An approximate construction of the scalar relative entropy cone
 
     Definition:
@@ -272,7 +269,7 @@ class RelEntrConeQuad(Constraint):
         pass
 
 
-class OpRelEntrConeQuad(Constraint):
+class OpRelEntrConeQuad(Cone):
     """An approximate construction of the operator relative entropy cone
 
     Definition:

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -149,12 +149,13 @@ class ExpCone(Cone):
     def dual_cone(self, *args):
         """Implements the dual cone of the exponential cone
         See Pg 85 of the MOSEK modelling cookbook for more information"""
-        if args is ():
+        if args == ():
             return ExpCone(-self.dual_variables[1], -self.dual_variables[0],
                            np.exp(1) * self.dual_variables[2])
         else:
             # some assertions for verifying `args`
-            f = lambda x: x.shape
+            def f(x):
+                return x.shape
             args_shapes = list(map(f, args))
             instance_args_shapes = list(map(f, self.args))
             assert len(args) == len(self.args)

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -146,7 +146,7 @@ class ExpCone(Cone):
         self.dual_variables[1].save_value(dv1)
         self.dual_variables[2].save_value(dv2)
 
-    def dual_cone(self, *args):
+    def _dual_cone(self, *args):
         """Implements the dual cone of the exponential cone
         See Pg 85 of the MOSEK modelling cookbook for more information"""
         if args == ():

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -146,6 +146,12 @@ class ExpCone(Constraint):
         self.dual_variables[1].save_value(dv1)
         self.dual_variables[2].save_value(dv2)
 
+    @staticmethod
+    def dual_cone(x, y, z):
+        return ExpCone(-y, -x, np.exp(1)*z)
+
+    def dual_violation(self):
+        return ExpCone.dual_cone(*self.dual_variables).residual
 
 class RelEntrConeQuad(Constraint):
     """An approximate construction of the scalar relative entropy cone

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -71,7 +71,6 @@ class PowCone3D(Constraint):
             raise ValueError(msg)
         super(PowCone3D, self).__init__([self.x, self.y, self.z],
                                         constr_id)
-
     def __str__(self) -> str:
         return "Pow3D(%s, %s, %s; %s)" % (self.x, self.y, self.z, self.alpha)
 
@@ -139,6 +138,14 @@ class PowCone3D(Constraint):
         self.dual_variables[2].save_value(dv2)
         # TODO: figure out why the reshaping had to be done differently,
         #   relative to ExpCone constraints.
+
+    @staticmethod
+    def dual_cone(x, y, z, alpha: float):
+        return PowCone3D(x/alpha, y/(1-alpha), z, alpha)
+
+    def dual_violation(self):
+        return PowCone3D.dual_cone(*self.dual_variables,
+                                   self.alpha).residual
 
 
 class PowConeND(Constraint):

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -18,12 +18,12 @@ from typing import List, Tuple
 
 import numpy as np
 
-from cvxpy.constraints.constraint import Constraint
+from cvxpy.constraints.cones import Cone
 from cvxpy.expressions import cvxtypes
 from cvxpy.utilities import scopes
 
 
-class PowCone3D(Constraint):
+class PowCone3D(Cone):
     """
     An object representing a collection of 3D power cone constraints
 
@@ -139,17 +139,11 @@ class PowCone3D(Constraint):
         # TODO: figure out why the reshaping had to be done differently,
         #   relative to ExpCone constraints.
 
-    @staticmethod
-    def dual_cone(x, y, z, alpha: float):
-        return PowCone3D(x/alpha, y/(1-alpha), z, alpha)
-
-    @property
-    def dual_residual(self):
-        return PowCone3D.dual_cone(*self.dual_variables,
-                                   self.alpha).residual
+    def dual_cone(self):
+        return PowCone3D(self.x/self.alpha, self.y/(1-self.alpha), self.z, self.alpha)
 
 
-class PowConeND(Constraint):
+class PowConeND(Cone):
     """
     Represents a collection of N-dimensional power cone constraints
     that is *mathematically* equivalent to the following code

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -139,8 +139,21 @@ class PowCone3D(Cone):
         # TODO: figure out why the reshaping had to be done differently,
         #   relative to ExpCone constraints.
 
-    def dual_cone(self):
-        return PowCone3D(self.x/self.alpha, self.y/(1-self.alpha), self.z, self.alpha)
+    def dual_cone(self, *args):
+        """Implements the dual cone of PowCone3D See Pg 85
+        of the MOSEK modelling cookbook for more information"""
+        if args is None:
+            PowCone3D(self.dual_variables[0]/self.alpha, self.dual_variables[1]/(1-self.alpha),
+                      self.dual_variables[2], self.alpha)
+        else:
+            # some assertions for verifying `args`
+            f = lambda x: x.shape
+            args_shapes = list(map(f, args))
+            instance_args_shapes = list(map(f, self.args))
+            assert len(args) == len(self.args)
+            assert args_shapes == instance_args_shapes
+            return PowCone3D(args[0]/self.alpha, args[1]/(1-self.alpha),
+                             args[2], self.alpha)
 
 
 class PowConeND(Cone):

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -139,7 +139,7 @@ class PowCone3D(Cone):
         # TODO: figure out why the reshaping had to be done differently,
         #   relative to ExpCone constraints.
 
-    def dual_cone(self, *args):
+    def _dual_cone(self, *args):
         """Implements the dual cone of PowCone3D See Pg 85
         of the MOSEK modelling cookbook for more information"""
         if args is None:

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -147,7 +147,8 @@ class PowCone3D(Cone):
                       self.dual_variables[2], self.alpha)
         else:
             # some assertions for verifying `args`
-            f = lambda x: x.shape
+            def f(x):
+                return x.shape
             args_shapes = list(map(f, args))
             instance_args_shapes = list(map(f, self.args))
             assert len(args) == len(self.args)

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -143,7 +143,8 @@ class PowCone3D(Constraint):
     def dual_cone(x, y, z, alpha: float):
         return PowCone3D(x/alpha, y/(1-alpha), z, alpha)
 
-    def dual_violation(self):
+    @property
+    def dual_residual(self):
         return PowCone3D.dual_cone(*self.dual_variables,
                                    self.alpha).residual
 

--- a/cvxpy/constraints/psd.py
+++ b/cvxpy/constraints/psd.py
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.constraints.constraint import Constraint
+from cvxpy.constraints.cones import Cone
 from cvxpy.expressions import cvxtypes
 from cvxpy.utilities import scopes
 
 
-class PSD(Constraint):
+class PSD(Cone):
     """A constraint of the form :math:`\\frac{1}{2}(X + X^T) \\succcurlyeq_{S_n^+} 0`
 
     Applying a ``PSD`` constraint to a two-dimensional expression ``X``
@@ -84,10 +84,5 @@ class PSD(Constraint):
         min_eig = cvxtypes.lambda_min()(self.args[0] + self.args[0].T)/2
         return cvxtypes.neg()(min_eig).value
 
-    @staticmethod
-    def dual_cone(X):
-        return X >> 0
-
-    @property
-    def dual_residual(self):
-        return PSD.dual_cone(*self.dual_variables).residual
+    def dual_cone(self):
+        return self.dual_variables[0] >> 0

--- a/cvxpy/constraints/psd.py
+++ b/cvxpy/constraints/psd.py
@@ -84,9 +84,9 @@ class PSD(Cone):
         min_eig = cvxtypes.lambda_min()(self.args[0] + self.args[0].T)/2
         return cvxtypes.neg()(min_eig).value
 
-    def dual_cone(self, *args):
-        """Implements the dual cone of the exponential cone
-        See Pg 85 of the MOSEK modelling cookbook for more information"""
+    def _dual_cone(self, *args):
+        """Implements the dual cone of the PSD cone See Pg 85 of the
+        MOSEK modelling cookbook for more information"""
         if args is None:
             return self.dual_variables[0] >> 0
         else:

--- a/cvxpy/constraints/psd.py
+++ b/cvxpy/constraints/psd.py
@@ -91,7 +91,8 @@ class PSD(Cone):
             return self.dual_variables[0] >> 0
         else:
             # some assertions for verifying `args`
-            f = lambda x: x.shape
+            def f(x):
+                return x.shape
             args_shapes = list(map(f, args))
             instance_args_shapes = list(map(f, self.args))
             assert len(args) == len(self.args)

--- a/cvxpy/constraints/psd.py
+++ b/cvxpy/constraints/psd.py
@@ -83,3 +83,10 @@ class PSD(Constraint):
             return None
         min_eig = cvxtypes.lambda_min()(self.args[0] + self.args[0].T)/2
         return cvxtypes.neg()(min_eig).value
+
+    @staticmethod
+    def dual_cone(X):
+        return X >> 0
+
+    def dual_violation(self):
+        return PSD.dual_cone(*self.dual_variables).residual

--- a/cvxpy/constraints/psd.py
+++ b/cvxpy/constraints/psd.py
@@ -84,5 +84,16 @@ class PSD(Cone):
         min_eig = cvxtypes.lambda_min()(self.args[0] + self.args[0].T)/2
         return cvxtypes.neg()(min_eig).value
 
-    def dual_cone(self):
-        return self.dual_variables[0] >> 0
+    def dual_cone(self, *args):
+        """Implements the dual cone of the exponential cone
+        See Pg 85 of the MOSEK modelling cookbook for more information"""
+        if args is None:
+            return self.dual_variables[0] >> 0
+        else:
+            # some assertions for verifying `args`
+            f = lambda x: x.shape
+            args_shapes = list(map(f, args))
+            instance_args_shapes = list(map(f, self.args))
+            assert len(args) == len(self.args)
+            assert args_shapes == instance_args_shapes
+            return args[0] >> 0

--- a/cvxpy/constraints/psd.py
+++ b/cvxpy/constraints/psd.py
@@ -88,5 +88,6 @@ class PSD(Constraint):
     def dual_cone(X):
         return X >> 0
 
-    def dual_violation(self):
+    @property
+    def dual_residual(self):
         return PSD.dual_cone(*self.dual_variables).residual

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -166,5 +166,16 @@ class SOC(Cone):
         self.dual_variables[0].save_value(t)
         self.dual_variables[1].save_value(X)
 
-    def dual_cone(self):
-        return SOC(self.dual_variables[0], self.dual_variables[1], self.axis)
+    def dual_cone(self, *args):
+        """Implements the dual cone of the second-order cone
+        See Pg 85 of the MOSEK modelling cookbook for more information"""
+        if args is None:
+            return SOC(self.dual_variables[0], self.dual_variables[1], self.axis)
+        else:
+            # some assertions for verifying `args`
+            f = lambda x: x.shape
+            args_shapes = list(map(f, args))
+            instance_args_shapes = list(map(f, self.args))
+            assert len(args) == len(self.args)
+            assert args_shapes == instance_args_shapes
+            return SOC(args[0], args[1], self.axis)

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -166,7 +166,7 @@ class SOC(Cone):
         self.dual_variables[0].save_value(t)
         self.dual_variables[1].save_value(X)
 
-    def dual_cone(self, *args):
+    def _dual_cone(self, *args):
         """Implements the dual cone of the second-order cone
         See Pg 85 of the MOSEK modelling cookbook for more information"""
         if args is None:

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -18,12 +18,12 @@ from typing import List, Optional
 
 import numpy as np
 
-from cvxpy.constraints.constraint import Constraint
+from cvxpy.constraints.cones import Cone
 from cvxpy.expressions import cvxtypes
 from cvxpy.utilities import scopes
 
 
-class SOC(Constraint):
+class SOC(Cone):
     """A second-order cone constraint for each row/column.
 
     Assumes ``t`` is a vector the same length as ``X``'s columns (rows) for
@@ -166,10 +166,5 @@ class SOC(Constraint):
         self.dual_variables[0].save_value(t)
         self.dual_variables[1].save_value(X)
 
-    @staticmethod
-    def dual_cone(t, X, axis=0):
-        return SOC(t, X, axis)
-
-    @property
-    def dual_residual(self):
-        return SOC.dual_cone(*self.dual_variables, axis=self.axis).residual
+    def dual_cone(self):
+        return SOC(self.dual_variables[0], self.dual_variables[1], self.axis)

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -170,5 +170,6 @@ class SOC(Constraint):
     def dual_cone(t, X, axis=0):
         return SOC(t, X, axis)
 
-    def dual_violation(self):
+    @property
+    def dual_residual(self):
         return SOC.dual_cone(*self.dual_variables, axis=self.axis).residual

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -165,3 +165,10 @@ class SOC(Constraint):
             X = X.T
         self.dual_variables[0].save_value(t)
         self.dual_variables[1].save_value(X)
+
+    @staticmethod
+    def dual_cone(t, X, axis=0):
+        return SOC(t, X, axis)
+
+    def dual_violation(self):
+        return SOC.dual_cone(*self.dual_variables, axis=self.axis).residual

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -173,7 +173,8 @@ class SOC(Cone):
             return SOC(self.dual_variables[0], self.dual_variables[1], self.axis)
         else:
             # some assertions for verifying `args`
-            f = lambda x: x.shape
+            def f(x):
+                return x.shape
             args_shapes = list(map(f, args))
             instance_args_shapes = list(map(f, self.args))
             assert len(args) == len(self.args)

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -74,18 +74,14 @@ class SolverTestHelper:
         #   (e.g. X = Variable(shape=(n,n), PSD=True)), check
         #   domains for dual variables of the attribute constraint.
         for con in self.constraints:
-            if isinstance(con, cp.constraints.PSD):
-                # TODO: move this to PSD.dual_violation
-                dv = con.dual_value
-                eigs = np.linalg.eigvalsh(dv)
-                min_eig = np.min(eigs)
-                self.tester.assertGreaterEqual(min_eig, -(10**(-places)))
-            elif isinstance(con, cp.constraints.ExpCone):
-                # TODO: implement this (preferably with ExpCone.dual_violation)
-                raise NotImplementedError()
-            elif isinstance(con, cp.constraints.SOC):
-                # TODO: implement this (preferably with SOC.dual_violation)
-                raise NotImplementedError()
+            if isinstance(con, (cp.constraints.ExpCone,
+                                cp.constraints.PowCone3D,
+                                cp.constraints.PSD,
+                                cp.constraints.SOC)):
+                dual_violation = con.dual_violation()
+                if isinstance(con, cp.constraints.SOC):
+                    dual_violation = np.linalg.norm(dual_violation)
+                self.tester.assertLessEqual(dual_violation, 10**(-places))
             elif isinstance(con, cp.constraints.Inequality):
                 # TODO: move this to Inequality.dual_violation
                 dv = con.dual_value
@@ -99,8 +95,6 @@ class SolverTestHelper:
                     self.tester.assertEqual(contents, float)
                 else:
                     self.tester.assertIsInstance(dv, float)
-            elif isinstance(con, cp.constraints.PowCone3D):
-                raise NotImplementedError()
             else:
                 raise ValueError('Unknown constraint type %s.' % type(con))
 

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -78,7 +78,7 @@ class SolverTestHelper:
                                 cp.constraints.PowCone3D,
                                 cp.constraints.PSD,
                                 cp.constraints.SOC)):
-                dual_violation = con.dual_violation()
+                dual_violation = con.dual_residual
                 if isinstance(con, cp.constraints.SOC):
                     dual_violation = np.linalg.norm(dual_violation)
                 self.tester.assertLessEqual(dual_violation, 10**(-places))

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -74,10 +74,7 @@ class SolverTestHelper:
         #   (e.g. X = Variable(shape=(n,n), PSD=True)), check
         #   domains for dual variables of the attribute constraint.
         for con in self.constraints:
-            if isinstance(con, (cp.constraints.ExpCone,
-                                cp.constraints.PowCone3D,
-                                cp.constraints.PSD,
-                                cp.constraints.SOC)):
+            if isinstance(con, cp.constraints.Cone):
                 dual_violation = con.dual_residual
                 if isinstance(con, cp.constraints.SOC):
                     dual_violation = np.linalg.norm(dual_violation)

--- a/cvxpy/tests/test_KKT.py
+++ b/cvxpy/tests/test_KKT.py
@@ -63,10 +63,7 @@ class TestKKT_SOCPs(BaseTest):
         sth.solve(solver='ECOS')
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
-        try:
-            sth.check_dual_domains(places)
-        except NotImplementedError:
-            pass
+        sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
         return sth
 
@@ -75,10 +72,7 @@ class TestKKT_SOCPs(BaseTest):
         sth.solve(solver='ECOS')
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
-        try:
-            sth.check_dual_domains(places)
-        except NotImplementedError:
-            pass
+        sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
         return sth
 
@@ -87,10 +81,7 @@ class TestKKT_SOCPs(BaseTest):
         sth.solve(solver='ECOS')
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
-        try:
-            sth.check_dual_domains(places)
-        except NotImplementedError:
-            pass
+        sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
         return sth
 
@@ -100,10 +91,7 @@ class TestKKT_SOCPs(BaseTest):
         sth.solve(solver='ECOS')
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
-        try:
-            sth.check_dual_domains(places)
-        except NotImplementedError:
-            pass
+        sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
         return sth
 
@@ -115,10 +103,7 @@ class TestKKT_ECPs(BaseTest):
         sth.solve(solver='ECOS')
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
-        try:
-            sth.check_dual_domains(places)
-        except NotImplementedError:
-            pass
+        sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
         return sth
 
@@ -159,10 +144,7 @@ class TestKKT_PCPs(BaseTest):
         sth.solve(solver='SCS', eps=1e-6)
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
-        try:
-            sth.check_dual_domains(places)
-        except NotImplementedError:
-            pass
+        sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
         return sth
 
@@ -171,10 +153,7 @@ class TestKKT_PCPs(BaseTest):
         sth.solve(solver='SCS', eps=1e-6)
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
-        try:
-            sth.check_dual_domains(places)
-        except NotImplementedError:
-            pass
+        sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
         return sth
 
@@ -183,10 +162,7 @@ class TestKKT_PCPs(BaseTest):
         sth.solve(solver='SCS', eps=1e-6)
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
-        try:
-            sth.check_dual_domains(places)
-        except NotImplementedError:
-            pass
+        sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
         return sth
 


### PR DESCRIPTION
This PR introduces the `dual_cone` methods for every `Constraint` class (which support dual variable recovery, which is all of them, with the exception of `PowConeND` and `OpRelEntrConeQuad`). A complementary `dual_violation` method if also implemented for ease in actually performing the feasibility checks.

These methods are used to update the existing `check_dual_domains` method in `solver_test_helpers.py` --- all the existing tests in `test_KKT.py` remain the same as they were when introduced as part of the `check_stationary_lagrangian` PR, and they all pass.

Again, I haven't added documentation for this method yet since it just lives within the `SolverTestHelper` class as of now.


## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.