### PR TITLE
Adds a clear error message to address a common student misuse of geo_mean

### DIFF
--- a/cvxpy/atoms/errormsg.py
+++ b/cvxpy/atoms/errormsg.py
@@ -1,0 +1,5 @@
+SECOND_ARG_SHOULD_NOT_BE_EXPRESSION_ERROR_MESSAGE = """
+The second argument has type cvxpy.Expression. However, that is not allowed.
+Most likely, you want to call this atom by using cvxpy.hstack to combine the
+two arguemnts into a vector.
+"""

--- a/cvxpy/atoms/geo_mean.py
+++ b/cvxpy/atoms/geo_mean.py
@@ -20,6 +20,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from cvxpy.atoms.atom import Atom
+from cvxpy.atoms.errormsg import SECOND_ARG_SHOULD_NOT_BE_EXPRESSION_ERROR_MESSAGE
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
 from cvxpy.utilities.power_tools import (
@@ -206,10 +207,12 @@ class geo_mean(Atom):
             The number of second order cones used to form this geometric mean
 
         """
-        if p is not None and hasattr(p, '__getitem__'):
+        Expression = cvxtypes.expression()
+        if p is not None and isinstance(p, Expression):
+            raise TypeError(SECOND_ARG_SHOULD_NOT_BE_EXPRESSION_ERROR_MESSAGE)
+        elif p is not None and hasattr(p, '__getitem__'):
             p = np.array(p)
             idxs = p > 0
-            Expression = cvxtypes.expression()
             x = Expression.cast_to_const(x)[idxs]
             p = p[idxs]
         super(geo_mean, self).__init__(x)

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -128,13 +128,13 @@ class Leaf(expression.Expression):
                            'integer':  integer, 'sparsity': sparsity}
 
         if boolean:
-            self.boolean_idx = boolean if not type(boolean) == bool else list(
+            self.boolean_idx = boolean if not isinstance(boolean, bool) else list(
                 np.ndindex(max(shape, (1,))))
         else:
             self.boolean_idx = []
 
         if integer:
-            self.integer_idx = integer if not type(integer) == bool else list(
+            self.integer_idx = integer if not isinstance(integer, bool) else list(
                 np.ndindex(max(shape, (1,))))
         else:
             self.integer_idx = []

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -26,6 +26,7 @@ from numpy import linalg as LA
 import cvxpy as cp
 import cvxpy.settings as s
 from cvxpy import Minimize, Problem
+from cvxpy.atoms.errormsg import SECOND_ARG_SHOULD_NOT_BE_EXPRESSION_ERROR_MESSAGE
 from cvxpy.expressions.constants import Constant, Parameter
 from cvxpy.expressions.variable import Variable
 from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS
@@ -203,6 +204,13 @@ class TestAtoms(BaseTest):
         self.assertTrue(type(copy) is type(atom))
         self.assertTrue(copy.args[0] is self.y)
         self.assertEqual(copy.get_data(), atom.get_data())
+
+        # Error message when geo_mean used incorrectly.
+        with pytest.raises(
+                TypeError, 
+                match=SECOND_ARG_SHOULD_NOT_BE_EXPRESSION_ERROR_MESSAGE
+            ):
+            cp.geo_mean(self.x, self.y)
 
     # Test the harmonic_mean class.
     def test_harmonic_mean(self) -> None:


### PR DESCRIPTION
## Description
Many of my students wrote `geo_mean(x, y)` when they needed to write `geo_mean(hstack([x, y]))`. They would get a type error about strict inequalities not being allowed, and be stuck on how to fix the issue. This was disappointing because we encouraged them to pay a lot of attention to error messages, so having a bad error message undermined our ability to make this point.

In order, to guide users to the correct use of the atom, I added an error message when the second argument is $p$. Further, I went through the atoms table and did not find any other atoms who are both sensibly used as a multiple argument function (I think norm taking a vector input is obvious enough there's no need to warn on it) and had a second argument which wasn't what someone might naively think. If I missed any please let me know and I'll add it to this PR.

Do we want tests of error messages? If so, I'll happily add one, but I don't recall the rules on atom testing tbh.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.