### PR TITLE
Remove setuptools version bound for cvxpy-base build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,6 +205,8 @@ jobs:
           sed -i.bak '/ecos >= /d' setup.py
           sed -i.bak '/scs >= /d' setup.py
           rm -rf setup.py.bak
+          sed -i.bak '/setuptools>/d' pyproject.toml
+          rm -rf pyproject.toml.bak
 
       - name: Verify that we can build by pip-install on each OS.
         if: ${{env.PIP_INSTALL == 'True'}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,7 @@ jobs:
           sed -i.bak '/ecos >= /d' setup.py
           sed -i.bak '/scs >= /d' setup.py
           rm -rf setup.py.bak
-          sed -i.bak '/setuptools>/d' pyproject.toml
+          sed -i.bak 's/setuptools>.*,/setuptools,/' pyproject.toml
           rm -rf pyproject.toml.bak
 
       - name: Verify that we can build by pip-install on each OS.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,7 @@ jobs:
           sed -i.bak '/ecos >= /d' setup.py
           sed -i.bak '/scs >= /d' setup.py
           rm -rf setup.py.bak
-          sed -i.bak 's/setuptools>.*,/setuptools,/' pyproject.toml
+          sed -i.bak 's/"setuptools>.*",/"setuptools",/' pyproject.toml
           rm -rf pyproject.toml.bak
 
       - name: Verify that we can build by pip-install on each OS.


### PR DESCRIPTION
The setuptools lower bound seems to be linked to the SCS installation (unless I am mistaken), so I'm hoping it can be dropped for the cvxpy-base build, or at least loosened.