### PR TITLE
CallbackParam Update

### DIFF
--- a/cvxpy/expressions/constants/callback_param.py
+++ b/cvxpy/expressions/constants/callback_param.py
@@ -19,11 +19,24 @@ from cvxpy.expressions.constants.parameter import Parameter
 
 class CallbackParam(Parameter):
     """
-    A parameter whose value is obtained by evaluating a function.
+    A parameter whose value is derived from a callback function.
+
+    Enables writing replacing expression that would not be DPP
+    by a new parameter that automatically updates its value.
+    
+    Example:
+    With p and q parameters, p * q is not DPP, but
+    pq = CallbackParameter(callback=p * q) is DPP.
+    
+    This is useful when only p and q should be exposed
+    to the user, but pq is needed internally.
     """
-    PARAM_COUNT = 0
 
     def __init__(self, callback, shape=(), **kwargs) -> None:
+        """
+        callback: function that returns the value of the parameter.
+        """
+        
         self._callback = callback
         super(CallbackParam, self).__init__(shape, **kwargs)
 
@@ -32,3 +45,7 @@ class CallbackParam(Parameter):
         """Evaluate the callback to get the value.
         """
         return self._validate_value(self._callback())
+
+    @value.setter
+    def value(self, _val):
+        raise NotImplementedError("Cannot set the value of a CallbackParam.")

--- a/cvxpy/expressions/constants/callback_param.py
+++ b/cvxpy/expressions/constants/callback_param.py
@@ -29,7 +29,7 @@ class CallbackParam(Parameter):
 
     Example:
     With p and q parameters, p * q is not DPP, but
-    pq = CallbackParameter(callback=p * q) is DPP.
+    pq = CallbackParameter(callback=callback=lambda: p.value * q.value) is DPP.
 
     This is useful when only p and q should be exposed
     to the user, but pq is needed internally.

--- a/cvxpy/expressions/constants/callback_param.py
+++ b/cvxpy/expressions/constants/callback_param.py
@@ -13,6 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import annotations
+
+from typing import Callable
 
 from cvxpy.expressions.constants.parameter import Parameter
 
@@ -23,20 +26,20 @@ class CallbackParam(Parameter):
 
     Enables writing replacing expression that would not be DPP
     by a new parameter that automatically updates its value.
-    
+
     Example:
     With p and q parameters, p * q is not DPP, but
     pq = CallbackParameter(callback=p * q) is DPP.
-    
+
     This is useful when only p and q should be exposed
     to the user, but pq is needed internally.
     """
 
-    def __init__(self, callback, shape=(), **kwargs) -> None:
+    def __init__(self, callback: Callable, shape: int | tuple[int, ...] = (), **kwargs) -> None:
         """
         callback: function that returns the value of the parameter.
         """
-        
+
         self._callback = callback
         super(CallbackParam, self).__init__(shape, **kwargs)
 

--- a/cvxpy/expressions/constants/callback_param.py
+++ b/cvxpy/expressions/constants/callback_param.py
@@ -29,7 +29,7 @@ class CallbackParam(Parameter):
 
     Example:
     With p and q parameters, p * q is not DPP, but
-    pq = CallbackParameter(callback=callback=lambda: p.value * q.value) is DPP.
+    pq = CallbackParameter(callback=lambda: p.value * q.value) is DPP.
 
     This is useful when only p and q should be exposed
     to the user, but pq is needed internally.

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -836,3 +836,25 @@ class TestDgp(BaseTest):
         expr = cp.gmatmul(A, x_par)
         self.assertFalse(expr.is_dgp(dpp=True))
         self.assertTrue(expr.is_dgp(dpp=False))
+
+
+class TestCallbackParam(BaseTest):
+    x = cp.Variable()
+    p = cp.Parameter()
+    q = cp.Parameter()
+
+    def test_callback_param(self) -> None:
+        callback_param = cp.CallbackParam(callback=lambda _ : self.p * self.q)
+        problem = cp.Problem(cp.Minimize(self.x), [self.x >= callback_param])
+        assert problem.is_dpp()
+        self.p.value = 1.0
+        self.q.value = 4.0
+        problem.solve()
+        self.assertAlmostEqual(self.x.value, 4.0)
+
+        self.p.value = 2.0
+        problem.solve()
+        self.assertAlmostEqual(self.x.value, 8.0)
+
+        with pytest.raises(NotImplementedError, match="Cannot set the value of a CallbackParam"):
+            callback_param.value = 1.0

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -844,7 +844,7 @@ class TestCallbackParam(BaseTest):
     q = cp.Parameter()
 
     def test_callback_param(self) -> None:
-        callback_param = cp.CallbackParam(callback=lambda _ : self.p * self.q)
+        callback_param = cp.CallbackParam(callback=lambda: self.p.value * self.q.value)
         problem = cp.Problem(cp.Minimize(self.x), [self.x >= callback_param])
         assert problem.is_dpp()
         self.p.value = 1.0

--- a/doc/source/api_reference/cvxpy.expressions.rst
+++ b/doc/source/api_reference/cvxpy.expressions.rst
@@ -64,6 +64,6 @@ CallbackParam
 -----------------------------------
 
 .. autoclass:: cvxpy.expressions.constants.callback_param.CallbackParam
-    :members: callback, shape, size, ndim, T, value, project, project_and_assign, round
+    :members: shape, size, ndim, T, value, project, project_and_assign, round
     :undoc-members:
     :show-inheritance:

--- a/doc/source/api_reference/cvxpy.expressions.rst
+++ b/doc/source/api_reference/cvxpy.expressions.rst
@@ -59,3 +59,11 @@ Constant
     :members: shape, size, ndim, T, value
     :undoc-members:
     :show-inheritance:
+
+CallbackParam
+-----------------------------------
+
+.. autoclass:: cvxpy.expressions.constants.callback_param.CallbackParam
+    :members: callback, shape, size, ndim, T, value, project, project_and_assign, round
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
## Description
Adds test and API reference for `CallbackParam`. Since it already is in the `cvxpy` namespace, we cannot make a breaking change to the class (e.g., switching from a callable to an expression).
Issue link (if applicable): #2211 

<img width="849" alt="image" src="https://github.com/cvxpy/cvxpy/assets/44360364/30388110-83a8-4b39-a8dd-0b8cc9935919">



## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.