### PR TITLE
[CI] Benchmark workflow needs to inherit secrets.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -8,3 +8,4 @@ on:
 jobs:
   benchmark:
     uses: cvxpy/actions/.github/workflows/benchmarks.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Description
The benchmark deploy step failed because of a missing secret: https://github.com/cvxpy/cvxpy/actions/runs/6027612733/job/16353179443

The secret allows to deploy to the `gh-pages` branch of `cvxpy/benchmarks` from `cvxpy/cvxpy`. These secrets must be passed to the reusable workflow explicitly.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.