### PR TITLE
Mark sum_largest and sum_smallest as piece-wise linear

### DIFF
--- a/cvxpy/atoms/sum_largest.py
+++ b/cvxpy/atoms/sum_largest.py
@@ -94,6 +94,11 @@ class sum_largest(Atom):
         """
         return False
 
+    def is_pwl(self) -> bool:
+        """Is the atom piecewise linear?
+        """
+        return all(arg.is_pwl() for arg in self.args)
+
     def get_data(self):
         """Returns the parameter k.
         """

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -850,6 +850,10 @@ class TestAtoms(BaseTest):
         copy = atom.copy()
         self.assertTrue(type(copy) is type(atom))
 
+        # Check that sum_largest is PWL so can be canonicalized as a QP.
+        atom = cp.sum_largest(self.x, 2)
+        assert atom.is_pwl()
+
     def test_sum_smallest(self) -> None:
         """Test the sum_smallest atom and related atoms.
         """
@@ -862,6 +866,10 @@ class TestAtoms(BaseTest):
             cp.lambda_sum_smallest(Variable((2, 2)), 2.4)
         self.assertEqual(str(cm.exception),
                          "Second argument must be a positive integer.")
+
+        # Check that sum_smallest is PWL so can be canonicalized as a QP.
+        atom = cp.sum_smallest(self.x, 2)
+        assert atom.is_pwl()
 
     def test_index(self) -> None:
         """Test the copy function for index.


### PR DESCRIPTION
## Description
sum_largest and sum_smallest are not marked as piece-wise linear, which makes it so cvxpy thinks they can't be canonicalized to a QP.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.