### PR TITLE
Atoms datatable

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,32 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -31,3 +31,5 @@ python:
   install:
     - method: pip
       path: .
+    - requirements: doc/requirements.txt
+    - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -28,5 +28,6 @@ sphinx:
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
-   install:
-   - requirements: doc/requirements.txt
+  install:
+    - method: pip
+      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-   configuration: docs/conf.py
+   configuration: doc/source/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
 # formats:
@@ -29,4 +29,4 @@ sphinx:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: docs/requirements.txt
+   - requirements: doc/requirements.txt

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 sphinx
+sphinxcontrib.jquery
 cloud_sptheme
 alabaster
 numpydoc

--- a/doc/source/_static/main.js
+++ b/doc/source/_static/main.js
@@ -1,0 +1,3 @@
+$(document).ready( function () {
+    $('table.datatable').DataTable();
+} );

--- a/doc/source/api_reference/cvxpy.atoms.elementwise.rst
+++ b/doc/source/api_reference/cvxpy.atoms.elementwise.rst
@@ -4,6 +4,21 @@ All of the atoms listed here operate elementwise on expressions. For example,
 :class:`~cvxpy.atoms.elementwise.exp.exp` exponentiates each entry of
 expressions that are supplied to it.
 
+.. _abs:
+
+abs
+-------------------------------------
+
+.. autoclass:: cvxpy.abs
+    :show-inheritance:
+
+.. _entr:
+
+entr
+--------------------------------------
+
+.. autoclass:: cvxpy.entr
+    :show-inheritance:
 
 .. _exp:
 

--- a/doc/source/api_reference/cvxpy.atoms.elementwise.rst
+++ b/doc/source/api_reference/cvxpy.atoms.elementwise.rst
@@ -4,13 +4,6 @@ All of the atoms listed here operate elementwise on expressions. For example,
 :class:`~cvxpy.atoms.elementwise.exp.exp` exponentiates each entry of
 expressions that are supplied to it.
 
-.. _entr:
-
-entr
---------------------------------------
-
-.. autoclass:: cvxpy.entr
-    :show-inheritance:
 
 .. _exp:
 

--- a/doc/source/api_reference/cvxpy.atoms.elementwise.rst
+++ b/doc/source/api_reference/cvxpy.atoms.elementwise.rst
@@ -4,14 +4,6 @@ All of the atoms listed here operate elementwise on expressions. For example,
 :class:`~cvxpy.atoms.elementwise.exp.exp` exponentiates each entry of
 expressions that are supplied to it.
 
-.. _abs:
-
-abs
--------------------------------------
-
-.. autoclass:: cvxpy.abs
-    :show-inheritance:
-
 .. _entr:
 
 entr

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -17,7 +17,7 @@ import mock
  
 MOCK_MODULES = ['numpy', 'scipy', 'cvxpy']
 for mod_name in MOCK_MODULES:
-sys.modules[mod_name] = mock.Mock()
+    sys.modules[mod_name] = mock.Mock()
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,11 +13,7 @@
 
 import os
 import sys
-import mock
- 
-MOCK_MODULES = ['numpy', 'scipy', 'cvxpy']
-for mod_name in MOCK_MODULES:
-    sys.modules[mod_name] = mock.Mock()
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,7 +13,11 @@
 
 import os
 import sys
-
+import mock
+ 
+MOCK_MODULES = ['numpy', 'scipy', 'cvxpy']
+for mod_name in MOCK_MODULES:
+sys.modules[mod_name] = mock.Mock()
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -179,7 +179,17 @@ html_title = f'CVXPY {version} documentation'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ['_static']
+
+html_css_files = [
+    'https://cdn.datatables.net/1.10.23/css/jquery.dataTables.min.css',
+]
+
+html_js_files = [
+    'https://cdn.datatables.net/1.10.23/js/jquery.dataTables.min.js',
+    'main.js',
+]
+
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -72,6 +72,7 @@ and returns a scalar.
    :trim:
 
 .. list-table::
+   :class: datatable
    :header-rows: 1
 
    * - Function
@@ -495,6 +496,7 @@ For example, if ``X`` and ``Y`` are both 3 by 3 matrix variables, then ``maximum
 scalars, which are promoted.
 
 .. list-table::
+   :class: datatable
    :header-rows: 1
 
    * - Function
@@ -791,6 +793,7 @@ would have different signs in different entries (for example, when stacking a po
 Expression and a negative Expression) then the returned Expression will have unknown sign.
 
 .. list-table::
+   :class: datatable
    :header-rows: 1
 
    * - Function


### PR DESCRIPTION
Implemented the atom data-table for atomic functions.

The steps were to add a static javascript file which renders the RST ``list-table`` into a dataTable.

The next goal will be to try and do a global atoms table and have the respective types only be views (filters) on that global table. Types can include DGP, DCP, DQCP, and also have sub-types such as matrix and scalar. 
