### PR TITLE
Add deprecation warning for ECOS

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -894,7 +894,8 @@ class Problem(u.Canonical):
                                        enforce_dpp=enforce_dpp,
                                        ignore_dpp=ignore_dpp,
                                        canon_backend=canon_backend,
-                                       solver_opts=solver_opts)
+                                       solver_opts=solver_opts,
+                                       specified_solver=solver)
 
     @staticmethod
     def _sort_candidate_solvers(solvers) -> None:

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -52,14 +52,17 @@ DPP_ERROR_MSG = (
     "faster than the first one. For more information, see the "
     "documentation on Discplined Parametrized Programming, at\n"
     "\thttps://www.cvxpy.org/tutorial/advanced/index.html#"
-    "disciplined-parametrized-programming")
+    "disciplined-parametrized-programming"
+)
 
-ECOS_DEPRECATION_MSG = """
-Your problem is being solved with the ECOS solver by default. Starting in 
-CVXPY 1.5.0, Clarabel will be used as the default solver instead. To continue 
-using ECOS, specify the ECOS solver explicitly using the ``solver=cp.ECOS`` 
-argument to the ``problem.solve`` method.
-"""
+ECOS_DEPRECATION_MSG = (
+    """
+    Your problem is being solved with the ECOS solver by default. Starting in 
+    CVXPY 1.5.0, Clarabel will be used as the default solver instead. To continue 
+    using ECOS, specify the ECOS solver explicitly using the ``solver=cp.ECOS`` 
+    argument to the ``problem.solve`` method.
+    """
+)
 
 def _is_lp(self):
     """Is problem a linear program?

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -44,6 +44,7 @@ from cvxpy.reductions.solvers.defines import (
     INSTALLED_SOLVERS,
     SOLVER_MAP_CONIC,
 )
+from cvxpy.reductions.solvers.solving_chain import ECOS_DEPRECATION_MSG
 from cvxpy.tests.base_test import BaseTest
 
 
@@ -2114,3 +2115,25 @@ class TestProblem(BaseTest):
             c = cp.sum(a)
             cp.Problem(cp.Maximize(0), [c >= 0])
             assert len(w) == 0
+
+    def test_ecos_warning(self) -> None:
+        """Test that a warning is raised when ECOS
+           is called by default.
+        """
+        # Setup a QCQP.
+        x = cp.Variable()
+        prob = cp.Problem(cp.Maximize(x), [x**2 <= 1])
+
+        # Check if ECOS is the top default solver.
+        candidate_solvers = prob._find_candidate_solvers(solver=None, gp=False)
+        prob._sort_candidate_solvers(candidate_solvers)
+        if candidate_solvers['conic_solvers'][0] == cp.ECOS:
+            with warnings.catch_warnings(record=True) as w:
+                prob.solve()
+                assert isinstance(w[0].message, FutureWarning)
+                assert str(w[0].message) == ECOS_DEPRECATION_MSG
+            
+            # No warning if ECOS solver specified.
+            with warnings.catch_warnings(record=True) as w:
+                prob.solve(solver=cp.ECOS)
+                assert len(w) == 0


### PR DESCRIPTION
## Description
This PR adds a FutureWarning when ECOS is called by default, since Clarabel will become the new default LP/SOCP solver in CVXPY 1.5.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.