### PR TITLE
New atoms and adds NumPy API methods

### DIFF
--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -33,7 +33,7 @@ from cvxpy.atoms.affine.reshape import deep_flatten, reshape
 from cvxpy.atoms.affine.sum import sum
 from cvxpy.atoms.affine.trace import trace
 from cvxpy.atoms.affine.transpose import transpose
-from cvxpy.atoms.affine.upper_tri import upper_tri
+from cvxpy.atoms.affine.upper_tri import upper_tri, vec_to_upper_tri
 from cvxpy.atoms.affine.vec import vec
 from cvxpy.atoms.affine.vstack import vstack
 from cvxpy.atoms.affine.wraps import (hermitian_wrap, psd_wrap,

--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -100,6 +100,8 @@ from cvxpy.atoms.sum_squares import sum_squares
 from cvxpy.atoms.total_variation import tv
 from cvxpy.atoms.tr_inv import tr_inv
 from cvxpy.atoms.von_neumann_entr import von_neumann_entr
+from cvxpy.atoms.stats import mean, std, var
+from cvxpy.atoms.ptp import ptp
 
 # TODO(akshayka): Perhaps couple this information with the atom classes
 # themselves.
@@ -111,6 +113,7 @@ SOC_ATOMS = [
     quad_over_lin,
     power,
     huber,
+    std,
 ]
 
 EXP_ATOMS = [
@@ -142,4 +145,5 @@ NONPOS_ATOMS = [
     norm1,
     abs,
     huber,
+    ptp
 ]

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -111,7 +111,10 @@ class upper_tri(AffAtom):
 
 
 def vec_to_upper_tri(expr, strict: bool = False):
-    """Reshapes a vector into an upper triangular matrix in XXX order
+    """Reshapes a vector into an upper triangular matrix in
+    row-major order.
+
+    Inverts cp.upper_tri.
     """
     expr = Expression.cast_to_const(expr)
 

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -112,8 +112,8 @@ class upper_tri(AffAtom):
 
 def vec_to_upper_tri(expr, strict: bool = False):
     """Reshapes a vector into an upper triangular matrix in
-    row-major order.
-
+    row-major order. The strict argument specifies whether an upper or a strict upper triangular
+    matrix should be returned.
     Inverts cp.upper_tri.
     """
     expr = Expression.cast_to_const(expr)

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -111,6 +111,8 @@ class upper_tri(AffAtom):
 
 
 def vec_to_upper_tri(expr, strict: bool = False):
+    """Reshapes a vector into an upper triangular matrix in XXX order
+    """
     expr = Expression.cast_to_const(expr)
 
     if not expr.is_vector():

--- a/cvxpy/atoms/affine/wraps.py
+++ b/cvxpy/atoms/affine/wraps.py
@@ -64,6 +64,20 @@ class Wrap(AffAtom):
         return (arg_objs[0], [])
 
 
+class nonneg_wrap(Wrap):
+    """Asserts that the expression is nonnegative.
+    """
+    def is_nonneg(self) -> bool:
+        return True
+
+
+class nonpos_wrap(Wrap):
+    """Asserts that the expression is nonpositive.
+    """
+    def is_nonpos(self) -> bool:
+        return True
+
+
 class psd_wrap(Wrap):
     """Asserts that a square matrix is PSD.
     """
@@ -81,6 +95,12 @@ class psd_wrap(Wrap):
 
     def is_nsd(self) -> bool:
         return False
+
+    def is_complex(self) -> bool:
+        return self.args[0].is_complex()
+
+    def is_symmetric(self) -> bool:
+        return not self.args[0].is_complex()
 
     def is_hermitian(self) -> bool:
         return True

--- a/cvxpy/atoms/affine/wraps.py
+++ b/cvxpy/atoms/affine/wraps.py
@@ -37,6 +37,9 @@ class Wrap(AffAtom):
         """
         return values[0]
 
+    def is_complex(self) -> bool:
+        return self.args[0].is_complex()
+
     def shape_from_args(self) -> Tuple[int, ...]:
         """Shape of input.
         """
@@ -95,9 +98,6 @@ class psd_wrap(Wrap):
 
     def is_nsd(self) -> bool:
         return False
-
-    def is_complex(self) -> bool:
-        return self.args[0].is_complex()
 
     def is_symmetric(self) -> bool:
         return not self.args[0].is_complex()

--- a/cvxpy/atoms/norm.py
+++ b/cvxpy/atoms/norm.py
@@ -28,7 +28,7 @@ from cvxpy.atoms.sigma_max import sigma_max
 from cvxpy.expressions.expression import Expression
 
 
-def norm(x, p: Union[int, str] = 2, axis=None):
+def norm(x, p: Union[int, str] = 2, axis=None, keepdims: bool = False):
     """Wrapper on the different norm atoms.
 
     Parameters
@@ -41,6 +41,8 @@ def norm(x, p: Union[int, str] = 2, axis=None):
         'fro' (for frobenius), 'nuc' (sum of singular values), np.inf or
         'inf' (infinity norm).
     axis : The axis along which to apply the norm, if any.
+    keepdims: If this is set to True, the axes which are reduced are left 
+        in the result as dimensions with size one.
 
     Returns
     -------
@@ -66,15 +68,16 @@ def norm(x, p: Union[int, str] = 2, axis=None):
             raise RuntimeError('Unsupported matrix norm.')
     else:
         if p == 1 or x.is_scalar():
-            return norm1(x, axis=axis)
+            return norm1(x, axis=axis, keepdims=keepdims)
         elif str(p).lower() == "inf":
-            return norm_inf(x, axis)
+            return norm_inf(x, axis=axis, keepdims=keepdims)
         elif str(p).lower() == "fro":
+            # TODO should not work for vectors.
             return pnorm(vec(x), 2, axis)
         elif isinstance(p, str):
             raise RuntimeError(f'Unsupported norm option {p} for non-matrix.')
         else:
-            return pnorm(x, p, axis)
+            return pnorm(x, p, axis=axis, keepdims=keepdims)
 
 
 def norm2(x, axis=None):

--- a/cvxpy/atoms/ptp.py
+++ b/cvxpy/atoms/ptp.py
@@ -1,0 +1,28 @@
+"""
+Copyright 2013 CVXPY Developers
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+from cvxpy.atoms.max import max as cvxpy_max
+from cvxpy.atoms.min import min as cvxpy_min
+
+
+def ptp(x, axis=None, keepdims=False):
+    """
+    Range of values (maximum - minimum) along an axis.
+
+    The name of the function comes from the acronym for ‘peak to peak’.
+    """
+    return cvxpy_max(x, axis, keepdims) - cvxpy_min(x, axis, keepdims)

--- a/cvxpy/atoms/ptp.py
+++ b/cvxpy/atoms/ptp.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 
-from cvxpy.atoms.affine.warp import nonneg_wrap
+from cvxpy.atoms.affine.wraps import nonneg_wrap
 from cvxpy.atoms.max import max as cvxpy_max
 from cvxpy.atoms.min import min as cvxpy_min
 

--- a/cvxpy/atoms/stats.py
+++ b/cvxpy/atoms/stats.py
@@ -17,6 +17,7 @@ limitations under the License.
 import numpy as np
 
 from cvxpy.atoms.affine.sum import sum as cvxpy_sum
+from cvxpy.atoms.elementwise.square import square
 from cvxpy.atoms.norm import norm
 from cvxpy.atoms.sum_squares import sum_squares
 
@@ -52,7 +53,8 @@ def var(x, axis=None, keepdims=False, ddof=0):
     if axis is None:
         return sum_squares(x - mean(x)) / (x.size - ddof)
     elif axis in (0, 1):
-        return sum_squares(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims) \
+        # TODO switch to sum_squares when axis and keepdims are implemented.
+        return square(norm(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims)) \
                 / (x.shape[axis] - ddof)
     else:
         raise RuntimeError("Invalid axis value.")

--- a/cvxpy/atoms/stats.py
+++ b/cvxpy/atoms/stats.py
@@ -57,7 +57,7 @@ def var(x, axis=None, keepdims=False, ddof=0):
             Use square(std(...)) instead.
             """
         )
-        # TODO switch to sum_squares when axis and keepdims are implemented.
+        # TODO when sum_squares implements axis and keepdims uncomment:
         # return sum_squares(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims) \
         #         / (x.shape[axis] - ddof)
     else:

--- a/cvxpy/atoms/stats.py
+++ b/cvxpy/atoms/stats.py
@@ -23,19 +23,21 @@ from cvxpy.atoms.sum_squares import sum_squares
 
 def mean(x, axis=None, keepdims=False):
     """
-    Returns the mean of x
+    Returns the mean of x.
     """
     if axis is None:
         return cvxpy_sum(x, axis, keepdims) / x.size
     elif axis in (0, 1):
         return cvxpy_sum(x, axis, keepdims) / x.shape[axis]
     else:
-        raise RuntimeError("Invalid axis value.")
+        raise ValueError("Invalid axis value.")
 
 
 def std(x, axis=None, keepdims=False, ddof=0):
     """
-    Returns the standard deviation of x
+    Returns the standard deviation of x.
+
+    `ddof` is the quantity to use in the Bessel correction.
     """
     if axis is None:
         return norm((x - mean(x)).flatten(), 2) / np.sqrt(x.size - ddof)
@@ -43,11 +45,13 @@ def std(x, axis=None, keepdims=False, ddof=0):
         return norm(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims) \
                 / np.sqrt(x.shape[axis] - ddof)
     else:
-        raise RuntimeError("Invalid axis value.")
+        raise ValueError("Invalid axis value.")
 
 def var(x, axis=None, keepdims=False, ddof=0):
     """
-    Returns the standard deviation of x
+    Returns the variance of x.
+
+    `ddof` is the quantity to use in the Bessel correction.
     """
     if axis is None:
         return sum_squares(x - mean(x)) / (x.size - ddof)
@@ -61,4 +65,4 @@ def var(x, axis=None, keepdims=False, ddof=0):
         # return sum_squares(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims) \
         #         / (x.shape[axis] - ddof)
     else:
-        raise RuntimeError("Invalid axis value.")
+        raise ValueError("Invalid axis value.")

--- a/cvxpy/atoms/stats.py
+++ b/cvxpy/atoms/stats.py
@@ -1,0 +1,58 @@
+"""
+Copyright 2013 CVXPY Developers
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import numpy as np
+
+from cvxpy.atoms.affine.sum import sum as cvxpy_sum
+from cvxpy.atoms.norm import norm
+from cvxpy.atoms.sum_squares import sum_squares
+
+
+def mean(x, axis=None, keepdims=False):
+    """
+    Returns the mean of x
+    """
+    if axis is None:
+        return cvxpy_sum(x, axis, keepdims) / x.size
+    elif axis in (0, 1):
+        return cvxpy_sum(x, axis, keepdims) / x.shape[axis]
+    else:
+        raise RuntimeError("Invalid axis value.")
+
+
+def std(x, axis=None, keepdims=False, ddof=0):
+    """
+    Returns the standard deviation of x
+    """
+    if axis is None:
+        return norm(x - mean(x), 2) / np.sqrt(x.size - ddof)
+    elif axis in (0, 1):
+        return norm(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims) \
+                / np.sqrt(x.shape[axis] - ddof)
+    else:
+        raise RuntimeError("Invalid axis value.")
+
+def var(x, axis=None, keepdims=False, ddof=0):
+    """
+    Returns the standard deviation of x
+    """
+    if axis is None:
+        return sum_squares(x - mean(x)) / (x.size - ddof)
+    elif axis in (0, 1):
+        return sum_squares(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims) \
+                / (x.shape[axis] - ddof)
+    else:
+        raise RuntimeError("Invalid axis value.")

--- a/cvxpy/atoms/stats.py
+++ b/cvxpy/atoms/stats.py
@@ -38,7 +38,7 @@ def std(x, axis=None, keepdims=False, ddof=0):
     Returns the standard deviation of x
     """
     if axis is None:
-        return norm(x - mean(x), 2) / np.sqrt(x.size - ddof)
+        return norm((x - mean(x)).flatten(), 2) / np.sqrt(x.size - ddof)
     elif axis in (0, 1):
         return norm(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims) \
                 / np.sqrt(x.shape[axis] - ddof)

--- a/cvxpy/atoms/stats.py
+++ b/cvxpy/atoms/stats.py
@@ -17,7 +17,6 @@ limitations under the License.
 import numpy as np
 
 from cvxpy.atoms.affine.sum import sum as cvxpy_sum
-from cvxpy.atoms.elementwise.square import square
 from cvxpy.atoms.norm import norm
 from cvxpy.atoms.sum_squares import sum_squares
 
@@ -53,8 +52,13 @@ def var(x, axis=None, keepdims=False, ddof=0):
     if axis is None:
         return sum_squares(x - mean(x)) / (x.size - ddof)
     elif axis in (0, 1):
+        raise NotImplementedError(
+            """axis and keepdims are not yet supported for var.
+            Use square(std(...)) instead.
+            """
+        )
         # TODO switch to sum_squares when axis and keepdims are implemented.
-        return square(norm(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims)) \
-                / (x.shape[axis] - ddof)
+        # return sum_squares(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims) \
+        #         / (x.shape[axis] - ddof)
     else:
         raise RuntimeError("Invalid axis value.")

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -765,12 +765,12 @@ class Expression(u.Canonical):
         from cvxpy import conj
         return conj(self)
 
-    def cumsum(self):
+    def cumsum(self, axis=0):
         """
-        Equivalent to `cp.cumsum(self)`
+        Equivalent to `cp.cumsum(self, axis)`
         """
         from cvxpy import cumsum
-        return cumsum(self)
+        return cumsum(self, axis)
 
     def max(self, axis=None, *, keepdims=False):
         """
@@ -779,12 +779,12 @@ class Expression(u.Canonical):
         from cvxpy import max as max_
         return max_(self, axis, keepdims)
 
-    def mean(self):
+    def mean(self, axis=0, *, keepdims=False):
         """
-        Returns the mean of the expression
+        Equivalent to `cp.mean(self, axis, keepdims)`
         """
-        from cvxpy import sum as sum_
-        return sum_(self) / self.size
+        from cvxpy import mean
+        return mean(self, axis, keepdims)
 
     def min(self, axis=None, *, keepdims=False):
         """
@@ -802,11 +802,10 @@ class Expression(u.Canonical):
 
     def ptp(self, axis=None, *, keepdims=False):
         """
-        Peak to peak (maximum - minimum) value along a given axis.
+        Equivalent to `cp.ptp(self, axis, keepdims)`
         """
-        from cvxpy import max as max_
-        from cvxpy import min as min_
-        return max_(self, axis, keepdims) - min_(self, axis, keepdims)
+        from cvxpy import ptp
+        return ptp(self, axis, keepdims)
 
     def reshape(self, shape, order='F'):
         """
@@ -815,16 +814,16 @@ class Expression(u.Canonical):
         from cvxpy import reshape
         return reshape(self, shape, order)
 
-    def std(self):
+    def std(self, axis=None, *, keepdims=False):
         """
-        Returns the standard deviation of the expression
+        Equivalent to `cp.std(self, axis, keepdims)`
         """
-        from cvxpy import norm
-        return norm(self - self.mean(), 2) / np.sqrt(self.size)
+        from cvxpy import std
+        return std(self, axis=axis, keepdims=keepdims)
  
     def sum(self, axis=None, *, keepdims=False):
         """
-        Equivalent to `cp.sum(self, axis
+        Equivalent to `cp.sum(self, axis, keepdims)`
         """
         from cvxpy import sum as sum_
         return sum_(self, axis, keepdims)
@@ -838,8 +837,8 @@ class Expression(u.Canonical):
 
     def var(self):
         """
-        Returns the standard deviation of the expression
+        Equivalent to `cp.var(self)`
         """
-        from cvxpy import sum_squares
-        return sum_squares(self - self.mean()) / self.size
+        from cvxpy import var
+        return var(self)
 

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -779,7 +779,7 @@ class Expression(u.Canonical):
         from cvxpy import max as max_
         return max_(self, axis, keepdims)
 
-    def mean(self, axis=0, *, keepdims=False):
+    def mean(self, axis=None, *, keepdims=False):
         """
         Equivalent to `cp.mean(self, axis, keepdims)`
         """
@@ -814,12 +814,12 @@ class Expression(u.Canonical):
         from cvxpy import reshape
         return reshape(self, shape, order)
 
-    def std(self, axis=None, *, keepdims=False):
+    def std(self, axis=None, *, ddof=0, keepdims=False):
         """
         Equivalent to `cp.std(self, axis, keepdims)`
         """
         from cvxpy import std
-        return std(self, axis=axis, keepdims=keepdims)
+        return std(self, axis=axis, ddof=ddof, keepdims=keepdims)
  
     def sum(self, axis=None, *, keepdims=False):
         """
@@ -835,10 +835,10 @@ class Expression(u.Canonical):
         from cvxpy import trace
         return trace(self)
 
-    def var(self):
+    def var(self, *, ddof=0):
         """
         Equivalent to `cp.var(self)`
         """
         from cvxpy import var
-        return var(self)
+        return var(self, ddof=ddof)
 

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -750,3 +750,96 @@ class Expression(u.Canonical):
 
     def __abs__(self):
         raise TypeError(__ABS_ERROR__)
+
+    def conj(self):
+        """
+        Equivalent to `cp.conj(self)`
+        """
+        from cvxpy import conj
+        return conj(self)
+
+    def conjugate(self):
+        """
+        Equivalent to `cp.conj(self)`
+        """
+        from cvxpy import conj
+        return conj(self)
+
+    def cumsum(self):
+        """
+        Equivalent to `cp.cumsum(self)`
+        """
+        from cvxpy import cumsum
+        return cumsum(self)
+
+    def max(self, axis=None, *, keepdims=False):
+        """
+        Equivalent to `cp.max(self, axis, keepdims)`
+        """
+        from cvxpy import max as max_
+        return max_(self, axis, keepdims)
+
+    def mean(self):
+        """
+        Returns the mean of the expression
+        """
+        from cvxpy import sum as sum_
+        return sum_(self) / self.size
+
+    def min(self, axis=None, *, keepdims=False):
+        """
+        Equivalent to `cp.min(self, axis, keepdims)`
+        """
+        from cvxpy import min as min_
+        return min_(self, axis, keepdims)
+
+    def prod(self, axis=None, *, keepdims=False):
+        """
+        Equivalent to `cp.prod(self, axis, keepdims)`
+        """
+        from cvxpy import prod
+        return prod(self, axis, keepdims)
+
+    def ptp(self, axis=None, *, keepdims=False):
+        """
+        Peak to peak (maximum - minimum) value along a given axis.
+        """
+        from cvxpy import max as max_
+        from cvxpy import min as min_
+        return max_(self, axis, keepdims) - min_(self, axis, keepdims)
+
+    def reshape(self, shape, order='F'):
+        """
+        Equivalent to `cp.reshape(self, shape, order)`
+        """
+        from cvxpy import reshape
+        return reshape(self, shape, order)
+
+    def std(self):
+        """
+        Returns the standard deviation of the expression
+        """
+        from cvxpy import norm
+        return norm(self - self.mean(), 2) / np.sqrt(self.size)
+ 
+    def sum(self, axis=None, *, keepdims=False):
+        """
+        Equivalent to `cp.sum(self, axis
+        """
+        from cvxpy import sum as sum_
+        return sum_(self, axis, keepdims)
+
+    def trace(self):
+        """
+        Equivalent to `cp.trace(self)`
+        """
+        from cvxpy import trace
+        return trace(self)
+
+    def var(self):
+        """
+        Returns the standard deviation of the expression
+        """
+        from cvxpy import sum_squares
+        return sum_squares(self - self.mean()) / self.size
+

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -753,91 +753,91 @@ class Expression(u.Canonical):
 
     def conj(self):
         """
-        Equivalent to `cp.conj(self)`
+        Equivalent to `cp.conj(self)`.
         """
         from cvxpy import conj
         return conj(self)
 
     def conjugate(self):
         """
-        Equivalent to `cp.conj(self)`
+        Equivalent to `cp.conj(self)`.
         """
         from cvxpy import conj
         return conj(self)
 
     def cumsum(self, axis=0):
         """
-        Equivalent to `cp.cumsum(self, axis)`
+        Equivalent to `cp.cumsum(self, axis)`.
         """
         from cvxpy import cumsum
         return cumsum(self, axis)
 
     def max(self, axis=None, *, keepdims=False):
         """
-        Equivalent to `cp.max(self, axis, keepdims)`
+        Equivalent to `cp.max(self, axis, keepdims)`.
         """
         from cvxpy import max as max_
         return max_(self, axis, keepdims)
 
     def mean(self, axis=None, *, keepdims=False):
         """
-        Equivalent to `cp.mean(self, axis, keepdims)`
+        Equivalent to `cp.mean(self, axis, keepdims)`.
         """
         from cvxpy import mean
         return mean(self, axis, keepdims)
 
     def min(self, axis=None, *, keepdims=False):
         """
-        Equivalent to `cp.min(self, axis, keepdims)`
+        Equivalent to `cp.min(self, axis, keepdims)`.
         """
         from cvxpy import min as min_
         return min_(self, axis, keepdims)
 
     def prod(self, axis=None, *, keepdims=False):
         """
-        Equivalent to `cp.prod(self, axis, keepdims)`
+        Equivalent to `cp.prod(self, axis, keepdims)`.
         """
         from cvxpy import prod
         return prod(self, axis, keepdims)
 
     def ptp(self, axis=None, *, keepdims=False):
         """
-        Equivalent to `cp.ptp(self, axis, keepdims)`
+        Equivalent to `cp.ptp(self, axis, keepdims)`.
         """
         from cvxpy import ptp
         return ptp(self, axis, keepdims)
 
     def reshape(self, shape, order='F'):
         """
-        Equivalent to `cp.reshape(self, shape, order)`
+        Equivalent to `cp.reshape(self, shape, order)`.
         """
         from cvxpy import reshape
         return reshape(self, shape, order)
 
     def std(self, axis=None, *, ddof=0, keepdims=False):
         """
-        Equivalent to `cp.std(self, axis, keepdims)`
+        Equivalent to `cp.std(self, axis, keepdims)`.
         """
         from cvxpy import std
         return std(self, axis=axis, ddof=ddof, keepdims=keepdims)
  
     def sum(self, axis=None, *, keepdims=False):
         """
-        Equivalent to `cp.sum(self, axis, keepdims)`
+        Equivalent to `cp.sum(self, axis, keepdims)`.
         """
         from cvxpy import sum as sum_
         return sum_(self, axis, keepdims)
 
     def trace(self):
         """
-        Equivalent to `cp.trace(self)`
+        Equivalent to `cp.trace(self)`.
         """
         from cvxpy import trace
         return trace(self)
 
     def var(self, *, ddof=0):
         """
-        Equivalent to `cp.var(self)`
+        Equivalent to `cp.var(self)`.
         """
         from cvxpy import var
         return var(self, ddof=ddof)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -237,6 +237,10 @@ class TestAtoms(BaseTest):
         self.assertEqual(atom.sign, s.NONNEG)
         expr = cp.norm(self.A, 2, axis=0)
         self.assertEqual(expr.shape, (2,))
+        expr = cp.norm(self.A, 2, axis=0, keepdims=True)
+        self.assertEqual(expr.shape, (1, 2))
+        expr = cp.norm(self.A, 2, axis=1, keepdims=True)
+        self.assertEqual(expr.shape, (2, 1))
 
         atom = cp.pnorm(self.x, p='inf')
         self.assertEqual(atom.shape, tuple())

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1035,15 +1035,15 @@ class TestAtoms(BaseTest):
         for axis in [0, 1]:
             for keepdims in [True, False]:
                 expr_mean = cp.mean(a, axis=axis, keepdims=keepdims)
-                expr_var = cp.var(a, axis=axis, keepdims=keepdims)
+                # expr_var = cp.var(a, axis=axis, keepdims=keepdims)
                 expr_std = cp.std(a, axis=axis, keepdims=keepdims)
 
                 assert expr_mean.shape == a.mean(axis=axis, keepdims=keepdims).shape
-                assert expr_var.shape == a.var(axis=axis, keepdims=keepdims).shape
+                # assert expr_var.shape == a.var(axis=axis, keepdims=keepdims).shape
                 assert expr_std.shape == a.std(axis=axis, keepdims=keepdims).shape
 
                 assert np.allclose(a.mean(axis=axis, keepdims=keepdims), expr_mean.value)
-                assert np.allclose(a.var(axis=axis, keepdims=keepdims), expr_var.value)
+                # assert np.allclose(a.var(axis=axis, keepdims=keepdims), expr_var.value)
                 assert np.allclose(a.std(axis=axis, keepdims=keepdims), expr_std.value)
 
     def test_partial_optimize_dcp(self) -> None:

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -983,37 +983,37 @@ class TestAtoms(BaseTest):
         a = np.array([[10., -10., 3.0], [6., 0., -1.5]])
         expr = cp.ptp(a)
         assert expr.is_nonneg()
-        self.assertEqual(expr.shape, ())
-        self.assertClose(expr.value, 20.)
+        assert expr.shape == ()
+        assert np.isclose(expr.value, 20.)
 
         expr = cp.ptp(a, axis=0)
         assert expr.is_nonneg()
-        self.assertEqual(expr.shape, (3,))
-        self.assertClose(expr.value, np.array([4, 10, 4.5]))
+        assert expr.shape == (3,)
+        assert np.allclose(expr.value, np.array([4, 10, 4.5]))
 
         expr = cp.ptp(a, axis=1)
         assert expr.is_nonneg()
-        self.assertEqual(expr.shape, (2,))
-        self.assertClose(expr.value, np.array([20., 7.5]))
+        expr.shape == (2,)
+        assert np.allclose(expr.value, np.array([20., 7.5]))
 
         expr = cp.ptp(a, 0, True)
         assert expr.is_nonneg()
-        self.assertEqual(expr.shape, (1, 3))
-        self.assertClose(expr.value, np.array([[4, 10, 4.5]]))
+        assert expr.shape == (1, 3)
+        assert np.allclose(expr.value, np.array([[4, 10, 4.5]]))
 
         expr = cp.ptp(a, 1, True)
         assert expr.is_nonneg()
-        self.assertEqual(expr.shape, (2, 1))
-        self.assertClose(expr.value, np.array([[20.], [7.5]]))
+        assert expr.shape == (2, 1)
+        assert np.allclose(expr.value, np.array([[20.], [7.5]]))
 
     def test_stats(self) -> None:
         """Test the mean, std, var atoms.
         """
         a = np.array([[10., 10., 3.0], [6., 0., 1.5]])
-        cp.mean(a)
+        expr_mean = cp.mean(a)
         expr_var = cp.var(a)
         expr_std = cp.std(a)
-        assert a.is_nonneg()
+        assert expr_mean.is_nonneg()
         assert expr_var.is_nonneg()
         assert expr_std.is_nonneg()
 

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -744,16 +744,15 @@ class TestAtoms(BaseTest):
                          "Argument to upper_tri must be a square matrix.")
 
     def test_vec_to_upper_tri(self) -> None:
-        from cvxpy.atoms.affine.upper_tri import vec_to_upper_tri
         x = Variable(shape=(3,))
-        X = vec_to_upper_tri(x)
+        X = cp.vec_to_upper_tri(x)
         x.value = np.array([1, 2, 3])
         actual = X.value
         expect = np.array([[1, 2], [0, 3]])
         assert np.allclose(actual, expect)
         y = Variable(shape=(1,))
         y.value = np.array([4])
-        Y = vec_to_upper_tri(y, strict=True)
+        Y = cp.vec_to_upper_tri(y, strict=True)
         actual = Y.value
         expect = np.array([[0, 4], [0, 0]])
         assert np.allclose(actual, expect)
@@ -762,8 +761,27 @@ class TestAtoms(BaseTest):
                              [0, 0, 0, 21],
                              [0, 0, 0, 0]])
         a = np.array([11, 12, 13, 16, 17, 21])
-        A_actual = vec_to_upper_tri(a, strict=True).value
+        A_actual = cp.vec_to_upper_tri(a, strict=True).value
         assert np.allclose(A_actual, A_expect)
+
+        with pytest.raises(ValueError, match="must be a triangular number"):
+            cp.vec_to_upper_tri(cp.Variable(shape=(4)))
+
+        with pytest.raises(ValueError, match="must be a triangular number"):
+            cp.vec_to_upper_tri(cp.Variable(shape=(4)), strict=True)
+
+        with pytest.raises(ValueError, match="must be a vector"):
+            cp.vec_to_upper_tri(cp.Variable(shape=(2, 2)))
+
+        # works with row vectors
+        assert np.allclose(
+            cp.vec_to_upper_tri(np.arange(6)).value, 
+            cp.vec_to_upper_tri(np.arange(6).reshape(1, 6)).value
+        )
+
+        # works with scalars
+        assert np.allclose(cp.vec_to_upper_tri(1, strict=True).value, np.array([[0, 1], [0, 0]]))
+
 
     def test_huber(self) -> None:
         # Valid.

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1017,32 +1017,30 @@ class TestAtoms(BaseTest):
         assert expr_var.is_nonneg()
         assert expr_std.is_nonneg()
 
-        # Finish writing these tests
-        assert False
-        """
-        self.assertEqual(expr.shape, ())
-        self.assertClose(expr.value, 20.)
+        assert np.isclose(a.mean(), expr_mean.value)
+        assert np.isclose(a.var(), expr_var.value)
+        assert np.isclose(a.std(), expr_std.value)
 
-        expr = cp.ptp(a, axis=0)
-        assert expr.is_nonneg()
-        self.assertEqual(expr.shape, (3,))
-        self.assertClose(expr.value, np.array([4, 10, 4.5]))
+        for ddof in [0, 1]:
+            expr_var = cp.var(a, ddof=ddof)
+            expr_std = cp.std(a, ddof=ddof)
 
-        expr = cp.ptp(a, axis=1)
-        assert expr.is_nonneg()
-        self.assertEqual(expr.shape, (2,))
-        self.assertClose(expr.value, np.array([20., 7.5]))
+            assert np.isclose(a.var(ddof=ddof), expr_var.value)
+            assert np.isclose(a.std(ddof=ddof), expr_std.value)
 
-        expr = cp.ptp(a, 0, True)
-        assert expr.is_nonneg()
-        self.assertEqual(expr.shape, (1, 3))
-        self.assertClose(expr.value, np.array([[4, 10, 4.5]]))
+        for axis in [0, 1]:
+            for keepdim in [True, False]:
+                expr_mean = cp.mean(a, axis=axis)
+                expr_var = cp.var(a, axis=axis)
+                expr_std = cp.std(a, axis=axis)
 
-        expr = cp.ptp(a, 1, True)
-        assert expr.is_nonneg()
-        self.assertEqual(expr.shape, (2, 1))
-        self.assertClose(expr.value, np.array([[20.], [7.5]]))
-        """
+                assert expr_mean.shape == a.mean(axis=axis, keepdim=keepdim).shape
+                assert expr_var.shape == a.var(axis=axis, keepdim=keepdim).shape
+                assert expr_std.shape == a.std(axis=axis, keepdim=keepdim).shape
+
+                assert np.allclose(a.mean(axis=axis, keepdim=keepdim), expr_mean.value)
+                assert np.allclose(a.var(axis=axis, keepdim=keepdim), expr_var.value)
+                assert np.allclose(a.std(axis=axis, keepdim=keepdim), expr_std.value)
 
     def test_partial_optimize_dcp(self) -> None:
         """Test DCP properties of partial optimize.

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1029,18 +1029,18 @@ class TestAtoms(BaseTest):
             assert np.isclose(a.std(ddof=ddof), expr_std.value)
 
         for axis in [0, 1]:
-            for keepdim in [True, False]:
-                expr_mean = cp.mean(a, axis=axis)
-                expr_var = cp.var(a, axis=axis)
-                expr_std = cp.std(a, axis=axis)
+            for keepdims in [True, False]:
+                expr_mean = cp.mean(a, axis=axis, keepdims=keepdims)
+                # expr_var = cp.var(a, axis=axis)
+                expr_std = cp.std(a, axis=axis, keepdims=keepdims)
 
-                assert expr_mean.shape == a.mean(axis=axis, keepdim=keepdim).shape
-                assert expr_var.shape == a.var(axis=axis, keepdim=keepdim).shape
-                assert expr_std.shape == a.std(axis=axis, keepdim=keepdim).shape
+                assert expr_mean.shape == a.mean(axis=axis, keepdims=keepdims).shape
+                # assert expr_var.shape == a.var(axis=axis, keepdims=keepdims).shape
+                assert expr_std.shape == a.std(axis=axis, keepdims=keepdims).shape
 
-                assert np.allclose(a.mean(axis=axis, keepdim=keepdim), expr_mean.value)
-                assert np.allclose(a.var(axis=axis, keepdim=keepdim), expr_var.value)
-                assert np.allclose(a.std(axis=axis, keepdim=keepdim), expr_std.value)
+                assert np.allclose(a.mean(axis=axis, keepdims=keepdims), expr_mean.value)
+                # assert np.allclose(a.var(axis=axis, keepdims=keepdims), expr_var.value)
+                assert np.allclose(a.std(axis=axis, keepdims=keepdims), expr_std.value)
 
     def test_partial_optimize_dcp(self) -> None:
         """Test DCP properties of partial optimize.

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1010,6 +1010,10 @@ class TestAtoms(BaseTest):
         assert expr.shape == (2, 1)
         assert np.allclose(expr.value, np.array([[20.], [7.5]]))
 
+        x = cp.Variable(10)
+        expr = cp.ptp(x)
+        assert expr.curvature == 'CONVEX'
+
     def test_stats(self) -> None:
         """Test the mean, std, var atoms.
         """

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1035,15 +1035,15 @@ class TestAtoms(BaseTest):
         for axis in [0, 1]:
             for keepdims in [True, False]:
                 expr_mean = cp.mean(a, axis=axis, keepdims=keepdims)
-                # expr_var = cp.var(a, axis=axis)
+                expr_var = cp.var(a, axis=axis, keepdims=keepdims)
                 expr_std = cp.std(a, axis=axis, keepdims=keepdims)
 
                 assert expr_mean.shape == a.mean(axis=axis, keepdims=keepdims).shape
-                # assert expr_var.shape == a.var(axis=axis, keepdims=keepdims).shape
+                assert expr_var.shape == a.var(axis=axis, keepdims=keepdims).shape
                 assert expr_std.shape == a.std(axis=axis, keepdims=keepdims).shape
 
                 assert np.allclose(a.mean(axis=axis, keepdims=keepdims), expr_mean.value)
-                # assert np.allclose(a.var(axis=axis, keepdims=keepdims), expr_var.value)
+                assert np.allclose(a.var(axis=axis, keepdims=keepdims), expr_var.value)
                 assert np.allclose(a.std(axis=axis, keepdims=keepdims), expr_std.value)
 
     def test_partial_optimize_dcp(self) -> None:

--- a/cvxpy/tests/test_expression_methods.py
+++ b/cvxpy/tests/test_expression_methods.py
@@ -129,7 +129,7 @@ class TestExpressionMethods(BaseTest):
         # Test C-style reshape.
         a = np.arange(10)
         A_np = np.reshape(a, (5, 2), order='C')
-        A_cp = a.reshape((5, 2), order='C')
+        A_cp = Constant(a).reshape((5, 2), order='C')
         self.assertItemsAlmostEqual(A_np, A_cp.value)
 
         X = cp.Variable((5, 2))
@@ -194,7 +194,7 @@ class TestExpressionMethods(BaseTest):
         A = np.array([[1, 2, 3], [4, 5, 6]])
         A_reshaped = Constant(A).reshape(-1, order='C')
         assert np.allclose(A_reshaped.value, A.reshape(-1, order='C'))
-        A_reshaped = Constant(A).reshape(A, -1, order='F')
+        A_reshaped = Constant(A).reshape(-1, order='F')
         assert np.allclose(A_reshaped.value, A.reshape(-1, order='F'))
 
     def test_vec(self) -> None:
@@ -242,7 +242,7 @@ class TestExpressionMethods(BaseTest):
         """Test the ptp atom.
         """
         a = Constant(np.array([[10., -10., 3.0], [6., 0., -1.5]]))
-        expr = Constant(a).ptp()
+        expr = a.ptp()
         assert expr.is_nonneg()
         assert expr.shape == ()
         assert np.isclose(expr.value, 20.)
@@ -257,12 +257,12 @@ class TestExpressionMethods(BaseTest):
         expr.shape == (2,)
         assert np.allclose(expr.value, np.array([20., 7.5]))
 
-        expr = a.ptp(0, True)
+        expr = a.ptp(0, keepdims=True)
         assert expr.is_nonneg()
         assert expr.shape == (1, 3)
         assert np.allclose(expr.value, np.array([[4, 10, 4.5]]))
 
-        expr = a.ptp(1, True)
+        expr = a.ptp(1, keepdims=True)
         assert expr.is_nonneg()
         assert expr.shape == (2, 1)
         assert np.allclose(expr.value, np.array([[20.], [7.5]]))

--- a/cvxpy/tests/test_expression_methods.py
+++ b/cvxpy/tests/test_expression_methods.py
@@ -1,0 +1,323 @@
+"""
+Copyright 2023 CVXPY Developers
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+import cvxpy as cp
+import cvxpy.settings as s
+from cvxpy.expressions.constants import Constant
+from cvxpy.expressions.variable import Variable
+from cvxpy.tests.base_test import BaseTest
+
+
+class TestExpressionMethods(BaseTest):
+    """ Unit tests for the atoms module. """
+
+    def setUp(self) -> None:
+        self.a = Variable(name='a')
+
+        self.x = Variable(2, name='x')
+        self.y = Variable(2, name='y')
+
+        self.A = Variable((2, 2), name='A')
+        self.B = Variable((2, 2), name='B')
+        self.C = Variable((3, 2), name='C')
+
+    def test_max(self) -> None:
+        """Test max.
+        """
+        # One arg, test sign.
+        self.assertEqual(Variable().max().sign, s.UNKNOWN)
+
+        # Test with axis argument.
+        self.assertEqual(Variable(2).max(axis=0, keepdims=True).shape, (1,))
+        self.assertEqual(Variable(2).max(axis=1).shape, (2,))
+        self.assertEqual(Variable((2, 3)).max(axis=0, keepdims=True).shape, (1, 3))
+        self.assertEqual(Variable((2, 3)).max(axis=1).shape, (2,))
+
+        # Invalid axis.
+        with self.assertRaises(Exception) as cm:
+            self.x.max(axis=4)
+        self.assertEqual(str(cm.exception), "Invalid argument for axis.")
+
+    def test_min(self) -> None:
+        """Test min.
+        """
+        # One arg, test sign.
+        self.assertEqual(Variable().min().sign, s.UNKNOWN)
+
+        # Test with axis argument.
+        self.assertEqual(Variable(2).min(axis=0).shape, tuple())
+        self.assertEqual(Variable(2).min(axis=1).shape, (2,))
+        self.assertEqual(Variable((2, 3)).min(axis=0).shape, (3,))
+        self.assertEqual(Variable((2, 3)).min(axis=1).shape, (2,))
+
+        # Invalid axis.
+        with self.assertRaises(Exception) as cm:
+            self.x.min(axis=4)
+        self.assertEqual(str(cm.exception), "Invalid argument for axis.")
+
+    def test_sum(self) -> None:
+        """Test the sum atom.
+        """
+        self.assertEqual(Constant([1, -1]).sum().sign, s.UNKNOWN)
+        self.assertEqual(Constant([1, -1]).sum().curvature, s.CONSTANT)
+        self.assertEqual(Variable(2).sum().sign, s.UNKNOWN)
+        self.assertEqual(Variable(2).sum().shape, tuple())
+        self.assertEqual(Variable(2).sum().curvature, s.AFFINE)
+        self.assertEqual(Variable((2, 1)).sum(keepdims=True).shape, (1, 1))
+        # Mixed curvature.
+        mat = np.array([[1, -1]])
+        self.assertEqual(cp.sum(mat @ cp.square(Variable(2))).curvature, s.UNKNOWN)
+
+        # Test with axis argument.
+        self.assertEqual(Variable(2).sum(axis=0).shape, tuple())
+        self.assertEqual(Variable(2).sum(axis=1).shape, (2,))
+        self.assertEqual(Variable((2, 3)).sum(axis=0, keepdims=True).shape, (1, 3))
+        self.assertEqual(Variable((2, 3)).sum(axis=0, keepdims=False).shape, (3,))
+        self.assertEqual(Variable((2, 3)).sum(axis=1).shape, (2,))
+
+        # Invalid axis.
+        with self.assertRaises(Exception) as cm:
+            cp.sum(self.x, axis=4)
+        self.assertEqual(str(cm.exception),
+                         "Invalid argument for axis.")
+
+        A = sp.eye(3)
+        self.assertEqual(Constant(A).sum().value, 3)
+
+        A = sp.eye(3)
+        self.assertItemsAlmostEqual(Constant(A).sum(axis=0).value, [1, 1, 1])
+
+    def test_reshape(self) -> None:
+        """Test the reshape class.
+        """
+        expr = self.A.reshape((4, 1))
+        self.assertEqual(expr.sign, s.UNKNOWN)
+        self.assertEqual(expr.curvature, s.AFFINE)
+        self.assertEqual(expr.shape, (4, 1))
+
+        expr = expr.reshape((2, 2))
+        self.assertEqual(expr.shape, (2, 2))
+
+        expr = cp.square(self.x).reshape((1, 2))
+        self.assertEqual(expr.sign, s.NONNEG)
+        self.assertEqual(expr.curvature, s.CONVEX)
+        self.assertEqual(expr.shape, (1, 2))
+
+        with self.assertRaises(Exception) as cm:
+            self.C.reshape((5, 4))
+        self.assertEqual(str(cm.exception),
+                         "Invalid reshape dimensions (5, 4).")
+
+        # Test C-style reshape.
+        a = np.arange(10)
+        A_np = np.reshape(a, (5, 2), order='C')
+        A_cp = a.reshape((5, 2), order='C')
+        self.assertItemsAlmostEqual(A_np, A_cp.value)
+
+        X = cp.Variable((5, 2))
+        prob = cp.Problem(cp.Minimize(0), [X == A_cp])
+        prob.solve(solver=cp.SCS)
+        self.assertItemsAlmostEqual(A_np, X.value)
+
+        a_np = np.reshape(A_np, 10, order='C')
+        a_cp = A_cp.reshape(10, order='C')
+
+        self.assertItemsAlmostEqual(a_np, a_cp.value)
+
+        x = cp.Variable(10)
+        prob = cp.Problem(cp.Minimize(0), [x == a_cp])
+        prob.solve(solver=cp.SCS)
+        self.assertItemsAlmostEqual(a_np, x.value)
+
+        # Test more complex C-style reshape: matrix to another matrix
+        b = np.array([
+            [0, 1, 2],
+            [3, 4, 5],
+            [6, 7, 8],
+            [9, 10, 11],
+        ])
+        b_reshaped = b.reshape((2, 6), order='C')
+        X = cp.Variable(b.shape)
+        X_reshaped = X.reshape((2, 6), order='C')
+        prob = cp.Problem(cp.Minimize(0), [X_reshaped == b_reshaped])
+        prob.solve(solver=cp.SCS)
+        self.assertItemsAlmostEqual(b_reshaped, X_reshaped.value)
+        self.assertItemsAlmostEqual(b, X.value)
+
+    def test_reshape_negative_one(self) -> None:
+        """
+        Test the reshape class with -1 in the shape.
+        """
+
+        expr = cp.Variable((2, 3))
+        numpy_expr = np.ones((2, 3))
+        shapes = [(-1, 1), (1, -1), (-1, 2), -1, (-1,)]
+        expected_shapes = [(6, 1), (1, 6), (3, 2), (6,), (6,)]
+
+        for shape, expected_shape in zip(shapes, expected_shapes):
+            expr_reshaped = expr.reshape(shape)
+            self.assertEqual(expr_reshaped.shape, expected_shape)
+
+            numpy_expr_reshaped = np.reshape(numpy_expr, shape)
+            self.assertEqual(numpy_expr_reshaped.shape, expected_shape)
+
+        with pytest.raises(ValueError, match="Cannot reshape expression"):
+            expr.reshape((8, -1))
+
+        with pytest.raises(AssertionError, match="Only one"):
+            expr.reshape((-1, -1))
+
+        with pytest.raises(ValueError, match="Invalid reshape dimensions"):
+            expr.reshape((-1, 0))
+
+        with pytest.raises(AssertionError, match="Specified dimension must be nonnegative"):
+            expr.reshape((-1, -2))
+
+        A = np.array([[1, 2, 3], [4, 5, 6]])
+        A_reshaped = Constant(A).reshape(-1, order='C')
+        assert np.allclose(A_reshaped.value, A.reshape(-1, order='C'))
+        A_reshaped = Constant(A).reshape(A, -1, order='F')
+        assert np.allclose(A_reshaped.value, A.reshape(-1, order='F'))
+
+    def test_vec(self) -> None:
+        """Test the vec atom.
+        """
+        expr = cp.vec(self.C)
+        self.assertEqual(expr.sign, s.UNKNOWN)
+        self.assertEqual(expr.curvature, s.AFFINE)
+        self.assertEqual(expr.shape, (6,))
+
+        expr = cp.vec(self.x)
+        self.assertEqual(expr.shape, (2,))
+
+        expr = cp.vec(cp.square(self.a))
+        self.assertEqual(expr.sign, s.NONNEG)
+        self.assertEqual(expr.curvature, s.CONVEX)
+        self.assertEqual(expr.shape, (1,))
+
+    def test_trace(self) -> None:
+        """Test the trace atom.
+        """
+        expr = self.A.trace()
+        self.assertEqual(expr.sign, s.UNKNOWN)
+        self.assertEqual(expr.curvature, s.AFFINE)
+        self.assertEqual(expr.shape, tuple())
+
+        with self.assertRaises(Exception) as cm:
+            self.C.trace()
+        self.assertEqual(str(cm.exception),
+                         "Argument to trace must be a square matrix.")
+
+    def test_trace_sign_psd(self) -> None:
+        """Test sign of trace for psd/nsd inputs.
+        """
+        X_psd = cp.Variable((2, 2), PSD=True)
+        X_nsd = cp.Variable((2, 2), NSD=True)
+
+        psd_trace = X_psd.trace()
+        nsd_trace = X_nsd.trace()
+
+        assert psd_trace.is_nonneg()
+        assert nsd_trace.is_nonpos()
+    
+    def test_ptp(self) -> None:
+        """Test the ptp atom.
+        """
+        a = Constant(np.array([[10., -10., 3.0], [6., 0., -1.5]]))
+        expr = Constant(a).ptp()
+        assert expr.is_nonneg()
+        assert expr.shape == ()
+        assert np.isclose(expr.value, 20.)
+
+        expr = a.ptp(axis=0)
+        assert expr.is_nonneg()
+        assert expr.shape == (3,)
+        assert np.allclose(expr.value, np.array([4, 10, 4.5]))
+
+        expr = a.ptp(axis=1)
+        assert expr.is_nonneg()
+        expr.shape == (2,)
+        assert np.allclose(expr.value, np.array([20., 7.5]))
+
+        expr = a.ptp(0, True)
+        assert expr.is_nonneg()
+        assert expr.shape == (1, 3)
+        assert np.allclose(expr.value, np.array([[4, 10, 4.5]]))
+
+        expr = a.ptp(1, True)
+        assert expr.is_nonneg()
+        assert expr.shape == (2, 1)
+        assert np.allclose(expr.value, np.array([[20.], [7.5]]))
+
+    def test_stats(self) -> None:
+        """Test the mean, std, var atoms.
+        """
+        a_np = np.array([[10., 10., 3.0], [6., 0., 1.5]])
+        a = Constant(a_np)
+        expr_mean = a.mean()
+        expr_var = a.var()
+        expr_std = a.std()
+        assert expr_mean.is_nonneg()
+        assert expr_var.is_nonneg()
+        assert expr_std.is_nonneg()
+
+        assert np.isclose(a_np.mean(), expr_mean.value)
+        assert np.isclose(a_np.var(), expr_var.value)
+        assert np.isclose(a_np.std(), expr_std.value)
+
+        for ddof in [0, 1]:
+            expr_var = a.var(ddof=ddof)
+            expr_std = a.std(ddof=ddof)
+
+            assert np.isclose(a_np.var(ddof=ddof), expr_var.value)
+            assert np.isclose(a_np.std(ddof=ddof), expr_std.value)
+
+        for axis in [0, 1]:
+            for keepdims in [True, False]:
+                expr_mean = a.mean(axis=axis, keepdims=keepdims)
+                # expr_var = cp.var(a, axis=axis, keepdims=keepdims)
+                expr_std = a.std(axis=axis, keepdims=keepdims)
+
+                assert expr_mean.shape == a_np.mean(axis=axis, keepdims=keepdims).shape
+                # assert expr_var.shape == a.var(axis=axis, keepdims=keepdims).shape
+                assert expr_std.shape == a_np.std(axis=axis, keepdims=keepdims).shape
+
+                assert np.allclose(a_np.mean(axis=axis, keepdims=keepdims), expr_mean.value)
+                # assert np.allclose(a.var(axis=axis, keepdims=keepdims), expr_var.value)
+                assert np.allclose(a_np.std(axis=axis, keepdims=keepdims), expr_std.value)
+
+    def test_conj(self) -> None:
+        """Test conj.
+        """
+        v = cp.Variable((4,))
+        obj = cp.Minimize(cp.sum(v))
+        prob = cp.Problem(obj, [v.conj() >= 1])
+        prob.solve(solver=cp.SCS)
+        assert np.allclose(v.value, np.ones((4,)))
+
+    def test_conjugate(self) -> None:
+        """Test conj.
+        """
+        v = cp.Variable((4,))
+        obj = cp.Minimize(cp.sum(v))
+        prob = cp.Problem(obj, [v.conjugate() >= 1])
+        prob.solve(solver=cp.SCS)
+        assert np.allclose(v.value, np.ones((4,)))

--- a/cvxpy/tests/test_expression_methods.py
+++ b/cvxpy/tests/test_expression_methods.py
@@ -104,8 +104,6 @@ class TestExpressionMethods(BaseTest):
                     assert fn.shape == method_fn.shape
                     assert np.allclose(fn.value, method_fn.value)
 
-
-        
         # Takes axis, keepdims, ddof arguments
         for method in [
             'std', 
@@ -187,6 +185,22 @@ class TestExpressionMethods(BaseTest):
         prob.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(b_reshaped, X_reshaped.value)
         self.assertItemsAlmostEqual(b, X.value)
+
+        # Test default is fortran
+        b = np.array([
+            [0, 1, 2],
+            [3, 4, 5],
+            [6, 7, 8],
+            [9, 10, 11],
+        ])
+        b_reshaped = b.reshape((2, 6), order='F')
+        X = cp.Variable(b.shape)
+        X_reshaped = X.reshape((2, 6))
+        prob = cp.Problem(cp.Minimize(0), [X_reshaped == b_reshaped])
+        prob.solve(solver=cp.SCS)
+        self.assertItemsAlmostEqual(b_reshaped, X_reshaped.value)
+        self.assertItemsAlmostEqual(b, X.value)
+
 
     def test_reshape_negative_one(self) -> None:
         """

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1483,11 +1483,13 @@ class TestExpressions(BaseTest):
         U = cp.Variable((2, 2), complex=True)
         expr = psd_wrap(Z)
         assert expr.is_psd()
+        assert not expr.is_complex()
         assert expr.is_symmetric()
         assert expr.is_hermitian()
 
         expr = psd_wrap(U)
         assert expr.is_psd()
+        assert expr.is_complex()
         assert not expr.is_symmetric()
         assert expr.is_hermitian()
 

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -24,7 +24,14 @@ import cvxpy.interface.matrix_utilities as intf
 import cvxpy.settings as s
 from cvxpy import Minimize, Problem
 from cvxpy.atoms.affine.add_expr import AddExpression
-from cvxpy.atoms.affine.wraps import psd_wrap
+from cvxpy.atoms.affine.wraps import (
+    hermitian_wrap,
+    nonneg_wrap,
+    nonpos_wrap,
+    psd_wrap,
+    skew_symmetric_wrap,
+    symmetric_wrap,
+)
 from cvxpy.expressions.constants import Constant, Parameter
 from cvxpy.expressions.variable import Variable
 from cvxpy.tests.base_test import BaseTest
@@ -1462,3 +1469,35 @@ class TestExpressions(BaseTest):
         true_val = (np.transpose(x.value) @ P @ x.value) * a
         assert quad.shape == ()
         self.assertEqual(expr.value, true_val)
+
+    def test_wraps(self) -> None:
+        """Test wrap classes."""
+        x = cp.Variable(2)
+        expr = nonneg_wrap(x)
+        assert expr.is_nonneg()
+
+        expr = nonpos_wrap(x)
+        assert expr.is_nonpos()
+
+        Z = cp.Variable((2, 2))
+        U = cp.Variable((2, 2), complex=True)
+        expr = psd_wrap(Z)
+        assert expr.is_psd()
+        assert expr.is_symmetric()
+        assert expr.is_hermitian()
+
+        expr = psd_wrap(U)
+        assert expr.is_psd()
+        assert not expr.is_symmetric()
+        assert expr.is_hermitian()
+
+        expr = symmetric_wrap(Z)
+        assert expr.is_symmetric()
+        assert expr.is_hermitian()
+
+        expr = skew_symmetric_wrap(Z)
+        assert expr.is_skew_symmetric()
+
+        expr = hermitian_wrap(U)
+        assert expr.is_hermitian()
+

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -323,7 +323,6 @@ and returns a scalar.
 
      - :math:`\max_{ij} X_{ij} - \min_{ij} X_{ij}`
      - :math:`X \in \mathbf{R}^{m \times n}`
-
      - |positive| positive
      - |convex| convex
      - None

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -188,6 +188,14 @@ and returns a scalar.
      - |convex| convex
      - |incr| incr.
 
+   * - :ref:`mean(X) <mean>`
+
+     - :math:`\frac{1}{m n}\sum_{ij}\left\{ X_{ij}\right\}`
+     - :math:`X \in\mathbf{R}^{m \times n}`
+     - same as X
+     - |affine| affine
+     - |incr| incr.
+
    * - :ref:`min(X) <min>`
 
      - :math:`\min_{ij}\left\{ X_{ij}\right\}`
@@ -311,6 +319,14 @@ and returns a scalar.
      - |concave| concave
      - |incr| incr.
 
+   * - :ref:`ptp(X) <ptp>`
+
+     - :math:`\max_{ij} X_{ij} - \min_{ij} X_{ij}`
+     - :math:`X \in \mathbf{R}^{m \times n}`
+
+     - |unknown| unknown
+     - |convex| convex
+     - None
 
    * - :ref:`quad_form(x, P) <quad-form>`
 
@@ -358,6 +374,14 @@ and returns a scalar.
        |decr| for :math:`X_{ij} \leq 0`
 
        |decr| decr. in :math:`y`
+
+   * - :ref:`std(X) <std>`
+
+     - :math:`\sqrt{\frac{1}{mn} \sum_{ij}\left(X_{ij} - \frac{1}{mn}\sum_{k\ell} X_{k\ell}\right)^2}`
+     - :math:`X \in\mathbf{R}^{m \times n}`
+     - |positive| positive
+     - |convex| convex
+     - None
 
    * - :ref:`sum(X) <sum>`
 
@@ -433,6 +457,14 @@ and returns a scalar.
      - |convex| convex
      - None
 
+   * - :ref:`var(X) <var>`
+
+     - :math:`{\frac{1}{mn} \sum_{ij}\left(X_{ij} - \frac{1}{mn}\sum_{k\ell} X_{k\ell}\right)^2}`
+     - :math:`X \in\mathbf{R}^{m \times n}`
+     - |positive| positive
+     - |convex| convex
+     - None
+
    * - :ref:`von_neumann_entr(X) <von-neumann-entr>`
      - :math:`-\operatorname{tr}(X\operatorname{logm}(X))`
      - :math:`X \in \mathbf{S}^{n}_+`
@@ -463,8 +495,8 @@ The CVXPY function ``sum`` sums all the entries in a single expression. The buil
 Functions along an axis
 -----------------------
 
-The functions ``sum``, ``norm``, ``max``, and ``min`` can be
-applied along an axis.
+The functions ``sum``, ``norm``, ``max``, ``min``, ``mean``, ``std``, ``var``, and ``ptp`` can
+be applied along an axis.
 Given an ``m`` by ``n`` expression ``expr``, the syntax ``func(expr, axis=0, keepdims=True)``
 applies ``func`` to each column, returning a 1 by ``n`` expression.
 The syntax ``func(expr, axis=1, keepdims=True)`` applies ``func`` to each row,
@@ -909,6 +941,15 @@ Expression and a negative Expression) then the returned Expression will have unk
 
      - :math:`x' \in\mathbf{R}^{mn}`
      - :math:`X \in\mathbf{R}^{m \times n}`
+     - |affine| affine
+     - |incr| incr.
+
+   * - :ref:`vec_to_upper_tri(X, strict=False) <vec-to-upper-tri>`
+
+     - :math:`x' \in\mathbf{R}^{n(n-1)/2}` for ``strict=True``
+
+       :math:`x' \in\mathbf{R}^{n(n+1)/2}` for ``strict=False``
+     - :math:`X \in\mathbf{R}^{n \times n}`
      - |affine| affine
      - |incr| incr.
 


### PR DESCRIPTION
## Description

Closes #2237 by cloning much of the [NumPy ndarray API](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html).

Supersedes and closes #2150 

Notes on specific methods:

 * I skipped `np.diagonal` because the RO API in NumPy made me feel that maybe we don't want to emulate it, and we don't support the optional arguments in diagonal yet
 * `.flatten` uses the opposite ordering as numpy, but is consistent with our default
 * `.max`, `.min`, `.prod` requires that `keepdims` be a keyword argument because NumPy has `out` as its second arg, and so this makes our API compatible with NumPy
 * `.mean`, `.ptp`, `.std`, `.var` do not have a corresponding `cp.mean`, `cp.ptp`, `cp.std`, `cp.var` respectively
 * I skipped .ravel, .repeat, .swapaxes, .take for no particular reason other than they felt a little weird to me with our API
 * I skipped `.transpose` because it is much less useful on 1d and 2d arrays

Once we confirm that this is more or less the API we're after and we want to include all the methods, I'll write tests.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.