### PR TITLE
Prepare for 3.12 / Drop 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, macos-11, windows-2022 ]
-        python-version: [ 3.7, 3.9, "3.10", "3.11"]
+        python-version: [ 3.9, "3.10", "3.11"]
         include:
           - os: ubuntu-20.04
             python-version: 3.8
@@ -164,7 +164,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, macos-11, windows-2022 ]
-        python-version: [ 3.7, 3.9, "3.10", "3.11", "3.12" ]
+        python-version: [ 3.9, "3.10", "3.11", "3.12" ]
         include:
           - os: ubuntu-20.04
             python-version: 3.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, macos-11, windows-2022 ]
-        python-version: [ 3.7, 3.9, "3.10", "3.11" ]
+        python-version: [ 3.9, "3.10", "3.11" ]
         include:
           - os: ubuntu-20.04
             python-version: 3.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,8 +104,8 @@ jobs:
       PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -128,7 +128,7 @@ jobs:
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_ARCHS_LINUX: auto aarch64
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.16.2
 
       - name: Build source
         if: ${{github.event_name == 'push' && env.SINGLE_ACTION_CONFIG == 'True'}}
@@ -164,7 +164,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, macos-11, windows-2022 ]
-        python-version: [ 3.7, 3.9, "3.10", "3.11" ]
+        python-version: [ 3.7, 3.9, "3.10", "3.11", "3.12" ]
         include:
           - os: ubuntu-20.04
             python-version: 3.8
@@ -186,8 +186,8 @@ jobs:
       PYPI_BASE_PASSWORD: ${{ secrets.PYPI_BASE_PASSWORD }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set Additional Envs
@@ -226,7 +226,7 @@ jobs:
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_ARCHS_LINUX: auto aarch64
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.16.2
 
       - name: Build source
         if: ${{github.event_name == 'push' && env.SINGLE_ACTION_CONFIG == 'True'}}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ conda install -c conda-forge cvxpy
 
 CVXPY has the following dependencies:
 
-- Python >= 3.7
+- Python >= 3.8
 - Clarabel >= 0.5.0
 - OSQP >= 0.4.1
 - ECOS >= 2

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -47,7 +47,7 @@ else
 fi
 
 # cylp has no wheels for Windows
-if [ "$RUNNER_OS" != "Windows" ]]; then
+if [[ "$RUNNER_OS" != "Windows" ]]; then
   python -m pip install cylp
 fi
 
@@ -57,7 +57,7 @@ if [[ "$PYTHON_VERSION" == "3.9" ]] || [[ "$RUNNER_OS" == "Windows" ]]; then
 fi
 
 # Only install Mosek if license is available (secret is not copied to forks)
-if [[ -n "$MOSEK_CI_BASE64" ]] then
+if [[ -n "$MOSEK_CI_BASE64" ]]; then
     python -m pip install mosek
 fi
 

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -10,10 +10,7 @@ conda config --set remote_max_retries 10
 conda config --set remote_backoff_factor 2
 conda config --set remote_read_timeout_secs 120.0
 
-# Issue with installing setuptools > 65.5.1 through conda on mac with Python 3.7.
-if [[ "$PYTHON_VERSION" == "3.7" ]] && [[ "$RUNNER_OS" == "macos-11" ]]; then
-  conda install scipy=1.3 numpy=1.16 mkl pip pytest pytest-cov lapack ecos scs osqp cvxopt proxsuite setuptools
-elif [[ "$PYTHON_VERSION" == "3.7" ]] || [[ "$PYTHON_VERSION" == "3.8" ]]; then
+if [[ "$PYTHON_VERSION" == "3.8" ]]; then
   conda install scipy=1.3 numpy=1.16 mkl pip pytest pytest-cov lapack ecos scs osqp cvxopt proxsuite "setuptools>65.5.1"
 elif [[ "$PYTHON_VERSION" == "3.9" ]]; then
   # The earliest version of numpy that works is 1.19.
@@ -49,8 +46,8 @@ else
   fi
 fi
 
-# cylp has wheels for all versions 3.7 - 3.10, except for 3.7 on Windows
-if [[ "$PYTHON_VERSION" != "3.7" ]] && [[ "$PYTHON_VERSION" != "3.11" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then
+# cylp has no wheels for Windows
+if [ "$RUNNER_OS" != "Windows" ]]; then
   python -m pip install cylp
 fi
 
@@ -60,7 +57,7 @@ if [[ "$PYTHON_VERSION" == "3.9" ]] || [[ "$RUNNER_OS" == "Windows" ]]; then
 fi
 
 # Only install Mosek if license is available (secret is not copied to forks)
-if [[ -n "$MOSEK_CI_BASE64" ]] && [[ "$PYTHON_VERSION" != "3.11" ]]; then
+if [[ -n "$MOSEK_CI_BASE64" ]] then
     python -m pip install mosek
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,6 @@ testpaths = [
 
 [build-system]
 requires = [
-    "numpy>=1.15,<1.16; python_version=='3.7' and platform_machine!='aarch64'",
-    "numpy>=1.19.2,<1.20; python_version=='3.7' and platform_machine=='aarch64'",
     "numpy>=1.17,<1.18; python_version=='3.8' and platform_machine!='aarch64'",
     "numpy>=1.19.2,<1.20; python_version=='3.8' and platform_machine=='aarch64'",
     "numpy>=1.19,<1.20; python_version=='3.9' and (platform_machine not in 'arm64|aarch64' or platform_system!='Darwin')",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ requires = [
     "numpy>=1.21,<1.22; python_version=='3.10' and (platform_machine!='arm64' or platform_system!='Darwin')",
     "numpy>=1.21.4,<1.22; python_version=='3.10' and (platform_machine=='arm64' and platform_system=='Darwin')",
     "numpy>=1.23.4,<1.24; python_version=='3.11'",
+    "numpy>=1.26.0,<1.27; python_version=='3.12'",
     "scipy >= 1.1.0",
     "setuptools>65.5.1",
     "wheel",

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     },
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=[
         "osqp >= 0.4.1",
         "ecos >= 2",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.organization=cvxpy
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=cvxpy
 sonar.language=py
-sonar.python.version=3.7, 3.8, 3.9, 3.10, 3.11
+sonar.python.version= 3.8, 3.9, 3.10, 3.11, 3.12
 sonar.c.file.suffixes=-
 sonar.cpp.file.suffixes=-
 sonar.objc.file.suffixes=-


### PR DESCRIPTION
## Description
To ensure cvxpy is usable with the newly released 3.12, we planned to ship cvxpy with a 3.12 wheel right away. 
I tested it locally and it works. Currently, our solvers do not have prebuilds for 3.12, but I managed to install all of them locally, except for SCS. I think the build would not go through if this was the case on the CI as well.

This PR also drops Python 3.7 support, as it has reached EOL (https://devguide.python.org/versions/).

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.