### PR TITLE
Fix / Partially remove flaky SciPy test

### DIFF
--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2195,15 +2195,8 @@ class TestSCIPY(unittest.TestCase):
     def test_scipy_mi_time_limit_reached(self) -> None:
         sth = sths.mi_lp_7()
 
-        # run without enough time to find optimum
-        sth.solve(solver='SCIPY', scipy_options={"time_limit": 0.01})
-        assert sth.prob.status == cp.OPTIMAL_INACCURATE
-        assert sth.objective.value > 0
-        assert sth.prob.solver_stats.extra_stats["mip_gap"] > 0
-
-        # run without enough time to do anything
-        with pytest.raises(cp.error.SolverError):
-            sth.solve(solver='SCIPY', scipy_options={"time_limit": 0.})
+        # We only check that the option does not raise an error.
+        sth.solve(solver='SCIPY', scipy_options={"time_limit": 0.1})
 
 
 @unittest.skipUnless('COPT' in INSTALLED_SOLVERS, 'COPT is not installed.')


### PR DESCRIPTION
## Description

This time based test failed on some systems (e.g., here: https://github.com/conda-forge/cvxpy-feedstock/pull/80).
I add 10x the time and reduce the scope of the tests to make sure it does not raise an error.

cc: @h-vetinari 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.