### PR TITLE
Docs new atmos api reference

### DIFF
--- a/doc/source/api_reference/cvxpy.atoms.affine.rst
+++ b/doc/source/api_reference/cvxpy.atoms.affine.rst
@@ -109,12 +109,12 @@ matmul
 
 .. autofunction:: cvxpy.matmul
 
-.. mean:
+.. _mean:
 
 mean
 ---------------------------------
 
-.. autofunction:: cvxpy.mean
+.. autofunction:: cvxpy.atoms.stats.mean
 
 .. _multiply:
 

--- a/doc/source/api_reference/cvxpy.atoms.affine.rst
+++ b/doc/source/api_reference/cvxpy.atoms.affine.rst
@@ -42,12 +42,12 @@ conj
 
 .. autoclass:: cvxpy.conj
 
-.. _conv:
+.. _convolve:
 
-conv
+convolve
 ---------------------------------
 
-.. autoclass:: cvxpy.conv
+.. autoclass:: cvxpy.convolve
     :show-inheritance:
 
 .. _cumsum:
@@ -108,6 +108,13 @@ matmul
 --------------------------------
 
 .. autofunction:: cvxpy.matmul
+
+.. mean:
+
+mean
+---------------------------------
+
+.. autofunction:: cvxpy.mean
 
 .. _multiply:
 
@@ -219,6 +226,13 @@ vec
 --------------------------------
 
 .. autofunction:: cvxpy.vec
+
+.. _vec_to_upper_tri:
+
+vec_to_upper_tri
+--------------------------------
+
+.. autofunction:: cvxpy.atoms.affine.upper_tri.vec_to_upper_tri
 
 .. _vstack:
 

--- a/doc/source/api_reference/cvxpy.atoms.other_atoms.rst
+++ b/doc/source/api_reference/cvxpy.atoms.other_atoms.rst
@@ -12,14 +12,14 @@ cummax
 .. autoclass:: cvxpy.atoms.cummax.cummax
     :show-inheritance:
 
-.. _diff-pos:
+.. _diff_pos:
 
 diff_pos
 --------
 
-.. autofunction:: cvxpy.atoms.one_minus.diff_pos
+.. autofunction:: cvxpy.atoms.one_minus_pos.diff_pos
 
-.. _eye-minus-inv:
+.. _diff_pos:
 
 .. _dotsort:
 
@@ -160,7 +160,6 @@ norm2
 --------------------------
 
 .. autofunction:: cvxpy.atoms.norm.norm2
-    :show-inheritance:
 
 .. _norm-inf:
 

--- a/doc/source/api_reference/cvxpy.atoms.other_atoms.rst
+++ b/doc/source/api_reference/cvxpy.atoms.other_atoms.rst
@@ -216,6 +216,13 @@ Pnorm
 
 .. autoclass:: cvxpy.atoms.pnorm.Pnorm
 
+.. _ptp:
+
+ptp
+--------------------------
+
+.. autofunction:: cvxpy.atoms.ptp.ptp
+
 .. _prod:
 
 prod
@@ -252,6 +259,13 @@ sigma_max
 
 .. autoclass:: cvxpy.atoms.sigma_max.sigma_max
     :show-inheritance:
+
+.. _std:
+
+std
+-------------------------------
+
+.. autofunction:: cvxpy.atoms.stats.std
 
 .. _sum-largest:
 
@@ -296,6 +310,14 @@ tv
 -------------------------------------
 
 .. autofunction:: cvxpy.atoms.total_variation.tv
+
+.. _var:
+
+var
+-------------------------------------
+
+.. autofunction:: cvxpy.atoms.stats.var
+
 
 .. _von-neumann-entr:
 


### PR DESCRIPTION
## Description
Adds API reference for atoms introduced in #2238.
Also contains two unrelated fixes for `norm2` and `diff_pos`.
I have opted for a fully qualified declaration. 

Updates:
![image](https://github.com/cvxpy/cvxpy/assets/44360364/4e84a273-5b43-4e7f-b52e-a5c459165fde)
![image](https://github.com/cvxpy/cvxpy/assets/44360364/1ee90af6-1633-4ff7-ab7f-33f500a6b6e4)
![image](https://github.com/cvxpy/cvxpy/assets/44360364/66812e4a-db57-40e8-b332-60f2df5eb1d1)
![image](https://github.com/cvxpy/cvxpy/assets/44360364/29d4a01b-0a2b-4c2b-af6b-bd1a58c516e3)
![image](https://github.com/cvxpy/cvxpy/assets/44360364/9e94dbec-ff84-46ce-90f2-029bb72d57ce)
![image](https://github.com/cvxpy/cvxpy/assets/44360364/273a4362-15d6-41cd-aefe-9ad783ab13cf)
![image](https://github.com/cvxpy/cvxpy/assets/44360364/11b2c4ec-5ed7-47a0-9fe5-d3470941c777)

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.