### PR TITLE
Re-compile if quadratic objective usage changed

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -107,8 +107,8 @@ class Cache:
         self.param_prog = None
         self.inverse_data = None
 
-    def make_key(self, solver, gp, ignore_dpp):
-        return (solver, gp, ignore_dpp)
+    def make_key(self, solver, gp, ignore_dpp, use_quad_obj):
+        return (solver, gp, ignore_dpp, use_quad_obj)
 
     def gp(self):
         return self.key is not None and self.key[1]
@@ -634,8 +634,13 @@ class Problem(u.Canonical):
             raise DPPError("Cannot set enforce_dpp = True and ignore_dpp = True.")
 
         start = time.time()
-        # Cache includes ignore_dpp because it alters compilation.
-        key = self._cache.make_key(solver, gp, ignore_dpp)
+        # Cache includes ignore_dpp and solver_opts['use_quad_obj']
+        # because they alter compilation.
+        if solver_opts is None:
+            use_quad_obj = None
+        else:
+            use_quad_obj = solver_opts.get('use_quad_obj', None)
+        key = self._cache.make_key(solver, gp, ignore_dpp, use_quad_obj)
         if key != self._cache.key:
             self._cache.invalidate()
             solving_chain = self._construct_chain(

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -237,6 +237,20 @@ class TestProblem(BaseTest):
         self.assertIsNone(data["A"])
         self.assertEqual(data["G"].shape, (3, 3))
 
+        # caching use_quad_obj
+        p = Problem(cp.Minimize(cp.sum_squares(self.x) + 2))
+        data, _, _ = p.get_problem_data(s.SCS, solver_opts={"use_quad_obj": False})
+        dims = data[ConicSolver.DIMS]
+        self.assertEqual(dims.soc, [4])
+        self.assertEqual(data["c"].shape, (3,))
+        self.assertEqual(data["A"].shape, (4, 3))
+        data, _, _ = p.get_problem_data(s.SCS, solver_opts={"use_quad_obj": True})
+        dims = data[ConicSolver.DIMS]
+        self.assertEqual(dims.soc, [])
+        self.assertEqual(data["P"].shape, (2, 2))
+        self.assertEqual(data["c"].shape, (2,))
+        self.assertEqual(data["A"].shape, (0, 2))
+
         if s.CVXOPT in INSTALLED_SOLVERS:
             data, _, _ = Problem(cp.Minimize(cp.norm(self.x) + 3)).get_problem_data(
                 s.CVXOPT)


### PR DESCRIPTION
## Description
When solving repeatedly with a different value of `use_quad_obj`, the compilation cache should be invalidated since the standard form changes.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.