### PR TITLE
SCIP return solution if [total]nodelimit hit

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
@@ -47,6 +47,8 @@ STATUS_MAP = {
     "optimal": s.OPTIMAL,
     "timelimit": s.OPTIMAL_INACCURATE,
     "gaplimit": s.OPTIMAL_INACCURATE,
+    "nodelimit": s.OPTIMAL_INACCURATE,
+    "totalnodelimit": s.OPTIMAL_INACCURATE,
     "bestsollimit": s.USER_LIMIT,
     # INF_OR_UNB
     "infeasible": s.INFEASIBLE,
@@ -56,8 +58,6 @@ STATUS_MAP = {
     "userinterrupt": s.SOLVER_ERROR,
     "memlimit": s.SOLVER_ERROR,
     "sollimit": s.SOLVER_ERROR,
-    "nodelimit": s.SOLVER_ERROR,
-    "totalnodelimit": s.SOLVER_ERROR,
     "stallnodelimit": s.SOLVER_ERROR,
     "restartlimit": s.SOLVER_ERROR,
     "unknown": s.SOLVER_ERROR,


### PR DESCRIPTION
## Description

Makes it so that the SCIP solver will still return a solution if it hits the maximum number of iterations (consistent with timeout behavior).

Issue link: https://github.com/cvxpy/cvxpy/issues/2278

## Type of change
- [x] Bug fix

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.