### PR TITLE
Test SCS Python 3.8 fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        if: ${{env.USE_OPENMP != 'True'}}
+        if: ${{github.event_name == 'push' && env.USE_OPENMP != 'True'}}
         env:
           CIBW_BUILD: "cp3${{env.PYTHON_SUBVERSION}}-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
@@ -131,13 +131,13 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.2
 
       - name: Build source
-        if: ${{env.SINGLE_ACTION_CONFIG == 'True'}}
+        if: ${{github.event_name == 'push' && env.SINGLE_ACTION_CONFIG == 'True'}}
         run: |
           pip install build
           python -m build --sdist -o wheelhouse
 
       - name: Check wheels
-        if: ${{env.USE_OPENMP != 'True'}}
+        if: ${{github.event_name == 'push' &&  env.USE_OPENMP != 'True'}}
         shell: bash
         run: |
           python -m pip install --upgrade twine
@@ -220,6 +220,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
+        if: ${{github.event_name == 'push'}}
         env:
           CIBW_BUILD: "cp3${{env.PYTHON_SUBVERSION}}-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
@@ -228,13 +229,14 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.2
 
       - name: Build source
-        if: ${{ env.SINGLE_ACTION_CONFIG == 'True'}}
+        if: ${{github.event_name == 'push' && env.SINGLE_ACTION_CONFIG == 'True'}}
         run: |
           pip install build
           python -m build --sdist -o wheelhouse
 
       - name: Check wheels
         shell: bash
+        if: ${{github.event_name == 'push'}}
         run: |
           python -m pip install --upgrade twine
           twine check wheelhouse/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        if: ${{github.event_name == 'push' && env.USE_OPENMP != 'True'}}
+        if: ${{env.USE_OPENMP != 'True'}}
         env:
           CIBW_BUILD: "cp3${{env.PYTHON_SUBVERSION}}-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
@@ -131,13 +131,13 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.2
 
       - name: Build source
-        if: ${{github.event_name == 'push' && env.SINGLE_ACTION_CONFIG == 'True'}}
+        if: ${{env.SINGLE_ACTION_CONFIG == 'True'}}
         run: |
           pip install build
           python -m build --sdist -o wheelhouse
 
       - name: Check wheels
-        if: ${{github.event_name == 'push' &&  env.USE_OPENMP != 'True'}}
+        if: ${{env.USE_OPENMP != 'True'}}
         shell: bash
         run: |
           python -m pip install --upgrade twine
@@ -230,7 +230,6 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        if: ${{github.event_name == 'push'}}
         env:
           CIBW_BUILD: "cp3${{env.PYTHON_SUBVERSION}}-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
@@ -239,14 +238,13 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.2
 
       - name: Build source
-        if: ${{github.event_name == 'push' && env.SINGLE_ACTION_CONFIG == 'True'}}
+        if: ${{ env.SINGLE_ACTION_CONFIG == 'True'}}
         run: |
           pip install build
           python -m build --sdist -o wheelhouse
 
       - name: Check wheels
         shell: bash
-        if: ${{github.event_name == 'push'}}
         run: |
           python -m pip install --upgrade twine
           twine check wheelhouse/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,16 +196,6 @@ jobs:
           echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
           echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
 
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-          channels: conda-forge,anaconda
-
-      - name: Install openblas
-        shell: bash
-        run: conda install openblas
-
       - name: Adapt pyproject.toml
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,6 +196,16 @@ jobs:
           echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
           echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
 
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge,anaconda
+
+      - name: Install openblas
+        shell: bash
+        run: conda install openblas
+
       - name: Adapt pyproject.toml
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,16 +196,16 @@ jobs:
           echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
           echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
 
-      - name: Adapt setup.py
+      - name: Adapt pyproject.toml
         shell: bash
         run: |
           # Mac has a different syntax for sed -i, this works across oses
-          sed -i.bak -e "s/name='cvxpy',/name='cvxpy-base',/g" setup.py
-          sed -i.bak '/clarabel >= /d' setup.py
-          sed -i.bak '/osqp >= /d' setup.py
-          sed -i.bak '/ecos >= /d' setup.py
-          sed -i.bak '/scs >= /d' setup.py
-          rm -rf setup.py.bak
+          sed -i.bak -e "s/name='cvxpy',/name='cvxpy-base',/g" pyproject.toml
+          sed -i.bak '/clarabel >= /d' pyproject.toml
+          sed -i.bak '/osqp >= /d' pyproject.toml
+          sed -i.bak '/ecos >= /d' pyproject.toml
+          sed -i.bak '/scs >= /d' pyproject.toml
+          rm -rf pyproject.toml.bak
 
       - name: Verify that we can build by pip-install on each OS.
         if: ${{env.PIP_INSTALL == 'True'}}

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -11,19 +11,19 @@ conda config --set remote_backoff_factor 2
 conda config --set remote_read_timeout_secs 120.0
 
 if [[ "$PYTHON_VERSION" == "3.8" ]]; then
-  conda install scipy=1.3 numpy=1.16 mkl pip pytest pytest-cov lapack ecos scs osqp cvxopt proxsuite "setuptools>65.5.1"
+  conda install scipy=1.3 numpy=1.16 mkl pip pytest pytest-cov openblas ecos scs osqp cvxopt proxsuite "setuptools>65.5.1"
 elif [[ "$PYTHON_VERSION" == "3.9" ]]; then
   # The earliest version of numpy that works is 1.19.
   # Given numpy 1.19, the earliest version of scipy we can use is 1.5.
-  conda install scipy=1.5 numpy=1.19 mkl pip pytest lapack ecos scs osqp cvxopt proxsuite "setuptools>65.5.1"
+  conda install scipy=1.5 numpy=1.19 mkl pip pytest openblas ecos scs osqp cvxopt proxsuite "setuptools>65.5.1"
 elif [[ "$PYTHON_VERSION" == "3.10" ]]; then
     # The earliest version of numpy that works is 1.21.
     # Given numpy 1.21, the earliest version of scipy we can use is 1.7.
-    conda install scipy=1.7 numpy=1.21 mkl pip pytest lapack ecos scs osqp cvxopt proxsuite "setuptools>65.5.1"
+    conda install scipy=1.7 numpy=1.21 mkl pip pytest openblas ecos scs osqp cvxopt proxsuite "setuptools>65.5.1"
 elif [[ "$PYTHON_VERSION" == "3.11" ]]; then
     # The earliest version of numpy that works is 1.23.4.
     # Given numpy 1.23.4, the earliest version of scipy we can use is 1.9.3.
-    conda install scipy=1.9.3 numpy=1.23.4 mkl pip pytest lapack ecos scs cvxopt proxsuite "setuptools>65.5.1"
+    conda install scipy=1.9.3 numpy=1.23.4 mkl pip pytest openblas ecos scs cvxopt proxsuite "setuptools>65.5.1"
 fi
 
 if [[ "$PYTHON_VERSION" == "3.11" ]]; then

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -52,7 +52,8 @@ if [[ "$RUNNER_OS" != "Windows" ]]; then
 fi
 
 # SCIP only works with scipy >= 1.5 due to dependency conflicts when installing on Linux/macOS
-if [[ "$PYTHON_VERSION" == "3.9" ]] || [[ "$RUNNER_OS" == "Windows" ]]; then
+# TODO make work on linux and mac.
+if [[ "$PYTHON_VERSION" == "3.9" ]] && [[ "$RUNNER_OS" == "Windows" ]]; then
   conda install pyscipopt
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "osqp >= 0.6.2",
     "ecos >= 2",
     "clarabel >= 0.5.0",
-    "scs >= 3.0",
+    "scs @ git+https://github.com/bodono/scs-python.git",
     "numpy >= 1.15",
     "scipy >= 1.1.0",
     "pybind11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 # Solver names as in cvxpy.settings = pip-installable distribution providing it
 CBC = ["cylp>=0.91.5"]
-CLARABEL = ["clarabel"]
+CLARABEL = []
 CVXOPT = ["cvxopt"]
 DIFFCP = ["diffcp"]
 ECOS = []


### PR DESCRIPTION
## Description
Various updates to the setup and build scripts:
- Use "oldest-supported-numpy". 
- Fix cvxpy-base build.
- Remove clarabel as an *optional* dependency. (Still kept as a *required* dependency.)

Issue link (if applicable): #2287 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.