### PR TITLE
[Docs] update contributing docs to reflect usage of ruff over flake8/isort

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,17 +72,14 @@ limitations under the License.
 ```
 
 ## Code style
-We use [flake8](https://flake8.pycqa.org/en/latest/) and [isort](https://pycqa.github.io/isort/) to enforce our Python coding
-style. Before sending us a pull request, navigate to the project root
-and run
+We use [ruff](https://docs.astral.sh/ruff/) to enforce our Python coding style. Before sending us a pull request, navigate to the project root and run
 
 ```
-flake8 cvxpy/
-isort .
+pip install ruff
+ruff check cvxpy
 ```
 
-to make sure that your changes abide by our style conventions. Please fix any
-errors that are reported before sending the pull request.
+to make sure that your changes abide by our style conventions. Please fix any errors that are reported before sending the pull request.
 
 Optionally, the package [pre-commit](https://pre-commit.com/) can be installed to check these conventions automatically before every commit.
 ```


### PR DESCRIPTION
## Description
Per a conversation [here](https://discord.com/channels/845323972962549790/1183448452357705749/1183448452357705749) with @SteveDiamond, I am opening a PR to update the CVX documentation to reflect usage of `ruff` instead of `flake8` and `isort`.

This change ensures the *Code Style* section in `CONTRIBUTING.md` matches the web docs @ https://www.cvxpy.org/contributing/index.html

Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.