### PR TITLE
Issue 1540 add expression curvatures property to return all curvatures

### DIFF
--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -17,7 +17,7 @@ limitations under the License.
 import abc
 import warnings
 from functools import wraps
-from typing import Tuple
+from typing import List, Tuple
 
 import numpy as np
 
@@ -163,6 +163,27 @@ class Expression(u.Canonical):
         return self
 
     # Curvature properties.
+    @property
+    def curvatures(self) -> List[str]:
+        """List : Returns a list of the curvatures of the expression."""
+        curvatures = [
+            (self.is_constant, s.CONSTANT),
+            (self.is_affine, s.AFFINE),
+            (self.is_convex, s.CONVEX),
+            (self.is_concave, s.CONCAVE),
+            (self.is_log_log_constant, s.LOG_LOG_CONSTANT),
+            (self.is_log_log_affine, s.LOG_LOG_AFFINE),
+            (self.is_log_log_convex, s.LOG_LOG_CONVEX),
+            (self.is_log_log_concave, s.LOG_LOG_CONCAVE),
+            (self.is_quasilinear, s.QUASILINEAR),
+            (self.is_quasiconvex, s.QUASICONVEX),
+            (self.is_quasiconcave, s.QUASICONCAVE),
+        ]
+        curvatures = [curvature for condition, curvature in curvatures if condition()]
+        if not curvatures:
+            return [s.UNKNOWN]
+        return curvatures
+
     @property
     def curvature(self) -> str:
         """str : The curvature of the expression.
@@ -844,4 +865,3 @@ class Expression(u.Canonical):
         """
         from cvxpy import var
         return var(self, ddof=ddof)
-

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1354,6 +1354,28 @@ class TestExpressions(BaseTest):
         R = A + row_scale
         self.assertEqual(R.shape, (m, n))
 
+    def test_curvatures(self) -> None:
+        """Test the curvatures property returns a list of valid curvatures
+        """
+        mat = np.array([[1, -1]])
+        self.assertEqual(cp.sum(mat @ cp.square(Variable(2))).curvatures, [s.UNKNOWN])
+
+        y = cp.Constant(42)
+        self.assertIn(s.CONSTANT, y.curvatures)
+
+        x = cp.Variable(pos=True)
+        assert x.curvatures == [s.AFFINE, s.CONVEX, s.CONCAVE, s.LOG_LOG_AFFINE, s.LOG_LOG_CONVEX,
+                                s.LOG_LOG_CONCAVE, s.QUASILINEAR, s.QUASICONVEX, s.QUASICONCAVE]
+
+        monomial = x*x*x
+        assert monomial.curvatures == [s.LOG_LOG_AFFINE, s.LOG_LOG_CONVEX, s.LOG_LOG_CONCAVE]
+
+        posynomial = x*x*x + x
+        assert posynomial.curvatures == [s.LOG_LOG_CONVEX]
+
+        llcv = 1/(x*x*x + x)
+        assert llcv.curvatures == [s.LOG_LOG_CONCAVE]
+
     def test_log_log_curvature(self) -> None:
         """Test that the curvature string is populated for log-log expressions.
         """

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1364,17 +1364,19 @@ class TestExpressions(BaseTest):
         self.assertIn(s.CONSTANT, y.curvatures)
 
         x = cp.Variable(pos=True)
-        assert x.curvatures == [s.AFFINE, s.CONVEX, s.CONCAVE, s.LOG_LOG_AFFINE, s.LOG_LOG_CONVEX,
-                                s.LOG_LOG_CONCAVE, s.QUASILINEAR, s.QUASICONVEX, s.QUASICONCAVE]
+        self.assertEqual(x.curvatures, [s.AFFINE, s.CONVEX, s.CONCAVE,
+                                        s.LOG_LOG_AFFINE, s.LOG_LOG_CONVEX, s.LOG_LOG_CONCAVE,
+                                        s.QUASILINEAR, s.QUASICONVEX, s.QUASICONCAVE])
 
         monomial = x*x*x
-        assert monomial.curvatures == [s.LOG_LOG_AFFINE, s.LOG_LOG_CONVEX, s.LOG_LOG_CONCAVE]
+        self.assertEqual(monomial.curvatures, [s.LOG_LOG_AFFINE,
+                                               s.LOG_LOG_CONVEX, s.LOG_LOG_CONCAVE])
 
         posynomial = x*x*x + x
-        assert posynomial.curvatures == [s.LOG_LOG_CONVEX]
+        self.assertEqual(posynomial.curvatures == [s.LOG_LOG_CONVEX])
 
         llcv = 1/(x*x*x + x)
-        assert llcv.curvatures == [s.LOG_LOG_CONCAVE]
+        self.assertEqual(llcv.curvatures == [s.LOG_LOG_CONCAVE])
 
     def test_log_log_curvature(self) -> None:
         """Test that the curvature string is populated for log-log expressions.

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1355,8 +1355,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(R.shape, (m, n))
 
     def test_curvatures(self) -> None:
-        """Test the curvatures property returns a list of valid curvatures
-        """
+        """Test the curvatures property returns a list of valid curvatures"""
         mat = np.array([[1, -1]])
         self.assertEqual(cp.sum(mat @ cp.square(Variable(2))).curvatures, [s.UNKNOWN])
 
@@ -1373,10 +1372,10 @@ class TestExpressions(BaseTest):
                                                s.LOG_LOG_CONVEX, s.LOG_LOG_CONCAVE])
 
         posynomial = x*x*x + x
-        self.assertEqual(posynomial.curvatures == [s.LOG_LOG_CONVEX])
+        self.assertEqual(posynomial.curvatures, [s.LOG_LOG_CONVEX])
 
         llcv = 1/(x*x*x + x)
-        self.assertEqual(llcv.curvatures == [s.LOG_LOG_CONCAVE])
+        self.assertEqual(llcv.curvatures, [s.LOG_LOG_CONCAVE])
 
     def test_log_log_curvature(self) -> None:
         """Test that the curvature string is populated for log-log expressions.


### PR DESCRIPTION
## Description
This PR is in response to a feature request outlined in [Issue 1540](https://github.com/cvxpy/cvxpy/issues/1540). In summary, I have created a `curvatures` property which will return a list of all known curvatures of an expression. 

Open to suggestions on next steps - please see the issue link to discuss if further steps should be taken (if any). 

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.