### PR TITLE
change some O(n) lookups in scip_conif.py to O(1)

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
@@ -125,8 +125,8 @@ class SCIP(ConicSolver):
 
         # data, inv_data = super(SCIP, self).apply(problem)
         variables = problem.x
-        data[s.BOOL_IDX] = [int(t[0]) for t in variables.boolean_idx]
-        data[s.INT_IDX] = [int(t[0]) for t in variables.integer_idx]
+        data[s.BOOL_IDX] = set(int(t[0]) for t in variables.boolean_idx)
+        data[s.INT_IDX] = set(int(t[0]) for t in variables.integer_idx)
         inv_data['is_mip'] = data[s.BOOL_IDX] or data[s.INT_IDX]
 
         return data, inv_data

--- a/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
@@ -125,6 +125,8 @@ class SCIP(ConicSolver):
 
         # data, inv_data = super(SCIP, self).apply(problem)
         variables = problem.x
+
+        # Use of sets here is minor lift to speed up get_variable_type(...) below.
         data[s.BOOL_IDX] = set(int(t[0]) for t in variables.boolean_idx)
         data[s.INT_IDX] = set(int(t[0]) for t in variables.integer_idx)
         inv_data['is_mip'] = data[s.BOOL_IDX] or data[s.INT_IDX]


### PR DESCRIPTION
## Description
Minor change for SCIP wrapper that reduces some O(n) lookups to O(1). The lookups get called as many times as there are variables by get_variable_type (in scip_conif.py). 

(Anecdotally, this reduced my create_variables() time from 10 minutes to 0.5 seconds.)


## Type of change
- [X] Bug fix

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Check that your code adheres to our coding style.
- [X] Run the unittests and check that they’re passing.
