### PR TITLE
avoid sparse identity matrix multiply in conic_solver.py

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
+++ b/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
@@ -44,6 +44,19 @@ class LinearOperator:
     def __call__(self, X):
         return self._matmul(X)
 
+class IdentityOperator(LinearOperator):
+    """A wrapper for the identity operator."""
+    def __init__(self, n):
+        self.shape = (n,n)
+    def __call__(self, X):
+        return X
+
+class NegativeIdentityOperator(LinearOperator):
+    """A wrapper for the negative identity operator."""
+    def __init__(self, n):
+        self.shape = (n,n)
+    def __call__(self, X):
+        return -X
 
 def as_linear_operator(linear_op):
     if isinstance(linear_op, LinearOperator):
@@ -187,9 +200,9 @@ class ConicSolver(Solver):
         for constr in problem.constraints:
             total_height = sum([arg.size for arg in constr.args])
             if type(constr) == Zero:
-                restruct_mat.append(-sp.eye(constr.size, format='csr'))
+                restruct_mat.append(NegativeIdentityOperator(constr.size))
             elif type(constr) == NonNeg:
-                restruct_mat.append(sp.eye(constr.size, format='csr'))
+                restruct_mat.append(IdentityOperator(constr.size))
             elif type(constr) == SOC:
                 # Group each t row with appropriate X rows.
                 assert constr.axis == 0, 'SOC must be lowered to axis == 0'


### PR DESCRIPTION
Compiling a "highly" parameterized linear program seems to hit a slow path involving a number of scipy sparse matrix multiplication operations within the ConicSolver reduction. By avoiding multiplication altogether for the trivial cases involving identity and negative identity operations, the initial compilation path for a parameterized linear program can be sped up by orders of magnitude.

As an example, for a relatively sparse problem with ~7k variables, ~20k constraints and ~7k parameters (all on the rhs of constraints), with this change the initial cvxpy compile time goes from ~140s to 0.4s (**350x speedup**).

pr_benchmark comments:
```
Benchmarks that have improved:

       before           after         ratio
     [8d1c56d4]       [987310df]
-         2.65±0s          2.40±0s     0.91  simple_LP_benchmarks.SimpleFullyParametrizedLPBenchmark.time_compile_problem
-         425±0ms          248±0ms     0.58  high_dim_convex_plasticity.ConvexPlasticity.time_compile_problem
```

## Type of change
- [x] performance enhancement

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] ~Write unittests~ (looks like there's already a benchmark that covers this, seems to have improved)
- [x] Run the unittests and checked that they’re passing (missing some solvers locally though)
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.