### PR TITLE
Restore Mosek 9 compatibility

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -513,7 +513,8 @@ class MOSEK(ConicSolver):
         problem_status = task.getprosta(sol_type)
         attr = {s.SOLVE_TIME: task.getdouinf(mosek.dinfitem.optimizer_time),
                 s.NUM_ITERS: task.getintinf(mosek.iinfitem.intpnt_iter) +
-                             task.getlintinf(mosek.liinfitem.simplex_iter) +
+                             task.getintinf(mosek.iinfitem.sim_primal_iter) +
+                             task.getintinf(mosek.iinfitem.sim_dual_iter) +
                              task.getintinf(mosek.iinfitem.mio_num_relax),
                 s.EXTRA_STATS: {
                     "mio_intpnt_iter": task.getlintinf(mosek.liinfitem.mio_intpnt_iter),


### PR DESCRIPTION
As discussed on Discord this PR restores compatibility with Mosek 9, currently broken by the appearance of a symbol from Mosek >= 10 only.

@rileyjmurray 