### PR TITLE
Better integration with Mosek>=10; remove Mosek<=9 code

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -274,18 +274,16 @@ class MOSEK(ConicSolver):
                     sol = Solution(s.OPTIMAL, 0.0, dict(), {s.EQ_DUAL: data[s.B]}, dict())
                     return {'sol': sol}
             else:
-                env = mosek.Env()
-                task = env.Task(0, 0)
-                solver_opts = MOSEK.handle_options(env, task, verbose, solver_opts)
+                task = mosek.Task()
+                solver_opts = MOSEK.handle_options(task, verbose, solver_opts)
                 task = MOSEK._build_dualized_task(task, data)
         else:
             if len(data[s.C]) == 0:
                 sol = Solution(s.OPTIMAL, 0.0, dict(), dict(), dict())
                 return {'sol': sol}
             else:
-                env = mosek.Env()
-                task = env.Task(0, 0)
-                solver_opts = MOSEK.handle_options(env, task, verbose, solver_opts)
+                task = mosek.Task()
+                solver_opts = MOSEK.handle_options(task, verbose, solver_opts)
                 task = MOSEK._build_slack_task(task, data)
 
         # Save the task to a file if requested.
@@ -304,7 +302,7 @@ class MOSEK(ConicSolver):
         if verbose:
             task.solutionsummary(mosek.streamtype.msg)
 
-        return {'env': env, 'task': task, 'solver_options': solver_opts}
+        return {'task': task, 'solver_options': solver_opts}
 
     @staticmethod
     def _build_dualized_task(task, data):
@@ -483,15 +481,8 @@ class MOSEK(ConicSolver):
         if solver_opts['accept_unknown']:
             STATUS_MAP[mosek.solsta.unknown] = s.OPTIMAL_INACCURATE
 
-        # "Near" statuses only up to Mosek 8.1
-        if hasattr(mosek.solsta, 'near_optimal'):
-            STATUS_MAP[mosek.solsta.near_optimal] = s.OPTIMAL_INACCURATE
-            STATUS_MAP[mosek.solsta.near_integer_optimal] = s.OPTIMAL_INACCURATE
-            STATUS_MAP[mosek.solsta.near_prim_infeas_cer] = s.INFEASIBLE_INACCURATE
-            STATUS_MAP[mosek.solsta.near_dual_infeas_cer] = s.UNBOUNDED_INACCURATE
         STATUS_MAP = defaultdict(lambda: s.SOLVER_ERROR, STATUS_MAP)
 
-        env = solver_output['env']
         task = solver_output['task']
         solver_opts = solver_output['solver_options']
         simplex_algs = [
@@ -555,8 +546,7 @@ class MOSEK(ConicSolver):
 
         # Delete the mosek Task and Environment
         task.__exit__(None, None, None)
-        env.__exit__(None, None, None)
-
+ 
         return sol
 
     @staticmethod
@@ -631,7 +621,7 @@ class MOSEK(ConicSolver):
         return prim_vars
 
     @staticmethod
-    def handle_options(env, task, verbose: bool, solver_opts: dict) -> dict:
+    def handle_options(task, verbose: bool, solver_opts: dict) -> dict:
         """
         Handle user-specified solver options.
 
@@ -648,7 +638,7 @@ class MOSEK(ConicSolver):
                 s.LOGGER.info(text.rstrip('\n'))
 
             print('\n')
-            env.set_Stream(mosek.streamtype.log, streamprinter)
+
             task.set_Stream(mosek.streamtype.log, streamprinter)
 
         solver_opts = MOSEK.parse_eps_keyword(solver_opts)
@@ -743,7 +733,7 @@ class MOSEK(ConicSolver):
     @staticmethod
     def tolerance_params() -> tuple[str]:
         # tolerance parameters from
-        # https://docs.mosek.com/9.3/pythonapi/param-groups.html
+        # https://docs.mosek.com/latest/pythonapi/param-groups.html
         return (
             # Conic interior-point tolerances
             "MSK_DPAR_INTPNT_CO_TOL_DFEAS",


### PR DESCRIPTION
As discussed on Discord, this PR slightly modernizes the Mosek interface, getting rid of the ``env`` object (Mosek environment), which was only dragged around through the code, and instead only creating a Mosek task ``task``. A default global environment will be created internally by the library, once for the whole process. See https://docs.mosek.com/latest/pythonapi/environment-and-task.html for more info.

In practice this change will only make a difference for users of commercial floating licenses. They will have one license checkout per process, instead of per solve, ie. the user experience should only improve, judging from some communication we had with users in the past. In any case, should this ever come up as a problem, this is a business issue Mosek support takes responsibility for. Otherwise the only difference is code simplicity.

Since this change **only works with Mosek >= 10**, I went ahead and removed all code parts only relevant for Mosek <= 9. Releasing this code makes CVXPY depend on Mosek>=10.