### PR TITLE
Implements inplace mutation error

### DIFF
--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -68,6 +68,14 @@ errors or code that doesn't behave as expected. Consider using one of the
 functions documented here: https://www.cvxpy.org/tutorial/functions/index.html
 """
 
+__INPLACE_MUTATION_ERROR__ = """
+You're trying to mutate a CVXPY expression inplace. This is prone to errors or
+code that doesn't behave as expected. Consider implementing replacing, for example:
+> x += 1
+with
+> x = x + 1
+"""
+
 __ABS_ERROR__ = """
 You're calling the built-in abs function on a CVXPY expression. This is not
 supported. Consider using the abs function provided by CVXPY.
@@ -767,6 +775,11 @@ class Expression(u.Canonical):
                     len(args) == 2 and \
                     args[1] is self:
                 return ufunc_handler(self, args[0])
+            elif kwargs.keys() == {'out'} and \
+                    len(args) == 2 and \
+                    args[1] is self:
+                raise RuntimeError(__INPLACE_MUTATION_ERROR__)
+                
         except KeyError:
             pass
 
@@ -774,6 +787,45 @@ class Expression(u.Canonical):
 
     def __abs__(self):
         raise TypeError(__ABS_ERROR__)
+
+    def __iadd__(self, other):
+        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
+
+    def __isub__(self, other):
+        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
+
+    def __imul__(self, other):
+        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
+
+    def __imatmul__(self, other):
+        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
+
+    def __itruediv__(self, other):
+        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
+
+    def __ifloordiv__(self, other):
+        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
+
+    def __imod__(self, other):
+        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
+
+    def __ipow__(self, other, modulo):
+        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
+
+    def __ilshift__(self, other):
+        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
+
+    def __irshift__(self, other):
+        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
+
+    def __iand__(self, other):
+        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
+
+    def __ixor__(self, other):
+        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
+
+    def __ior__(self, other):
+        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
 
     def conj(self):
         """

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -70,7 +70,7 @@ functions documented here: https://www.cvxpy.org/tutorial/functions/index.html
 
 __INPLACE_MUTATION_ERROR__ = """
 You're trying to mutate a CVXPY expression inplace. This is prone to errors or
-code that doesn't behave as expected. Consider implementing replacing, for example:
+code that doesn't behave as expected. Consider alternatives. For example, replace
 > x += 1
 with
 > x = x + 1
@@ -779,7 +779,7 @@ class Expression(u.Canonical):
                     len(args) == 2 and \
                     args[1] is self and \
                     args[0] is kwargs['out']:
-                return ufunc_handler(self, args[0])
+                raise RuntimeError(__INPLACE_MUTATION_ERROR__)
 
         except KeyError:
             pass

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -777,9 +777,10 @@ class Expression(u.Canonical):
                 return ufunc_handler(self, args[0])
             elif kwargs.keys() == {'out'} and \
                     len(args) == 2 and \
-                    args[1] is self:
-                raise RuntimeError(__INPLACE_MUTATION_ERROR__)
-                
+                    args[1] is self and \
+                    args[0] is kwargs['out']:
+                return ufunc_handler(self, args[0])
+
         except KeyError:
             pass
 
@@ -787,45 +788,6 @@ class Expression(u.Canonical):
 
     def __abs__(self):
         raise TypeError(__ABS_ERROR__)
-
-    def __iadd__(self, other):
-        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
-
-    def __isub__(self, other):
-        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
-
-    def __imul__(self, other):
-        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
-
-    def __imatmul__(self, other):
-        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
-
-    def __itruediv__(self, other):
-        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
-
-    def __ifloordiv__(self, other):
-        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
-
-    def __imod__(self, other):
-        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
-
-    def __ipow__(self, other, modulo):
-        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
-
-    def __ilshift__(self, other):
-        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
-
-    def __irshift__(self, other):
-        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
-
-    def __iand__(self, other):
-        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
-
-    def __ixor__(self, other):
-        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
-
-    def __ior__(self, other):
-        raise RuntimeError(__INPLACE_MUTATION_ERROR__)
 
     def conj(self):
         """

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -71,9 +71,9 @@ functions documented here: https://www.cvxpy.org/tutorial/functions/index.html
 __INPLACE_MUTATION_ERROR__ = """
 You're trying to mutate a CVXPY expression inplace. This is prone to errors or
 code that doesn't behave as expected. Consider alternatives. For example, replace
-> x += 1
+    x += 1
 with
-> x = x + 1
+    x = x + 1
 """
 
 __ABS_ERROR__ = """
@@ -778,7 +778,9 @@ class Expression(u.Canonical):
             elif kwargs.keys() == {'out'} and \
                     len(args) == 2 and \
                     args[1] is self and \
-                    args[0] is kwargs['out']:
+                    isinstance(kwargs['out'], tuple) and \
+                    len(kwargs['out']) == 1 and \
+                    args[0] is kwargs['out'][0]:
                 raise RuntimeError(__INPLACE_MUTATION_ERROR__)
 
         except KeyError:

--- a/cvxpy/tests/test_errors.py
+++ b/cvxpy/tests/test_errors.py
@@ -16,10 +16,10 @@ limitations under the License.
 
 
 import builtins
+import re
 
 import numpy as np
 import pytest
-import re
 
 import cvxpy as cp
 from cvxpy.expressions.expression import (

--- a/cvxpy/tests/test_errors.py
+++ b/cvxpy/tests/test_errors.py
@@ -68,7 +68,7 @@ class TestErrors(BaseTest):
                 continue  # We don't implement __rpow__ yet.
             with pytest.raises(RuntimeError, match=__NUMPY_UFUNC_ERROR__):
                 ufunc(self.x, a)
-            with pytest.raises(RuntimeError, match=__NUMPY_UFUNC_ERROR__):
+            with pytest.raises(RuntimeError, match=__INPLACE_MUTATION_ERROR__):
                 ufunc(a, self.x, out=a)
 
             if ufunc is np.left_shift or \

--- a/cvxpy/tests/test_errors.py
+++ b/cvxpy/tests/test_errors.py
@@ -24,6 +24,7 @@ import cvxpy as cp
 from cvxpy.expressions.expression import (
     __ABS_ERROR__,
     __BINARY_EXPRESSION_UFUNCS__,
+    __INPLACE_MUTATION_ERROR__,
     __NUMPY_UFUNC_ERROR__,
 )
 from cvxpy.tests.base_test import BaseTest
@@ -46,6 +47,15 @@ class TestErrors(BaseTest):
 
         with pytest.raises(RuntimeError, match=__NUMPY_UFUNC_ERROR__):
             np.log(self.x)
+
+    def test_inplace_mutation_errors(self) -> None:
+        a = np.array([1, 2, 3])
+        with pytest.raises(RuntimeError, match=__INPLACE_MUTATION_ERROR__):
+            a += self.x
+
+        with pytest.raises(RuntimeError, match=__INPLACE_MUTATION_ERROR__):
+            np.add(a, self.x, out=a)
+
 
     def test_some_np_ufunc_works(self) -> None:
         a = np.array([[1., 3.], [3., 1.]])

--- a/cvxpy/tests/test_errors.py
+++ b/cvxpy/tests/test_errors.py
@@ -92,7 +92,7 @@ class TestErrors(BaseTest):
             with pytest.raises(RuntimeError, match=__NUMPY_UFUNC_ERROR__):
                 ufunc(self.x, b)
 
-            with pytest.raises(RuntimeError, match=__NUMPY_UFUNC_ERROR__):
+            with pytest.raises(RuntimeError, match=re.escape(__INPLACE_MUTATION_ERROR__)):
                 ufunc(b, self.x, out=b)
 
             if ufunc is np.left_shift or \

--- a/cvxpy/tests/test_errors.py
+++ b/cvxpy/tests/test_errors.py
@@ -19,6 +19,7 @@ import builtins
 
 import numpy as np
 import pytest
+import re
 
 import cvxpy as cp
 from cvxpy.expressions.expression import (
@@ -50,10 +51,10 @@ class TestErrors(BaseTest):
 
     def test_inplace_mutation_errors(self) -> None:
         a = np.array([1, 2, 3])
-        with pytest.raises(RuntimeError, match=__INPLACE_MUTATION_ERROR__):
+        with pytest.raises(RuntimeError, match=re.escape(__INPLACE_MUTATION_ERROR__)):
             a += self.x
 
-        with pytest.raises(RuntimeError, match=__INPLACE_MUTATION_ERROR__):
+        with pytest.raises(RuntimeError, match=re.escape(__INPLACE_MUTATION_ERROR__)):
             np.add(a, self.x, out=a)
 
 
@@ -68,7 +69,7 @@ class TestErrors(BaseTest):
                 continue  # We don't implement __rpow__ yet.
             with pytest.raises(RuntimeError, match=__NUMPY_UFUNC_ERROR__):
                 ufunc(self.x, a)
-            with pytest.raises(RuntimeError, match=__INPLACE_MUTATION_ERROR__):
+            with pytest.raises(RuntimeError, match=re.escape(__INPLACE_MUTATION_ERROR__)):
                 ufunc(a, self.x, out=a)
 
             if ufunc is np.left_shift or \


### PR DESCRIPTION
## Description

Implementing @rileyjmurray's suggestion from #2282 that we should error when someone attempts inplace mutation of a CVXPY expression.

This is a breaking change for the following code:

```python
x = cp.Variable()
x += 1
``` 

It also improves the error message on code we broke a few releases ago:

```python
x = cp.Variable(4)
c = np.array([1, 2, 3, 4])
x += c
```

It is possible to not break the first code while improving the error messages on the other code.

Once we have consensus on what we want this to do, I'll write unit tests.

## Type of change
- [ ] New feature (backwards compatible)
- [x] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.