### PR TITLE
Added HIGHS solver stats (LP/MILP)

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -262,8 +262,8 @@ class SCIPY(ConicSolver):
             
             attr = {}
             if "nit" in solution: # Number of interior-point or simplex iterations
-                attr[s.EXTRA_STATS] = {"nit": solution['nit']}
-            if "mip_gap" in solution: # Add branch and bound statistics
+                attr[s.NUM_ITERS] = solution['nit']
+            if "mip_gap" in solution: # Branch and bound statistics
                 attr[s.EXTRA_STATS] = {"mip_gap": solution['mip_gap'], 
                                        "mip_node_count": solution['mip_node_count'], 
                                        "mip_dual_bound": solution['mip_dual_bound']}

--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -259,9 +259,15 @@ class SCIPY(ConicSolver):
                     inverse_data[self.NEQ_CONSTR])
                 eq_dual.update(leq_dual)
                 dual_vars = eq_dual
+            
             attr = {}
-            if "mip_gap" in solution:
-                attr[s.EXTRA_STATS] = {"mip_gap": solution['mip_gap']}
+            if "nit" in solution: # Number of interior-point or simplex iterations
+                attr[s.EXTRA_STATS] = {"nit": solution['nit']}
+            if "mip_gap" in solution: # Add branch and bound statistics
+                attr[s.EXTRA_STATS] = {"mip_gap": solution['mip_gap'], 
+                                       "mip_node_count": solution['mip_node_count'], 
+                                       "mip_dual_bound": solution['mip_dual_bound']}
+
             return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
             return failure_solution(status)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2167,6 +2167,11 @@ class TestSCIPY(unittest.TestCase):
     def test_scipy_lp_5(self) -> None:
         StandardTestLPs.test_lp_5(solver='SCIPY', duals=self.d)
 
+    def test_scipy_lp_solver_stats(self) -> None:
+        sth = StandardTestLPs.test_lp_0(solver='SCIPY', duals=self.d)
+
+        self.assertTrue("nit" in sth.prob.solver_stats.extra_stats)
+
     @unittest.skipUnless('SCIPY' in INSTALLED_MI_SOLVERS, 'SCIPY version cannot solve MILPs')
     def test_scipy_mi_lp_0(self) -> None:
         StandardTestLPs.test_mi_lp_0(solver='SCIPY')
@@ -2198,6 +2203,14 @@ class TestSCIPY(unittest.TestCase):
         # We only check that the option does not raise an error.
         sth.solve(solver='SCIPY', scipy_options={"time_limit": 0.1})
 
+    @unittest.skipUnless('SCIPY' in INSTALLED_MI_SOLVERS, 'SCIPY version cannot solve MILPs')
+    def test_scipy_mi_solver_stats(self) -> None:
+        sth = sths.mi_lp_7()
+        sth.solve(solver='SCIPY')
+
+        self.assertTrue("mip_gap" in sth.prob.solver_stats.extra_stats)
+        self.assertTrue("mip_node_count" in sth.prob.solver_stats.extra_stats)
+        self.assertTrue("mip_dual_bound" in sth.prob.solver_stats.extra_stats)
 
 @unittest.skipUnless('COPT' in INSTALLED_SOLVERS, 'COPT is not installed.')
 class TestCOPT(unittest.TestCase):

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2170,7 +2170,8 @@ class TestSCIPY(unittest.TestCase):
     def test_scipy_lp_solver_stats(self) -> None:
         sth = StandardTestLPs.test_lp_0(solver='SCIPY', duals=self.d)
 
-        self.assertTrue("nit" in sth.prob.solver_stats.extra_stats)
+        # Equal because presolve might directly find the solution in 0 iterations
+        self.assertGreaterEqual(sth.prob.solver_stats.num_iters, 0)
 
     @unittest.skipUnless('SCIPY' in INSTALLED_MI_SOLVERS, 'SCIPY version cannot solve MILPs')
     def test_scipy_mi_lp_0(self) -> None:


### PR DESCRIPTION
## Description
I have added LP/MILP statistics information when solving problems with the HiGHS solver. It is a really minor change. The stats are different for continuous and discrete problems so I added two different unit tests.

(By the way, I did all of this in 5 minutes with codespaces. It was amazing!)

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
