### PR TITLE
Removes pybind11 runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
     "scs >= 3.2.4.post1",
     "numpy >= 1.15",
     "scipy >= 1.1.0",
-    "pybind11"
 ]
 requires-python = ">=3.8"
 urls = {Homepage = "https://github.com/cvxpy/cvxpy"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ ecos
 scs
 numpy
 scipy
-pybind11


### PR DESCRIPTION
## Description
Removes pybind11 runtime dependency from `requirements.txt` and `pyproject.toml`.
Issue link (if applicable): resolves #2330 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.