### PR TITLE
Adding quadratic objective support to NAG solver wrapper

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/nag_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/nag_conif.py
@@ -253,6 +253,10 @@ class NAG(ConicSolver):
             opt.handle_opt_set(handle, "Monitoring File = 6")
             opt.handle_opt_set(handle, "Monitoring Level = 2")
 
+        
+        # use_quad_obj is only for canonicalization
+        if "use_quad_obj" in solver_opts: 
+            del solver_opts["use_quad_obj"]
         # Set the optional parameters
         kwargs = sorted(solver_opts.keys())
         if "nag_params" in kwargs:

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1855,7 +1855,7 @@ class TestXPRESS(BaseTest):
 
 
 @unittest.skipUnless('NAG' in INSTALLED_SOLVERS, 'NAG is not installed.')
-class TestNAG(unittest.TestCase):
+class TestNAG(BaseTest):
 
     def test_nag_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver='NAG')
@@ -1889,6 +1889,33 @@ class TestNAG(unittest.TestCase):
         StandardTestSOCPs.test_socp_3ax0(solver='NAG')
         # axis 1
         StandardTestSOCPs.test_socp_3ax1(solver='NAG')
+
+    def test_nag_quad_obj(self) -> None:
+        """Test NAG canonicalization with a quadratic objective.
+        """    
+        x = cp.Variable(2)
+        expr = cp.sum_squares(x)
+        constr = [x >= 1]
+        prob = cp.Problem(cp.Minimize(expr), constr)
+        data = prob.get_problem_data(solver='NAG')
+        self.assertItemsAlmostEqual(data[0]["P"].A, 2*np.eye(2))
+        solution1 = prob.solve(solver='NAG')
+
+        # When use_quad_obj = False, the quadratic objective is
+        # canonicalized to a SOC constraint.
+        prob = cp.Problem(cp.Minimize(expr), constr)
+        solver_opts = {"use_quad_obj": False}
+        data = prob.get_problem_data(solver='NAG', solver_opts=solver_opts)
+        assert "P" not in data[0]
+        solution2 = prob.solve(solver='NAG', **solver_opts)
+
+        assert np.isclose(solution1, solution2)
+
+        # Check that there is no P for non-quadratic objectives.
+        expr = cp.norm(x, 1)
+        prob = cp.Problem(cp.Minimize(expr), constr)
+        data = prob.get_problem_data(solver='NAG')
+        assert "P" not in data[0]
 
 
 @unittest.skipUnless("SCIP" in INSTALLED_SOLVERS, "SCIP is not installed.")


### PR DESCRIPTION
## Description
We have modified the wrapper for the NAG solver to allow quadratic objective information to be passed directly to the solver (without cone transformation). This was done to improve the performance.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files. [no new files added]
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.

Benchmark without changes:
================================================= test session starts =================================================
platform win32 -- Python 3.10.8, pytest-7.4.4, pluggy-1.4.0
rootdir: C:\Users\charlotte.silvester\nag\cvxpy
configfile: pyproject.toml
collected 12 items

cvxpy\tests\test_benchmarks.py ss-------------------------------------------------------------------------------
                                  Compilation
-------------------------------------------------------------------------------
(CVXPY) Jan 31 12:52:42 PM: Compiling problem (target solver=ECOS).
(CVXPY) Jan 31 12:52:42 PM: Reduction chain: Dcp2Cone -> CvxAttr2Constr -> ConeMatrixStuffing -> ECOS
(CVXPY) Jan 31 12:52:42 PM: Applying reduction Dcp2Cone
(CVXPY) Jan 31 12:52:42 PM: Applying reduction CvxAttr2Constr
(CVXPY) Jan 31 12:52:42 PM: Applying reduction ConeMatrixStuffing
(CVXPY) Jan 31 12:52:42 PM: Applying reduction ECOS
(CVXPY) Jan 31 12:52:42 PM: Finished problem compilation (took 3.642e-01 seconds).
Issue #1668 regression test
Compilation time:  0.3642103672027588
.least_squares: avg=2.084e-03 s , std=0.000e+00 s (1 iterations)
.ssqp: avg=1.010e-02 s , std=0.000e+00 s (1 iterations)
.small_cone_matrix_stuffing: avg=2.224e-02 s , std=9.971e-03 s (10 iterations)
.small_lp: avg=8.214e-03 s , std=0.000e+00 s (1 iterations)
small_lp_second_time: avg=0.000e+00 s , std=0.000e+00 s (1 iterations)
.sss

============================================ 5 passed, 7 skipped in 1.27s =============================================


Benchmark with changes:

================================================= test session starts =================================================
platform win32 -- Python 3.10.8, pytest-7.4.4, pluggy-1.4.0
rootdir: C:\Users\charlotte.silvester\nag\cvxpy
configfile: pyproject.toml
collected 12 items

cvxpy\tests\test_benchmarks.py ss-------------------------------------------------------------------------------
                                  Compilation
-------------------------------------------------------------------------------
(CVXPY) Jan 31 12:53:36 PM: Compiling problem (target solver=ECOS).
(CVXPY) Jan 31 12:53:36 PM: Reduction chain: Dcp2Cone -> CvxAttr2Constr -> ConeMatrixStuffing -> ECOS
(CVXPY) Jan 31 12:53:36 PM: Applying reduction Dcp2Cone
(CVXPY) Jan 31 12:53:36 PM: Applying reduction CvxAttr2Constr
(CVXPY) Jan 31 12:53:36 PM: Applying reduction ConeMatrixStuffing
(CVXPY) Jan 31 12:53:36 PM: Applying reduction ECOS
(CVXPY) Jan 31 12:53:36 PM: Finished problem compilation (took 3.687e-01 seconds).
Issue #1668 regression test
Compilation time:  0.3687434196472168
.least_squares: avg=0.000e+00 s , std=0.000e+00 s (1 iterations)
.ssqp: avg=1.007e-02 s , std=0.000e+00 s (1 iterations)
.small_cone_matrix_stuffing: avg=2.236e-02 s , std=1.095e-02 s (10 iterations)
.small_lp: avg=1.048e-02 s , std=0.000e+00 s (1 iterations)
small_lp_second_time: avg=0.000e+00 s , std=0.000e+00 s (1 iterations)
.sss

============================================ 5 passed, 7 skipped in 1.25s =============================================
