### PR TITLE
Address deprecation warning

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/sdpa_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/sdpa_conif.py
@@ -156,7 +156,6 @@ class SDPA(ConicSolver):
         https://sdpa-python.github.io/docs/formats/sdpa_sedumi.html
         """
         import sdpap
-        from scipy import matrix
 
         data[s.DIMS] = dims_to_solver_dict(data[s.DIMS])
 
@@ -174,7 +173,7 @@ class SDPA(ConicSolver):
         if 'print' not in solver_opts:
             solver_opts['print'] = 'display' if verbose else 'no'
         x, y, sdpapinfo, timeinfo, sdpainfo = sdpap.solve(
-            A, -matrix(b), matrix(c), K, J, solver_opts)
+            A, -b, c, K, J, solver_opts)
 
         solution = {}
         solution[s.STATUS] = self.STATUS_MAP[sdpapinfo['phasevalue']]


### PR DESCRIPTION
## Description

The solver will accept `numpy.ndarray` as well as one of the sparse array formats (e.g. `csr_array` or `csc_array`) in `scipy.sparse` for each of `A`, `b` and `c`.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.