### PR TITLE
Fix invalid escape sequences in docstrings

### DIFF
--- a/cvxpy/reductions/cone2cone/soc2psd.py
+++ b/cvxpy/reductions/cone2cone/soc2psd.py
@@ -47,7 +47,7 @@ class SOC2PSD(Reduction):
 
         for constraint in soc_constraints:
             """
-            The SOC constraint :math:`\\lVert X \\rVert_2 \leq t` is modeled by `t` and `X`.
+            The SOC constraint :math:`\\lVert X \\rVert_2 \\leq t` is modeled by `t` and `X`.
             We extract these `t` and `X` from the SOC constraint object.
             """
             t, X = constraint.args

--- a/cvxpy/reductions/cone2cone/soc2psd.py
+++ b/cvxpy/reductions/cone2cone/soc2psd.py
@@ -46,8 +46,8 @@ class SOC2PSD(Reduction):
         soc_id_from_psd = {}
 
         for constraint in soc_constraints:
-            """
-            The SOC constraint :math:`\\lVert X \\rVert_2 \\leq t` is modeled by `t` and `X`.
+            r"""
+            The SOC constraint :math:`\lVert X \rVert_2 \leq t` is modeled by `t` and `X`.
             We extract these `t` and `X` from the SOC constraint object.
             """
             t, X = constraint.args

--- a/cvxpy/reductions/solvers/conic_solvers/sdpa_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/sdpa_conif.py
@@ -133,7 +133,7 @@ class SDPA(ConicSolver):
             return failure_solution(status)
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
-        """
+        r"""
         CVXPY represents cone programs as
             (P) min_x { c^T x : A x + b \in K } + d
 

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -154,7 +154,7 @@ class SolverTestHelper:
             self.tester.fail(msg)
         bad_norms = []
 
-        """The convention that we follow for construting the Lagrangian is: 1) Move all
+        r"""The convention that we follow for construting the Lagrangian is: 1) Move all
         explicitly passed constraints to the problem (via Problem.constraints) into the
         Lagrangian --- dLdX == 0 for any such variables 2) Constraints that have
         implicitly been imposed on variables at the time of declaration via specific
@@ -191,7 +191,7 @@ class SolverTestHelper:
                     if diag_entries > 10**(-places):
                         bad_norms.append((dual_cone_violation, opt_var))
                 elif opt_var.is_symmetric():
-                    """The dual cone to the set of symmetric matrices is the
+                    r"""The dual cone to the set of symmetric matrices is the
                     set of skew-symmetric matrices, so we check if dLdX \in
                     set(skew-symmetric-matrices)
                     g[opt_var] is the problematic gradient in question"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ select = [
     "F",
     "I",
     "NPY201",
-    "W605",  # Check for invalid escape sequences in docstrings (errors in py > 3.11)
+    "W605",  # Check for invalid escape sequences in docstrings (errors in py >= 3.11)
 ]
 line-length = 100
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,11 @@
 [tool.ruff]
-select = ["E", "F", "I", "NPY201"]
+select = [
+    "E",
+    "F",
+    "I",
+    "NPY201",
+    "W605",  # Check for invalid escape sequences in docstrings (errors in py > 3.11)
+]
 line-length = 100
 exclude = [
     "build",


### PR DESCRIPTION
## Description

As mentioned in #2270, there are several invalid escape sequences in docstrings that can cause issues in newer Python versions. In particular, it (somehow only sometimes) can make the package raise exceptions on import. This PR adds a ruff rule to explicitly disallow these invalid sequences and applies the fixes from `ruff check --fix`.

Issue link: Fixes #2270

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.