### PR TITLE
add solver-only verbose switch as kwarg

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -1081,6 +1081,8 @@ class Problem(u.Canonical):
                     solving_chain.reductions[-1].name())
         start = time.time()
         solver_verbose = kwargs.pop('solver_verbose', verbose)
+        if solver_verbose and (not verbose):
+            print(_NUM_SOLVER_STR)
         solution = solving_chain.solve_via_data(
             self, data, warm_start, solver_verbose, kwargs)
         end = time.time()

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -1080,8 +1080,9 @@ class Problem(u.Canonical):
                     'Invoking solver %s  to obtain a solution.',
                     solving_chain.reductions[-1].name())
         start = time.time()
+        solver_verbose = kwargs.pop('solver_verbose', verbose)
         solution = solving_chain.solve_via_data(
-            self, data, warm_start, verbose, kwargs)
+            self, data, warm_start, solver_verbose, kwargs)
         end = time.time()
         self._solve_time = end - start
         self.unpack_results(solution, solving_chain, inverse_data)

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -333,6 +333,48 @@ class TestProblem(BaseTest):
             print(solver)
             assert len(output) == 0
 
+    def test_solver_verbose(self) -> None:
+        """Test silencing and enabling solver-only messages.
+        """
+        # setup the environment
+        outputs = {True: [], False: []}
+        backup = sys.stdout
+        ######
+        for solver in INSTALLED_SOLVERS:
+            for solver_verbose in [True, False]:
+                sys.stdout = StringIO()  # capture output
+
+                p = Problem(cp.Minimize(self.a + self.x[0]),
+                            [self.a >= 2, self.x >= 2])
+                p.solve(solver_verbose=solver_verbose, solver=solver)
+
+                if solver in SOLVER_MAP_CONIC:
+                    if SOLVER_MAP_CONIC[solver].MIP_CAPABLE:
+                        p.constraints.append(Variable(boolean=True) == 0)
+                        p.solve(solver_verbose=solver_verbose, solver=solver)
+
+                    if ExpCone in SOLVER_MAP_CONIC[solver].SUPPORTED_CONSTRAINTS:
+                        p = Problem(cp.Minimize(self.a), [cp.log(self.a) >= 2])
+                        p.solve(solver_verbose=solver_verbose, solver=solver)
+
+                    if PSD in SOLVER_MAP_CONIC[solver].SUPPORTED_CONSTRAINTS:
+                        a_mat = cp.reshape(self.a, shape=(1, 1))
+                        p = Problem(cp.Minimize(self.a), [cp.lambda_min(a_mat) >= 2])
+                        p.solve(solver_verbose=solver_verbose, solver=solver)
+
+                out = sys.stdout.getvalue()  # release output
+                sys.stdout.close()  # close the stream
+                sys.stdout = backup  # restore original stdout
+
+                outputs[solver_verbose].append((out, solver))
+
+        for output, solver in outputs[True]:
+            print(solver)
+            assert len(output) > 0
+        for output, solver in outputs[False]:
+            print(solver)
+            assert len(output) == 0
+
     # Test registering other solve methods.
     def test_register_solve(self) -> None:
         Problem.register_solve("test", lambda self: 1)

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -342,6 +342,11 @@ class TestProblem(BaseTest):
         ######
         for solver in INSTALLED_SOLVERS:
             for solver_verbose in [True, False]:
+                # Don't test GLPK because there's a race
+                # condition in setting CVXOPT solver options.
+                if solver in [cp.GLPK, cp.GLPK_MI, cp.MOSEK, cp.CBC,
+                              cp.SCIPY, cp.COPT]:
+                    continue
                 sys.stdout = StringIO()  # capture output
 
                 p = Problem(cp.Minimize(self.a + self.x[0]),

--- a/doc/source/tutorial/solvers/index.rst
+++ b/doc/source/tutorial/solvers/index.rst
@@ -175,7 +175,7 @@ Use the ``installed_solvers`` utility function to get a list of the solvers your
 Viewing solver output
 ^^^^^^^^^^^^^^^^^^^^^
 
-All the solvers can print out information about their progress while solving the problem. This information can be useful in debugging a solver error. To see the output from both cvxpy and the solvers, set ``verbose=True`` in the solve method. If you want to see the output from the solver only, set ``solver_verbose=True``.
+All the solvers can print out information about their progress while solving the problem. This information can be useful in debugging a solver error. To see the output from both CVXPY and the solvers, set ``verbose=True`` in the solve method. If you want to see the output from the solver only, set ``solver_verbose=True``.
 
 .. code:: python
 

--- a/doc/source/tutorial/solvers/index.rst
+++ b/doc/source/tutorial/solvers/index.rst
@@ -175,7 +175,7 @@ Use the ``installed_solvers`` utility function to get a list of the solvers your
 Viewing solver output
 ^^^^^^^^^^^^^^^^^^^^^
 
-All the solvers can print out information about their progress while solving the problem. This information can be useful in debugging a solver error. To see the output from the solvers, set ``verbose=True`` in the solve method.
+All the solvers can print out information about their progress while solving the problem. This information can be useful in debugging a solver error. To see the output from both cvxpy and the solvers, set ``verbose=True`` in the solve method. If you want to see the output from the solver only, set ``solver_verbose=True``.
 
 .. code:: python
 


### PR DESCRIPTION
## Description
adds a solver-only verbose switch as kwarg.

the old behaviour is kept if the user does not provide `solver_verbose` as a kwarg.

Issue link (if applicable):
https://github.com/cvxpy/cvxpy/issues/2353


## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
