### PR TITLE
Fixes Capitalization in Search Engine Results

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -11,6 +11,17 @@ Welcome to CVXPY 1.5
                  Express your problem in a natural way that follows the math.
    :keywords: convex optimization, open source, software,
 
+.. raw:: html
+
+      <script type="application/ld+json">
+      {
+         "@context" : "https://schema.org",
+         "@type" : "WebSite",
+         "name" : "CVXPY",
+         "url" : "https://www.cvxpy.org/"
+      }
+      </script>
+
 **Convex optimization, for everyone.**
 
 *We are building a CVXPY community* `on Discord <https://discord.gg/4urRQeGBCr>`_. *Join the conversation!*


### PR DESCRIPTION
## Description
This PR attempts to fix the capitalization of CVXPY in search engine results.
Issue link (if applicable): NA

Google shows `CVXPy` as the site name, which is the wrong capitalization:
<img width="568" alt="image" src="https://github.com/cvxpy/cvxpy/assets/44360364/7ca11062-4160-4286-adcd-6c28233bc6f9">

This PR follows the [Google developers instructions](https://developers.google.com/search/docs/appearance/site-names#how-site-names-in-google-search-are-created) to add structured data to the page.

Below is the section of the page source after the change.
<img width="1011" alt="image" src="https://github.com/cvxpy/cvxpy/assets/44360364/fcb895a5-343f-4eab-9dd2-b1aadb75b7c8">

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.