### PR TITLE
Redirect model output to Python instead of Terminal

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
@@ -174,6 +174,7 @@ class SCIP(ConicSolver):
         from pyscipopt.scip import Model
 
         model = Model()
+        model.redirectOutput()
         A, b, c, dims = self._define_data(data)
         variables = self._create_variables(model, data, c)
         constraints = self._add_constraints(model, variables, A, b, dims)


### PR DESCRIPTION
## Description
Redirected model output to Python. SCIP solve would not display output in certain environments such as Jupyter Notebooks.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)
