### PR TITLE
Allow pure Python builds

### DIFF
--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -205,7 +205,7 @@ def decomp_quad(P, cond=None, rcond=None, lower=True, check_finite: bool = True)
                 return 1.0, L[p, :], np.empty((0, 0))
             else:
                 return 1.0, np.empty((0, 0)), L[:, p]
-        except ValueError:
+        except ValueError or ModuleNotFoundError:
             P = np.array(P.todense())  # make dense (needs to happen for eigh).
     w, V = LA.eigh(P, lower=lower, check_finite=check_finite)
 

--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -205,7 +205,7 @@ def decomp_quad(P, cond=None, rcond=None, lower=True, check_finite: bool = True)
                 return 1.0, L[p, :], np.empty((0, 0))
             else:
                 return 1.0, np.empty((0, 0)), L[:, p]
-        except ValueError or ModuleNotFoundError:
+        except (ValueError, ModuleNotFoundError):
             P = np.array(P.todense())  # make dense (needs to happen for eigh).
     w, V = LA.eigh(P, lower=lower, check_finite=check_finite)
 

--- a/cvxpy/cvxcore/python/__init__.py
+++ b/cvxpy/cvxcore/python/__init__.py
@@ -7,4 +7,7 @@ except ImportError:
 
 # TODO(akshayka): This is a hack; the swig-auto-generated cvxcore.py
 # tries to import cvxcore as `from . import _cvxcore`
-import _cvxcore
+try:
+	import _cvxcore
+except ImportError:
+	pass

--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -22,6 +22,11 @@ import numpy as np
 import scipy.sparse as sp
 
 import cvxpy.settings as s
+try:
+    import cvxpy.cvxcore.python.cvxcore as cvxcore
+except ModuleNotFoundError:
+    # Allow to run without cvxcore, cannot use C++ backend
+    cvxcore = None
 from cvxpy.lin_ops import lin_op as lo
 from cvxpy.lin_ops.canon_backend import CanonBackend
 
@@ -294,11 +299,6 @@ def get_problem_matrix(linOps,
     canon_backend = default_canon_backend if not canon_backend else canon_backend
 
     if canon_backend == s.CPP_CANON_BACKEND:
-        try:
-            import cvxpy.cvxcore.python.cvxcore as cvxcore
-        except ModuleNotFoundError:
-            raise ImportError("cvxcore is not installed. Please install cvxcore "
-                              "to use the C++ backend.")
 
         lin_vec = cvxcore.ConstLinOpVector()
 
@@ -405,7 +405,6 @@ def get_type_map() -> dict:
     """
     Returns a map from string type to cvxcore type
     """
-    import cvxpy.cvxcore.python.cvxcore as cvxcore
     type_map = {
         "VARIABLE": cvxcore.VARIABLE,
         "PARAM": cvxcore.PARAM,
@@ -453,7 +452,6 @@ def set_matrix_data(linC, linPy) -> None:
     """Calls the appropriate cvxcore function to set the matrix data field of
        our C++ linOp.
     """
-    import cvxpy.cvxcore.python.cvxcore as cvxcore
 
     if get_type(linPy) == cvxcore.SPARSE_CONST:
         coo = format_matrix(linPy.data, format='sparse')
@@ -472,7 +470,6 @@ def set_slice_data(linC, linPy) -> None:
     Python.  Note that the 'None' cases had to be handled at the wrapper level,
     since we must load integers into our vector.
     """
-    import cvxpy.cvxcore.python.cvxcore as cvxcore
 
     for i, sl in enumerate(linPy.data):
         slice_vec = cvxcore.IntVector()
@@ -499,7 +496,6 @@ def make_linC_from_linPy(linPy, linPy_to_linC) -> None:
 
     Children of linPy are retrieved from linPy_to_linC.
     """
-    import cvxpy.cvxcore.python.cvxcore as cvxcore
 
     if linPy in linPy_to_linC:
         return

--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -294,7 +294,7 @@ def get_problem_matrix(linOps,
 
     if canon_backend == s.CPP_CANON_BACKEND:
         from cvxpy.cvxcore.python.cppbackend import build_matrix
-        build_matrix(id_to_col, param_to_size, param_to_col, var_length, linOps, constr_length)
+        build_matrix(id_to_col, param_to_size, param_to_col, var_length, constr_length, linOps)
 
     elif canon_backend in {s.SCIPY_CANON_BACKEND, s.RUST_CANON_BACKEND,
                            s.NUMPY_CANON_BACKEND}:

--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -294,7 +294,7 @@ def get_problem_matrix(linOps,
 
     if canon_backend == s.CPP_CANON_BACKEND:
         from cvxpy.cvxcore.python.cppbackend import build_matrix
-        build_matrix(id_to_col, param_to_size, param_to_col, var_length, constr_length, linOps)
+        return build_matrix(id_to_col, param_to_size, param_to_col, var_length, constr_length, linOps)
 
     elif canon_backend in {s.SCIPY_CANON_BACKEND, s.RUST_CANON_BACKEND,
                            s.NUMPY_CANON_BACKEND}:

--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -15,18 +15,12 @@ Copyright 2017 Steven Diamond
 """
 from __future__ import annotations
 
-import numbers
 import os
 
 import numpy as np
 import scipy.sparse as sp
 
 import cvxpy.settings as s
-try:
-    import cvxpy.cvxcore.python.cvxcore as cvxcore
-except ModuleNotFoundError:
-    # Allow to run without cvxcore, cannot use C++ backend
-    cvxcore = None
 from cvxpy.lin_ops import lin_op as lo
 from cvxpy.lin_ops.canon_backend import CanonBackend
 
@@ -299,72 +293,8 @@ def get_problem_matrix(linOps,
     canon_backend = default_canon_backend if not canon_backend else canon_backend
 
     if canon_backend == s.CPP_CANON_BACKEND:
-
-        lin_vec = cvxcore.ConstLinOpVector()
-
-        id_to_col_C = cvxcore.IntIntMap()
-        for id, col in id_to_col.items():
-            id_to_col_C[int(id)] = int(col)
-
-        param_to_size_C = cvxcore.IntIntMap()
-        for id, size in param_to_size.items():
-            param_to_size_C[int(id)] = int(size)
-
-        # dict to memoize construction of C++ linOps, and to keep Python references
-        # to them to prevent their deletion
-        linPy_to_linC = {}
-        for lin in linOps:
-            build_lin_op_tree(lin, linPy_to_linC)
-            tree = linPy_to_linC[lin]
-            lin_vec.push_back(tree)
-
-        problemData = cvxcore.build_matrix(lin_vec,
-                                           int(var_length),
-                                           id_to_col_C,
-                                           param_to_size_C,
-                                           s.get_num_threads())
-
-        # Populate tensors with info from problemData.
-        tensor_V = {}
-        tensor_I = {}
-        tensor_J = {}
-        for param_id, size in param_to_size.items():
-            tensor_V[param_id] = []
-            tensor_I[param_id] = []
-            tensor_J[param_id] = []
-            problemData.param_id = param_id
-            for i in range(size):
-                problemData.vec_idx = i
-                prob_len = problemData.getLen()
-                tensor_V[param_id].append(problemData.getV(prob_len))
-                tensor_I[param_id].append(problemData.getI(prob_len))
-                tensor_J[param_id].append(problemData.getJ(prob_len))
-
-        # Reduce tensors to a single sparse CSR matrix.
-        V = []
-        I = []
-        J = []
-        # one of the 'parameters' in param_to_col is a constant scalar offset,
-        # hence 'plus_one'
-        param_size_plus_one = 0
-        for param_id, col in param_to_col.items():
-            size = param_to_size[param_id]
-            param_size_plus_one += size
-            for i in range(size):
-                V.append(tensor_V[param_id][i])
-                I.append(tensor_I[param_id][i] +
-                         tensor_J[param_id][i]*constr_length)
-                J.append(tensor_J[param_id][i]*0 + (i + col))
-        V = np.concatenate(V)
-        I = np.concatenate(I)
-        J = np.concatenate(J)
-
-        output_shape = (np.int64(constr_length)*np.int64(var_length+1),
-                   param_size_plus_one)
-        A = sp.csc_matrix(
-            (V, (I, J)),
-            shape=output_shape)
-        return A
+        from cvxpy.cvxcore.python.cppbackend import build_matrix
+        build_matrix(id_to_col, param_to_size, param_to_col, var_length, linOps, constr_length)
 
     elif canon_backend in {s.SCIPY_CANON_BACKEND, s.RUST_CANON_BACKEND,
                            s.NUMPY_CANON_BACKEND}:
@@ -383,162 +313,3 @@ def get_problem_matrix(linOps,
     else:
         raise ValueError(f'Unknown backend: {canon_backend}')
 
-
-def format_matrix(matrix, shape=None, format='dense'):
-    """Returns the matrix in the appropriate form for SWIG wrapper"""
-    if (format == 'dense'):
-        # Ensure is 2D.
-        if len(shape) == 0:
-            shape = (1, 1)
-        elif len(shape) == 1:
-            shape = shape + (1,)
-        return np.reshape(matrix, shape, order='F')
-    elif (format == 'sparse'):
-        return sp.coo_matrix(matrix)
-    elif (format == 'scalar'):
-        return np.asfortranarray([[matrix]])
-    else:
-        raise NotImplementedError()
-
-
-def get_type_map() -> dict:
-    """
-    Returns a map from string type to cvxcore type
-    """
-    type_map = {
-        "VARIABLE": cvxcore.VARIABLE,
-        "PARAM": cvxcore.PARAM,
-        "PROMOTE": cvxcore.PROMOTE,
-        "MUL": cvxcore.MUL,
-        "RMUL": cvxcore.RMUL,
-        "MUL_ELEM": cvxcore.MUL_ELEM,
-        "DIV": cvxcore.DIV,
-        "SUM": cvxcore.SUM,
-        "NEG": cvxcore.NEG,
-        "INDEX": cvxcore.INDEX,
-        "TRANSPOSE": cvxcore.TRANSPOSE,
-        "SUM_ENTRIES": cvxcore.SUM_ENTRIES,
-        "TRACE": cvxcore.TRACE,
-        "RESHAPE": cvxcore.RESHAPE,
-        "DIAG_VEC": cvxcore.DIAG_VEC,
-        "DIAG_MAT": cvxcore.DIAG_MAT,
-        "UPPER_TRI": cvxcore.UPPER_TRI,
-        "CONV": cvxcore.CONV,
-        "HSTACK": cvxcore.HSTACK,
-        "VSTACK": cvxcore.VSTACK,
-        "SCALAR_CONST": cvxcore.SCALAR_CONST,
-        "DENSE_CONST": cvxcore.DENSE_CONST,
-        "SPARSE_CONST": cvxcore.SPARSE_CONST,
-        "NO_OP": cvxcore.NO_OP,
-        "KRON_R": cvxcore.KRON_R,
-        "KRON_L": cvxcore.KRON_L
-    }
-    return type_map
-
-
-def get_type(linPy):
-    """
-    Returns the cvxcore type corresponding to the type of linPy.
-    """
-    ty = linPy.type.upper()
-    type_map = get_type_map()
-    if ty in type_map:
-        return type_map[ty]
-    else:
-        raise NotImplementedError(f"Type {ty} is not supported.")
-
-
-def set_matrix_data(linC, linPy) -> None:
-    """Calls the appropriate cvxcore function to set the matrix data field of
-       our C++ linOp.
-    """
-
-    if get_type(linPy) == cvxcore.SPARSE_CONST:
-        coo = format_matrix(linPy.data, format='sparse')
-        linC.set_sparse_data(coo.data, coo.row.astype(float),
-                             coo.col.astype(float), coo.shape[0],
-                             coo.shape[1])
-    else:
-        linC.set_dense_data(format_matrix(linPy.data, shape=linPy.shape))
-        linC.set_data_ndim(len(linPy.data.shape))
-
-
-def set_slice_data(linC, linPy) -> None:
-    """
-    Loads the slice data, start, stop, and step into our C++ linOp.
-    The semantics of the slice operator is treated exactly the same as in
-    Python.  Note that the 'None' cases had to be handled at the wrapper level,
-    since we must load integers into our vector.
-    """
-
-    for i, sl in enumerate(linPy.data):
-        slice_vec = cvxcore.IntVector()
-        for var in [sl.start, sl.stop, sl.step]:
-            slice_vec.push_back(int(var))
-        linC.push_back_slice_vec(slice_vec)
-
-
-def set_linC_data(linC, linPy) -> None:
-    """Sets numerical data fields in linC."""
-    assert linPy.data is not None
-    if isinstance(linPy.data, tuple) and isinstance(linPy.data[0], slice):
-        set_slice_data(linC, linPy)
-    elif isinstance(linPy.data, float) or isinstance(linPy.data,
-                                                   numbers.Integral):
-        linC.set_dense_data(format_matrix(linPy.data, format='scalar'))
-        linC.set_data_ndim(0)
-    else:
-        set_matrix_data(linC, linPy)
-
-
-def make_linC_from_linPy(linPy, linPy_to_linC) -> None:
-    """Construct a C++ LinOp corresponding to LinPy.
-
-    Children of linPy are retrieved from linPy_to_linC.
-    """
-
-    if linPy in linPy_to_linC:
-        return
-    typ = get_type(linPy)
-    shape = cvxcore.IntVector()
-    lin_args_vec = cvxcore.ConstLinOpVector()
-    for dim in linPy.shape:
-        shape.push_back(int(dim))
-    for argPy in linPy.args:
-        lin_args_vec.push_back(linPy_to_linC[argPy])
-    linC = cvxcore.LinOp(typ, shape, lin_args_vec)
-    linPy_to_linC[linPy] = linC
-
-    if linPy.data is not None:
-        if isinstance(linPy.data, lo.LinOp):
-            linC_data = linPy_to_linC[linPy.data]
-            linC.set_linOp_data(linC_data)
-            linC.set_data_ndim(len(linPy.data.shape))
-        else:
-            set_linC_data(linC, linPy)
-
-
-def build_lin_op_tree(root_linPy, linPy_to_linC) -> None:
-    """Construct C++ LinOp tree from Python LinOp tree.
-
-    Constructed C++ linOps are stored in the linPy_to_linC dict,
-    which maps Python linOps to their corresponding C++ linOps.
-
-    Parameters
-    ----------
-        linPy_to_linC: a dict for memoizing construction and storing
-            the C++ LinOps
-    """
-    bfs_stack = [root_linPy]
-    post_order_stack = []
-    while bfs_stack:
-        linPy = bfs_stack.pop()
-        if linPy not in linPy_to_linC:
-            post_order_stack.append(linPy)
-            for arg in linPy.args:
-                bfs_stack.append(arg)
-            if isinstance(linPy.data, lo.LinOp):
-                bfs_stack.append(linPy.data)
-    while post_order_stack:
-        linPy = post_order_stack.pop()
-        make_linC_from_linPy(linPy, linPy_to_linC)

--- a/cvxpy/cvxcore/python/cppbackend.py
+++ b/cvxpy/cvxcore/python/cppbackend.py
@@ -24,8 +24,9 @@ import cvxpy.settings as s
 try:
     import cvxpy.cvxcore.python.cvxcore as cvxcore
 except ModuleNotFoundError:
-    # Allow to run without cvxcore, cannot use C++ backend
-    cvxcore = None
+    raise ModuleNotFoundError(
+        "Tried using the C++ backend, but the cvxcore module was not installed."
+    )
 
 
 def build_matrix(

--- a/cvxpy/cvxcore/python/cppbackend.py
+++ b/cvxpy/cvxcore/python/cppbackend.py
@@ -15,6 +15,8 @@ limitations under the License.
 """
 
 import numbers
+from typing import List
+
 import numpy as np
 import scipy.sparse as sp
 
@@ -35,7 +37,7 @@ def build_matrix(
     param_to_col: dict,
     var_length: int,
     constr_length: int,
-    linOps: list[lo.LinOp],
+    linOps: List[lo.LinOp],
 ) -> sp.csc_matrix:
     lin_vec = cvxcore.ConstLinOpVector()
 

--- a/cvxpy/cvxcore/python/cppbackend.py
+++ b/cvxpy/cvxcore/python/cppbackend.py
@@ -19,6 +19,7 @@ import numpy as np
 import scipy.sparse as sp
 
 import cvxpy.lin_ops.lin_op as lo
+import cvxpy.settings as s
 
 try:
     import cvxpy.cvxcore.python.cvxcore as cvxcore

--- a/cvxpy/cvxcore/python/cppbackend.py
+++ b/cvxpy/cvxcore/python/cppbackend.py
@@ -1,0 +1,257 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import numbers
+import numpy as np
+import scipy.sparse as sp
+
+import cvxpy.lin_ops.lin_op as lo
+
+try:
+    import cvxpy.cvxcore.python.cvxcore as cvxcore
+except ModuleNotFoundError:
+    # Allow to run without cvxcore, cannot use C++ backend
+    cvxcore = None
+
+
+def build_matrix(
+    id_to_col: dict,
+    param_to_size: dict,
+    param_to_col: dict,
+    var_length: int,
+    constr_length: int,
+    linOps: list[lo.LinOp],
+) -> sp.csc_matrix:
+    lin_vec = cvxcore.ConstLinOpVector()
+
+    id_to_col_C = cvxcore.IntIntMap()
+    for id, col in id_to_col.items():
+        id_to_col_C[int(id)] = int(col)
+
+    param_to_size_C = cvxcore.IntIntMap()
+    for id, size in param_to_size.items():
+        param_to_size_C[int(id)] = int(size)
+
+    # dict to memoize construction of C++ linOps, and to keep Python references
+    # to them to prevent their deletion
+    linPy_to_linC = {}
+    for lin in linOps:
+        build_lin_op_tree(lin, linPy_to_linC)
+        tree = linPy_to_linC[lin]
+        lin_vec.push_back(tree)
+
+    problemData = cvxcore.build_matrix(
+        lin_vec, int(var_length), id_to_col_C, param_to_size_C, s.get_num_threads()
+    )
+
+    # Populate tensors with info from problemData.
+    tensor_V = {}
+    tensor_I = {}
+    tensor_J = {}
+    for param_id, size in param_to_size.items():
+        tensor_V[param_id] = []
+        tensor_I[param_id] = []
+        tensor_J[param_id] = []
+        problemData.param_id = param_id
+        for i in range(size):
+            problemData.vec_idx = i
+            prob_len = problemData.getLen()
+            tensor_V[param_id].append(problemData.getV(prob_len))
+            tensor_I[param_id].append(problemData.getI(prob_len))
+            tensor_J[param_id].append(problemData.getJ(prob_len))
+
+    # Reduce tensors to a single sparse CSR matrix.
+    V = []
+    I = []
+    J = []
+    # one of the 'parameters' in param_to_col is a constant scalar offset,
+    # hence 'plus_one'
+    param_size_plus_one = 0
+    for param_id, col in param_to_col.items():
+        size = param_to_size[param_id]
+        param_size_plus_one += size
+        for i in range(size):
+            V.append(tensor_V[param_id][i])
+            I.append(tensor_I[param_id][i] + tensor_J[param_id][i] * constr_length)
+            J.append(tensor_J[param_id][i] * 0 + (i + col))
+    V = np.concatenate(V)
+    I = np.concatenate(I)
+    J = np.concatenate(J)
+
+    output_shape = (
+        np.int64(constr_length) * np.int64(var_length + 1),
+        param_size_plus_one,
+    )
+    A = sp.csc_matrix((V, (I, J)), shape=output_shape)
+    return A
+
+
+TYPE_MAP = {
+    "VARIABLE": cvxcore.VARIABLE,
+    "PARAM": cvxcore.PARAM,
+    "PROMOTE": cvxcore.PROMOTE,
+    "MUL": cvxcore.MUL,
+    "RMUL": cvxcore.RMUL,
+    "MUL_ELEM": cvxcore.MUL_ELEM,
+    "DIV": cvxcore.DIV,
+    "SUM": cvxcore.SUM,
+    "NEG": cvxcore.NEG,
+    "INDEX": cvxcore.INDEX,
+    "TRANSPOSE": cvxcore.TRANSPOSE,
+    "SUM_ENTRIES": cvxcore.SUM_ENTRIES,
+    "TRACE": cvxcore.TRACE,
+    "RESHAPE": cvxcore.RESHAPE,
+    "DIAG_VEC": cvxcore.DIAG_VEC,
+    "DIAG_MAT": cvxcore.DIAG_MAT,
+    "UPPER_TRI": cvxcore.UPPER_TRI,
+    "CONV": cvxcore.CONV,
+    "HSTACK": cvxcore.HSTACK,
+    "VSTACK": cvxcore.VSTACK,
+    "SCALAR_CONST": cvxcore.SCALAR_CONST,
+    "DENSE_CONST": cvxcore.DENSE_CONST,
+    "SPARSE_CONST": cvxcore.SPARSE_CONST,
+    "NO_OP": cvxcore.NO_OP,
+    "KRON_R": cvxcore.KRON_R,
+    "KRON_L": cvxcore.KRON_L,
+}
+
+
+def get_type(linPy):
+    """
+    Returns the cvxcore type corresponding to the type of linPy.
+    """
+
+    ty = linPy.type.upper()
+    if ty in TYPE_MAP:
+        return TYPE_MAP[ty]
+    else:
+        raise NotImplementedError(f"Type {ty} is not supported.")
+
+
+def set_linC_data(linC, linPy) -> None:
+    """Sets numerical data fields in linC."""
+    assert linPy.data is not None
+    if isinstance(linPy.data, tuple) and isinstance(linPy.data[0], slice):
+        set_slice_data(linC, linPy)
+    elif isinstance(linPy.data, float) or isinstance(linPy.data, numbers.Integral):
+        linC.set_dense_data(format_matrix(linPy.data, format="scalar"))
+        linC.set_data_ndim(0)
+    else:
+        set_matrix_data(linC, linPy)
+
+
+def make_linC_from_linPy(linPy, linPy_to_linC) -> None:
+    """Construct a C++ LinOp corresponding to LinPy.
+
+    Children of linPy are retrieved from linPy_to_linC.
+    """
+
+    if linPy in linPy_to_linC:
+        return
+    typ = get_type(linPy)
+    shape = cvxcore.IntVector()
+    lin_args_vec = cvxcore.ConstLinOpVector()
+    for dim in linPy.shape:
+        shape.push_back(int(dim))
+    for argPy in linPy.args:
+        lin_args_vec.push_back(linPy_to_linC[argPy])
+    linC = cvxcore.LinOp(typ, shape, lin_args_vec)
+    linPy_to_linC[linPy] = linC
+
+    if linPy.data is not None:
+        if isinstance(linPy.data, lo.LinOp):
+            linC_data = linPy_to_linC[linPy.data]
+            linC.set_linOp_data(linC_data)
+            linC.set_data_ndim(len(linPy.data.shape))
+        else:
+            set_linC_data(linC, linPy)
+
+
+def set_slice_data(linC, linPy) -> None:
+    """
+    Loads the slice data, start, stop, and step into our C++ linOp.
+    The semantics of the slice operator is treated exactly the same as in
+    Python.  Note that the 'None' cases had to be handled at the wrapper level,
+    since we must load integers into our vector.
+    """
+
+    for sl in linPy.data:
+        slice_vec = cvxcore.IntVector()
+        for var in [sl.start, sl.stop, sl.step]:
+            slice_vec.push_back(int(var))
+        linC.push_back_slice_vec(slice_vec)
+
+
+def build_lin_op_tree(root_linPy, linPy_to_linC) -> None:
+    """Construct C++ LinOp tree from Python LinOp tree.
+
+    Constructed C++ linOps are stored in the linPy_to_linC dict,
+    which maps Python linOps to their corresponding C++ linOps.
+
+    Parameters
+    ----------
+        linPy_to_linC: a dict for memoizing construction and storing
+            the C++ LinOps
+    """
+    bfs_stack = [root_linPy]
+    post_order_stack = []
+    while bfs_stack:
+        linPy = bfs_stack.pop()
+        if linPy not in linPy_to_linC:
+            post_order_stack.append(linPy)
+            for arg in linPy.args:
+                bfs_stack.append(arg)
+            if isinstance(linPy.data, lo.LinOp):
+                bfs_stack.append(linPy.data)
+    while post_order_stack:
+        linPy = post_order_stack.pop()
+        make_linC_from_linPy(linPy, linPy_to_linC)
+
+
+def set_matrix_data(linC, linPy) -> None:
+    """Calls the appropriate cvxcore function to set the matrix data field of
+    our C++ linOp.
+    """
+
+    if get_type(linPy) == cvxcore.SPARSE_CONST:
+        coo = format_matrix(linPy.data, format="sparse")
+        linC.set_sparse_data(
+            coo.data,
+            coo.row.astype(float),
+            coo.col.astype(float),
+            coo.shape[0],
+            coo.shape[1],
+        )
+    else:
+        linC.set_dense_data(format_matrix(linPy.data, shape=linPy.shape))
+        linC.set_data_ndim(len(linPy.data.shape))
+
+
+def format_matrix(matrix, shape=None, format="dense"):
+    """Returns the matrix in the appropriate form for SWIG wrapper"""
+    if format == "dense":
+        # Ensure is 2D.
+        if len(shape) == 0:
+            shape = (1, 1)
+        elif len(shape) == 1:
+            shape = shape + (1,)
+        return np.reshape(matrix, shape, order="F")
+    elif format == "sparse":
+        return sp.coo_matrix(matrix)
+    elif format == "scalar":
+        return np.asfortranarray([[matrix]])
+    else:
+        raise NotImplementedError()

--- a/cvxpy/tests/test_linalg_utils.py
+++ b/cvxpy/tests/test_linalg_utils.py
@@ -15,10 +15,17 @@ limitations under the License.
 """
 
 import numpy as np # noqa F403
+import pytest
 import scipy.sparse as spar
+
 from cvxpy.tests.base_test import BaseTest
 from cvxpy.utilities import linalg as lau
 
+try:
+    import lau.sparse_cholesky
+    missing_extension = False
+except ModuleNotFoundError:
+    missing_extension = True
 
 class TestSparseCholesky(BaseTest):
 
@@ -33,6 +40,7 @@ class TestSparseCholesky(BaseTest):
         delta = (L - spar.tril(L)).toarray().flatten()
         self.assertItemsAlmostEqual(delta, np.zeros(delta.size), places)
 
+    @pytest.mark.skipif(missing_extension, reason="requires sparse_cholesky")
     def test_diagonal(self):
         np.random.seed(0)
         A = spar.csc_matrix(np.diag(np.random.rand(4)))
@@ -40,6 +48,7 @@ class TestSparseCholesky(BaseTest):
         self.check_factor(L)
         self.check_gram(L[p, :], A)
 
+    @pytest.mark.skipif(missing_extension, reason="requires sparse_cholesky")
     def test_tridiagonal(self):
         np.random.seed(0)
         n = 5
@@ -50,6 +59,7 @@ class TestSparseCholesky(BaseTest):
         self.check_factor(L)
         self.check_gram(L[p, :], A)
 
+    @pytest.mark.skipif(missing_extension, reason="requires sparse_cholesky")
     def test_generic(self):
         np.random.seed(0)
         B = np.random.randn(3, 3)
@@ -58,6 +68,7 @@ class TestSparseCholesky(BaseTest):
         self.check_factor(L)
         self.check_gram(L[p, :], A)
 
+    @pytest.mark.skipif(missing_extension, reason="requires sparse_cholesky")
     def test_singular(self):
         # error on singular PSD matrix
         np.random.seed(0)
@@ -66,6 +77,7 @@ class TestSparseCholesky(BaseTest):
         with self.assertRaises(ValueError, msg=lau.SparseCholeskyMessages.EIGEN_FAIL):
             lau.sparse_cholesky(A)
 
+    @pytest.mark.skipif(missing_extension, reason="requires sparse_cholesky")
     def test_nonsingular_indefinite(self):
         np.random.seed(0)
         n = 5

--- a/cvxpy/utilities/linalg.py
+++ b/cvxpy/utilities/linalg.py
@@ -1,10 +1,10 @@
-import cvxpy.utilities.cpp.sparsecholesky as spchol  # noqa: I001
-import cvxpy.settings as settings
 import numpy as np
 import scipy.linalg as la
 import scipy.sparse as spar
 import scipy.sparse.linalg as sparla
 from scipy.sparse import csc_matrix
+
+import cvxpy.settings as settings
 
 
 def orth(V, tol=1e-12):
@@ -203,6 +203,8 @@ def sparse_cholesky(A, sym_tol=settings.CHOL_SYM_TOL, assume_posdef=False):
     before calling Eigen. While checking for indefiniteness, we also check that
      ||A - A'||_Fro / sqrt(n) <= sym_tol, where n is the order of the matrix.
     """
+    import cvxpy.utilities.cpp.sparsecholesky as spchol  # noqa: I001
+
     if not isinstance(A, spar.spmatrix):
         raise ValueError(SparseCholeskyMessages.NOT_SPARSE)
     if np.iscomplexobj(A):


### PR DESCRIPTION
## Description
We recently discussed the possibility to run CVXPY within [Pyodide](https://pyodide.org). 
Pure Python wheels are directly supported, and since we a backend that only relies on SciPy, which is already supported by Pyodide, this should be fairly easy.

This PR moves all calls to the C++ backend into a separate file and makes the Eigen-based sparse Cholesky optional

Issue link (if applicable): NA

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.