### PR TITLE
Replace cp.scalar_product with cp.vdot

### DIFF
--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 from cvxpy.atoms.affine.binary_operators import (matmul, multiply,
-                                                 vdot, outer)
+                                                 vdot, scalar_product, outer,)
 from cvxpy.atoms.affine.bmat import bmat
 from cvxpy.atoms.affine.conj import conj
 from cvxpy.atoms.affine.conv import conv, convolve

--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 from cvxpy.atoms.affine.binary_operators import (matmul, multiply,
-                                                 scalar_product, outer,)
+                                                 vdot, outer)
 from cvxpy.atoms.affine.bmat import bmat
 from cvxpy.atoms.affine.conj import conj
 from cvxpy.atoms.affine.conv import conv, convolve

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -455,10 +455,10 @@ def vdot(x, y):
 
 
 def scalar_product(x, y):
-    x = deep_flatten(x)
-    y = deep_flatten(y)
-    prod = multiply(conj(x), y)
-    return cvxpy_sum(prod)
+    """
+    Alias for vdot.
+    """
+    return vdot(x, y)
 
 
 def outer(x, y):

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -422,7 +422,7 @@ class DivExpression(BinaryOperator):
         return (lu.div_expr(arg_objs[0], arg_objs[1]), [])
 
 
-def scalar_product(x, y):
+def vdot(x, y):
     """
     Return the standard inner product (or "scalar product") of (x,y).
 
@@ -448,6 +448,13 @@ def scalar_product(x, y):
     real scalars), then this function returns an Expression representing
     ``a * c + b * d``.
     """
+    x = deep_flatten(x)
+    y = deep_flatten(y)
+    prod = multiply(conj(x), y)
+    return cvxpy_sum(prod)
+
+
+def scalar_product(x, y):
     x = deep_flatten(x)
     y = deep_flatten(y)
     prod = multiply(conj(x), y)

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -1302,7 +1302,7 @@ class StandardTestSDPs:
         return sth
 
     @staticmethod
-    def test_sdp_2(solver, places: int = 3, duals: bool = True, **kwargs) -> SolverTestHelper:
+    def test_sdp_2(solver, places: int = 2, duals: bool = True, **kwargs) -> SolverTestHelper:
         # places is set to 3 rather than 4, because analytic solution isn't known.
         sth = sdp_2()
         sth.solve(solver, **kwargs)

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -103,7 +103,7 @@ class SolverTestHelper:
         for con in self.constraints:
             if isinstance(con, (cp.constraints.Inequality,
                                 cp.constraints.Equality)):
-                comp = cp.scalar_product(con.expr, con.dual_value).value
+                comp = cp.vdot(con.expr, con.dual_value).value
             elif isinstance(con, (cp.constraints.ExpCone,
                                   cp.constraints.SOC,
                                   cp.constraints.NonNeg,
@@ -111,7 +111,7 @@ class SolverTestHelper:
                                   cp.constraints.PSD,
                                   cp.constraints.PowCone3D,
                                   cp.constraints.PowConeND)):
-                comp = cp.scalar_product(con.args, con.dual_value).value
+                comp = cp.vdot(con.args, con.dual_value).value
             elif isinstance(con, cp.RelEntrConeQuad) or isinstance(con, cp.OpRelEntrConeQuad):
                 msg = '\nDual variables not implemented for quadrature based approximations;' \
                        + '\nSkipping complementarity check.'
@@ -132,7 +132,7 @@ class SolverTestHelper:
                                 cp.constraints.Equality)):
                 dual_var_value = con.dual_value
                 prim_var_expr = con.expr
-                L = L + cp.scalar_product(dual_var_value, prim_var_expr)
+                L = L + cp.vdot(dual_var_value, prim_var_expr)
             elif isinstance(con, (cp.constraints.ExpCone,
                                   cp.constraints.SOC,
                                   cp.constraints.Zero,
@@ -140,7 +140,7 @@ class SolverTestHelper:
                                   cp.constraints.PSD,
                                   cp.constraints.PowCone3D,
                                   cp.constraints.PowConeND)):
-                L = L - cp.scalar_product(con.args, con.dual_value)
+                L = L - cp.vdot(con.args, con.dual_value)
             else:
                 raise NotImplementedError()
         try:

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1270,18 +1270,15 @@ class TestAtoms(BaseTest):
         """Test that norm1 and normInf match definition for matrices.
         """
         A = np.array([[1, 2], [3, 4]])
-        print(A)
         X = Variable((2, 2))
         obj = Minimize(cp.norm(X, 1))
         prob = cp.Problem(obj, [X == A])
         result = prob.solve(solver=cp.SCS)
-        print(result)
         self.assertAlmostEqual(result, cp.norm(A, 1).value, places=3)
 
         obj = Minimize(cp.norm(X, np.inf))
         prob = cp.Problem(obj, [X == A])
         result = prob.solve(solver=cp.SCS)
-        print(result)
         self.assertAlmostEqual(result, cp.norm(A, np.inf).value, places=3)
 
     def test_indicator(self) -> None:

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1349,14 +1349,14 @@ class TestAtoms(BaseTest):
             -result, 4 * np.log(scipy.stats.norm.cdf(2)), places=None, delta=1e-2
         )
 
-    def test_scalar_product(self) -> None:
+    def test_vdot(self) -> None:
         """Test scalar product.
         """
         p = np.ones((4,))
         v = cp.Variable((4,))
 
         p = np.ones((4,))
-        obj = cp.Minimize(cp.scalar_product(v, p))
+        obj = cp.Minimize(cp.vdot(v, p))
         prob = cp.Problem(obj, [v >= 1])
         prob.solve(solver=cp.SCS)
         assert np.allclose(v.value, p)
@@ -1366,7 +1366,7 @@ class TestAtoms(BaseTest):
         v = cp.Variable((4,))
 
         p.value = np.ones((4,))
-        obj = cp.Minimize(cp.scalar_product(v, p))
+        obj = cp.Minimize(cp.vdot(v, p))
         prob = cp.Problem(obj, [v >= 1])
         prob.solve(solver=cp.SCS)
         assert np.allclose(v.value, p.value)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1355,8 +1355,12 @@ class TestAtoms(BaseTest):
         p = np.ones((4,))
         v = cp.Variable((4,))
 
-        p = np.ones((4,))
         obj = cp.Minimize(cp.vdot(v, p))
+        prob = cp.Problem(obj, [v >= 1])
+        prob.solve(solver=cp.SCS)
+        assert np.allclose(v.value, p)
+
+        obj = cp.Minimize(cp.scalar_product(v, p))
         prob = cp.Problem(obj, [v >= 1])
         prob.solve(solver=cp.SCS)
         assert np.allclose(v.value, p)
@@ -1367,6 +1371,11 @@ class TestAtoms(BaseTest):
 
         p.value = np.ones((4,))
         obj = cp.Minimize(cp.vdot(v, p))
+        prob = cp.Problem(obj, [v >= 1])
+        prob.solve(solver=cp.SCS)
+        assert np.allclose(v.value, p.value)
+
+        obj = cp.Minimize(cp.scalar_product(v, p))
         prob = cp.Problem(obj, [v >= 1])
         prob.solve(solver=cp.SCS)
         assert np.allclose(v.value, p.value)

--- a/doc/source/api_reference/cvxpy.atoms.affine.rst
+++ b/doc/source/api_reference/cvxpy.atoms.affine.rst
@@ -174,12 +174,12 @@ reshape
 .. autoclass:: cvxpy.reshape
     :show-inheritance:
 
-.. _scalar_product:
+.. _vdot:
 
-scalar_product
+vdot
 --------------
 
-.. autofunction:: cvxpy.scalar_product
+.. autofunction:: cvxpy.vdot
 
 .. _sum:
 


### PR DESCRIPTION
## Description
This PR attempts to introduce cp.vdot as a replacement for cp.scalar_product. 
In the issue below, it was suggested to not deprecate cp.scalar_product, but instead remove it from the documentation.
When running ``grep -ir "scalar_product"`` I saw that there were a lot of instances under ``cvxcore``, I am not sure if the code there also needs to be updated.
Issue link (if applicable): #2336 

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.