### PR TITLE
removing some test warnings

### DIFF
--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -50,9 +50,8 @@ DPP_ERROR_MSG = (
     "You are solving a parameterized problem that is not DPP. "
     "Because the problem is not DPP, subsequent solves will not be "
     "faster than the first one. For more information, see the "
-    "documentation on Discplined Parametrized Programming, at\n"
-    "\thttps://www.cvxpy.org/tutorial/advanced/index.html#"
-    "disciplined-parametrized-programming"
+    "documentation on Disciplined Parametrized Programming, at "
+    "https://www.cvxpy.org/tutorial/dpp/index.html"
 )
 
 ECOS_DEP_DEPRECATION_MSG = (

--- a/cvxpy/tests/test_kron_canon.py
+++ b/cvxpy/tests/test_kron_canon.py
@@ -92,7 +92,7 @@ class TestKronRightVar(TestKron):
         for c_dims in TestKronRightVar.C_DIMS:
             Z, C, L, prob = self.make_kron_prob(z_dims, c_dims, param=True,
                                                 var_left=False, seed=0)
-            prob.solve(solver='ECOS', abstol=1e-8, reltol=1e-8)
+            prob.solve(solver=cp.CLARABEL)
             self.assertEqual(prob.status, cp.OPTIMAL)
             con_viols = prob.constraints[0].violation()
             self.assertLessEqual(np.max(con_viols), 1e-4)
@@ -103,7 +103,7 @@ class TestKronRightVar(TestKron):
         for c_dims in TestKronRightVar.C_DIMS:
             Z, C, L, prob = self.make_kron_prob(z_dims, c_dims, param=False,
                                                 var_left=False, seed=0)
-            prob.solve(solver='ECOS', abstol=1e-8, reltol=1e-8)
+            prob.solve(solver=cp.CLARABEL)
             self.assertEqual(prob.status, cp.OPTIMAL)
             con_viols = prob.constraints[0].violation()
             self.assertLessEqual(np.max(con_viols), 1e-4)
@@ -180,7 +180,7 @@ class TestKronLeftVar(TestKron):
         for c_dims in TestKronLeftVar.C_DIMS:
             Z, C, L, prob = self.make_kron_prob(z_dims, c_dims, param=True,
                                                 var_left=True, seed=0)
-            prob.solve(solver='ECOS', abstol=1e-8, reltol=1e-8)
+            prob.solve(solver=cp.CLARABEL)
             self.assertEqual(prob.status, cp.OPTIMAL)
             con_viols = prob.constraints[0].violation()
             self.assertLessEqual(np.max(con_viols), 1e-4)
@@ -191,7 +191,7 @@ class TestKronLeftVar(TestKron):
         for c_dims in TestKronLeftVar.C_DIMS:
             Z, C, L, prob = self.make_kron_prob(z_dims, c_dims, param=False,
                                                 var_left=True, seed=0)
-            prob.solve(solver='ECOS', abstol=1e-8, reltol=1e-8)
+            prob.solve(solver=cp.CLARABEL)
             self.assertEqual(prob.status, cp.OPTIMAL)
             con_viols = prob.constraints[0].violation()
             self.assertLessEqual(np.max(con_viols), 1e-4)


### PR DESCRIPTION
## Description
I saw that the summary of the tests had many warnings. This PR attempts to clean up a small subset of those warnings.
I was wondering if we should change all occurrences of using ECOS to CLARABEL in the tests, now that we are planning to change default solvers? 
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.