### PR TITLE
Add option save_file

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -51,6 +51,9 @@ class COPT(ConicSolver):
     # Only supports MI LPs
     MI_SUPPORTED_CONSTRAINTS = ConicSolver.SUPPORTED_CONSTRAINTS
 
+    # Keyword arguments for the CVXPY interface.
+    INTERFACE_ARGS = ["save_file", "reoptimize"]
+
     # Map between COPT status and CVXPY status
     STATUS_MAP = {
                   1: s.OPTIMAL,             # optimal
@@ -299,7 +302,12 @@ class COPT(ConicSolver):
 
         # Set parameters
         for key, value in solver_opts.items():
-            model.setParam(key, value)
+            # Ignore arguments unique to the CVXPY interface.
+            if key not in self.INTERFACE_ARGS:
+                model.setParam(key, value)
+
+        if 'save_file' in solver_opts:
+            model.write(solver_opts['save_file'])
 
         solution = {}
         try:

--- a/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
@@ -16,6 +16,9 @@ class COPT(QpSolver):
     # Solve capabilities
     MIP_CAPABLE = True
 
+    # Keyword arguments for the CVXPY interface.
+    INTERFACE_ARGS = ["save_file", "reoptimize"]
+
     # Map between COPT status and CVXPY status
     STATUS_MAP = {
                   1: s.OPTIMAL,             # optimal
@@ -150,7 +153,12 @@ class COPT(QpSolver):
 
         # Set parameters
         for key, value in solver_opts.items():
-            model.setParam(key, value)
+            # Ignore arguments unique to the CVXPY interface.
+            if key not in self.INTERFACE_ARGS:
+                model.setParam(key, value)
+
+        if 'save_file' in solver_opts:
+            model.write(solver_opts['save_file'])
 
         # Solve problem
         solution = {}

--- a/cvxpy/tests/test_copt_write.py
+++ b/cvxpy/tests/test_copt_write.py
@@ -1,0 +1,49 @@
+"""
+Copyright 2022, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import os
+import unittest
+
+import numpy as np
+
+import cvxpy as cp
+from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS
+from cvxpy.tests.base_test import BaseTest
+
+
+@unittest.skipUnless('COPT' in INSTALLED_SOLVERS, 'COPT is not installed.')
+class TestCOPTWrite(BaseTest):
+    def test_write(self) -> None:
+        """Test the COPT model.write().
+        """
+        import py
+
+        tmpdir = py.path.local()
+        tmpfile = tmpdir.mkdir("outfiles").join("copt_model.bin")
+
+        m = 20
+        n = 15
+        np.random.seed(0)
+        A = np.random.randn(m, n)
+        b = np.random.randn(m)
+
+        x = cp.Variable(n)
+        cost = cp.sum_squares(A @ x - b)
+        prob = cp.Problem(cp.Minimize(cost))
+        prob.solve(solver=cp.COPT,
+                   verbose=True,
+                   save_file=tmpfile)
+
+        assert os.path.exists(tmpfile)

--- a/cvxpy/tests/test_copt_write.py
+++ b/cvxpy/tests/test_copt_write.py
@@ -32,6 +32,7 @@ class TestCOPTWrite(BaseTest):
 
         tmpdir = py.path.local()
         tmpfile = tmpdir.mkdir("outfiles").join("copt_model.bin")
+        tmpname = str(tmpfile)
 
         m = 20
         n = 15
@@ -44,6 +45,6 @@ class TestCOPTWrite(BaseTest):
         prob = cp.Problem(cp.Minimize(cost))
         prob.solve(solver=cp.COPT,
                    verbose=True,
-                   save_file=tmpfile)
+                   save_file=tmpname)
 
-        assert os.path.exists(tmpfile)
+        assert os.path.exists(tmpname)


### PR DESCRIPTION
## Description
Add option `save_file` to enable writing out problem loaded into COPT to file.

## Type of change
- [x] New feature (backwards compatible)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.