### PR TITLE
[Bug] Parametrized quad form broken when values are zero

### DIFF
--- a/cvxpy/tests/test_coeff_extractor.py
+++ b/cvxpy/tests/test_coeff_extractor.py
@@ -33,7 +33,7 @@ def coeff_extractor():
     return CoeffExtractor(inverset_data, backend)
 
 
-def test_issue_2402_scalar():
+def test_issue_2402_scalar_parameter():
     """
     This is the problem reported in #2402, failing to solve when two parameters
     are used on quadratic forms with the same variable.
@@ -59,6 +59,35 @@ def test_issue_2402_scalar():
     
     assert prob.value is not None
     assert w.value is not None
+
+
+def test_issue_2402_scalar_constant():
+    """
+    This slight modification uses a constant instead of a parameter,
+    which was a separate issue in the same problem.
+    """
+
+    r =  np.array([-0.48,  0.11,  0.09, -0.39,  0.03])
+    Sigma = np.array([
+        [2.4e-04, 1.3e-04, 2.0e-04, 1.6e-04, 2.0e-04],
+        [1.3e-04, 2.8e-04, 2.1e-04, 1.7e-04, 1.5e-04],
+        [2.0e-04, 2.1e-04, 5.8e-04, 3.3e-04, 2.3e-04],
+        [1.6e-04, 1.7e-04, 3.3e-04, 6.9e-04, 2.1e-04],
+        [2.0e-04, 1.5e-04, 2.3e-04, 2.1e-04, 3.6e-04]])
+
+    w = cp.Variable(5)
+    risk_aversion = cp.Parameter(value=1., nonneg=True)
+    ridge_coef = 0
+    
+    obj_func = r @ w - risk_aversion * cp.quad_form(w, Sigma) -  ridge_coef * cp.sum_squares(w)
+    objective = cp.Maximize(obj_func)
+    constraints = [cp.sum(w) == 1]
+    prob = cp.Problem(objective, constraints)
+    prob.solve()
+    
+    assert prob.value is not None
+    assert w.value is not None
+
 
 def test_issue_2402_vector():
     """

--- a/cvxpy/tests/test_coeff_extractor.py
+++ b/cvxpy/tests/test_coeff_extractor.py
@@ -5,7 +5,7 @@ import pytest
 
 import cvxpy as cp
 from cvxpy.atoms.quad_form import SymbolicQuadForm
-from cvxpy.utilities.coeff_extractor import CoeffExtractor
+from cvxpy.utilities.coeff_extractor import COOData, CoeffExtractor
 
 
 @dataclass
@@ -78,12 +78,12 @@ def test_coeff_extractor(coeff_extractor):
     coeffs, constant = coeff_extractor.extract_quadratic_coeffs(affine_expr, quad_forms)
     
     assert len(coeffs) == 1
-    assert np.allclose(coeffs[1]["q"], np.zeros((2, 3)))
+    assert np.allclose(coeffs[1]["q"].toarray(), np.zeros((2, 3)))
     P = coeffs[1]["P"]
-    assert len(P) == 3
-    assert np.allclose(P[0], np.array([[1, 0, 0], [1, 0, 0], [0, 1, 0], [0, 1, 0]]))
-    assert len(P[1]) == 2
-    assert np.allclose(P[1][0], np.array([0, 1, 0, 1]))
-    assert np.allclose(P[1][1], np.array([0, 1, 0, 1]))
-    assert P[2] == (2, 2)
+    assert isinstance(P, COOData)
+    assert np.allclose(P.data, np.ones((4)))
+    assert np.allclose(P.row, np.array([0, 1, 0, 1]))
+    assert np.allclose(P.col, np.array([0, 1, 0, 1]))
+    assert P.shape == (2, 2)
+    assert np.allclose(P.param_idxs, np.array([0,1]))
     assert np.allclose(constant.toarray(), np.zeros((3)))

--- a/cvxpy/tests/test_coeff_extractor.py
+++ b/cvxpy/tests/test_coeff_extractor.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+import cvxpy as cp
+from cvxpy.atoms.quad_form import SymbolicQuadForm
+from cvxpy.utilities.coeff_extractor import CoeffExtractor
+
+
+@dataclass
+class MockeInverseData:
+    var_offsets: dict
+    x_length: int
+    var_shapes: dict
+    param_shapes: dict
+    param_to_size: dict
+    param_id_map: dict
+
+
+@pytest.fixture
+def coeff_extractor():
+    inverset_data = MockeInverseData(
+        var_offsets={1: 0},
+        x_length=2,
+        var_shapes={1: (2,)},
+        param_shapes={2: (), 3: ()},
+        param_to_size={-1: 1, 2: 1, 3: 1},
+        param_id_map={2: 0, 3: 1, -1: 2},
+    )
+    backend = cp.CPP_CANON_BACKEND
+    return CoeffExtractor(inverset_data, backend)
+
+
+def test_problem_end_to_end():
+    """
+    This is a MWE / regression test for the issue reported in #2402.
+    """
+    x = cp.Variable(2)
+    p1 = cp.Parameter(value=1.0, nonneg=True)
+    p2 = cp.Parameter(value=0.0, nonneg=True)
+
+    P = np.eye(2)
+
+    objective = cp.Minimize(p1 * cp.quad_form(x, P) + p2 * cp.sum_squares(x))
+    problem = cp.Problem(objective, constraints=[cp.sum(x) == 1])
+    problem.solve()
+    assert np.isclose(problem.value, 0.5)
+    assert np.allclose(x.value, [0.5, 0.5])
+
+
+def test_coeff_extractor(coeff_extractor):
+    """
+    This is a unit test for the same problem.
+    The variable and parameter namings are derived from the problem above.
+    """
+    x1 = cp.Variable(2, var_id=1)
+    x14 = cp.Variable((1, 1), var_id=14)
+    x16 = cp.Variable(var_id=16)
+
+    p2 = cp.Parameter(value=1.0, nonneg=True, id=2)
+    p3 = cp.Parameter(value=0.0, nonneg=True, id=3)
+
+    affine_expr = p2 * x14 + p3 * x16
+
+    quad_forms = {
+        x14.id: (
+            p2 * x14,
+            1,
+            SymbolicQuadForm(x1, cp.Constant(np.eye(2)), cp.quad_form(x1, np.eye(2))),
+        ),
+        x16.id: (
+            p3 * x16,
+            1,
+            SymbolicQuadForm(x1, cp.Constant(np.eye(2)), cp.quad_over_lin(x1, 1.0)),
+        ),
+    }
+    coeffs, constant = coeff_extractor.extract_quadratic_coeffs(affine_expr, quad_forms)
+    
+    assert len(coeffs) == 1
+    assert np.allclose(coeffs[1]["q"], np.zeros((2, 3)))
+    P = coeffs[1]["P"]
+    assert len(P) == 3
+    assert np.allclose(P[0], np.array([[1, 0, 0], [1, 0, 0], [0, 1, 0], [0, 1, 0]]))
+    assert len(P[1]) == 2
+    assert np.allclose(P[1][0], np.array([0, 1, 0, 1]))
+    assert np.allclose(P[1][1], np.array([0, 1, 0, 1]))
+    assert P[2] == (2, 2)
+    assert np.allclose(constant.toarray(), np.zeros((3)))

--- a/cvxpy/tests/test_coeff_extractor.py
+++ b/cvxpy/tests/test_coeff_extractor.py
@@ -5,7 +5,7 @@ import pytest
 
 import cvxpy as cp
 from cvxpy.atoms.quad_form import SymbolicQuadForm
-from cvxpy.utilities.coeff_extractor import COOData, CoeffExtractor
+from cvxpy.utilities.coeff_extractor import CoeffExtractor, COOData
 
 
 @dataclass

--- a/cvxpy/tests/test_coeff_extractor.py
+++ b/cvxpy/tests/test_coeff_extractor.py
@@ -81,7 +81,7 @@ def test_coeff_extractor(coeff_extractor):
     assert np.allclose(coeffs[1]["q"].toarray(), np.zeros((2, 3)))
     P = coeffs[1]["P"]
     assert isinstance(P, COOData)
-    assert np.allclose(P.data, np.ones((4)))
+    assert np.allclose(P.data, np.ones((2,2)))
     assert np.allclose(P.row, np.array([0, 1, 0, 1]))
     assert np.allclose(P.col, np.array([0, 1, 0, 1]))
     assert P.shape == (2, 2)

--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -269,7 +269,7 @@ class CoeffExtractor:
             P_list: List[TensorRepresentation],
             P_height: int, 
             num_params: int,
-        ) -> sp.coo_matrix:
+        ) -> sp.csc_matrix:
         """Conceptually we build a block diagonal matrix
            out of all the Ps, then flatten the first two dimensions.
            eg P1
@@ -283,7 +283,7 @@ class CoeffExtractor:
             num_params: number of parameters in the problem.
         
         Returns:
-            A COO sparse representation of the merged P matrix.
+            A CSC sparse representation of the merged P matrix.
         """
 
         offset = 0
@@ -300,7 +300,7 @@ class CoeffExtractor:
 
         combined = TensorRepresentation.combine(P_list)
 
-        return combined.flatten_tensor(num_params).tocoo()  # todo: check if csc works
+        return combined.flatten_tensor(num_params)
 
     def merge_q_list(
         self,

--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -44,21 +44,6 @@ class CoeffExtractor:
         self.param_id_map = inverse_data.param_id_map
         self.canon_backend = canon_backend
 
-    def get_coeffs(self, expr):
-        if expr.is_constant():
-            return self.constant(expr)
-        elif expr.is_affine():
-            return self.affine(expr)
-        elif expr.is_quadratic():
-            return self.quad_form(expr)
-        else:
-            raise Exception("Unknown expression type %s." % type(expr))
-
-    def constant(self, expr):
-        size = expr.size
-        return sp.csr_matrix((size, self.N)), np.reshape(expr.value, (size,),
-                                                         order='F')
-
     def affine(self, expr):
         """Extract problem data tensor from an expression that is reducible to
         A*x + b.
@@ -316,7 +301,7 @@ class CoeffExtractor:
         """Stack q with constant offset as last row.
 
         Args:
-            q_list: list of q submatrices as scipy sparse matrices or numpy arrays.
+            q_list: list of q submatrices as SciPy sparse matrices or NumPy arrays.
             constant: The constant offset as a CSC sparse matrix.
             num_params: number of parameters in the problem.
 

--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -174,7 +174,6 @@ class CoeffExtractor:
                     # Eliminate zeros from data by tracking
                     # which indices of the global parameter vector are used.
                     nonzero_idxs = c_part[0] != 0
-                    # nonzero_idxs = np.arange(c_part.shape[1])
                     data = P.data[:, None] * c_part[:, nonzero_idxs]
                     param_idxs = np.arange(c_part.shape[1])[nonzero_idxs]
                 P_tup = COOData(data, P.row, P.col, P.shape, param_idxs)

--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -17,7 +17,6 @@ limitations under the License.
 
 from __future__ import annotations, division
 
-from collections import defaultdict
 import operator
 from dataclasses import dataclass
 from typing import List
@@ -58,10 +57,16 @@ class COOData:
         col = np.concatenate([self.col, other.col], axis=0)
         param_idxs = np.concatenate([self.param_idxs, other.param_idxs], axis=0)
         return COOData(data, row, col, self.shape, param_idxs)
-    
+
     @classmethod
     def empty_with_shape(cls, shape: tuple[int, int]) -> COOData:
-        return COOData(np.array([]), np.array([], dtype=int), np.array([], dtype=int), shape, np.array([], dtype=int))
+        return COOData(
+            np.array([]),
+            np.array([], dtype=int),
+            np.array([], dtype=int),
+            shape,
+            np.array([], dtype=int),
+        )
 
 # TODO find best format for sparse matrices: csr, csc, dok, lil, ...
 class CoeffExtractor:
@@ -178,7 +183,9 @@ class CoeffExtractor:
 
                 # Convert to sparse matrix.
                 P = quad_forms[var_id][2].P
-                assert P.value is not None, "P matrix must be instantiated before calling extract_quadratic_coeffs."
+                assert (
+                    P.value is not None
+                ), "P matrix must be instantiated before calling extract_quadratic_coeffs."
                 if sp.issparse(P) and not isinstance(P, sp.coo_matrix):
                     P = P.value.tocoo()
                 else:

--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -174,7 +174,8 @@ class CoeffExtractor:
                     # Eliminate zeros from data by tracking
                     # which indices of the global parameter vector are used.
                     nonzero_idxs = c_part[0] != 0
-                    data = P.data[:, None] * c_part[0:, nonzero_idxs]
+                    # nonzero_idxs = np.arange(c_part.shape[1])
+                    data = P.data[:, None] * c_part[:, nonzero_idxs]
                     param_idxs = np.arange(c_part.shape[1])[nonzero_idxs]
                 P_tup = COOData(data, P.row, P.col, P.shape, param_idxs)
                 # Conceptually similar to
@@ -189,6 +190,7 @@ class CoeffExtractor:
                         acc_data = np.concatenate([acc_P.data, data], axis=0)
                         acc_row = np.concatenate([acc_P.row, P.row], axis=0)
                         acc_col = np.concatenate([acc_P.col, P.col], axis=0)
+                        param_idxs = np.concatenate([acc_P.param_idxs, param_idxs], axis=0)
                         P_tup = COOData(acc_data, acc_row, acc_col, P.shape, param_idxs)
                         coeffs[orig_id]['P'] = P_tup
                     else:
@@ -323,9 +325,9 @@ class CoeffExtractor:
                 )
                 P_cols_ext = P.col.astype(np.int64) * np.int64(P_height)
                 base_rows = gap_above + acc_height + P.row + P_cols_ext
-                full_rows = np.tile(base_rows, len(P.param_idxs))
+                full_rows = np.tile(base_rows, P.data.size//len(base_rows))
                 rows[entry_offset:entry_offset + P.data.size] = full_rows
-                full_cols = np.repeat(P.param_idxs, P.col.size)
+                full_cols = np.repeat(P.param_idxs, P.data.size//len(P.param_idxs))
                 cols[entry_offset:entry_offset + P.data.size] = full_cols
                 entry_offset += P.data.size
             gap_above += P.shape[0]


### PR DESCRIPTION
## Description
This PR should eventually contain the fix for #2402. 

Current status:
- [x] Identify origin, this behavior exists since #2226 
- [x] Adding MWE and test case. This test currently fails but passes on version <1.4.
- [x] Fix logic
 
Issue link (if applicable): #2402

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.