### PR TITLE
Fix issue #2408: `value.A` is deprecated and will be removed in scipy 1.14.0

### DIFF
--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -341,7 +341,7 @@ class DivExpression(BinaryOperator):
         """
         for i in range(2):
             if sp.issparse(values[i]):
-                values[i] = values[i].todense().A
+                values[i] = values[i].toarray()
         return np.divide(values[0], values[1])
 
     def is_quadratic(self) -> bool:

--- a/cvxpy/atoms/affine/sum.py
+++ b/cvxpy/atoms/affine/sum.py
@@ -57,7 +57,7 @@ class Sum(AxisAtom, AffAtom):
         """Sums the entries of value.
         """
         if intf.is_sparse(values[0]):
-            result = np.sum(values[0].toarray(), axis=self.axis)
+            result = np.asarray(values[0].sum(axis=self.axis))
             if not self.keepdims and self.axis is not None:
                 result = result.flatten()
         else:

--- a/cvxpy/atoms/affine/sum.py
+++ b/cvxpy/atoms/affine/sum.py
@@ -57,9 +57,9 @@ class Sum(AxisAtom, AffAtom):
         """Sums the entries of value.
         """
         if intf.is_sparse(values[0]):
-            result = np.sum(values[0], axis=self.axis)
+            result = np.sum(values[0].toarray(), axis=self.axis)
             if not self.keepdims and self.axis is not None:
-                result = result.A.flatten()
+                result = result.flatten()
         else:
             result = np.sum(values[0], axis=self.axis, keepdims=self.keepdims)
         return result

--- a/cvxpy/atoms/norm_inf.py
+++ b/cvxpy/atoms/norm_inf.py
@@ -30,7 +30,7 @@ class norm_inf(AxisAtom):
         """
         if self.axis is None:
             if sp.issparse(values[0]):
-                values = values[0].todense().A.flatten()
+                values = values[0].toarray().flatten()
             else:
                 values = np.array(values[0]).flatten()
         else:

--- a/cvxpy/atoms/prod.py
+++ b/cvxpy/atoms/prod.py
@@ -84,9 +84,9 @@ class Prod(AxisAtom):
         """Takes the product of the entries of value.
         """
         if intf.is_sparse(values[0]):
-            result = np.prod(values[0], axis=self.axis)
+            result = np.prod(values[0].toarray(), axis=self.axis)
             if not self.keepdims and self.axis is not None:
-                result = result.A.flatten()
+                result = result.flatten()
         else:
             result = np.prod(values[0], axis=self.axis, keepdims=self.keepdims)
         return result

--- a/cvxpy/atoms/prod.py
+++ b/cvxpy/atoms/prod.py
@@ -84,9 +84,23 @@ class Prod(AxisAtom):
         """Takes the product of the entries of value.
         """
         if intf.is_sparse(values[0]):
-            result = np.prod(values[0].toarray(), axis=self.axis)
-            if not self.keepdims and self.axis is not None:
-                result = result.flatten()
+            sp_mat = values[0]
+            if self.axis is None:
+                if sp_mat.nnz == sp_mat.shape[0] * sp_mat.shape[1]:
+                    data = sp_mat.data
+                else:
+                    data = np.zeros(1, dtype=sp_mat.dtype)
+                result = np.prod(data)
+            else:
+                assert self.axis in [0, 1]
+                # The following snippet is taken from stackoverflow.
+                # https://stackoverflow.com/questions/44320865/
+                mask = sp_mat.getnnz(axis=self.axis) == sp_mat.shape[self.axis]
+                result = np.zeros(sp_mat.shape[1-self.axis], dtype=sp_mat.dtype)
+                data = sp_mat[:, mask] if self.axis == 0 else sp_mat[mask, :]
+                result[mask] = np.prod(data.toarray(), axis=self.axis)
+                if self.keepdims:
+                    result = np.expand_dims(result, self.axis)
         else:
             result = np.prod(values[0], axis=self.axis, keepdims=self.keepdims)
         return result

--- a/cvxpy/interface/numpy_interface/ndarray_interface.py
+++ b/cvxpy/interface/numpy_interface/ndarray_interface.py
@@ -43,9 +43,9 @@ class NDArrayInterface(base.BaseMatrixInterface):
             A matrix of type self.target_matrix or a scalar.
         """
         if scipy.sparse.issparse(value):
-            result = value.A
+            result = value.toarray()
         elif isinstance(value, numpy.matrix):
-            result = value.A
+            result = numpy.asarray(value)
         elif isinstance(value, list):
             result = numpy.asarray(value).T
         else:

--- a/cvxpy/lin_ops/tree_mat.py
+++ b/cvxpy/lin_ops/tree_mat.py
@@ -256,7 +256,7 @@ def op_tmul(lin_op, value):
         # The return type in numpy versions < 1.10 was ndarray.
         result = np.diag(value)
         if isinstance(result, np.matrix):
-            result = result.A[0]
+            result = np.asarray(result)[0]
     elif lin_op.type is lo.CONV:
         result = conv_mul(lin_op, value, transpose=True)
     else:

--- a/cvxpy/tests/test_constant.py
+++ b/cvxpy/tests/test_constant.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy.sparse as sp
 import scipy.sparse.linalg as sparla
 
 import cvxpy as cp
@@ -52,3 +53,23 @@ def test_print():
     assert str(
         B) == '[[1.00 1.00]\n [1.00 1.00]\n [1.00 1.00]\n [1.00 1.00]\n [1.00 1.00]]'
     s.PRINT_EDGEITEMS = default
+
+
+def test_prod():
+    rows = np.concatenate([np.arange(100), np.zeros(100)[1:]])
+    cols = np.concatenate([np.zeros(100), np.arange(100)[1:]])
+    values = np.ones(199)
+    A = sp.coo_matrix((values, (rows, cols)), shape=(100, 100))
+
+    assert np.allclose(cp.prod(A).value, 0.0)
+    assert np.allclose(cp.prod(A, axis=0).value, [1] + [0] * 99)
+    assert cp.prod(A, axis=0).shape == (100,)
+    assert np.allclose(cp.prod(A, axis=1).value, [1] + [0] * 99)
+    assert cp.prod(A, axis=1).shape == (100,)
+    assert np.allclose(cp.prod(A, axis=0, keepdims=True).value, [[1] + [0] * 99])
+    assert cp.prod(A, axis=0, keepdims=True).shape == (1, 100)
+    assert np.allclose(cp.prod(A, axis=1, keepdims=True).value, [[1]] + [[0]] * 99)
+    assert cp.prod(A, axis=1, keepdims=True).shape == (100, 1)
+
+    B = np.arange(4).reshape(2, 2) + 1
+    assert np.allclose(cp.prod(sp.coo_matrix(B)).value, 24)

--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -321,7 +321,7 @@ class CoeffExtractor:
         # Fast path for no parameters.
         if num_params == 1:
             q = np.vstack(q_list)
-            q = np.vstack([q, constant.A])
+            q = np.vstack([q, constant.toarray()])
             return sp.csr_matrix(q)
         else:
             q = sp.vstack(q_list + [constant])


### PR DESCRIPTION
## Description
Fix the `.A` property of sparse matrices which is deprecated and will be removed in SciPy 1.14.0.
Issue link (if applicable): #2408

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.