### PR TITLE
Patch/1.4.3.post0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,7 @@ jobs:
         shell: bash
         run: |
           echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
-          echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
+          echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
 
       - name: Adapt setup.py
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,6 +200,7 @@ jobs:
         shell: bash
         run: |
           # Mac has a different syntax for sed -i, this works across oses
+          sed -i.bak -e "s/name='cvxpy',/name='cvxpy-base',/g" setup.py
           sed -i.bak '/clarabel >= /d' setup.py
           sed -i.bak '/osqp >= /d' setup.py
           sed -i.bak '/ecos >= /d' setup.py


### PR DESCRIPTION
In the `setup.py` version of the build setup, removing this line has cause the wheels to lose the `_base` suffix, preventing the upload to PyPI.

Removing the deploy trigger in the `prep for 1.4.4` commit. 