### PR TITLE
fix: keepdims passed through 'min' correctly

### DIFF
--- a/cvxpy/reductions/eliminate_pwl/canonicalizers/min_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/canonicalizers/min_canon.py
@@ -20,8 +20,9 @@ from cvxpy.reductions.eliminate_pwl.canonicalizers.max_canon import max_canon
 
 def min_canon(expr, args):
     axis = expr.axis
+    keepdims = expr.keepdims
     del expr
     assert len(args) == 1
-    tmp = max(-args[0], axis=axis)
+    tmp = max(-args[0], axis=axis, keepdims=keepdims)
     canon, constr = max_canon(tmp, tmp.args)
     return -canon, constr


### PR DESCRIPTION
## Description
The `min` atom ignores the `keepdims` flag.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.