### PR TITLE
Preserve expression sign in canonicalization of minimum and maximum

### DIFF
--- a/cvxpy/reductions/eliminate_pwl/canonicalizers/maximum_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/canonicalizers/maximum_canon.py
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.expressions.variable import Variable
 from cvxpy.atoms.affine.wraps import nonneg_wrap, nonpos_wrap
+from cvxpy.expressions.variable import Variable
 
 
 def maximum_canon(expr, args):
@@ -23,9 +23,9 @@ def maximum_canon(expr, args):
     t = Variable(shape)
     
     if expr.is_nonneg():
-    	t = nonneg_wrap(t)
+        t = nonneg_wrap(t)
     if expr.is_nonpos():
-    	t = nonpos_wrap(t)
+        t = nonpos_wrap(t)
     
     constraints = [t >= elem for elem in args]
     return t, constraints

--- a/cvxpy/reductions/eliminate_pwl/canonicalizers/maximum_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/canonicalizers/maximum_canon.py
@@ -15,10 +15,17 @@ limitations under the License.
 """
 
 from cvxpy.expressions.variable import Variable
+from cvxpy.atoms.affine.wraps import nonneg_wrap, nonpos_wrap
 
 
 def maximum_canon(expr, args):
     shape = expr.shape
     t = Variable(shape)
+    
+    if expr.is_nonneg():
+    	t = nonneg_wrap(t)
+    if expr.is_nonpos():
+    	t = nonpos_wrap(t)
+    
     constraints = [t >= elem for elem in args]
     return t, constraints

--- a/cvxpy/tests/test_canon_sign.py
+++ b/cvxpy/tests/test_canon_sign.py
@@ -1,0 +1,45 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import cvxpy as cp
+from cvxpy.tests.base_test import BaseTest
+from cvxpy.reductions.eliminate_pwl.canonicalizers.maximum_canon import maximum_canon
+
+from typing import Iterable
+
+
+class TestCanonSign(BaseTest):
+    @staticmethod
+    def exprs() -> Iterable[cp.Expression]:
+        """List of test expressions"""
+        expr_nonneg = cp.Variable(pos=True)
+        expr_nonpos = cp.Variable(neg=True)
+        expr_zero = cp.Constant(0)
+
+        return [expr_nonneg, expr_nonpos, expr_zero]
+
+    def expr_sign_assertions(self, a: cp.Expression, b: cp.Expression) -> None:
+        """Asserting sign methods are preserved across a & b (a function of a)"""
+        self.assertEqual(a.is_nonpos(), b.is_nonpos())
+        self.assertEqual(a.is_nonneg(), b.is_nonneg())
+
+    def test_maximum_sign(self):
+        """Iterate over test expressions,
+        check that sign is preserved for composition of all with maximum_canon"""
+        args = [0]
+        for expr in self.exprs():
+            canon_expr, canon_cons = maximum_canon(expr, args)
+            self.expr_sign_assertions(expr, canon_expr)

--- a/cvxpy/tests/test_canon_sign.py
+++ b/cvxpy/tests/test_canon_sign.py
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy as cp
+from typing import Iterable
+
 import numpy as np
-from cvxpy.tests.base_test import BaseTest
+
+import cvxpy as cp
 from cvxpy.reductions.eliminate_pwl.canonicalizers.maximum_canon import maximum_canon
 from cvxpy.reductions.eliminate_pwl.canonicalizers.minimum_canon import minimum_canon
-
-
-from typing import Iterable
+from cvxpy.tests.base_test import BaseTest
 
 
 class TestCanonSign(BaseTest):
@@ -43,13 +43,13 @@ class TestCanonSign(BaseTest):
         """Iterate over test expressions,
         check that sign is preserved for composition of all with maximum_canon"""
         for expr in self.exprs():
-            tmp = cp.maximum(expr, -np.Inf)
+            tmp = cp.maximum(expr, -np.inf)
             canon_expr, canon_cons = maximum_canon(tmp, tmp.args)
             self.expr_sign_assertions(tmp, canon_expr)
 
     def test_minimum_sign(self):
         """cf. test_maximum_sign"""
         for expr in self.exprs():
-            tmp = cp.minimum(expr, np.Inf)
+            tmp = cp.minimum(expr, np.inf)
             canon_expr, canon_cons = minimum_canon(tmp, tmp.args)
             self.expr_sign_assertions(tmp, canon_expr)

--- a/cvxpy/tests/test_canon_sign.py
+++ b/cvxpy/tests/test_canon_sign.py
@@ -15,8 +15,11 @@ limitations under the License.
 """
 
 import cvxpy as cp
+import numpy as np
 from cvxpy.tests.base_test import BaseTest
 from cvxpy.reductions.eliminate_pwl.canonicalizers.maximum_canon import maximum_canon
+from cvxpy.reductions.eliminate_pwl.canonicalizers.minimum_canon import minimum_canon
+
 
 from typing import Iterable
 
@@ -39,7 +42,14 @@ class TestCanonSign(BaseTest):
     def test_maximum_sign(self):
         """Iterate over test expressions,
         check that sign is preserved for composition of all with maximum_canon"""
-        args = [0]
         for expr in self.exprs():
-            canon_expr, canon_cons = maximum_canon(expr, args)
-            self.expr_sign_assertions(expr, canon_expr)
+            tmp = cp.maximum(expr, -np.Inf)
+            canon_expr, canon_cons = maximum_canon(tmp, tmp.args)
+            self.expr_sign_assertions(tmp, canon_expr)
+
+    def test_minimum_sign(self):
+        """cf. test_maximum_sign"""
+        for expr in self.exprs():
+            tmp = cp.minimum(expr, np.Inf)
+            canon_expr, canon_cons = minimum_canon(tmp, tmp.args)
+            self.expr_sign_assertions(tmp, canon_expr)


### PR DESCRIPTION
## Description
This change fixes #2374, preserving the sign of arguments to `cp.minimum` and `cp.maximum` during canonicalization. 

Specific review desired on breadth / specificity / quality / naming of new unittest `test_canon_sign.py`; is it too narrow of a test? Other edge cases that ought to be included? 

Default benchmarks do appear to be somewhat slower. Is this acceptable? Do additional benchmarks need to be written and/or should iteration counts be increased to control somewhat for noise?

Issue link: #2374 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [X] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [X] Add our license to new files.
- [X] Check that your code adheres to our coding style.
- [X] Write unittests.
- [X] Run the unittests and check that they’re passing.
- [X] Run the benchmarks to make sure your change doesn’t introduce a regression.


## Tests and Benchmarks
<details>
  <summary>All tests are passing</summary>

  ```
cvxpy on  master via 🐍 v3.12.2 via 🅒 cvxdev 
❯ pytest                                  
=========================================== test session starts ===========================================
platform linux -- Python 3.12.2, pytest-8.1.1, pluggy-1.4.0
rootdir: /home/zacharyweiss/Documents/GitHub/cvxpy
configfile: pyproject.toml
testpaths: cvxpy/tests/
collected 1371 items                                                                                      

cvxpy/tests/test_KKT.py ............................                                                [  2%]
cvxpy/tests/test_atoms.py ......................................................................... [  7%]
.........                                                                                           [  8%]
cvxpy/tests/test_benchmarks.py ss..ss...sss                                                         [  8%]
cvxpy/tests/test_canon_sign.py .                                                                    [  8%]
cvxpy/tests/test_complex.py ...................................                                     [ 11%]
cvxpy/tests/test_cone2cone.py ...................s...........ssssss                                 [ 14%]
cvxpy/tests/test_conic_solvers.py ........................................s...................sssss [ 18%]
sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 26%]
ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss................... [ 33%]
...............s..s...................ssssssssssssssssssss                                          [ 37%]
cvxpy/tests/test_constant.py ..                                                                     [ 37%]
cvxpy/tests/test_constant_atoms.py ................................................................ [ 42%]
.............................................................................                       [ 48%]
cvxpy/tests/test_constraints.py ...............                                                     [ 49%]
cvxpy/tests/test_convolution.py ....                                                                [ 49%]
cvxpy/tests/test_copy.py .....                                                                      [ 49%]
cvxpy/tests/test_curvature.py .....                                                                 [ 50%]
cvxpy/tests/test_custom_solver.py ........                                                          [ 50%]
cvxpy/tests/test_derivative.py ssssssssssssssssssssssssssssss                                       [ 52%]
cvxpy/tests/test_dgp.py ..............                                                              [ 53%]
cvxpy/tests/test_dgp2dcp.py ................s............s........                                  [ 56%]
cvxpy/tests/test_domain.py ............                                                             [ 57%]
cvxpy/tests/test_dpp.py ..........................................................                  [ 61%]
cvxpy/tests/test_dqcp.py ...........................................                                [ 64%]
cvxpy/tests/test_errors.py .....                                                                    [ 65%]
cvxpy/tests/test_examples.py ..........                                                             [ 66%]
cvxpy/tests/test_expression_methods.py ............                                                 [ 66%]
cvxpy/tests/test_expressions.py ........................................                            [ 69%]
cvxpy/tests/test_grad.py .............................                                              [ 71%]
cvxpy/tests/test_gurobi_write.py s                                                                  [ 72%]
cvxpy/tests/test_interfaces.py ....                                                                 [ 72%]
cvxpy/tests/test_kron_canon.py ........                                                             [ 72%]
cvxpy/tests/test_lin_ops.py .........                                                               [ 73%]
cvxpy/tests/test_linalg_utils.py sssss                                                              [ 73%]
cvxpy/tests/test_linear_cone.py .......                                                             [ 74%]
cvxpy/tests/test_matrices.py ....                                                                   [ 74%]
cvxpy/tests/test_mip_vars.py .                                                                      [ 74%]
cvxpy/tests/test_monotonicity.py ..                                                                 [ 74%]
cvxpy/tests/test_nonlinear_atoms.py ........                                                        [ 75%]
cvxpy/tests/test_objectives.py .....                                                                [ 75%]
cvxpy/tests/test_param_cone_prog.py ...                                                             [ 76%]
cvxpy/tests/test_param_quad_prog.py s...                                                            [ 76%]
cvxpy/tests/test_perspective.py ........................................                            [ 79%]
cvxpy/tests/test_power_tools.py ..                                                                  [ 79%]
cvxpy/tests/test_problem.py ....................................................................... [ 84%]
................                                                                                    [ 85%]
cvxpy/tests/test_python_backends.py ............................................................... [ 90%]
............................                                                                        [ 92%]
cvxpy/tests/test_qp_solvers.py .......                                                              [ 92%]
cvxpy/tests/test_quad_form.py ...........                                                           [ 93%]
cvxpy/tests/test_quadratic.py ..........                                                            [ 94%]
cvxpy/tests/test_scalarize.py ......                                                                [ 94%]
cvxpy/tests/test_semidefinite_vars.py ..                                                            [ 95%]
cvxpy/tests/test_shape.py ......                                                                    [ 95%]
cvxpy/tests/test_sign.py .....                                                                      [ 95%]
cvxpy/tests/test_suppfunc.py ............                                                           [ 96%]
cvxpy/tests/test_valinvec2mixedint.py sssssssssssssssssssssssssssssssss                             [ 99%]
cvxpy/tests/test_versioning.py ...                                                                  [ 99%]
cvxpy/tests/test_von_neumann_entr.py ........                                                       [100%]

============================================ warnings summary =============================================
cvxpy/tests/test_KKT.py: 10 warnings
cvxpy/tests/test_atoms.py: 5 warnings
cvxpy/tests/test_benchmarks.py: 1 warning
cvxpy/tests/test_complex.py: 3 warnings
cvxpy/tests/test_cone2cone.py: 9 warnings
cvxpy/tests/test_conic_solvers.py: 14 warnings
cvxpy/tests/test_constant_atoms.py: 125 warnings
cvxpy/tests/test_constraints.py: 3 warnings
cvxpy/tests/test_dgp2dcp.py: 27 warnings
cvxpy/tests/test_domain.py: 1 warning
cvxpy/tests/test_dpp.py: 14 warnings
cvxpy/tests/test_dqcp.py: 1084 warnings
cvxpy/tests/test_examples.py: 3 warnings
cvxpy/tests/test_grad.py: 1 warning
cvxpy/tests/test_linear_cone.py: 5 warnings
cvxpy/tests/test_nonlinear_atoms.py: 7 warnings
cvxpy/tests/test_perspective.py: 22 warnings
cvxpy/tests/test_power_tools.py: 1 warning
cvxpy/tests/test_problem.py: 22 warnings
cvxpy/tests/test_suppfunc.py: 6 warnings
  /home/zacharyweiss/Documents/GitHub/cvxpy/cvxpy/reductions/solvers/solving_chain.py:354: FutureWarning: 
      You specified your problem should be solved by ECOS. Starting in
      CXVPY 1.6.0, ECOS will no longer be installed by default with CVXPY.
      Please either add an explicit dependency on ECOS or switch to our new
      default solver, Clarabel, by either not specifying a solver argument
      or specifying ``solver=cp.CLARABEL``.
      
    warnings.warn(ECOS_DEP_DEPRECATION_MSG, FutureWarning)

cvxpy/tests/test_KKT.py::TestKKT_QPs::test_qp_0
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_QPs.test_qp_0 of <cvxpy.tests.test_KKT.TestKKT_QPs testMethod=test_qp_0>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_SOCPs::test_socp_0
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_SOCPs.test_socp_0 of <cvxpy.tests.test_KKT.TestKKT_SOCPs testMethod=test_socp_0>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_SOCPs::test_socp_1
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_SOCPs.test_socp_1 of <cvxpy.tests.test_KKT.TestKKT_SOCPs testMethod=test_socp_1>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_SOCPs::test_socp_2
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_SOCPs.test_socp_2 of <cvxpy.tests.test_KKT.TestKKT_SOCPs testMethod=test_socp_2>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_SOCPs::test_socp_3ax0
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_SOCPs.test_socp_3ax0 of <cvxpy.tests.test_KKT.TestKKT_SOCPs testMethod=test_socp_3ax0>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_SOCPs::test_socp_3ax1
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_SOCPs.test_socp_3ax1 of <cvxpy.tests.test_KKT.TestKKT_SOCPs testMethod=test_socp_3ax1>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_ECPs::test_expcone_1
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_ECPs.test_expcone_1 of <cvxpy.tests.test_KKT.TestKKT_ECPs testMethod=test_expcone_1>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py: 19 warnings
cvxpy/tests/test_complex.py: 4 warnings
cvxpy/tests/test_conic_solvers.py: 14 warnings
cvxpy/tests/test_constant_atoms.py: 65 warnings
cvxpy/tests/test_constraints.py: 8 warnings
cvxpy/tests/test_dqcp.py: 2 warnings
cvxpy/tests/test_problem.py: 1 warning
cvxpy/tests/test_von_neumann_entr.py: 1 warning
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/site-packages/scipy/linalg/_decomp.py:1022: DeprecationWarning: Keyword argument 'eigvals' is deprecated in favour of 'subset_by_index' keyword instead and will be removed in SciPy 1.12.0.
    return eigh(a, b=b, lower=lower, eigvals_only=True,

cvxpy/tests/test_KKT.py::TestKKT_SDPs::test_sdp_1max
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_SDPs.test_sdp_1max of <cvxpy.tests.test_KKT.TestKKT_SDPs testMethod=test_sdp_1max>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_SDPs::test_sdp_1min
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_SDPs.test_sdp_1min of <cvxpy.tests.test_KKT.TestKKT_SDPs testMethod=test_sdp_1min>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_SDPs::test_sdp_2
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_SDPs.test_sdp_2 of <cvxpy.tests.test_KKT.TestKKT_SDPs testMethod=test_sdp_2>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_PCPs::test_pcp_1
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_PCPs.test_pcp_1 of <cvxpy.tests.test_KKT.TestKKT_PCPs testMethod=test_pcp_1>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_PCPs::test_pcp_2
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_PCPs.test_pcp_2 of <cvxpy.tests.test_KKT.TestKKT_PCPs testMethod=test_pcp_2>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_PCPs::test_pcp_3
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_PCPs.test_pcp_3 of <cvxpy.tests.test_KKT.TestKKT_PCPs testMethod=test_pcp_3>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py: 3 warnings
cvxpy/tests/test_complex.py: 1 warning
cvxpy/tests/test_dqcp.py: 44 warnings
cvxpy/tests/test_examples.py: 1 warning
cvxpy/tests/test_grad.py: 1 warning
  /home/zacharyweiss/Documents/GitHub/cvxpy/cvxpy/problems/problem.py:1407: UserWarning: Solution may be inaccurate. Try another solver, adjusting the solver settings, or solve with verbose=True for more information.
    warnings.warn(

cvxpy/tests/test_KKT.py::TestKKT_PCPs::test_pcp_4
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_PCPs.test_pcp_4 of <cvxpy.tests.test_KKT.TestKKT_PCPs testMethod=test_pcp_4>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_PCPs::test_pcp_5
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_PCPs.test_pcp_5 of <cvxpy.tests.test_KKT.TestKKT_PCPs testMethod=test_pcp_5>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_PCPs::test_pcp_6
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_PCPs.test_pcp_6 of <cvxpy.tests.test_KKT.TestKKT_PCPs testMethod=test_pcp_6>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_Flags::test_kkt_nonneg_var
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_Flags.test_kkt_nonneg_var of <cvxpy.tests.test_KKT.TestKKT_Flags testMethod=test_kkt_nonneg_var>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_Flags::test_kkt_nonpos_var
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_Flags.test_kkt_nonpos_var of <cvxpy.tests.test_KKT.TestKKT_Flags testMethod=test_kkt_nonpos_var>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_Flags::test_kkt_nsd_var
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_Flags.test_kkt_nsd_var of <cvxpy.tests.test_KKT.TestKKT_Flags testMethod=test_kkt_nsd_var>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_Flags::test_kkt_psd_var
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_Flags.test_kkt_psd_var of <cvxpy.tests.test_KKT.TestKKT_Flags testMethod=test_kkt_psd_var>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_Flags::test_kkt_symmetric_var
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_Flags.test_kkt_symmetric_var of <cvxpy.tests.test_KKT.TestKKT_Flags testMethod=test_kkt_symmetric_var>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_atoms.py::TestAtoms::test_conv
cvxpy/tests/test_atoms.py::TestAtoms::test_conv
cvxpy/tests/test_atoms.py::TestAtoms::test_conv
cvxpy/tests/test_atoms.py::TestAtoms::test_conv
cvxpy/tests/test_convolution.py::TestConvolution::test_0D_conv
cvxpy/tests/test_convolution.py::TestConvolution::test_0D_conv
cvxpy/tests/test_convolution.py::TestConvolution::test_conv_prob
cvxpy/tests/test_convolution.py::TestConvolution::test_conv_prob
  /home/zacharyweiss/Documents/GitHub/cvxpy/cvxpy/atoms/affine/conv.py:50: DeprecationWarning: conv is deprecated. Use convolve instead.
    warnings.warn("conv is deprecated. Use convolve instead.", DeprecationWarning)

cvxpy/tests/test_atoms.py::TestAtoms::test_reshape_negative_one
cvxpy/tests/test_expression_methods.py::TestExpressionMethods::test_reshape_negative_one
  /home/zacharyweiss/Documents/GitHub/cvxpy/cvxpy/atoms/affine/reshape.py:71: RuntimeWarning: divide by zero encountered in scalar divmod
    unspecified, remainder = divmod(size, shape[1 - unspecified_index])

cvxpy/tests/test_complex.py::TestComplex::test_illegal_complex_args
cvxpy/tests/test_constraints.py::TestConstraints::test_nonpos
cvxpy/tests/test_constraints.py::TestConstraints::test_nonpos
cvxpy/tests/test_constraints.py::TestConstraints::test_nonpos
  /home/zacharyweiss/Documents/GitHub/cvxpy/cvxpy/constraints/nonpos.py:57: DeprecationWarning: 
      Explicitly invoking "NonPos(expr)" to a create a constraint is deprecated.
      Please use operator overloading or "NonNeg(-expr)" instead.
      
      Sign conventions on dual variables associated with NonPos constraints may
      change in the future.
      
    warnings.warn(NonPos.DEPRECATION_MESSAGE, DeprecationWarning)

cvxpy/tests/test_complex.py::TestComplex::test_matrix_frac
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/logging/__init__.py:392: ComplexWarning: Casting complex values to real discards the imaginary part
    msg = msg % self.args

cvxpy/tests/test_dqcp.py::TestDqcp::test_gen_lambda_max_matrix_completion
  /home/zacharyweiss/Documents/GitHub/cvxpy/cvxpy/atoms/gen_lambda_max.py:37: DeprecationWarning: Keyword argument 'eigvals' is deprecated in favour of 'subset_by_index' keyword instead and will be removed in SciPy 1.12.0.
    return LA.eigh(a=values[0],

cvxpy/tests/test_errors.py::TestErrors::test_broken_numpy_functions
  /home/zacharyweiss/Documents/GitHub/cvxpy/cvxpy/expressions/expression.py:642: UserWarning: 
  This use of ``*`` has resulted in matrix multiplication.
  Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.
      Use ``*`` for matrix-scalar and vector-scalar multiplication.
      Use ``@`` for matrix-matrix and matrix-vector multiplication.
      Use ``multiply`` for elementwise multiplication.
  This code path has been hit 1 times so far.
  
    warnings.warn(msg, UserWarning)

cvxpy/tests/test_errors.py::TestErrors::test_broken_numpy_functions
  /home/zacharyweiss/Documents/GitHub/cvxpy/cvxpy/expressions/expression.py:643: DeprecationWarning: 
  This use of ``*`` has resulted in matrix multiplication.
  Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.
      Use ``*`` for matrix-scalar and vector-scalar multiplication.
      Use ``@`` for matrix-matrix and matrix-vector multiplication.
      Use ``multiply`` for elementwise multiplication.
  This code path has been hit 1 times so far.
  
    warnings.warn(msg, DeprecationWarning)

cvxpy/tests/test_interfaces.py: 42 warnings
  /home/zacharyweiss/miniconda3/envs/cvxdev/lib/python3.12/site-packages/numpy/matrixlib/defmatrix.py:70: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
    return matrix(data, dtype=dtype, copy=False)

cvxpy/tests/test_kron_canon.py::TestKronRightVar::test_gen_kronr_param
cvxpy/tests/test_kron_canon.py::TestKronLeftVar::test_gen_kronl_param
cvxpy/tests/test_kron_canon.py::TestKronLeftVar::test_scalar_kronl_param
cvxpy/tests/test_kron_canon.py::TestKronLeftVar::test_symvar_kronl_param
cvxpy/tests/test_perspective.py::test_parameter
  /home/zacharyweiss/Documents/GitHub/cvxpy/cvxpy/reductions/solvers/solving_chain.py:235: UserWarning: You are solving a parameterized problem that is not DPP. Because the problem is not DPP, subsequent solves will not be faster than the first one. For more information, see the documentation on Disciplined Parametrized Programming, at https://www.cvxpy.org/tutorial/dpp/index.html
    warnings.warn(DPP_ERROR_MSG)

cvxpy/tests/test_python_backends.py::TestSciPyBackend::test_tensor_view_add_dicts
  /home/zacharyweiss/Documents/GitHub/cvxpy/cvxpy/tests/test_python_backends.py:1999: SparseEfficiencyWarning: Comparing sparse matrices using == is inefficient, try using != instead.
    assert view.add_dicts({"a": one}, {"a": two}) == {"a": three}

cvxpy/tests/test_python_backends.py::TestSciPyBackend::test_tensor_view_add_dicts
  /home/zacharyweiss/Documents/GitHub/cvxpy/cvxpy/tests/test_python_backends.py:2001: SparseEfficiencyWarning: Comparing sparse matrices using == is inefficient, try using != instead.
    assert view.add_dicts({"a": {"c": one}}, {"a": {"c": one}}) == {'a': {'c': two}}

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================ 1078 passed, 293 skipped, 1615 warnings in 22.81s ============================

  ```
</details>


<details>
  <summary>Default benchmark pre-changes</summary>

  ```
cvxpy on  master via 🐍 v3.12.2 via 🅒 cvxdev 
❯ pytest -s cvxpy/tests/test_benchmarks.py
=========================================== test session starts ===========================================
platform linux -- Python 3.12.2, pytest-8.1.1, pluggy-1.4.0
rootdir: /home/zacharyweiss/Documents/GitHub/cvxpy
configfile: pyproject.toml
collected 12 items                                                                                        

cvxpy/tests/test_benchmarks.py ss-------------------------------------------------------------------------------
                                  Compilation                                  
-------------------------------------------------------------------------------
(CVXPY) Apr 20 06:39:56 PM: Compiling problem (target solver=ECOS).
(CVXPY) Apr 20 06:39:56 PM: Reduction chain: Dcp2Cone -> CvxAttr2Constr -> ConeMatrixStuffing -> ECOS
(CVXPY) Apr 20 06:39:56 PM: Applying reduction Dcp2Cone
(CVXPY) Apr 20 06:39:56 PM: Applying reduction CvxAttr2Constr
(CVXPY) Apr 20 06:39:56 PM: Applying reduction ConeMatrixStuffing
(CVXPY) Apr 20 06:39:56 PM: Applying reduction ECOS
(CVXPY) Apr 20 06:39:56 PM: Finished problem compilation (took 3.691e-01 seconds).
Issue #1668 regression test
Compilation time:  0.3698410987854004
.least_squares: avg=2.605e-03 s , std=0.000e+00 s (1 iterations)
.ssqp: avg=3.658e-03 s , std=0.000e+00 s (1 iterations)
.small_cone_matrix_stuffing: avg=1.418e-02 s , std=4.819e-03 s (10 iterations)
.small_lp: avg=9.312e-03 s , std=0.000e+00 s (1 iterations)
small_lp_second_time: avg=4.992e-04 s , std=0.000e+00 s (1 iterations)
.sss

============================================ warnings summary =============================================
cvxpy/tests/test_benchmarks.py::TestBenchmarks::test_issue_1668_slow_pruning
  /home/zacharyweiss/Documents/GitHub/cvxpy/cvxpy/reductions/solvers/solving_chain.py:354: FutureWarning: 
      You specified your problem should be solved by ECOS. Starting in
      CXVPY 1.6.0, ECOS will no longer be installed by default with CVXPY.
      Please either add an explicit dependency on ECOS or switch to our new
      default solver, Clarabel, by either not specifying a solver argument
      or specifying ``solver=cp.CLARABEL``.
      
    warnings.warn(ECOS_DEP_DEPRECATION_MSG, FutureWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================= 5 passed, 7 skipped, 1 warning in 1.19s =================================
  ```
</details>


<details>
  <summary>Default benchmark post-changes</summary>

  ```
cvxpy on  master via 🐍 v3.12.2 via 🅒 cvxdev took 23s 
❯ pytest -s cvxpy/tests/test_benchmarks.py
=========================================== test session starts ===========================================
platform linux -- Python 3.12.2, pytest-8.1.1, pluggy-1.4.0
rootdir: /home/zacharyweiss/Documents/GitHub/cvxpy
configfile: pyproject.toml
collected 12 items                                                                                        

cvxpy/tests/test_benchmarks.py ss-------------------------------------------------------------------------------
                                  Compilation                                  
-------------------------------------------------------------------------------
(CVXPY) Apr 20 06:38:58 PM: Compiling problem (target solver=ECOS).
(CVXPY) Apr 20 06:38:58 PM: Reduction chain: Dcp2Cone -> CvxAttr2Constr -> ConeMatrixStuffing -> ECOS
(CVXPY) Apr 20 06:38:58 PM: Applying reduction Dcp2Cone
(CVXPY) Apr 20 06:38:58 PM: Applying reduction CvxAttr2Constr
(CVXPY) Apr 20 06:38:58 PM: Applying reduction ConeMatrixStuffing
(CVXPY) Apr 20 06:38:59 PM: Applying reduction ECOS
(CVXPY) Apr 20 06:38:59 PM: Finished problem compilation (took 5.396e-01 seconds).
Issue #1668 regression test
Compilation time:  0.5404493808746338
.least_squares: avg=2.580e-03 s , std=0.000e+00 s (1 iterations)
.ssqp: avg=3.639e-03 s , std=0.000e+00 s (1 iterations)
.small_cone_matrix_stuffing: avg=1.567e-02 s , std=5.063e-03 s (10 iterations)
.small_lp: avg=1.074e-02 s , std=0.000e+00 s (1 iterations)
small_lp_second_time: avg=5.858e-04 s , std=0.000e+00 s (1 iterations)
.sss

============================================ warnings summary =============================================
cvxpy/tests/test_benchmarks.py::TestBenchmarks::test_issue_1668_slow_pruning
  /home/zacharyweiss/Documents/GitHub/cvxpy/cvxpy/reductions/solvers/solving_chain.py:354: FutureWarning: 
      You specified your problem should be solved by ECOS. Starting in
      CXVPY 1.6.0, ECOS will no longer be installed by default with CVXPY.
      Please either add an explicit dependency on ECOS or switch to our new
      default solver, Clarabel, by either not specifying a solver argument
      or specifying ``solver=cp.CLARABEL``.
      
    warnings.warn(ECOS_DEP_DEPRECATION_MSG, FutureWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================= 5 passed, 7 skipped, 1 warning in 1.50s =================================
  ```
</details>