### PR TITLE
Adds warning for constants from nested lists

### DIFF
--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import warnings
 from typing import List, Optional, Tuple
 
 import numpy as np
@@ -25,6 +26,9 @@ import cvxpy.settings as s
 import cvxpy.utilities.linalg as eig_util
 from cvxpy.expressions.leaf import Leaf
 from cvxpy.utilities import performance_utils as perf
+
+NESTED_LIST_WARNING =  "Initializing a Constant with a nested list is " \
+    "undefined behavior. Consider using a numpy array instead."
 
 
 class Constant(Leaf):
@@ -45,6 +49,9 @@ class Constant(Leaf):
                 value, convert_scalars=True)
             self._sparse = True
         else:
+            if isinstance(value, list) and any(isinstance(i, list) for i in value):
+                warnings.warn(NESTED_LIST_WARNING)
+
             self._value = intf.DEFAULT_INTF.const_to_matrix(value)
             self._sparse = False
         self._imag: Optional[bool] = None

--- a/cvxpy/tests/test_constant.py
+++ b/cvxpy/tests/test_constant.py
@@ -87,4 +87,7 @@ def test_nested_lists():
         constant_from_lists = cp.Constant(A)
 
     assert np.allclose(constant_from_numpy.value, numpy_array)
+
+    # CVXPY behaviour currenlty is different from NumPy for nested lists,
+    # with the order being reversed.
     assert np.allclose(constant_from_lists.value.T, numpy_array)

--- a/cvxpy/tests/test_constant.py
+++ b/cvxpy/tests/test_constant.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import scipy.sparse as sp
 import scipy.sparse.linalg as sparla
 
@@ -73,3 +74,17 @@ def test_prod():
 
     B = np.arange(4).reshape(2, 2) + 1
     assert np.allclose(cp.prod(sp.coo_matrix(B)).value, 24)
+
+
+def test_nested_lists():
+
+    A = [[1, 2], [3, 4], [5, 6]]
+
+    numpy_array = np.array(A)
+    constant_from_numpy = cp.Constant(numpy_array)
+
+    with pytest.warns(match="nested list is undefined behavior"):
+        constant_from_lists = cp.Constant(A)
+
+    assert np.allclose(constant_from_numpy.value, numpy_array)
+    assert np.allclose(constant_from_lists.value.T, numpy_array)


### PR DESCRIPTION
## Description
This addresses the discrepancy from the NumPy behaviour mentioned in #2317 by:
- emitting a warning
- adding a test case that makes sure any change in behaviour would be noticed

Issue link (if applicable): closes #2317 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.