### PR TITLE
Fixes XPRESS interface

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
@@ -24,6 +24,7 @@ from cvxpy.reductions.solvers.conic_solvers.conic_solver import (
     ConicSolver,
     dims_to_solver_dict,
 )
+from cvxpy.utilities.versioning import Version
 
 
 def makeMstart(A, n, ifCol: int = 1):
@@ -218,11 +219,16 @@ class XPRESS(ConicSolver):
             currow += k
 
             # Create new (cone) variables and add them to the problem
-            conevar = np.array([xp.var(name='cX{0:d}_{1:d}'.format(iCone, i),
-                                       lb=-xp.infinity if i > 0 else 0)
-                                for i in range(k)])
+            if Version(xp.__version__) >= Version('9.4.0'):
+                conevar = [self.prob_.addVariable(name='cX{0:d}_{1:d}'.format(iCone, i),
+                                                  lb=-xp.infinity if i > 0 else 0)
+                                                  for i in range(k)]
+            else:
+                conevar = np.array([xp.var(name='cX{0:d}_{1:d}'.format(iCone, i),
+                            lb=-xp.infinity if i > 0 else 0)
+                    for i in range(k)])
+                self.prob_.addVariable(conevar)
 
-            self.prob_.addVariable(conevar)
 
             initrow = self.prob_.attributes.rows
 


### PR DESCRIPTION
## Description
From the 9.4 release notes:
> Python:
New Python API to create variables that are linked to the problem, such that when their properties are modified, the Optimizer problem is updated. It is advised to update existing models to use the new API:
Instead of calling xpress.var(properties) and then adding the resulting variable to the problem with problem.addVariable(myvar), call problem.addVariable(properties) directly.
Instead of calling xpress.vars(indices, properties) and then adding the resulting dictionary or array of variables to the problem with problem.addVariable(myvars), call problem.addVariables(indices, properties) directly.
Instead of calling xpress.sos(properties) and then adding the resulting SOS to the problem with problem.addSOS(mysos), call problem.addSOS(properties) directly.

Looks like we are not using the other two deprecated methods. The API change is not backward compatible, so I added a version check. 
Issue link (if applicable): closes #2422 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.