### PR TITLE
Fix nuclear norm gradient for non-square inputs

### DIFF
--- a/cvxpy/atoms/norm_nuc.py
+++ b/cvxpy/atoms/norm_nuc.py
@@ -47,7 +47,7 @@ class normNuc(Atom):
             A list of SciPy CSC sparse matrices or None.
         """
         # Grad UV^T
-        U, _, V = np.linalg.svd(values[0])
+        U, _, V = np.linalg.svd(values[0], full_matrices=False)
         D = U.dot(V)
         return [sp.csc_matrix(D.ravel(order='F')).T]
 

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -887,3 +887,22 @@ class TestGrad(BaseTest):
         self.x.value = [1, 2]
         val = np.eye(2)
         self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
+
+    def test_nuclear_norm(self) -> None:
+        """Test the gradient of the nuclear norm.
+        """
+        # Failed for rectangular inputs.
+        # https://github.com/cvxpy/cvxpy/issues/2364
+        n = 10
+        m = 20 
+        z = cp.Variable((n, m))
+        np.random.seed(1)
+        z.value = np.random.randn(n, m)
+        objective = cp.Minimize(cp.norm(z, "nuc"))
+
+        arg_values = []
+        for arg in objective.expr.args:
+            arg_values.append(arg.value)
+            
+        # Does not crash.
+        objective.expr._grad(arg_values)

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -894,15 +894,16 @@ class TestGrad(BaseTest):
         # Failed for rectangular inputs.
         # https://github.com/cvxpy/cvxpy/issues/2364
         n = 10
-        m = 20 
-        z = cp.Variable((n, m))
-        np.random.seed(1)
-        z.value = np.random.randn(n, m)
-        objective = cp.Minimize(cp.norm(z, "nuc"))
+        # Test both square and rectangular.
+        for m in [10, 20]:
+            z = cp.Variable((n, m))
+            np.random.seed(1)
+            z.value = np.random.randn(n, m)
+            objective = cp.Minimize(cp.norm(z, "nuc"))
 
-        arg_values = []
-        for arg in objective.expr.args:
-            arg_values.append(arg.value)
-            
-        # Does not crash.
-        objective.expr._grad(arg_values)
+            arg_values = []
+            for arg in objective.expr.args:
+                arg_values.append(arg.value)
+                
+            # Does not crash.
+            objective.expr._grad(arg_values)


### PR DESCRIPTION
## Description
Fix nuclear norm gradient for non-square inputs
Issue link (if applicable): #2364

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.