### PR TITLE
Fix convolve bug

### DIFF
--- a/cvxpy/atoms/affine/conv.py
+++ b/cvxpy/atoms/affine/conv.py
@@ -25,6 +25,7 @@ import cvxpy.lin_ops.lin_utils as lu
 import cvxpy.utilities as u
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions.constants.parameter import is_param_free
 
 
 class conv(AffAtom):
@@ -68,6 +69,22 @@ class conv(AffAtom):
             raise ValueError("The arguments to conv must resolve to vectors.")
         if not self.args[0].is_constant():
             raise ValueError("The first argument to conv must be constant.")
+
+    def is_atom_convex(self) -> bool:
+        """Is the atom convex?
+        """
+        # TODO support a non-constant first argument.
+        if u.scopes.dpp_scope_active():
+            # conv is not DPP if any parameters are present.
+            c = self.args[0]
+            return c.is_constant() and is_param_free(c)
+        else:
+            return self.args[0].is_constant()
+
+    def is_atom_concave(self) -> bool:
+        """Is the atom concave?
+        """
+        return self.is_atom_convex()
 
     def shape_from_args(self) -> Tuple[int, int]:
         """The sum of the argument dimensions - 1.
@@ -153,6 +170,22 @@ class convolve(AffAtom):
             raise ValueError("The arguments to conv must be scalar or 1D.")
         if not self.args[0].is_constant():
             raise ValueError("The first argument to conv must be constant.")
+
+    def is_atom_convex(self) -> bool:
+        """Is the atom convex?
+        """
+        # TODO support a non-constant first argument.
+        if u.scopes.dpp_scope_active():
+            # conv is not DPP if any parameters are present.
+            c = self.args[0]
+            return c.is_constant() and is_param_free(c)
+        else:
+            return self.args[0].is_constant()
+
+    def is_atom_concave(self) -> bool:
+        """Is the atom concave?
+        """
+        return self.is_atom_convex()
 
     def shape_from_args(self) -> Tuple[int, int]:
         """The sum of the argument dimensions - 1.

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -1407,7 +1407,8 @@ class SciPyCanonBackend(PythonCanonBackend):
             lhs = lhs.T
 
         rows = lin.shape[0]
-        cols = lin.args[0].shape[0]
+        # lin.args[0] can have shape (), ie, scalar, or (n,), ie, vector
+        cols = lin.args[0].shape[0] if len(lin.args[0].shape) > 0 else 1
         nonzeros = lhs.shape[0]
 
         lhs = lhs.tocoo()

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -1407,7 +1407,6 @@ class SciPyCanonBackend(PythonCanonBackend):
             lhs = lhs.T
 
         rows = lin.shape[0]
-        # lin.args[0] can have shape (), ie, scalar, or (n,), ie, vector
         cols = lin.args[0].shape[0] if len(lin.args[0].shape) > 0 else 1
         nonzeros = lhs.shape[0]
 

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -947,6 +947,17 @@ class TestAtoms(BaseTest):
         self.assertEqual(str(cm.exception),
                          "The arguments to conv must resolve to vectors.")
 
+        # Test with parameter input.
+        # https://github.com/cvxpy/cvxpy/issues/2218
+        x = cp.Variable()
+        p = cp.Parameter()
+        problem = cp.Problem(cp.Minimize(cp.conv(p, x)), [0 <= x, x <= 1])
+
+        p.value = -1.0
+        result = problem.solve(canon_backend=cp.CPP_CANON_BACKEND)
+        self.assertAlmostEqual(result, -1)
+        self.assertAlmostEqual(x.value, 1)
+
     def test_kron_expr(self) -> None:
         """Test the kron atom.
         """
@@ -980,6 +991,17 @@ class TestAtoms(BaseTest):
                          "The first argument to conv must be constant.")
         with pytest.raises(ValueError, match="scalar or 1D"):
             cp.convolve([[0, 1], [0, 1]], self.x)
+
+        # Test with parameter input.
+        # https://github.com/cvxpy/cvxpy/issues/2218
+        x = cp.Variable()
+        p = cp.Parameter()
+        problem = cp.Problem(cp.Minimize(cp.convolve(p, x)), [0 <= x, x <= 1])
+
+        p.value = -1.0
+        result = problem.solve(canon_backend=cp.CPP_CANON_BACKEND)
+        self.assertAlmostEqual(result, -1)
+        self.assertAlmostEqual(x.value, 1)
 
     def test_ptp(self) -> None:
         """Test the ptp atom.

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -958,6 +958,9 @@ class TestAtoms(BaseTest):
         self.assertAlmostEqual(result, -1)
         self.assertAlmostEqual(x.value, 1)
 
+        with pytest.raises(cp.DPPError):
+            problem.solve(canon_backend=cp.CPP_CANON_BACKEND, enforce_dpp=True)
+
     def test_kron_expr(self) -> None:
         """Test the kron atom.
         """

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -954,12 +954,13 @@ class TestAtoms(BaseTest):
         problem = cp.Problem(cp.Minimize(cp.conv(p, x)), [0 <= x, x <= 1])
 
         p.value = -1.0
-        result = problem.solve(canon_backend=cp.CPP_CANON_BACKEND)
+        result = problem.solve()
         self.assertAlmostEqual(result, -1)
         self.assertAlmostEqual(x.value, 1)
 
+        problem = cp.Problem(cp.Minimize(cp.conv(p, x)), [0 <= x, x <= 1])
         with pytest.raises(cp.DPPError):
-            problem.solve(canon_backend=cp.CPP_CANON_BACKEND, enforce_dpp=True)
+            problem.solve(enforce_dpp=True)
 
     def test_kron_expr(self) -> None:
         """Test the kron atom.
@@ -1005,6 +1006,10 @@ class TestAtoms(BaseTest):
         result = problem.solve(canon_backend=cp.CPP_CANON_BACKEND)
         self.assertAlmostEqual(result, -1)
         self.assertAlmostEqual(x.value, 1)
+
+        problem = cp.Problem(cp.Minimize(cp.convolve(p, x)), [0 <= x, x <= 1])
+        with pytest.raises(cp.DPPError):
+            problem.solve(enforce_dpp=True)
 
     def test_ptp(self) -> None:
         """Test the ptp atom.


### PR DESCRIPTION
## Description
Fixes bug with convolve where the input is a parameter by disabling DPP for convolve. This is the same approach taken with kron.
Issue link (if applicable): #2218

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.