### PR TITLE
Reduce memory consumption for sum(list)

### DIFF
--- a/cvxpy/atoms/affine/add_expr.py
+++ b/cvxpy/atoms/affine/add_expr.py
@@ -30,8 +30,6 @@ class AddExpression(AffAtom):
     """
 
     def __init__(self, arg_groups: Iterable[Expression]) -> None:
-        # For efficiency group args as sums.
-        self._arg_groups = arg_groups
         super(AddExpression, self).__init__(*arg_groups)
         self.args = []
         for group in arg_groups:
@@ -46,8 +44,6 @@ class AddExpression(AffAtom):
         """Helper function to extract the arguments from an AddExpression.
         """
         if isinstance(expr, AddExpression):
-            # Remove the _arg_groups attribute to avoid copying it.
-            expr._arg_groups = None
             return expr.args
         else:
             return [expr]
@@ -98,10 +94,8 @@ class AddExpression(AffAtom):
         AddExpression atom
         """
         if args is None:
-            if self._arg_groups is None:
-                raise ValueError("Cannot copy AddExpression without arg_groups.")
-            args = self._arg_groups
-        # Takes advantage of _arg_groups if present for efficiency.
+            # arg_groups are stored as the args attribute.
+            args = self.args
         copy = type(self).__new__(type(self))
         copy.__init__(args)
         return copy

--- a/cvxpy/atoms/affine/add_expr.py
+++ b/cvxpy/atoms/affine/add_expr.py
@@ -29,14 +29,12 @@ class AddExpression(AffAtom):
     """The sum of any number of expressions.
     """
 
-    def __init__(self, arg_groups) -> None:
+    def __init__(self, arg_groups: Iterable[Expression]) -> None:
         # For efficiency group args as sums.
         self._arg_groups = arg_groups
         super(AddExpression, self).__init__(*arg_groups)
-        
-        # arg_groups has at least one element, checked in Atom
-        self.args = self.expand_args(arg_groups[0])
-        for group in arg_groups[1:]:
+        self.args = []
+        for group in arg_groups:
             self.args += self.expand_args(group)
 
     def shape_from_args(self) -> Tuple[int, ...]:
@@ -48,10 +46,10 @@ class AddExpression(AffAtom):
         """Helper function to extract the arguments from an AddExpression.
         """
         if isinstance(expr, AddExpression):
+            expr._arg_groups = None
             return expr.args
         else:
             return [expr]
-
     def name(self) -> str:
         result = str(self.args[0])
         for i in range(1, len(self.args)):

--- a/cvxpy/atoms/affine/add_expr.py
+++ b/cvxpy/atoms/affine/add_expr.py
@@ -33,12 +33,11 @@ class AddExpression(AffAtom):
         # For efficiency group args as sums.
         self._arg_groups = arg_groups
         super(AddExpression, self).__init__(*arg_groups)
-        self.args = None
-        for group in arg_groups:
-            if self.args is None:
-                self.args = self.expand_args(group)
-            else:
-                self.args += self.expand_args(group)
+        
+        # arg_groups has at least one element, checked in Atom
+        self.args = self.expand_args(arg_groups[0])
+        for group in arg_groups[1:]:
+            self.args += self.expand_args(group)
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Returns the (row, col) shape of the expression.

--- a/cvxpy/atoms/affine/add_expr.py
+++ b/cvxpy/atoms/affine/add_expr.py
@@ -94,7 +94,11 @@ class AddExpression(AffAtom):
         AddExpression atom
         """
         if args is None:
-            args = [self]
+            # The __init__ method of AddExpression recreates the args,
+            # but passes *arg_groups to the super class for checks.
+            # Since these checks are already done for self, we pass [self], i.e., 
+            # a single [AddExpression], before the args are recreated.
+            args = [self]  
         copy = type(self).__new__(type(self))
         copy.__init__(args)
         return copy

--- a/cvxpy/atoms/affine/add_expr.py
+++ b/cvxpy/atoms/affine/add_expr.py
@@ -46,6 +46,7 @@ class AddExpression(AffAtom):
         """Helper function to extract the arguments from an AddExpression.
         """
         if isinstance(expr, AddExpression):
+            # Remove the _arg_groups attribute to avoid copying it.
             expr._arg_groups = None
             return expr.args
         else:
@@ -97,6 +98,8 @@ class AddExpression(AffAtom):
         AddExpression atom
         """
         if args is None:
+            if self._arg_groups is None:
+                raise ValueError("Cannot copy AddExpression without arg_groups.")
             args = self._arg_groups
         # Takes advantage of _arg_groups if present for efficiency.
         copy = type(self).__new__(type(self))

--- a/cvxpy/atoms/affine/add_expr.py
+++ b/cvxpy/atoms/affine/add_expr.py
@@ -33,9 +33,12 @@ class AddExpression(AffAtom):
         # For efficiency group args as sums.
         self._arg_groups = arg_groups
         super(AddExpression, self).__init__(*arg_groups)
-        self.args = []
+        self.args = None
         for group in arg_groups:
-            self.args += self.expand_args(group)
+            if self.args is None:
+                self.args = self.expand_args(group)
+            else:
+                self.args += self.expand_args(group)
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Returns the (row, col) shape of the expression.

--- a/cvxpy/atoms/affine/add_expr.py
+++ b/cvxpy/atoms/affine/add_expr.py
@@ -94,8 +94,7 @@ class AddExpression(AffAtom):
         AddExpression atom
         """
         if args is None:
-            # arg_groups are stored as the args attribute.
-            args = self.args
+            args = [self]
         copy = type(self).__new__(type(self))
         copy.__init__(args)
         return copy

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -32,7 +32,6 @@ from cvxpy.expressions.variable import Variable
 from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS
 from cvxpy.tests.base_test import BaseTest
 from cvxpy.transforms.partial_optimize import partial_optimize
-from cvxpy.atoms.affine.add_expr import AddExpression
 
 
 class TestAtoms(BaseTest):
@@ -65,24 +64,6 @@ class TestAtoms(BaseTest):
         self.assertTrue(copy.args[0] is self.A)
         self.assertTrue(copy.args[1] is self.B)
         self.assertEqual(copy.get_data(), atom.get_data())
-
-    def test_add_expr_arg_groups(self) -> None:
-        """Test the arg_groups attribute for AddExpression class.
-        """
-        x, y, z = Variable(), Variable(), Variable()
-
-
-        first_sum = AddExpression([x, y])
-        assert all(i is j for i, j in zip(first_sum._arg_groups, [x, y]))
-
-        assert isinstance(first_sum.copy(), AddExpression)
-
-        second_sum = AddExpression([first_sum, z])
-        assert all(i is j for i, j in zip(second_sum._arg_groups, [first_sum, z]))
-
-        # Fails because creating second_sum removes the _arg_groups attribute from first_sum.
-        first_sum.copy()
-
 
     def test_norm_inf(self) -> None:
         """Test the norm_inf class.

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -32,6 +32,7 @@ from cvxpy.expressions.variable import Variable
 from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS
 from cvxpy.tests.base_test import BaseTest
 from cvxpy.transforms.partial_optimize import partial_optimize
+from cvxpy.atoms.affine.add_expr import AddExpression
 
 
 class TestAtoms(BaseTest):
@@ -64,6 +65,24 @@ class TestAtoms(BaseTest):
         self.assertTrue(copy.args[0] is self.A)
         self.assertTrue(copy.args[1] is self.B)
         self.assertEqual(copy.get_data(), atom.get_data())
+
+    def test_add_expr_arg_groups(self) -> None:
+        """Test the arg_groups attribute for AddExpression class.
+        """
+        x, y, z = Variable(), Variable(), Variable()
+
+
+        first_sum = AddExpression([x, y])
+        assert all(i is j for i, j in zip(first_sum._arg_groups, [x, y]))
+
+        assert isinstance(first_sum.copy(), AddExpression)
+
+        second_sum = AddExpression([first_sum, z])
+        assert all(i is j for i, j in zip(second_sum._arg_groups, [first_sum, z]))
+
+        # Fails because creating second_sum removes the _arg_groups attribute from first_sum.
+        first_sum.copy()
+
 
     def test_norm_inf(self) -> None:
         """Test the norm_inf class.


### PR DESCRIPTION
## Description
I memory-profiled the script from #2385
Issue link (if applicable): Closes #2385

```py
x = [cp.Variable() for i in range(20000)]
expr = cp.sum(x)
```

I found the place that results in the quadratic memory consumption, changed in this PR.
The memory consumption is quadratic because we keep track of the (linearly) growing list of `arg_groups` of every subexpression.

It turns out that the only use of `arg_groups` was to make the copy more efficient, passing the groups instead of the (expanded) args. Turns out a neat trick is to simply pass `[self]` as args in the copy function, making it even more efficient than the original speedup.

Before:
```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
     3  111.594 MiB  111.594 MiB           1   @profile
     4                                         def func():
     5  135.875 MiB   24.281 MiB       20003       x = [cp.Variable() for i in range(20000)]
     6 1694.438 MiB 1558.562 MiB           1       expr = cp.sum(x)
```

After:
```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
     3  111.188 MiB  111.188 MiB           1   @profile
     4                                         def func():
     5  135.469 MiB   24.281 MiB       20003       x = [cp.Variable() for i in range(20000)]
     6  136.609 MiB    1.141 MiB           1       expr = cp.sum(x)
```

-> 1558 MiB to 1.1 MiB

@SteveDiamond @rileyjmurray 


## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.