### PR TITLE
Fix keep dims for min atom

### DIFF
--- a/cvxpy/reductions/eliminate_pwl/canonicalizers/min_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/canonicalizers/min_canon.py
@@ -20,8 +20,9 @@ from cvxpy.reductions.eliminate_pwl.canonicalizers.max_canon import max_canon
 
 def min_canon(expr, args):
     axis = expr.axis
+    keepdims = expr.keepdims
     del expr
     assert len(args) == 1
-    tmp = max(-args[0], axis=axis)
+    tmp = max(-args[0], axis=axis, keepdims=keepdims)
     canon, constr = max_canon(tmp, tmp.args)
     return -canon, constr

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -400,6 +400,16 @@ class TestAtoms(BaseTest):
             cp.min(self.x, self.x)  # a common erroneous use-case
         self.assertEqual(str(cm.exception), cp.min.__EXPR_AXIS_ERROR__)
 
+        # Test canonicalization with keepdims=True
+        # https://github.com/cvxpy/cvxpy/pull/2419
+        X = cp.Variable((2, 3))
+        X_val = np.arange(6).reshape((2, 3))
+        c = np.ones((1, 3))
+        expr = cp.min(X, axis=0, keepdims=True)
+        obj = cp.Maximize(cp.sum(expr + c))
+        prob = cp.Problem(obj, [X == X_val])
+        prob.solve()
+
     # Test sign logic for maximum.
     def test_maximum_sign(self) -> None:
         # Two args.


### PR DESCRIPTION
## Description
Cherry-picked @allenlawrence94's commit from #2419 so we can move forward with the 1.5 release.
Added @SteveDiamond's test case.

The `min` atom ignores the `keepdims` flag.

Issue link (if applicable): NA

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.