### PR TITLE
Fix for issue with quad_over_lin parameters

### DIFF
--- a/cvxpy/atoms/quad_over_lin.py
+++ b/cvxpy/atoms/quad_over_lin.py
@@ -91,7 +91,11 @@ class quad_over_lin(Atom):
     def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
-        return True
+        # Disable DPP when the second argument is a parameter.
+        if u.scopes.dpp_scope_active():
+            return is_param_free(self.args[1])
+        else:
+            return True
 
     def is_atom_concave(self) -> bool:
         """Is the atom concave?
@@ -101,7 +105,11 @@ class quad_over_lin(Atom):
     def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
-        return True
+        # Disable DPP when the second argument is a parameter.
+        if u.scopes.dpp_scope_active():
+            return is_param_free(self.args[1])
+        else:
+            return True
 
     def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?
@@ -130,34 +138,14 @@ class quad_over_lin(Atom):
     def is_quadratic(self) -> bool:
         """Quadratic if x is affine and y is constant.
         """
-        # quad_over_lin is not DPP if the second argument is parameterized
-        # and it is being canonicalized as a quadratic term (rather 
-        # than with SOC constraints).
-        if u.scopes.dpp_scope_active():
-            const_no_params = self.args[1].is_constant() and is_param_free(self.args[1])
-            return self.args[0].is_affine() and const_no_params
-        else:
-            return self.args[0].is_affine() and self.args[1].is_constant()
+        return self.args[0].is_affine() and self.args[1].is_constant()
 
     def has_quadratic_term(self) -> bool:
         """A quadratic term if y is constant.
         """
-        # quad_over_lin is not DPP if the second argument is parameterized
-        # and it is being canonicalized as a quadratic term (rather 
-        # than with SOC constraints).
-        if u.scopes.dpp_scope_active():
-            return self.args[1].is_constant() and is_param_free(self.args[1])
-        else:
-            return self.args[1].is_constant()
+        return self.args[1].is_constant()
 
     def is_qpwa(self) -> bool:
         """Quadratic of piecewise affine if x is PWL and y is constant.
         """
-        # quad_over_lin is not DPP if the second argument is parameterized
-        # and it is being canonicalized as a quadratic term (rather 
-        # than with SOC constraints).
-        if u.scopes.dpp_scope_active():
-            const_no_params = self.args[1].is_constant() and is_param_free(self.args[1])
-            return self.args[0].is_pwl() and const_no_params
-        else:
-            return self.args[0].is_pwl() and self.args[1].is_constant()
+        return self.args[0].is_pwl() and self.args[1].is_constant()

--- a/cvxpy/atoms/quad_over_lin.py
+++ b/cvxpy/atoms/quad_over_lin.py
@@ -20,8 +20,10 @@ import numpy as np
 import scipy as scipy
 import scipy.sparse as sp
 
+import cvxpy.utilities as u
 from cvxpy.atoms.atom import Atom
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions.constants.parameter import is_param_free
 
 
 class quad_over_lin(Atom):
@@ -128,14 +130,25 @@ class quad_over_lin(Atom):
     def is_quadratic(self) -> bool:
         """Quadratic if x is affine and y is constant.
         """
-        return self.args[0].is_affine() and self.args[1].is_constant()
+        if u.scopes.dpp_scope_active():
+            const_no_params = self.args[1].is_constant() and is_param_free(self.args[1])
+            return self.args[0].is_affine() and const_no_params
+        else:
+            return self.args[0].is_affine() and self.args[1].is_constant()
 
     def has_quadratic_term(self) -> bool:
         """A quadratic term if y is constant.
         """
-        return self.args[1].is_constant()
+        if u.scopes.dpp_scope_active():
+            return self.args[1].is_constant() and is_param_free(self.args[1])
+        else:
+            return self.args[1].is_constant()
 
     def is_qpwa(self) -> bool:
         """Quadratic of piecewise affine if x is PWL and y is constant.
         """
-        return self.args[0].is_pwl() and self.args[1].is_constant()
+        if u.scopes.dpp_scope_active():
+            const_no_params = self.args[1].is_constant() and is_param_free(self.args[1])
+            return self.args[0].is_pwl() and const_no_params
+        else:
+            return self.args[0].is_pwl() and self.args[1].is_constant()

--- a/cvxpy/atoms/quad_over_lin.py
+++ b/cvxpy/atoms/quad_over_lin.py
@@ -130,6 +130,9 @@ class quad_over_lin(Atom):
     def is_quadratic(self) -> bool:
         """Quadratic if x is affine and y is constant.
         """
+        # quad_over_lin is not DPP if the second argument is parameterized
+        # and it is being canonicalized as a quadratic term (rather 
+        # than with SOC constraints).
         if u.scopes.dpp_scope_active():
             const_no_params = self.args[1].is_constant() and is_param_free(self.args[1])
             return self.args[0].is_affine() and const_no_params
@@ -139,6 +142,9 @@ class quad_over_lin(Atom):
     def has_quadratic_term(self) -> bool:
         """A quadratic term if y is constant.
         """
+        # quad_over_lin is not DPP if the second argument is parameterized
+        # and it is being canonicalized as a quadratic term (rather 
+        # than with SOC constraints).
         if u.scopes.dpp_scope_active():
             return self.args[1].is_constant() and is_param_free(self.args[1])
         else:
@@ -147,6 +153,9 @@ class quad_over_lin(Atom):
     def is_qpwa(self) -> bool:
         """Quadratic of piecewise affine if x is PWL and y is constant.
         """
+        # quad_over_lin is not DPP if the second argument is parameterized
+        # and it is being canonicalized as a quadratic term (rather 
+        # than with SOC constraints).
         if u.scopes.dpp_scope_active():
             const_no_params = self.args[1].is_constant() and is_param_free(self.args[1])
             return self.args[0].is_pwl() and const_no_params

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -344,7 +344,7 @@ def construct_solving_chain(problem, candidates,
             else:
                 use_quad_obj = solver_opts.get("use_quad_obj", True)
             quad_obj = use_quad_obj and solver_instance.supports_quad_obj() and \
-                    problem.objective.expr.has_quadratic_term()
+                problem.objective.expr.has_quadratic_term()
             reductions += [
                 Dcp2Cone(quad_obj=quad_obj),
                 CvxAttr2Constr(reduce_bounds=not solver_instance.BOUNDED_VARIABLES),

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -45,6 +45,7 @@ from cvxpy.reductions.solvers.constant_solver import ConstantSolver
 from cvxpy.reductions.solvers.solver import Solver
 from cvxpy.settings import CLARABEL, ECOS, PARAM_THRESHOLD
 from cvxpy.utilities.debug_tools import build_non_disciplined_error_msg
+from cvxpy.utilities.scopes import dpp_scope
 
 DPP_ERROR_MSG = (
     "You are solving a parameterized problem that is not DPP. "
@@ -343,8 +344,11 @@ def construct_solving_chain(problem, candidates,
                 use_quad_obj = True
             else:
                 use_quad_obj = solver_opts.get("use_quad_obj", True)
-            quad_obj = use_quad_obj and solver_instance.supports_quad_obj() and \
-                problem.objective.expr.has_quadratic_term()
+            # Need to make sure that the problem is DPP if the objective is canonicalized
+            # as a quadratic.
+            with dpp_scope():
+                quad_obj = use_quad_obj and solver_instance.supports_quad_obj() and \
+                    problem.objective.expr.has_quadratic_term()
             reductions += [
                 Dcp2Cone(quad_obj=quad_obj),
                 CvxAttr2Constr(reduce_bounds=not solver_instance.BOUNDED_VARIABLES),

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -45,7 +45,6 @@ from cvxpy.reductions.solvers.constant_solver import ConstantSolver
 from cvxpy.reductions.solvers.solver import Solver
 from cvxpy.settings import CLARABEL, ECOS, PARAM_THRESHOLD
 from cvxpy.utilities.debug_tools import build_non_disciplined_error_msg
-from cvxpy.utilities.scopes import dpp_scope
 
 DPP_ERROR_MSG = (
     "You are solving a parameterized problem that is not DPP. "
@@ -344,10 +343,7 @@ def construct_solving_chain(problem, candidates,
                 use_quad_obj = True
             else:
                 use_quad_obj = solver_opts.get("use_quad_obj", True)
-            # Need to make sure that the problem is DPP if the objective is canonicalized
-            # as a quadratic.
-            with dpp_scope():
-                quad_obj = use_quad_obj and solver_instance.supports_quad_obj() and \
+            quad_obj = use_quad_obj and solver_instance.supports_quad_obj() and \
                     problem.objective.expr.has_quadratic_term()
             reductions += [
                 Dcp2Cone(quad_obj=quad_obj),

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -314,19 +314,22 @@ class TestDcp(BaseTest):
             cp.Minimize(loss),
         )
 
-        p.value = 1
-        prob.solve(solver=cp.CLARABEL)
-        sol1 = x.value.copy()
-        p.value = 1000
-        prob.solve(solver=cp.CLARABEL)
-        sol2 = x.value.copy()
-        p.value = 1
-        prob.solve(solver=cp.CLARABEL)
-        sol3 = x.value.copy()
-        assert not np.isclose(sol1, sol2)
-        assert np.isclose(sol1, sol3)
+        with warnings.catch_warnings():
+            # TODO(akshayka): Try to emit DPP problems in Dqcp2Dcp
+            warnings.filterwarnings('ignore', message=r'.*DPP.*')
+            p.value = 1
+            prob.solve(solver=cp.CLARABEL)
+            sol1 = x.value.copy()
+            p.value = 1000
+            prob.solve(solver=cp.CLARABEL)
+            sol2 = x.value.copy()
+            p.value = 1
+            prob.solve(solver=cp.CLARABEL)
+            sol3 = x.value.copy()
+            assert not np.isclose(sol1, sol2)
+            assert np.isclose(sol1, sol3)
 
-        # TODO this should fail.
+        # Cannot solve as a QP with DPP.
         with pytest.raises(error.DPPError):
             prob.solve(cp.OSQP, enforce_dpp=True)
 

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -326,6 +326,10 @@ class TestDcp(BaseTest):
         assert not np.isclose(sol1, sol2)
         assert np.isclose(sol1, sol3)
 
+        # TODO this should fail.
+        with pytest.raises(error.DPPError):
+            prob.solve(cp.OSQP, enforce_dpp=True)
+
 
 class TestDgp(BaseTest):
     def test_basic_equality_constraint(self) -> None:

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -300,6 +300,32 @@ class TestDcp(BaseTest):
         with pytest.raises(error.DPPError):
             problem.solve(cp.SCS, enforce_dpp=True, ignore_dpp=True)
 
+    def test_quad_over_lin(self) -> None:
+        """Test case with parameter in quad_over_lin."""
+        # Bug where the second argument to quad_over_lin
+        # was a parameter and the problem was solved
+        # as a cone program with a quadratic objective:
+        # https://github.com/cvxpy/cvxpy/issues/2433
+        x = cp.Variable()
+        p = cp.Parameter()
+
+        loss = cp.quad_over_lin(x,p) + x
+        prob = cp.Problem(
+            cp.Minimize(loss),
+        )
+
+        p.value = 1
+        prob.solve(solver=cp.CLARABEL)
+        sol1 = x.value.copy()
+        p.value = 1000
+        prob.solve(solver=cp.CLARABEL)
+        sol2 = x.value.copy()
+        p.value = 1
+        prob.solve(solver=cp.CLARABEL)
+        sol3 = x.value.copy()
+        assert not np.isclose(sol1, sol2)
+        assert np.isclose(sol1, sol3)
+
 
 class TestDgp(BaseTest):
     def test_basic_equality_constraint(self) -> None:


### PR DESCRIPTION
## Description
When the second argument to quad_over_lin is parameterized, the atom is DPP when canonicalized as an SOCP but not when canonicalized as a quadratic. This PR resolves the bug by making quad_over_lin not DPP in all cases whenever the second argument is parameterized.

Issue link (if applicable): #2433 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.