### PR TITLE
Adds back DGP + DPP quad_over_lin

### DIFF
--- a/cvxpy/atoms/quad_over_lin.py
+++ b/cvxpy/atoms/quad_over_lin.py
@@ -105,11 +105,7 @@ class quad_over_lin(Atom):
     def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
-        # Disable DPP when the second argument is a parameter.
-        if u.scopes.dpp_scope_active():
-            return is_param_free(self.args[1])
-        else:
-            return True
+        return True
 
     def is_atom_log_log_concave(self) -> bool:
         """Is the atom log-log concave?

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -333,6 +333,25 @@ class TestDcp(BaseTest):
         with pytest.raises(error.DPPError):
             prob.solve(cp.OSQP, enforce_dpp=True)
 
+        # works for DPP + DGP
+        x = cp.Variable(2, pos = True)
+        y = cp.Parameter(pos = True, value = 1)
+        constraints = [x >= 1]
+
+        objective = cp.quad_over_lin(x,y)
+
+        prob = cp.Problem(cp.Minimize(objective), constraints)
+        sol1 = prob.solve(gp=True)
+        y.value = 2
+        sol2 = prob.solve(gp=True)
+        y.value = 1
+        sol3 = prob.solve(gp=True)
+        assert np.isclose(sol1, 2)
+        assert np.isclose(sol2, 1)
+        assert np.isclose(sol3, 2)
+
+
+
 
 class TestDgp(BaseTest):
     def test_basic_equality_constraint(self) -> None:


### PR DESCRIPTION
## Description
Quick follow-up to #2435, allowing DGP + DPP `quad_over_lin`.
Marked as bug as it should be considered part of #2435.

Issue link (if applicable): NA

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.