### PR TITLE
Fix integer overflow on Windows in TensorRepresentation.flatten_tensor

### DIFF
--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -108,7 +108,7 @@ class TensorRepresentation:
         """
         rows = (self.col.astype(np.int64) * np.int64(self.shape[0]) + self.row.astype(np.int64))
         cols = self.parameter_offset.astype(np.int64)
-        shape = (np.int64(np.prod(self.shape)), num_param_slices)
+        shape = (np.prod(self.shape, dtype=np.int64), num_param_slices)
         return sp.csc_matrix((self.data, (rows, cols)), shape=shape)
 
     def get_param_slice(self, param_offset: int) -> sp.csc_matrix:


### PR DESCRIPTION
## Description
Numpy's default integer type on Windows is int32. The implementation in flatten_tensor explicitly converts Python integers into int64, but in on place it does it after the damage has been done on Windows.
On Windows, `np.prod` returns an int32 when given a Python tuple of ints, but can be directed to work with int64 instead. This prevents an integer overflow for e.g. `np.prod((60000, 60000))`, which returns a negative number on Windows. Setting the dtype for `np.prod` explicitly fixes that.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [X] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.