### PR TITLE
allow M to be a Parameter in the huber function

### DIFF
--- a/cvxpy/atoms/elementwise/huber.py
+++ b/cvxpy/atoms/elementwise/huber.py
@@ -20,7 +20,6 @@ import numpy as np
 import scipy.special
 
 from cvxpy.atoms.elementwise.elementwise import Elementwise
-from cvxpy.expressions.constants.parameter import Parameter
 
 # TODO(akshayka): DGP support.
 

--- a/cvxpy/atoms/elementwise/huber.py
+++ b/cvxpy/atoms/elementwise/huber.py
@@ -47,13 +47,13 @@ class huber(Elementwise):
     """
 
     def __init__(self, x, M: int = 1) -> None:
-        self.M = M if isinstance(M, Parameter) else self.cast_to_const(M)
+        self.M = self.cast_to_const(M)
         super(huber, self).__init__(x)
 
     def parameters(self):
         """If M is a Parameter, include it in the list of Parameters"""
         if isinstance(self.M, Parameter):
-            return super().parameters() + [self.M]
+            return super().parameters() + self.M.parameters()
         return super().parameters()
 
     @Elementwise.numpy_numeric

--- a/cvxpy/atoms/elementwise/huber.py
+++ b/cvxpy/atoms/elementwise/huber.py
@@ -22,7 +22,6 @@ import scipy.special
 from cvxpy.atoms.elementwise.elementwise import Elementwise
 from cvxpy.expressions.constants.parameter import Parameter
 
-
 # TODO(akshayka): DGP support.
 
 
@@ -59,57 +58,45 @@ class huber(Elementwise):
 
     @Elementwise.numpy_numeric
     def numeric(self, values) -> float:
-        """Returns the huber function applied elementwise to x.
-        """
-        return 2*scipy.special.huber(self.M.value, values[0])
+        """Returns the huber function applied elementwise to x."""
+        return 2 * scipy.special.huber(self.M.value, values[0])
 
     def sign_from_args(self) -> Tuple[bool, bool]:
-        """Returns sign (is positive, is negative) of the expression.
-        """
+        """Returns sign (is positive, is negative) of the expression."""
         # Always positive.
         return (True, False)
 
     def is_atom_convex(self) -> bool:
-        """Is the atom convex?
-        """
+        """Is the atom convex?"""
         return True
 
     def is_atom_concave(self) -> bool:
-        """Is the atom concave?
-        """
+        """Is the atom concave?"""
         return False
 
     def is_incr(self, idx) -> bool:
-        """Is the composition non-decreasing in argument idx?
-        """
+        """Is the composition non-decreasing in argument idx?"""
         return self.args[idx].is_nonneg()
 
     def is_decr(self, idx) -> bool:
-        """Is the composition non-increasing in argument idx?
-        """
+        """Is the composition non-increasing in argument idx?"""
         return self.args[idx].is_nonpos()
 
     def is_quadratic(self) -> bool:
-        """Quadratic if x is affine.
-        """
+        """Quadratic if x is affine."""
         return self.args[0].is_affine()
 
     def has_quadratic_term(self) -> bool:
-        """Always generates a quadratic term.
-        """
+        """Always generates a quadratic term."""
         return True
 
     def get_data(self):
-        """Returns the parameter M.
-        """
+        """Returns the parameter M."""
         return [self.M]
 
     def validate_arguments(self) -> None:
-        """Checks that M >= 0 and is a constant or Parameter.
-        """
-        if not (self.M.is_nonneg() and
-                self.M.is_scalar() and
-                self.M.is_constant()):
+        """Checks that M >= 0 and is a constant or Parameter."""
+        if not (self.M.is_nonneg() and self.M.is_scalar() and self.M.is_constant()):
             raise ValueError("M must be a non-negative scalar constant or Parameter.")
         super(huber, self).validate_arguments()
 
@@ -127,5 +114,5 @@ class huber(Elementwise):
         rows = self.args[0].size
         cols = self.size
         min_val = np.minimum(np.abs(values[0]), self.M.value)
-        grad_vals = 2*np.multiply(np.sign(values[0]), min_val)
+        grad_vals = 2 * np.multiply(np.sign(values[0]), min_val)
         return [huber.elemwise_grad_to_diag(grad_vals, rows, cols)]

--- a/cvxpy/atoms/elementwise/huber.py
+++ b/cvxpy/atoms/elementwise/huber.py
@@ -52,9 +52,7 @@ class huber(Elementwise):
 
     def parameters(self):
         """If M is a Parameter, include it in the list of Parameters"""
-        if isinstance(self.M, Parameter):
-            return super().parameters() + self.M.parameters()
-        return super().parameters()
+        return super().parameters() + self.M.parameters()
 
     @Elementwise.numpy_numeric
     def numeric(self, values) -> float:

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -804,12 +804,12 @@ class TestAtoms(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.huber(self.x, -1)
         self.assertEqual(str(cm.exception),
-                         "M must be a non-negative scalar constant.")
+                         "M must be a non-negative scalar constant or Parameter.")
 
         with self.assertRaises(Exception) as cm:
             cp.huber(self.x, [1, 1])
         self.assertEqual(str(cm.exception),
-                         "M must be a non-negative scalar constant.")
+                         "M must be a non-negative scalar constant or Parameter.")
 
         # M parameter.
         M = Parameter(nonneg=True)
@@ -822,7 +822,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.huber(self.x, M)
         self.assertEqual(str(cm.exception),
-                         "M must be a non-negative scalar constant.")
+                         "M must be a non-negative scalar constant or Parameter.")
 
         # Test copy with args=None
         atom = cp.huber(self.x, 2)
@@ -839,6 +839,19 @@ class TestAtoms(BaseTest):
         self.assertTrue(type(copy) is type(atom))
         self.assertTrue(copy.args[0] is self.y)
         self.assertEqual(copy.get_data()[0].value, atom.get_data()[0].value)
+
+        # Test usage of M as parameter
+        M = Parameter(nonneg=True)
+        expr = cp.huber(1.0, M)
+        M.value = 1
+        self.assertAlmostEqual(expr.value, 1.0)
+        M.value = 0.5
+        self.assertAlmostEqual(expr.value, 0.75)
+        M.value = 0.25
+        self.assertAlmostEqual(expr.value, 0.4375)
+        M.value = 1
+        self.assertAlmostEqual(expr.value, 1.0)
+
 
     def test_sum_largest(self) -> None:
         """Test the sum_largest atom and related atoms.

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -863,19 +863,19 @@ class TestAtoms(BaseTest):
         # Test with DPP
         x = cp.Variable()
         M = cp.Parameter(nonneg=True)
-        problem = cp.Problem(cp.Minimize(x**2 + cp.huber(3*x-5, M)), [x >= 0.5])
+        problem = cp.Problem(cp.Minimize(x**2 + cp.huber(3*x-5, 2 * M + 0.15)), [x >= 0.5])
 
-        M.value = 1.0
+        M.value = 0.425
         result = problem.solve()
         self.assertAlmostEqual(result, 2.5)
         self.assertAlmostEqual(x.value, 1.5)
 
-        M.value = 0.15
+        M.value = 0.0
         result = problem.solve()
         self.assertAlmostEqual(result, 1.2775)
         self.assertAlmostEqual(x.value, 0.5)
 
-        M.value = 1.0
+        M.value = 0.425
         result = problem.solve()
         self.assertAlmostEqual(result, 2.5)
         self.assertAlmostEqual(x.value, 1.5)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -852,6 +852,14 @@ class TestAtoms(BaseTest):
         M.value = 1
         self.assertAlmostEqual(expr.value, 1.0)
 
+        # Test M as affine expression of parameter
+        expr = cp.huber(1.0, 0.25 * M + 0.25)
+        M.value = 1
+        self.assertAlmostEqual(expr.value, 0.75)
+        M.value = 0.5
+        self.assertAlmostEqual(expr.value, 0.609375)
+        M.value = 1
+        self.assertAlmostEqual(expr.value, 0.75)
 
     def test_sum_largest(self) -> None:
         """Test the sum_largest atom and related atoms.

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -860,6 +860,25 @@ class TestAtoms(BaseTest):
         self.assertAlmostEqual(expr.value, 0.609375)
         M.value = 1
         self.assertAlmostEqual(expr.value, 0.75)
+        # Test with DPP
+        x = cp.Variable()
+        M = cp.Parameter(nonneg=True)
+        problem = cp.Problem(cp.Minimize(x**2 + cp.huber(3*x-5, M)), [x >= 0.5])
+
+        M.value = 1.0
+        result = problem.solve()
+        self.assertAlmostEqual(result, 2.5)
+        self.assertAlmostEqual(x.value, 1.5)
+
+        M.value = 0.15
+        result = problem.solve()
+        self.assertAlmostEqual(result, 1.2775)
+        self.assertAlmostEqual(x.value, 0.5)
+
+        M.value = 1.0
+        result = problem.solve()
+        self.assertAlmostEqual(result, 2.5)
+        self.assertAlmostEqual(x.value, 1.5)
 
     def test_sum_largest(self) -> None:
         """Test the sum_largest atom and related atoms.


### PR DESCRIPTION
## Description
This change allows the M parameter in the huber function to be a parameter for DPP.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.