### PR TITLE
Adding support for n-dimensional sum(axis, keepdims) operation

### DIFF
--- a/cvxpy/atoms/affine/sum.py
+++ b/cvxpy/atoms/affine/sum.py
@@ -86,7 +86,7 @@ class Sum(AxisAtom, AffAtom):
         axis = data[0]
         keepdims = data[1]
         if axis is None:
-            obj = lu.sum_entries(arg_objs[0], shape=shape)
+            obj = lu.sum_entries(arg_objs[0], shape=shape, axis=axis, keepdims=keepdims)
         elif axis == 1:
             if keepdims:
                 const_shape = (arg_objs[0].shape[1], 1)
@@ -101,7 +101,7 @@ class Sum(AxisAtom, AffAtom):
                 const_shape = (arg_objs[0].shape[0],)
             ones = lu.create_const(np.ones(const_shape), const_shape)
             obj = lu.mul_expr(ones, arg_objs[0], shape)
-
+        obj = lu.sum_entries(arg_objs[0], shape=shape, axis=axis, keepdims=keepdims)
         return (obj, [])
 
 

--- a/cvxpy/atoms/affine/sum.py
+++ b/cvxpy/atoms/affine/sum.py
@@ -86,7 +86,7 @@ class Sum(AxisAtom, AffAtom):
         axis = data[0]
         keepdims = data[1]
         if axis is None:
-            obj = lu.sum_entries(arg_objs[0], shape=shape, axis=axis, keepdims=keepdims)
+            obj = lu.sum_entries(arg_objs[0], shape=shape)
         elif axis == 1:
             if keepdims:
                 const_shape = (arg_objs[0].shape[1], 1)

--- a/cvxpy/atoms/affine/sum.py
+++ b/cvxpy/atoms/affine/sum.py
@@ -22,7 +22,6 @@ import numpy as np
 import cvxpy.interface as intf
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
-import cvxpy.settings as s
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.atoms.axis_atom import AxisAtom
 from cvxpy.constraints.constraint import Constraint
@@ -84,9 +83,10 @@ class Sum(AxisAtom, AffAtom):
         tuple
             (LinOp for objective, list of constraints)
         """
-        if s.DEFAULT_CANON_BACKEND == 'CPP':
-            axis = data[0]
-            keepdims = data[1]
+        axis, keepdims = data
+        if len(arg_objs[0].shape) > 2 or axis not in {None, 0, 1}:
+            obj = lu.sum_entries(arg_objs[0], shape=shape, axis=axis, keepdims=keepdims)
+        else:
             if axis is None:
                 obj = lu.sum_entries(arg_objs[0], shape=shape)
             elif axis == 1:
@@ -103,9 +103,6 @@ class Sum(AxisAtom, AffAtom):
                     const_shape = (arg_objs[0].shape[0],)
                 ones = lu.create_const(np.ones(const_shape), const_shape)
                 obj = lu.mul_expr(ones, arg_objs[0], shape)
-        else:
-            axis, keepdims = data
-            obj = lu.sum_entries(arg_objs[0], shape=shape, axis=axis, keepdims=keepdims)
         return (obj, [])
 
 

--- a/cvxpy/atoms/affine/sum.py
+++ b/cvxpy/atoms/affine/sum.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 import builtins
 from functools import wraps
-from typing import Iterable, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -40,7 +40,7 @@ class Sum(AxisAtom, AffAtom):
         Whether to drop dimensions after summing.
     """
 
-    def __init__(self, expr, axis: Optional[int | Iterable] = None, keepdims: bool = False) -> None:
+    def __init__(self, expr, axis: Optional[int] = None, keepdims: bool = False) -> None:
         super(Sum, self).__init__(expr, axis=axis, keepdims=keepdims)
 
     def is_atom_log_log_convex(self) -> bool:
@@ -110,7 +110,7 @@ class Sum(AxisAtom, AffAtom):
 
 
 @wraps(Sum)
-def sum(expr, axis: Optional[int | Iterable] = None, keepdims: bool = False):
+def sum(expr, axis: Optional[int] = None, keepdims: bool = False):
     """
     Wrapper for Sum class.
     """

--- a/cvxpy/atoms/affine/sum.py
+++ b/cvxpy/atoms/affine/sum.py
@@ -83,24 +83,7 @@ class Sum(AxisAtom, AffAtom):
         tuple
             (LinOp for objective, list of constraints)
         """
-        axis = data[0]
-        keepdims = data[1]
-        if axis is None:
-            obj = lu.sum_entries(arg_objs[0], shape=shape)
-        elif axis == 1:
-            if keepdims:
-                const_shape = (arg_objs[0].shape[1], 1)
-            else:
-                const_shape = (arg_objs[0].shape[1],)
-            ones = lu.create_const(np.ones(const_shape), const_shape)
-            obj = lu.rmul_expr(arg_objs[0], ones, shape)
-        else:  # axis == 0
-            if keepdims:
-                const_shape = (1, arg_objs[0].shape[0])
-            else:
-                const_shape = (arg_objs[0].shape[0],)
-            ones = lu.create_const(np.ones(const_shape), const_shape)
-            obj = lu.mul_expr(ones, arg_objs[0], shape)
+        axis, keepdims = data
         obj = lu.sum_entries(arg_objs[0], shape=shape, axis=axis, keepdims=keepdims)
         return (obj, [])
 

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -49,10 +49,6 @@ class Atom(Expression):
         self.args = [Atom.cast_to_const(arg) for arg in args]
         self.validate_arguments()
         self._shape = self.shape_from_args()
-        """
-        if len(self._shape) > 2:
-            raise ValueError("Atoms must be at most 2D.")
-        """
 
     def name(self) -> str:
         """Returns the string representation of the function call.

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -23,6 +23,7 @@ import numpy as np
 
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
+import cvxpy.settings as s
 from cvxpy import interface as intf
 from cvxpy import utilities as u
 from cvxpy.expressions import cvxtypes
@@ -49,6 +50,8 @@ class Atom(Expression):
         self.args = [Atom.cast_to_const(arg) for arg in args]
         self.validate_arguments()
         self._shape = self.shape_from_args()
+        if not s.ALLOW_ND_EXPR and len(self._shape) > 2:
+            raise ValueError("Atoms must be at most 2D.")
 
     def name(self) -> str:
         """Returns the string representation of the function call.

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -49,8 +49,10 @@ class Atom(Expression):
         self.args = [Atom.cast_to_const(arg) for arg in args]
         self.validate_arguments()
         self._shape = self.shape_from_args()
+        """
         if len(self._shape) > 2:
             raise ValueError("Atoms must be at most 2D.")
+        """
 
     def name(self) -> str:
         """Returns the string representation of the function call.

--- a/cvxpy/atoms/axis_atom.py
+++ b/cvxpy/atoms/axis_atom.py
@@ -71,7 +71,7 @@ class AxisAtom(Atom):
             for axis in axes:
                 if axis < 0:
                     axis += dim
-                if axis >= dim or axis < 0:
+                if axis > dim or axis < 0:
                     raise ValueError(f"axis {axis} is out of bounds for array of dimension {dim}")
         super(AxisAtom, self).validate_arguments()
 

--- a/cvxpy/atoms/axis_atom.py
+++ b/cvxpy/atoms/axis_atom.py
@@ -71,7 +71,7 @@ class AxisAtom(Atom):
             for axis in axes:
                 if axis < 0:
                     axis += dim
-                if axis > dim or axis < 0:
+                if axis >= dim or axis < 0:
                     raise ValueError(f"axis {axis} is out of bounds for array of dimension {dim}")
         super(AxisAtom, self).validate_arguments()
 

--- a/cvxpy/constraints/constraint.py
+++ b/cvxpy/constraints/constraint.py
@@ -67,8 +67,17 @@ class Constraint(u.Canonical):
 
     @property
     def shape(self):
-        """int : The shape of the constrained expression."""
+        """
+        int : The shape of the constrained expression.
+        """
         return self.args[0].shape
+
+    @property
+    def ndim(self) -> int:
+        """
+        int : The maximum number of dimensions of the constrained expression.
+        """
+        return len(self.args[0].shape)
 
     @property
     def size(self):

--- a/cvxpy/cvxcore/python/cppbackend.py
+++ b/cvxpy/cvxcore/python/cppbackend.py
@@ -174,7 +174,8 @@ def make_linC_from_linPy(linPy, linPy_to_linC) -> None:
         lin_args_vec.push_back(linPy_to_linC[argPy])
     linC = cvxcore.LinOp(typ, shape, lin_args_vec)
     linPy_to_linC[linPy] = linC
-
+    # Note: added special case for sum_entries, since it has a data field
+    # that doesn't need to get converted to actual data.
     if linPy.data is not None and linPy.type != "sum_entries":
         if isinstance(linPy.data, lo.LinOp):
             linC_data = linPy_to_linC[linPy.data]

--- a/cvxpy/cvxcore/python/cppbackend.py
+++ b/cvxpy/cvxcore/python/cppbackend.py
@@ -175,7 +175,7 @@ def make_linC_from_linPy(linPy, linPy_to_linC) -> None:
     linC = cvxcore.LinOp(typ, shape, lin_args_vec)
     linPy_to_linC[linPy] = linC
 
-    if linPy.data is not None:
+    if linPy.data is not None and linPy.type != "sum_entries":
         if isinstance(linPy.data, lo.LinOp):
             linC_data = linPy_to_linC[linPy.data]
             linC.set_linOp_data(linC_data)

--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -67,7 +67,7 @@ class Constant(Leaf):
 
     def name(self) -> str:
         """
-        The value of the constant as a string.
+         The value of the constant as a string.
         """
         if self._name is None:
             if len(self.shape) == 2 and "\n" in str(self.value):

--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 import warnings
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import numpy as np
 import scipy.sparse as sp
@@ -27,8 +27,8 @@ import cvxpy.utilities.linalg as eig_util
 from cvxpy.expressions.leaf import Leaf
 from cvxpy.utilities import performance_utils as perf
 
-NESTED_LIST_WARNING =  "Initializing a Constant with a nested list is " \
-    "undefined behavior. Consider using a numpy array instead."
+NESTED_LIST_WARNING = "Initializing a Constant with a nested list is " \
+                      "undefined behavior. Consider using a numpy array instead."
 
 
 class Constant(Leaf):
@@ -66,14 +66,15 @@ class Constant(Leaf):
         super(Constant, self).__init__(intf.shape(self.value))
 
     def name(self) -> str:
-        """The value as a string.
+        """
+        The value of the constant as a string.
         """
         if self._name is None:
             if len(self.shape) == 2 and "\n" in str(self.value):
                 return np.array2string(self.value,
-                                    edgeitems=s.PRINT_EDGEITEMS,
-                                    threshold=s.PRINT_THRESHOLD,
-                                    formatter={'float': lambda x: f'{x:.2f}'})
+                                       edgeitems=s.PRINT_EDGEITEMS,
+                                       threshold=s.PRINT_THRESHOLD,
+                                       formatter={'float': lambda x: f'{x:.2f}'})
             return str(self.value)
         else:
             return self._name
@@ -87,7 +88,7 @@ class Constant(Leaf):
         return True
 
     @property
-    def value(self):
+    def value(self) -> np.ndarray | None:
         """NumPy.ndarray or None: The numeric value of the constant.
         """
         return self._value
@@ -116,7 +117,7 @@ class Constant(Leaf):
         return {}
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> int | Tuple[int, Any]:
         """Returns the (row, col) dimensions of the expression.
         """
         return self._shape

--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 import warnings
-from typing import Any, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 import scipy.sparse as sp
@@ -88,7 +88,7 @@ class Constant(Leaf):
         return True
 
     @property
-    def value(self) -> np.ndarray | None:
+    def value(self):
         """NumPy.ndarray or None: The numeric value of the constant.
         """
         return self._value
@@ -117,7 +117,7 @@ class Constant(Leaf):
         return {}
 
     @property
-    def shape(self) -> int | Tuple[int, Any]:
+    def shape(self) -> Tuple[int, ...]:
         """Returns the (row, col) dimensions of the expression.
         """
         return self._shape

--- a/cvxpy/expressions/constants/constant.py
+++ b/cvxpy/expressions/constants/constant.py
@@ -35,11 +35,10 @@ class Constant(Leaf):
     """
     A constant value.
 
-    Raw numerical constants (Python primite types, NumPy ndarrays,
-    and NumPy matrices) are implicitly cast to constants via Expression
-    operator overloading. For example, if ``x`` is an expression and
-    ``c`` is a raw constant, then ``x + c`` creates an expression by
-    casting ``c`` to a Constant.
+    Raw numerical constants such as Python primitive types or NumPy ndarrays
+    are implicitly cast to constants via Expression operator overloading.
+    For example, if ``x`` is an expression and``c`` is a raw constant,
+    then ``x + c`` creates an expression by casting ``c`` to a Constant.
     """
 
     def __init__(self, value, name: Optional[str] = None) -> None:

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -115,7 +115,8 @@ class Expression(u.Canonical):
     # Handles arithmetic operator overloading with Numpy.
     __array_priority__ = 100
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def value(self):
         """NumPy.ndarray or None : The numeric value of the expression.
         """
@@ -126,7 +127,8 @@ class Expression(u.Canonical):
         """
         return self.value
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def grad(self):
         """Gives the (sub/super)gradient of the expression w.r.t. each variable.
 
@@ -140,7 +142,8 @@ class Expression(u.Canonical):
         """
         raise NotImplementedError()
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def domain(self):
         """list : The constraints describing the closure of the region
            where the expression is finite.

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -29,6 +29,7 @@ import numpy.linalg as LA
 import scipy.sparse as sp
 
 import cvxpy.interface as intf
+import cvxpy.settings as s
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import expression
 from cvxpy.settings import (
@@ -56,6 +57,7 @@ class Leaf(expression.Expression):
     shape : Iterable of ints or int
         The leaf dimensions. Either an integer n for a 1D shape, or an
         iterable where the semantics are the same as NumPy ndarray shapes.
+        **Shapes cannot be more than 2D**.
     value : numeric type
         A value to assign to the leaf.
     nonneg : bool
@@ -96,7 +98,7 @@ class Leaf(expression.Expression):
     __metaclass__ = abc.ABCMeta
 
     def __init__(
-        self, shape: int | Iterable, value=None, nonneg: bool = False,
+        self, shape: int | tuple[int, ...], value=None, nonneg: bool = False,
         nonpos: bool = False, complex: bool = False, imag: bool = False,
         symmetric: bool = False, diag: bool = False, PSD: bool = False,
         NSD: bool = False, hermitian: bool = False,
@@ -105,6 +107,9 @@ class Leaf(expression.Expression):
     ) -> None:
         if isinstance(shape, numbers.Integral):
             shape = (int(shape),)
+        elif not s.ALLOW_ND_EXPR and len(shape) > 2:
+            raise ValueError("Expressions of dimension greater than 2 "
+                             "are not supported.")
         for d in shape:
             if not isinstance(d, numbers.Integral) or d <= 0:
                 raise ValueError("Invalid dimensions %s." % (shape,))

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -56,7 +56,6 @@ class Leaf(expression.Expression):
     shape : Iterable of ints or int
         The leaf dimensions. Either an integer n for a 1D shape, or an
         iterable where the semantics are the same as NumPy ndarray shapes.
-        **Shapes cannot be more than 2D**.
     value : numeric type
         A value to assign to the leaf.
     nonneg : bool
@@ -106,9 +105,11 @@ class Leaf(expression.Expression):
     ) -> None:
         if isinstance(shape, numbers.Integral):
             shape = (int(shape),)
+        """
         elif len(shape) > 2:
             raise ValueError("Expressions of dimension greater than 2 "
                              "are not supported.")
+        """
         for d in shape:
             if not isinstance(d, numbers.Integral) or d <= 0:
                 raise ValueError("Invalid dimensions %s." % (shape,))

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -96,7 +96,7 @@ class Leaf(expression.Expression):
     __metaclass__ = abc.ABCMeta
 
     def __init__(
-        self, shape: int | Iterable[int, ...], value=None, nonneg: bool = False,
+        self, shape: int | Iterable, value=None, nonneg: bool = False,
         nonpos: bool = False, complex: bool = False, imag: bool = False,
         symmetric: bool = False, diag: bool = False, PSD: bool = False,
         NSD: bool = False, hermitian: bool = False,
@@ -105,11 +105,6 @@ class Leaf(expression.Expression):
     ) -> None:
         if isinstance(shape, numbers.Integral):
             shape = (int(shape),)
-        """
-        elif len(shape) > 2:
-            raise ValueError("Expressions of dimension greater than 2 "
-                             "are not supported.")
-        """
         for d in shape:
             if not isinstance(d, numbers.Integral) or d <= 0:
                 raise ValueError("Invalid dimensions %s." % (shape,))

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -1190,7 +1190,15 @@ class SciPyCanonBackend(PythonCanonBackend):
         """
         def func(x, p):
             if p == 1:
-                return sp.csr_matrix(x.sum(axis=0))
+                axis, _ = _lin.data
+                if axis is None:
+                    return sp.csr_matrix(x.sum(axis=0))
+                else:
+                    shape = _lin.args[0].shape
+                    n = np.prod(shape, dtype=int)
+                    d = shape[axis]
+                    x = x.toarray().reshape((shape)+(n,), order='F').sum(axis=axis)
+                    return sp.csr_matrix(x.reshape((n//d, n), order='F'))
             else:
                 m = x.shape[0] // p
                 return (sp.kron(sp.eye(p, format="csc"), np.ones(m)) @ x).tocsc()

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -765,7 +765,7 @@ class NumPyCanonBackend(PythonCanonBackend):
         d = _lin.shape[axis]
         def func(x):
             idx = np.arange(n).reshape((n//d, d), order='F')
-            return x[idx].sum(axis=axis-1).reshape(1,n//d,n)
+            return x[0][idx].sum(axis=axis-1).reshape(1,n//d,n)
 
         view.apply_all(func)
         return view

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -767,9 +767,14 @@ class NumPyCanonBackend(PythonCanonBackend):
             else:
                 shape = _lin.args[0].shape
                 n = np.prod(shape, dtype=int)
-                d = shape[axis]
                 p = x.shape[0]
-                x = x.reshape((p,)+(shape)+(n,), order='F').sum(axis=axis + 1)
+                if isinstance(axis, tuple):
+                    d = np.prod([shape[i] for i in axis], dtype=int)
+                    axis = tuple([a + 1 for a in axis])
+                else:
+                    d = shape[axis]
+                    axis += 1
+                x = x.reshape((p,)+(shape)+(n,), order='F').sum(axis=axis)
                 return x.reshape((p, n//d, n), order='F')
 
         view.apply_all(func)
@@ -1196,7 +1201,10 @@ class SciPyCanonBackend(PythonCanonBackend):
                 else:
                     shape = _lin.args[0].shape
                     n = np.prod(shape, dtype=int)
-                    d = shape[axis]
+                    if isinstance(axis, tuple):
+                        d = np.prod([shape[i] for i in axis], dtype=int)
+                    else:
+                        d = shape[axis]
                     x = x.toarray().reshape((shape)+(n,), order='F').sum(axis=axis)
                     return sp.csr_matrix(x.reshape((n//d, n), order='F'))
             else:

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -226,7 +226,7 @@ class PythonCanonBackend(CanonBackend):
         # Leaf nodes
         if lin_op.type == "variable":
             assert isinstance(lin_op.data, int)
-            assert len(lin_op.shape) in {0, 1, 2}
+            # assert len(lin_op.shape) in {0, 1, 2}
             variable_tensor = self.get_variable_tensor(lin_op.shape, lin_op.data)
             return empty_view.create_new_tensor_view({lin_op.data}, variable_tensor,
                                                      is_parameter_free=True)
@@ -760,8 +760,12 @@ class NumPyCanonBackend(PythonCanonBackend):
         Given (A, b) in view, return the sum of the representation
         on the row axis, ie: (sum(A,axis=1), sum(b, axis=1)).
         """
+        axis, keepdims = _lin.data
+        n = np.prod(_lin.shape)
+        d = _lin.shape[axis]
         def func(x):
-            return x.sum(axis=1, keepdims=True)
+            idx = np.arange(n).reshape((n//d, d), order='F')
+            return x[idx].sum(axis=axis-1).reshape(1,n//d,n)
 
         view.apply_all(func)
         return view

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -770,6 +770,7 @@ class NumPyCanonBackend(PythonCanonBackend):
                 p = x.shape[0]
                 if isinstance(axis, tuple):
                     d = np.prod([shape[i] for i in axis], dtype=int)
+                    # adding offset of 1 to every axis because of param axis.
                     axis = tuple([a + 1 for a in axis])
                 else:
                     d = shape[axis]

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -24,6 +24,7 @@ import numpy as np
 import scipy.sparse as sp
 from scipy.signal import convolve
 
+import cvxpy.settings as s
 from cvxpy.lin_ops import LinOp
 from cvxpy.settings import (
     NUMPY_CANON_BACKEND,
@@ -226,6 +227,8 @@ class PythonCanonBackend(CanonBackend):
         # Leaf nodes
         if lin_op.type == "variable":
             assert isinstance(lin_op.data, int)
+            if not s.ALLOW_ND_EXPR:
+                 assert len(lin_op.shape) in {0, 1, 2}
             variable_tensor = self.get_variable_tensor(lin_op.shape, lin_op.data)
             return empty_view.create_new_tensor_view({lin_op.data}, variable_tensor,
                                                      is_parameter_free=True)

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -227,8 +227,7 @@ class PythonCanonBackend(CanonBackend):
         # Leaf nodes
         if lin_op.type == "variable":
             assert isinstance(lin_op.data, int)
-            if not s.ALLOW_ND_EXPR:
-             assert s.ALLOW_ND_ARRAY or len(lin_op.shape) in {0, 1, 2}
+            assert s.ALLOW_ND_EXPR or len(lin_op.shape) in {0, 1, 2}
             variable_tensor = self.get_variable_tensor(lin_op.shape, lin_op.data)
             return empty_view.create_new_tensor_view({lin_op.data}, variable_tensor,
                                                      is_parameter_free=True)
@@ -1230,7 +1229,7 @@ class SciPyCanonBackend(PythonCanonBackend):
                         d = np.prod([shape[i] for i in axis], dtype=int)
                     else:
                         d = shape[axis]
-                    #TODO avoid changing x to dense
+                    # TODO avoid changing x to dense
                     x = x.toarray().reshape(shape+(n,), order='F').sum(axis=axis)
                     return sp.csr_matrix(x.reshape((n//d, n), order='F'))
             else:

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -788,7 +788,7 @@ class NumPyCanonBackend(PythonCanonBackend):
                 else:
                     d = shape[axis]
                     axis += 1
-                x = x.reshape((p,)+(shape)+(n,), order='F').sum(axis=axis)
+                x = x.reshape((p,)+shape+(n,), order='F').sum(axis=axis)
                 return x.reshape((p, n//d, n), order='F')
 
         view.apply_all(func)
@@ -1230,7 +1230,8 @@ class SciPyCanonBackend(PythonCanonBackend):
                         d = np.prod([shape[i] for i in axis], dtype=int)
                     else:
                         d = shape[axis]
-                    x = x.toarray().reshape((shape)+(n,), order='F').sum(axis=axis)
+                    #TODO avoid changing x to dense
+                    x = x.toarray().reshape(shape+(n,), order='F').sum(axis=axis)
                     return sp.csr_matrix(x.reshape((n//d, n), order='F'))
             else:
                 m = x.shape[0] // p

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -228,7 +228,7 @@ class PythonCanonBackend(CanonBackend):
         if lin_op.type == "variable":
             assert isinstance(lin_op.data, int)
             if not s.ALLOW_ND_EXPR:
-                 assert len(lin_op.shape) in {0, 1, 2}
+             assert s.ALLOW_ND_ARRAY or len(lin_op.shape) in {0, 1, 2}
             variable_tensor = self.get_variable_tensor(lin_op.shape, lin_op.data)
             return empty_view.create_new_tensor_view({lin_op.data}, variable_tensor,
                                                      is_parameter_free=True)

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -766,7 +766,7 @@ class NumPyCanonBackend(PythonCanonBackend):
                 return x.sum(axis=1, keepdims=True)
             else:
                 shape = _lin.args[0].shape
-                n = np.prod(shape, dtype=int)
+                n = x.shape[-1]
                 p = x.shape[0]
                 if isinstance(axis, tuple):
                     d = np.prod([shape[i] for i in axis], dtype=int)
@@ -1200,7 +1200,7 @@ class SciPyCanonBackend(PythonCanonBackend):
                     return sp.csr_matrix(x.sum(axis=0))
                 else:
                     shape = _lin.args[0].shape
-                    n = np.prod(shape, dtype=int)
+                    n = x.shape[-1]
                     if isinstance(axis, tuple):
                         d = np.prod([shape[i] for i in axis], dtype=int)
                     else:

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -760,20 +760,17 @@ class NumPyCanonBackend(PythonCanonBackend):
         Given (A, b) in view, return the sum of the representation
         on the row axis, ie: (sum(A,axis=1), sum(b, axis=1)).
         """
-        axis, _ = _lin.data
-        shape = _lin.shape
-        n = np.prod(shape, dtype=int)
-        if axis is None:
-            d = n
-            axis = tuple(np.arange(len(shape)))
-        else:
-            d = _lin.shape[axis]
         def func(x):
-            if _lin.shape == ():
+            axis, _ = _lin.data
+            if axis is None:
                 return x.sum(axis=1, keepdims=True)
-            p = x.shape[0]
-            x = x.reshape((p,)+(shape)+(n,), order='F').sum(axis=tuple(x+1 for x in axis))
-            return x.reshape((p, n//d, n), order='F')
+            else:
+                shape = _lin.args[0].shape
+                n = np.prod(shape, dtype=int)
+                d = shape[axis]
+                p = x.shape[0]
+                x = x.reshape((p,)+(shape)+(n,), order='F').sum(axis=axis + 1)
+                return x.reshape((p, n//d, n), order='F')
 
         view.apply_all(func)
         return view

--- a/cvxpy/lin_ops/lin_utils.py
+++ b/cvxpy/lin_ops/lin_utils.py
@@ -384,7 +384,7 @@ def sum_entries(operator, shape: Tuple[int, ...], axis=None, keepdims=None):
     LinOp
         An operator representing the sum.
     """
-    data = [axis, keepdims] if s.DEFAULT_CANON_BACKEND == "SCIPY" else None
+    data = None if s.DEFAULT_CANON_BACKEND == "CPP" else [axis, keepdims]
     return lo.LinOp(lo.SUM_ENTRIES, shape, [operator], data=data)
 
 

--- a/cvxpy/lin_ops/lin_utils.py
+++ b/cvxpy/lin_ops/lin_utils.py
@@ -21,6 +21,7 @@ from typing import Tuple
 import numpy as np
 
 import cvxpy.lin_ops.lin_op as lo
+import cvxpy.settings as s
 import cvxpy.utilities as u
 from cvxpy.lin_ops.lin_constraints import LinEqConstr, LinLeqConstr
 
@@ -383,7 +384,8 @@ def sum_entries(operator, shape: Tuple[int, ...], axis=None, keepdims=None):
     LinOp
         An operator representing the sum.
     """
-    return lo.LinOp(lo.SUM_ENTRIES, shape, [operator], [axis, keepdims])
+    data = [axis, keepdims] if s.DEFAULT_CANON_BACKEND == "SCIPY" else None
+    return lo.LinOp(lo.SUM_ENTRIES, shape, [operator], data=data)
 
 
 def trace(operator):

--- a/cvxpy/lin_ops/lin_utils.py
+++ b/cvxpy/lin_ops/lin_utils.py
@@ -368,7 +368,7 @@ def promote(operator, shape: Tuple[int, ...]):
     return lo.LinOp(lo.PROMOTE, shape, [operator], None)
 
 
-def sum_entries(operator, shape: Tuple[int, ...], axis, keepdims):
+def sum_entries(operator, shape: Tuple[int, ...], axis=None, keepdims=None):
     """Sum the entries of an operator.
 
     Parameters

--- a/cvxpy/lin_ops/lin_utils.py
+++ b/cvxpy/lin_ops/lin_utils.py
@@ -368,7 +368,7 @@ def promote(operator, shape: Tuple[int, ...]):
     return lo.LinOp(lo.PROMOTE, shape, [operator], None)
 
 
-def sum_entries(operator, shape: Tuple[int, ...]):
+def sum_entries(operator, shape: Tuple[int, ...], axis, keepdims):
     """Sum the entries of an operator.
 
     Parameters
@@ -383,7 +383,7 @@ def sum_entries(operator, shape: Tuple[int, ...]):
     LinOp
         An operator representing the sum.
     """
-    return lo.LinOp(lo.SUM_ENTRIES, shape, [operator], None)
+    return lo.LinOp(lo.SUM_ENTRIES, shape, [operator], [axis, keepdims])
 
 
 def trace(operator):

--- a/cvxpy/lin_ops/lin_utils.py
+++ b/cvxpy/lin_ops/lin_utils.py
@@ -21,7 +21,6 @@ from typing import Tuple
 import numpy as np
 
 import cvxpy.lin_ops.lin_op as lo
-import cvxpy.settings as s
 import cvxpy.utilities as u
 from cvxpy.lin_ops.lin_constraints import LinEqConstr, LinLeqConstr
 
@@ -384,8 +383,7 @@ def sum_entries(operator, shape: Tuple[int, ...], axis=None, keepdims=None):
     LinOp
         An operator representing the sum.
     """
-    data = None if s.DEFAULT_CANON_BACKEND == "CPP" else [axis, keepdims]
-    return lo.LinOp(lo.SUM_ENTRIES, shape, [operator], data=data)
+    return lo.LinOp(lo.SUM_ENTRIES, shape, [operator], data=[axis, keepdims])
 
 
 def trace(operator):

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -258,6 +258,16 @@ class Problem(u.Canonical):
           expr.is_dcp(dpp) for expr in self.constraints + [self.objective])
 
     @perf.compute_once
+    def _max_ndim(self) -> int:
+        """
+        Returns the maximum number of dimensions of any argument in the problem.
+        """
+        prob_max_ndim = self.objective.expr._max_ndim()
+        for con in self.constraints:
+            prob_max_ndim = max([prob_max_ndim] + [arg._max_ndim() for arg in con.args])
+        return prob_max_ndim
+
+    @perf.compute_once
     def is_dgp(self, dpp: bool = False) -> bool:
         """Does the problem satisfy DGP rules?
 

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -264,7 +264,7 @@ class Problem(u.Canonical):
         """
         prob_max_ndim = self.objective.expr._max_ndim()
         for con in self.constraints:
-            prob_max_ndim = max([prob_max_ndim] + [arg._max_ndim() for arg in con.args])
+            prob_max_ndim = max(prob_max_ndim, max(arg._max_ndim() for arg in con.args))
         return prob_max_ndim
 
     @perf.compute_once

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -401,9 +401,7 @@ def _get_canon_backend(problem, canon_backend):
     canon_backend : str
         The canonicalization backend to use.
     """
-    max_var_dim = max([p.ndim for p in problem.variables()] or [0])
-    max_param_dim = max([p.ndim for p in problem.parameters()] or [0])
-    if max(max_var_dim, max_param_dim) > 2:
+    if problem._max_ndim() > 2:
         if canon_backend is None:
             warnings.warn(UserWarning(
                 "The problem has an expression with dimension greater than 2. "

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -43,7 +43,14 @@ from cvxpy.reductions.reduction import Reduction
 from cvxpy.reductions.solvers import defines as slv_def
 from cvxpy.reductions.solvers.constant_solver import ConstantSolver
 from cvxpy.reductions.solvers.solver import Solver
-from cvxpy.settings import CLARABEL, ECOS, PARAM_THRESHOLD
+from cvxpy.settings import (
+    CLARABEL,
+    CPP_CANON_BACKEND,
+    ECOS,
+    NUMPY_CANON_BACKEND,
+    PARAM_THRESHOLD,
+    SCIPY_CANON_BACKEND,
+)
 from cvxpy.utilities.debug_tools import build_non_disciplined_error_msg
 
 DPP_ERROR_MSG = (
@@ -404,12 +411,13 @@ def _get_canon_backend(problem, canon_backend):
     if problem._max_ndim() > 2:
         if canon_backend is None:
             warnings.warn(UserWarning(
-                "The problem has an expression with dimension greater than 2. "
-                "Defaulting to the 'SCIPY' backend for canonicalization."))
-            return "SCIPY"
-        elif canon_backend == "CPP":
-            raise ValueError("Only the 'SCIPY' and 'NUMPY' backends are supported for "
-                             "problems with expressions of dimension greater than 2.")
+                f"The problem has an expression with dimension greater than 2. "
+                f"Defaulting to the {SCIPY_CANON_BACKEND} backend for canonicalization."))
+            return SCIPY_CANON_BACKEND
+        elif canon_backend == CPP_CANON_BACKEND:
+            raise ValueError(f"Only the {SCIPY_CANON_BACKEND} and {NUMPY_CANON_BACKEND} "
+                             f"backends are supported for problems with expressions of "
+                             f"dimension greater than 2.")
     return canon_backend
 
 

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -391,9 +391,6 @@ def _get_canon_backend(problem, canon_backend):
     than 2, then raises a warning if the default backend is not specified or 
     raises an error if the backend is specified as 'CPP'.
 
-    TODO: The correct way to do this in the future is to check all nodes of
-    the expression tree to find the largest dimension.
-
     Parameters
     ----------
     problem : Problem

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -183,7 +183,7 @@ RUST_CANON_BACKEND = "RUST"
 CPP_CANON_BACKEND = "CPP"
 
 # Default canonicalization backend, pyodide uses SciPy
-DEFAULT_CANON_BACKEND = NUMPY_CANON_BACKEND
+DEFAULT_CANON_BACKEND = CPP_CANON_BACKEND if sys.platform != "emscripten" else SCIPY_CANON_BACKEND
 
 # Numerical tolerances
 EIGVAL_TOL = 1e-10

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -183,7 +183,7 @@ RUST_CANON_BACKEND = "RUST"
 CPP_CANON_BACKEND = "CPP"
 
 # Default canonicalization backend, pyodide uses SciPy
-DEFAULT_CANON_BACKEND = SCIPY_CANON_BACKEND
+DEFAULT_CANON_BACKEND = CPP_CANON_BACKEND if sys.platform != "emscripten" else SCIPY_CANON_BACKEND
 
 # Numerical tolerances
 EIGVAL_TOL = 1e-10

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -183,7 +183,7 @@ RUST_CANON_BACKEND = "RUST"
 CPP_CANON_BACKEND = "CPP"
 
 # Default canonicalization backend, pyodide uses SciPy
-DEFAULT_CANON_BACKEND = CPP_CANON_BACKEND if sys.platform != "emscripten" else SCIPY_CANON_BACKEND
+DEFAULT_CANON_BACKEND = SCIPY_CANON_BACKEND
 
 # Numerical tolerances
 EIGVAL_TOL = 1e-10

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -183,7 +183,7 @@ RUST_CANON_BACKEND = "RUST"
 CPP_CANON_BACKEND = "CPP"
 
 # Default canonicalization backend, pyodide uses SciPy
-DEFAULT_CANON_BACKEND = CPP_CANON_BACKEND if sys.platform != "emscripten" else SCIPY_CANON_BACKEND
+DEFAULT_CANON_BACKEND = NUMPY_CANON_BACKEND
 
 # Numerical tolerances
 EIGVAL_TOL = 1e-10

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -202,6 +202,9 @@ PARAM_THRESHOLD = 1e4
 # environment variable)
 NUM_THREADS = -1
 
+# Flag to allow ND expressions.
+ALLOW_ND_EXPR = True
+
 PRINT_EDGEITEMS = 2
 PRINT_THRESHOLD = 5
 

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -366,14 +366,13 @@ class TestAtoms(BaseTest):
 
         # Test with axis argument.
         self.assertEqual(cp.max(Variable(2), axis=0, keepdims=True).shape, (1,))
-        self.assertEqual(cp.max(Variable(2), axis=1).shape, (2,))
         self.assertEqual(cp.max(Variable((2, 3)), axis=0, keepdims=True).shape, (1, 3))
         self.assertEqual(cp.max(Variable((2, 3)), axis=1).shape, (2,))
 
         # Invalid axis.
         with self.assertRaises(Exception) as cm:
             cp.max(self.x, axis=4)
-        self.assertEqual(str(cm.exception), "Invalid argument for axis.")
+        self.assertEqual(str(cm.exception), "axis 4 is out of bounds for array of dimension 1")
         with self.assertRaises(ValueError) as cm:
             cp.max(self.x, self.x)  # a common erroneous use-case
         self.assertEqual(str(cm.exception), cp.max.__EXPR_AXIS_ERROR__)
@@ -389,14 +388,13 @@ class TestAtoms(BaseTest):
 
         # Test with axis argument.
         self.assertEqual(cp.min(Variable(2), axis=0).shape, tuple())
-        self.assertEqual(cp.min(Variable(2), axis=1).shape, (2,))
         self.assertEqual(cp.min(Variable((2, 3)), axis=0).shape, (3,))
         self.assertEqual(cp.min(Variable((2, 3)), axis=1).shape, (2,))
 
         # Invalid axis.
         with self.assertRaises(Exception) as cm:
             cp.min(self.x, axis=4)
-        self.assertEqual(str(cm.exception), "Invalid argument for axis.")
+        self.assertEqual(str(cm.exception), "axis 4 is out of bounds for array of dimension 1")
         with self.assertRaises(ValueError) as cm:
             cp.min(self.x, self.x)  # a common erroneous use-case
         self.assertEqual(str(cm.exception), cp.min.__EXPR_AXIS_ERROR__)
@@ -481,7 +479,6 @@ class TestAtoms(BaseTest):
 
         # Test with axis argument.
         self.assertEqual(cp.sum(Variable(2), axis=0).shape, tuple())
-        self.assertEqual(cp.sum(Variable(2), axis=1).shape, (2,))
         self.assertEqual(cp.sum(Variable((2, 3)), axis=0, keepdims=True).shape, (1, 3))
         self.assertEqual(cp.sum(Variable((2, 3)), axis=0, keepdims=False).shape, (3,))
         self.assertEqual(cp.sum(Variable((2, 3)), axis=1).shape, (2,))
@@ -490,7 +487,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.sum(self.x, axis=4)
         self.assertEqual(str(cm.exception),
-                         "Invalid argument for axis.")
+                        "axis 4 is out of bounds for array of dimension 1")
 
         A = sp.eye(3)
         self.assertEqual(cp.sum(A).value, 3)
@@ -1712,6 +1709,8 @@ class TestAtoms(BaseTest):
         # where X of the naive result is I.
         self.assertTrue(prob.value < naiveRes)
 
+class Test_ND_Atoms(BaseTest):
+    pass
 
 class TestDotsort(BaseTest):
     """ Unit tests for the dotsort atom. """

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -373,6 +373,9 @@ class TestAtoms(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.max(self.x, axis=4)
         self.assertEqual(str(cm.exception), "axis 4 is out of bounds for array of dimension 1")
+        with self.assertRaises(Exception) as cm:
+            cp.max(Variable(2), axis=1).shape
+        self.assertEqual(str(cm.exception), "axis 1 is out of bounds for array of dimension 1")
         with self.assertRaises(ValueError) as cm:
             cp.max(self.x, self.x)  # a common erroneous use-case
         self.assertEqual(str(cm.exception), cp.max.__EXPR_AXIS_ERROR__)
@@ -395,6 +398,9 @@ class TestAtoms(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.min(self.x, axis=4)
         self.assertEqual(str(cm.exception), "axis 4 is out of bounds for array of dimension 1")
+        with self.assertRaises(Exception) as cm:
+            cp.min(Variable(2), axis=1).shape
+        self.assertEqual(str(cm.exception), "axis 1 is out of bounds for array of dimension 1")
         with self.assertRaises(ValueError) as cm:
             cp.min(self.x, self.x)  # a common erroneous use-case
         self.assertEqual(str(cm.exception), cp.min.__EXPR_AXIS_ERROR__)
@@ -488,6 +494,9 @@ class TestAtoms(BaseTest):
             cp.sum(self.x, axis=4)
         self.assertEqual(str(cm.exception),
                         "axis 4 is out of bounds for array of dimension 1")
+        with self.assertRaises(Exception) as cm:
+            cp.sum(Variable(2), axis=1).shape
+        self.assertEqual(str(cm.exception), "axis 1 is out of bounds for array of dimension 1")
 
         A = sp.eye(3)
         self.assertEqual(cp.sum(A).value, 3)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1718,9 +1718,6 @@ class TestAtoms(BaseTest):
         # where X of the naive result is I.
         self.assertTrue(prob.value < naiveRes)
 
-class Test_ND_Atoms(BaseTest):
-    pass
-
 class TestDotsort(BaseTest):
     """ Unit tests for the dotsort atom. """
 

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -695,6 +695,7 @@ class TestDqcp(base_test.BaseTest):
         problem.solve(SOLVER, qcp=True)
         self.assertAlmostEqual(problem.value, 0, places=3)
 
+        # TODO: Make this test pass. Need to add a special case for scalar sums.
         with self.assertRaises(Exception) as cm:
             problem = cp.Problem(cp.Minimize(cp.cumsum(1/x)))
             problem.solve(SOLVER, qcp=True)

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -695,9 +695,10 @@ class TestDqcp(base_test.BaseTest):
         problem.solve(SOLVER, qcp=True)
         self.assertAlmostEqual(problem.value, 0, places=3)
 
-        problem = cp.Problem(cp.Minimize(cp.cumsum(1/x)))
-        problem.solve(SOLVER, qcp=True)
-        self.assertAlmostEqual(problem.value, 0, places=3)
+        with self.assertRaises(Exception) as cm:
+            problem = cp.Problem(cp.Minimize(cp.cumsum(1/x)))
+            problem.solve(SOLVER, qcp=True)
+        self.assertEqual(str(cm.exception), "axis 0 is out of bounds for array of dimension 0")
 
     def test_parameter_bug(self) -> None:
         """Test bug with parameters arising from interaction of

--- a/cvxpy/tests/test_expression_methods.py
+++ b/cvxpy/tests/test_expression_methods.py
@@ -240,41 +240,42 @@ class TestExpressionMethods(BaseTest):
 
 
     def test_max(self) -> None:
-        """Test max.
+        """
+        Test max.
         """
         # One arg, test sign.
         self.assertEqual(Variable().max().sign, s.UNKNOWN)
 
         # Test with axis argument.
         self.assertEqual(Variable(2).max(axis=0, keepdims=True).shape, (1,))
-        self.assertEqual(Variable(2).max(axis=1).shape, (2,))
         self.assertEqual(Variable((2, 3)).max(axis=0, keepdims=True).shape, (1, 3))
         self.assertEqual(Variable((2, 3)).max(axis=1).shape, (2,))
 
         # Invalid axis.
         with self.assertRaises(Exception) as cm:
             self.x.max(axis=4)
-        self.assertEqual(str(cm.exception), "Invalid argument for axis.")
+        self.assertEqual(str(cm.exception), "axis 4 is out of bounds for array of dimension 1")
 
     def test_min(self) -> None:
-        """Test min.
+        """
+        Test min.
         """
         # One arg, test sign.
         self.assertEqual(Variable().min().sign, s.UNKNOWN)
 
         # Test with axis argument.
         self.assertEqual(Variable(2).min(axis=0).shape, tuple())
-        self.assertEqual(Variable(2).min(axis=1).shape, (2,))
         self.assertEqual(Variable((2, 3)).min(axis=0).shape, (3,))
         self.assertEqual(Variable((2, 3)).min(axis=1).shape, (2,))
 
         # Invalid axis.
         with self.assertRaises(Exception) as cm:
             self.x.min(axis=4)
-        self.assertEqual(str(cm.exception), "Invalid argument for axis.")
+        self.assertEqual(str(cm.exception), "axis 4 is out of bounds for array of dimension 1")
 
     def test_sum(self) -> None:
-        """Test the sum atom.
+        """
+        Test the sum atom.
         """
         self.assertEqual(Constant([1, -1]).sum().sign, s.UNKNOWN)
         self.assertEqual(Constant([1, -1]).sum().curvature, s.CONSTANT)
@@ -288,7 +289,6 @@ class TestExpressionMethods(BaseTest):
 
         # Test with axis argument.
         self.assertEqual(Variable(2).sum(axis=0).shape, tuple())
-        self.assertEqual(Variable(2).sum(axis=1).shape, (2,))
         self.assertEqual(Variable((2, 3)).sum(axis=0, keepdims=True).shape, (1, 3))
         self.assertEqual(Variable((2, 3)).sum(axis=0, keepdims=False).shape, (3,))
         self.assertEqual(Variable((2, 3)).sum(axis=1).shape, (2,))
@@ -297,7 +297,7 @@ class TestExpressionMethods(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.sum(self.x, axis=4)
         self.assertEqual(str(cm.exception),
-                         "Invalid argument for axis.")
+                        "axis 4 is out of bounds for array of dimension 1")
 
         A = sp.eye(3)
         self.assertEqual(Constant(A).sum().value, 3)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1537,16 +1537,22 @@ class TestND_Expressions(BaseTest):
     
     def test_nd_variable(self) -> None:
         x = Variable((2, 2, 2))
-        y = np.arange(8).reshape(2,2,2)
+        y = (np.arange(8) + 1).reshape(2,2,2)
         obj = cp.Minimize(0)
         prob = cp.Problem(obj, [x == y])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(x.value, y)
 
         x = Variable((2, 2, 2))
-        expr = x.sum(axis=1)
-        target = y.sum(axis=1)
-        obj = cp.Minimize(0)
+        expr = cp.multiply(x, 3)
+        target = y
+        prob = cp.Problem(obj, [expr == target])
+        prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+        assert np.allclose(expr.value, target)
+
+        x = Variable((2, 2, 2))
+        expr = x / y
+        target = y
         prob = cp.Problem(obj, [expr == target])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, target)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1576,3 +1576,11 @@ class TestND_Expressions(BaseTest):
         prob = cp.Problem(obj, [expr == target])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, target)
+
+        """
+        x = Variable((2, 2, 2))
+        expr = cp.sum(x, axis=2, keepdims=True)
+        prob = cp.Problem(obj, [expr == target.sum(axis=2, keepdims=True)])
+        prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+        assert np.allclose(expr.value, target)
+        """

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1537,22 +1537,42 @@ class TestND_Expressions(BaseTest):
     
     def test_nd_variable(self) -> None:
         x = Variable((2, 2, 2))
-        y = (np.arange(8) + 1).reshape(2,2,2)
+        target = (np.arange(8) + 1).reshape(2,2,2)
         obj = cp.Minimize(0)
-        prob = cp.Problem(obj, [x == y])
+        prob = cp.Problem(obj, [x == target])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
-        assert np.allclose(x.value, y)
+        assert np.allclose(x.value, target)
 
         x = Variable((2, 2, 2))
         expr = cp.multiply(x, 3)
-        target = y
         prob = cp.Problem(obj, [expr == target])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, target)
 
         x = Variable((2, 2, 2))
-        expr = x / y
-        target = y
+        expr = x / target
+        prob = cp.Problem(obj, [expr == target])
+        prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+        assert np.allclose(expr.value, target)
+
+        x = Variable((1, 2, 2))
+        z = Variable((1, 2, 2))
+        expr = cp.vstack([x,z])
+        prob = cp.Problem(obj, [expr == target])
+        prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+        assert np.allclose(expr.value, target)
+
+        """
+        x = Variable((2, 1, 2))
+        z = Variable((2, 1, 2))
+        expr = cp.hstack([x,z])
+        prob = cp.Problem(obj, [expr == target])
+        prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+        assert np.allclose(expr.value, target)
+        """
+
+        x = [cp.Variable((2,2,2)) for i in range(10)]
+        expr = sum(x)
         prob = cp.Problem(obj, [expr == target])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, target)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1531,13 +1531,13 @@ class TestND_Expressions():
     def test_nd_variable_warning(self) -> None:
         prob = cp.Problem(self.obj, [self.x == self.target])
         warning_str = "The problem has an expression with dimension greater than 2. " \
-                    "Defaulting to the 'SCIPY' backend for canonicalization."
+                    "Defaulting to the SCIPY backend for canonicalization."
         with pytest.warns(UserWarning, match=warning_str):
             prob.solve()
 
     def test_nd_variable_value_error(self) -> None:
         prob = cp.Problem(self.obj, [self.x == self.target])
-        error_str = "Only the 'SCIPY' and 'NUMPY' backends are supported " \
+        error_str = "Only the SCIPY and NUMPY backends are supported " \
                     "for problems with expressions of dimension greater than 2."
         with pytest.raises(ValueError, match=error_str):
             prob.solve(canon_backend=cp.CPP_CANON_BACKEND)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1532,3 +1532,21 @@ class TestExpressions(BaseTest):
         expr = hermitian_wrap(U)
         assert expr.is_hermitian()
 
+
+class TestND_Expressions(BaseTest):
+    
+    def test_nd_variable(self) -> None:
+        x = Variable((2, 2, 2))
+        y = np.arange(8).reshape(2,2,2)
+        obj = cp.Minimize(0)
+        prob = cp.Problem(obj, [x == y])
+        prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+        assert np.allclose(x.value, y)
+
+        x = Variable((2, 2, 2))
+        expr = x.sum(axis=1)
+        target = y.sum(axis=1)
+        obj = cp.Minimize(0)
+        prob = cp.Problem(obj, [expr == target])
+        prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+        assert np.allclose(expr.value, target)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1528,6 +1528,20 @@ class TestND_Expressions():
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(self.x.value, self.target)
 
+    def test_nd_variable_warning(self) -> None:
+        prob = cp.Problem(self.obj, [self.x == self.target])
+        warning_str = "The problem has an expression with dimension greater than 2. " \
+                    "Defaulting to the 'SCIPY' backend for canonicalization."
+        with pytest.warns(UserWarning, match=warning_str):
+            prob.solve()
+
+    def test_nd_variable_value_error(self) -> None:
+        prob = cp.Problem(self.obj, [self.x == self.target])
+        error_str = "Only the 'SCIPY' and 'NUMPY' backends are supported " \
+                    "for problems with expressions of dimension greater than 2."
+        with pytest.raises(ValueError, match=error_str):
+            prob.solve(canon_backend=cp.CPP_CANON_BACKEND)
+
     def test_nd_mul_elem(self) -> None:
         expr = cp.multiply(self.x, 3)
         prob = cp.Problem(self.obj, [expr == self.target])

--- a/cvxpy/tests/test_python_backends.py
+++ b/cvxpy/tests/test_python_backends.py
@@ -1085,18 +1085,18 @@ class TestBackends:
         assert view.combine_potentially_none(None, a) == a
         assert view.combine_potentially_none(a, b) == view.add_dicts(a, b)
 
-    def test_sum(self, backend):
+    def test_nd_sum_entries(self, backend):
         """
         define x = Variable((2,2,2)) with
-        [[[x1, x5],
-        [x3, x7]],
+        [[[x111, x112],
+        [x121, x122]],
 
-        [[x2, x6],
-        [x4, x8]]]
+        [[x211, x212],
+        [x221, x222]]]
 
         x is represented as eye(8) in the A matrix (in column-major order), i.e.,
 
-         x1  x3  x5  x7  x2  x4  x6  x8
+        x111 x211 x121 x221 x112 x212 x122 x222
         [[1   0   0   0   0   0   0   0],
          [0   1   0   0   0   0   0   0],
          [0   0   1   0   0   0   0   0],
@@ -1106,31 +1106,46 @@ class TestBackends:
          [0   0   0   0   0   0   1   0],
          [0   0   0   0   0   0   0   1]]
 
-        sum(x, axis = 0, keepdims = True) means we only consider entries in a given axis (axes)
+        sum(x, axis = 0) means we only consider entries in a given axis (axes)
 
         which, when using the same columns as before, now maps to
-
-         x1  x3  x5  x7  x2  x4  x6  x8
-        [[1   0   0   0   1   0   0   0],
-         [0   1   0   0   0   1   0   0],
-         [0   0   1   0   0   0   1   0],
-         [0   0   0   1   0   0   0   1]]
-
-        sum(x, axis = 1, keepdims = True)
-         x1  x3  x5  x7  x2  x4  x6  x8
+        
+        sum(x, axis = 0)
+        x111 x211 x121 x221 x112 x212 x122 x222
         [[1   1   0   0   0   0   0   0],
          [0   0   1   1   0   0   0   0],
          [0   0   0   0   1   1   0   0],
          [0   0   0   0   0   0   1   1]]
 
-        sum(x, axis = 2, keepdims = True)
-         x1  x3  x5  x7  x2  x4  x6  x8
+        sum(x, axis = 1)
+        x111 x211 x121 x221 x112 x212 x122 x222
         [[1   0   1   0   0   0   0   0],
          [0   1   0   1   0   0   0   0],
          [0   0   0   0   1   0   1   0],
          [0   0   0   0   0   1   0   1]]
 
-        -> It reduces to summing subsets of the rows of A.
+        sum(x, axis = 2)
+        x111 x211 x121 x221 x112 x212 x122 x222
+        [[1   0   0   0   1   0   0   0],
+         [0   1   0   0   0   1   0   0],
+         [0   0   1   0   0   0   1   0],
+         [0   0   0   1   0   0   0   1]]
+        
+        sum(x, axis = (0,1))
+        x111 x211 x121 x221 x112 x212 x122 x222
+        [[1   1   1   1   0   0   0   0],
+         [0   0   0   0   1   1   1   1]]
+
+        sum(x, axis = (0,2))
+        x111 x211 x121 x221 x112 x212 x122 x222
+        [[1   1   0   0   1   1   0   0],
+         [0   0   1   1   0   0   1   1]]
+
+        To reproduce the outputs above, eliminate the given axis (axes)
+        and put ones where the remaining axes (axis) match. 
+
+        Note: sum(x, keepdims=True) is equivalent to sum(x, keepdims=False)
+        with a reshape, which is NO-OP in the backend.
         """
 
         variable_lin_op = linOpHelper((2, 2, 2), type="variable", data=1)

--- a/cvxpy/tests/test_python_backends.py
+++ b/cvxpy/tests/test_python_backends.py
@@ -499,7 +499,7 @@ class TestBackends:
         view_A = sp.coo_matrix((view_A.data, (view_A.row, view_A.col)), shape=(2, 2)).toarray()
         assert np.all(view_A == np.eye(2))
 
-        sum_entries_lin_op = linOpHelper(data = [1, True])
+        sum_entries_lin_op = linOpHelper(shape = (2,), data = [None, True])
         out_view = backend.sum_entries(sum_entries_lin_op, view)
         A = out_view.get_tensor_representation(0, 1)
 
@@ -1141,6 +1141,11 @@ class TestBackends:
         [[1   1   0   0   1   1   0   0],
          [0   0   1   1   0   0   1   1]]
 
+        sum(x, axis = (1,2))
+        x111 x211 x121 x221 x112 x212 x122 x222
+        [[1   0   1   0   1   0   1   0],
+         [0   1   0   1   0   1   0   1]]
+
         To reproduce the outputs above, eliminate the given axis (axes)
         and put ones where the remaining axes (axis) match. 
 
@@ -1346,7 +1351,7 @@ class TestParametrizedBackends:
         mul_elem_lin_op = linOpHelper(data=param_lin_op)
         param_var_view = param_backend.mul_elem(mul_elem_lin_op, var_view)
 
-        sum_entries_lin_op = linOpHelper()
+        sum_entries_lin_op = linOpHelper(shape=(2,), data=[None, True])
         out_view = param_backend.sum_entries(sum_entries_lin_op, param_var_view)
         out_repr = out_view.get_tensor_representation(0, 1)
 

--- a/cvxpy/tests/test_python_backends.py
+++ b/cvxpy/tests/test_python_backends.py
@@ -1085,6 +1085,7 @@ class TestBackends:
         assert view.combine_potentially_none(None, a) == a
         assert view.combine_potentially_none(a, b) == view.add_dicts(a, b)
 
+
 class TestParametrizedBackends:
     @staticmethod
     @pytest.fixture(params=backends)
@@ -1770,6 +1771,7 @@ class TestParametrizedBackends:
             0, 1
         )
 
+
 class TestND_Backends:
     @staticmethod
     @pytest.fixture(params=backends)
@@ -1835,22 +1837,7 @@ class TestND_Backends:
          [0   0   1   0   0   0   1   0],
          [0   0   0   1   0   0   0   1]]
         
-        sum(x, axis = (0,1))
-        x111 x211 x121 x221 x112 x212 x122 x222
-        [[1   1   1   1   0   0   0   0],
-         [0   0   0   0   1   1   1   1]]
-
-        sum(x, axis = (0,2))
-        x111 x211 x121 x221 x112 x212 x122 x222
-        [[1   1   0   0   1   1   0   0],
-         [0   0   1   1   0   0   1   1]]
-
-        sum(x, axis = (1,2))
-        x111 x211 x121 x221 x112 x212 x122 x222
-        [[1   0   1   0   1   0   1   0],
-         [0   1   0   1   0   1   0   1]]
-
-        To reproduce the outputs above, eliminate the given axis (axes)
+        To reproduce the outputs above, eliminate the given axis
         and put ones where the remaining axes (axis) match. 
 
         Note: sum(x, keepdims=True) is equivalent to sum(x, keepdims=False)
@@ -1876,6 +1863,74 @@ class TestND_Backends:
                              [0, 0, 1, 0, 0, 0, 1, 0],
                              [0, 0, 0, 1, 0, 0, 0, 1]])
         assert np.all(A == expected)
+
+        # Note: view is edited in-place:
+        assert out_view.get_tensor_representation(0, 4) == view.get_tensor_representation(0, 4)
+
+    @pytest.mark.parametrize("axes, expected", [((0,1),
+                                                [[1, 1, 1, 1, 0, 0, 0, 0],
+                                                [0, 0, 0, 0, 1, 1, 1, 1]]),
+                                                ((0,2),
+                                                [[1, 1, 0, 0, 1, 1, 0, 0],
+                                                [0, 0, 1, 1, 0, 0, 1, 1]]),
+                                                ((2,1),
+                                                [[1, 0, 1, 0, 1, 0, 1, 0],
+                                                [0, 1, 0, 1, 0, 1, 0, 1]])])
+    def test_nd_sum_entries_multiple_axes(self, backend, axes, expected):
+        """
+        define x = Variable((2,2,2)) with
+        [[[x111, x112],
+        [x121, x122]],
+
+        [[x211, x212],
+        [x221, x222]]]
+
+        x is represented as eye(8) in the A matrix (in column-major order), i.e.,
+
+        x111 x211 x121 x221 x112 x212 x122 x222
+        [[1   0   0   0   0   0   0   0],
+         [0   1   0   0   0   0   0   0],
+         [0   0   1   0   0   0   0   0],
+         [0   0   0   1   0   0   0   0],
+         [0   0   0   0   1   0   0   0],
+         [0   0   0   0   0   1   0   0],
+         [0   0   0   0   0   0   1   0],
+         [0   0   0   0   0   0   0   1]]
+
+        sum(x, axis = (0,1))
+        x111 x211 x121 x221 x112 x212 x122 x222
+        [[1   1   1   1   0   0   0   0],
+         [0   0   0   0   1   1   1   1]]
+
+        sum(x, axis = (0,2))
+        x111 x211 x121 x221 x112 x212 x122 x222
+        [[1   1   0   0   1   1   0   0],
+         [0   0   1   1   0   0   1   1]]
+
+        sum(x, axis = (1,2))
+        x111 x211 x121 x221 x112 x212 x122 x222
+        [[1   0   1   0   1   0   1   0],
+         [0   1   0   1   0   1   0   1]]
+
+        To reproduce the outputs above, eliminate the given axes
+        and put ones where the remaining axes match.
+        """
+
+        variable_lin_op = linOpHelper((2, 2, 2), type="variable", data=1)
+        view = backend.process_constraint(variable_lin_op, backend.get_empty_view())
+
+        # cast to numpy
+        view_A = view.get_tensor_representation(0, 8)
+        view_A = sp.coo_matrix((view_A.data, (view_A.row, view_A.col)), shape=(8, 8)).toarray()
+        assert np.all(view_A == np.eye(8))
+
+        sum_lin_op = linOpHelper(shape=(2, 2, 2), data=[axes, True], args=[variable_lin_op])
+        out_view = backend.sum_entries(sum_lin_op, view)
+        A = out_view.get_tensor_representation(0, 4)
+
+        # cast to numpy
+        A = sp.coo_matrix((A.data, (A.row, A.col)), shape=(2, 8)).toarray()
+        assert np.all(A == np.array(expected))
 
         # Note: view is edited in-place:
         assert out_view.get_tensor_representation(0, 4) == view.get_tensor_representation(0, 4)

--- a/cvxpy/tests/test_python_backends.py
+++ b/cvxpy/tests/test_python_backends.py
@@ -1161,7 +1161,7 @@ class TestBackends:
         view_A = sp.coo_matrix((view_A.data, (view_A.row, view_A.col)), shape=(8, 8)).toarray()
         assert np.all(view_A == np.eye(8))
 
-        sum_lin_op = linOpHelper(shape=(2, 2, 2), data=[2, True])
+        sum_lin_op = linOpHelper(shape=(2, 2, 2), data=[2, True], args=[variable_lin_op])
         out_view = backend.sum_entries(sum_lin_op, view)
         A = out_view.get_tensor_representation(0, 4)
 

--- a/cvxpy/tests/test_shape.py
+++ b/cvxpy/tests/test_shape.py
@@ -107,6 +107,3 @@ class TestShape(unittest.TestCase):
 
         d = reshape(b, (n, n))
         self.assertEqual((a + d).shape, (n, n))
-
-class TestAxisAtom(unittest.TestCase):
-    pass

--- a/cvxpy/tests/test_shape.py
+++ b/cvxpy/tests/test_shape.py
@@ -107,3 +107,6 @@ class TestShape(unittest.TestCase):
 
         d = reshape(b, (n, n))
         self.assertEqual((a + d).shape, (n, n))
+
+class TestAxisAtom(unittest.TestCase):
+    pass

--- a/cvxpy/utilities/canonical.py
+++ b/cvxpy/utilities/canonical.py
@@ -154,6 +154,13 @@ class Canonical:
         # Remove duplicates.
         return unique_list(atom for arg in self.args for atom in arg.atoms())
 
+    @pu.compute_once
+    def _max_ndim(self) -> int:
+        """
+        The maximum number of dimensions of the sub-expression.
+        """
+        return max([self.ndim] + [arg._max_ndim() for arg in self.args])
+
 
 _MISSING = object()
 


### PR DESCRIPTION
## Description
This PR aims to add support for n-dimensional sum operations with the ability to pass in any axis, including multiple axes as well. In addition, a new function has been added to choose the correct backend depending on the dimensions of the underlying expressions of the problem. 

This PR is also a small step towards enabling full nd support in light of cvxpy 2.0, hence I have commented out the ValueErrors for related instances. 

Future todos to complement this PR:
- parametrized nd-sum
- keep the scipy backend implementation sparse (will need to do some indexing hacks).

Issue link (if applicable):

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.