### PR TITLE
updating pyproject to support numpy 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ exclude = [
     "*__init__.py"
 ]
 # The minimum Python version that should be supported
-target-version = "py37"
+target-version = "py38"
 
 
 [tool.pytest.ini_options]
@@ -25,10 +25,10 @@ testpaths = [
 
 [build-system]
 requires = [
-    "oldest-supported-numpy",
+    "numpy >= 2.0.0",
     "scipy >= 1.1.0",
     # 68.1.0 Promoted pyproject.toml's [tool.setuptools] out of beta.
-    "setuptools>=68.1.0",
+    "setuptools >= 68.1.0",
     "wheel",
     "pybind11"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ testpaths = [
 
 [build-system]
 requires = [
-    "numpy >= 2.0.0",
+    "numpy >= 2.0.0; python_version > '3.8'",
+    "oldest-supported-numpy; python_version <= '3.8'",
     "scipy >= 1.1.0",
     # 68.1.0 Promoted pyproject.toml's [tool.setuptools] out of beta.
     "setuptools >= 68.1.0",


### PR DESCRIPTION
## Description
Please include a short summary of the change.
Now that NumPy 2.0 is officially available through pip, the build systems need to reflect this change to ensure a smooth user experience. 
Using the [build](https://pypi.org/project/build/) library I was able to test the new pyproject.toml build instruction which ran successfully. 
```
Successfully built cvxpy-1.6.0.tar.gz and cvxpy-1.6.0-cp312-cp312-macosx_11_0_arm64.whl
```
These changes do not affect our support of older NumPy versions since the dependencies still list the following requirement: ``numpy >= 1.15``, see [here](https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice) for more details.

Issue link (if applicable): #2474 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.