### PR TITLE
Changing solver in tests from ECOS to CLARABEL

### DIFF
--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1227,13 +1227,13 @@ class TestAtoms(BaseTest):
         # Solve the (simple) two-stage problem by "combining" the two stages
         # (i.e., by solving a single linear program)
         p1 = Problem(Minimize(x+y), [x+y >= 3, y >= 4, x >= 5])
-        p1.solve(solver=cp.ECOS)
+        p1.solve(solver=cp.CLARABEL)
 
         # Solve the two-stage problem via partial_optimize
         p2 = Problem(Minimize(y), [x+y >= 3, y >= 4])
         g = partial_optimize(p2, [y], [x], solver='ECOS')
         p3 = Problem(Minimize(x+g), [x >= 5])
-        p3.solve(solver=cp.ECOS)
+        p3.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(p1.value, p3.value)
 
     @unittest.skipUnless(len(INSTALLED_MI_SOLVERS) > 0, 'No mixed-integer solver is installed.')
@@ -1428,7 +1428,7 @@ class TestAtoms(BaseTest):
         y = Variable((2, 2))
         obj = Minimize(cp.sum(-cp.log_normcdf(y)))
         prob = Problem(obj, [y == 2])
-        result = prob.solve(solver=cp.ECOS)
+        result = prob.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(
             -result, 4 * np.log(scipy.stats.norm.cdf(2)), places=None, delta=1e-2
         )

--- a/cvxpy/tests/test_benchmarks.py
+++ b/cvxpy/tests/test_benchmarks.py
@@ -253,7 +253,7 @@ class TestBenchmarks(BaseTest):
         start = time.time()
         A.value = np.random.randn(m, n)
         b.value = np.random.randn(m)
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         end = time.time()
 
         print('Conic canonicalization')
@@ -298,7 +298,7 @@ class TestBenchmarks(BaseTest):
         problem = cp.Problem(objective)
 
         start = time.time()
-        problem.get_problem_data(cp.ECOS, verbose=True)
+        problem.get_problem_data(cp.CLARABEL, verbose=True)
         end = time.time()
 
         print("Issue #1668 regression test")

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -363,7 +363,7 @@ class TestConstraints(BaseTest):
         c = np.arange(3)
         prob = cp.Problem(cp.Minimize(cp.sum(x)),
                           [cp.NonNeg(x - c)])
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertItemsAlmostEqual(x.value, c)
         prob.solve(solver=cp.OSQP)
         self.assertItemsAlmostEqual(x.value, c)
@@ -375,7 +375,7 @@ class TestConstraints(BaseTest):
         x = cp.Variable(3)
         c = np.arange(3)
         prob = cp.Problem(cp.Maximize(cp.sum(x)), [cp.NonPos(x - c)])
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertItemsAlmostEqual(x.value, c)
         prob.solve(solver=cp.OSQP)
         self.assertItemsAlmostEqual(x.value, c)
@@ -386,12 +386,12 @@ class TestConstraints(BaseTest):
         c = np.arange(3)
         objective = cp.Minimize(cp.sum(x))
         prob = cp.Problem(objective, [c - x <= 0])
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         dual = prob.constraints[0].dual_value
         # reported dual variables are the same with NonNeg, even though
         # the convention for how they add to the Lagrangian differs by sign.
         prob = cp.Problem(objective, [cp.NonNeg(x - c)])
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertItemsAlmostEqual(prob.constraints[0].dual_value, dual)
         prob.solve(solver=cp.OSQP)
         self.assertItemsAlmostEqual(prob.constraints[0].dual_value, dual)

--- a/cvxpy/tests/test_derivative.py
+++ b/cvxpy/tests/test_derivative.py
@@ -325,7 +325,7 @@ class TestBackward(BaseTest):
         with self.assertRaisesRegex(ValueError,
                                     "When requires_grad is True, the "
                                     "only supported solver is SCS.*"):
-            problem.solve(cp.ECOS, requires_grad=True)
+            problem.solve(cp.CLARABEL, requires_grad=True)
 
     def test_zero_in_problem_data(self) -> None:
         x = cp.Variable()

--- a/cvxpy/tests/test_domain.py
+++ b/cvxpy/tests/test_domain.py
@@ -57,7 +57,7 @@ class TestDomain(BaseTest):
             dom = expr.domain
             constr = [self.a >= -100, self.x >= 0]
             prob = Problem(Minimize(sum(self.x + self.a)), dom + constr)
-            prob.solve(solver=cp.ECOS)
+            prob.solve(solver=cp.CLARABEL)
             self.assertAlmostEqual(prob.value, 0)
             assert self.a.value >= -1e-3
             self.assertItemsAlmostEqual(self.x.value, [0, 0])
@@ -67,7 +67,7 @@ class TestDomain(BaseTest):
             dom = expr.domain
             constr = [self.a >= -100, self.x >= 0]
             prob = Problem(Minimize(sum(self.x + self.a)), dom + constr)
-            prob.solve(solver=cp.ECOS)
+            prob.solve(solver=cp.CLARABEL)
             self.assertAlmostEqual(self.a.value, -100)
             self.assertItemsAlmostEqual(self.x.value, [0, 0])
 

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -7,7 +7,7 @@ import cvxpy as cp
 import cvxpy.error as error
 from cvxpy.tests.base_test import BaseTest
 
-SOLVER = cp.ECOS
+SOLVER = cp.CLARABEL
 
 
 class TestDcp(BaseTest):

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -799,7 +799,7 @@ class TestDgp(BaseTest):
         np.testing.assert_almost_equal(w.value, np.array([4, 4]), decimal=3)
 
         alpha.value = [4.0, 4.0]
-        problem.solve(SOLVER, gp=True, enforce_dpp=True)
+        problem.solve(cp.ECOS, gp=True, enforce_dpp=True)
         self.assertAlmostEqual(problem.value, 40)
         np.testing.assert_almost_equal(h.value, np.array([20, 20]), decimal=3)
         np.testing.assert_almost_equal(w.value, np.array([1, 1]), decimal=3)

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -22,7 +22,7 @@ from cvxpy.reductions.dqcp2dcp.dqcp2dcp import Dqcp2Dcp
 from cvxpy.reductions.solvers import bisection
 from cvxpy.tests import base_test
 
-SOLVER = cp.ECOS
+SOLVER = cp.CLARABEL
 
 
 class TestDqcp(base_test.BaseTest):

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -223,7 +223,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(problem.is_dcp())
         self.assertFalse(problem.is_dgp())
 
-        problem.solve(SOLVER, qcp=True)
+        problem.solve(cp.ECOS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 72, places=1)
         self.assertAlmostEqual(x.value, 12, places=1)
         self.assertAlmostEqual(y.value, 6, places=1)
@@ -242,7 +242,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(problem.is_dcp())
         self.assertFalse(problem.is_dgp())
 
-        problem.solve(SOLVER, qcp=True)
+        problem.solve(cp.ECOS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 72, places=1)
         self.assertAlmostEqual(x.value, -12, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
@@ -262,7 +262,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(problem.is_dcp())
         self.assertFalse(problem.is_dgp())
 
-        problem.solve(SOLVER, qcp=True)
+        problem.solve(cp.ECOS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, -42, places=1)
         self.assertAlmostEqual(x.value, 7, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
@@ -281,7 +281,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(problem.is_dcp())
         self.assertFalse(problem.is_dgp())
 
-        problem.solve(SOLVER, qcp=True)
+        problem.solve(cp.ECOS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, -42, places=1)
         self.assertAlmostEqual(x.value, 7, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
@@ -294,7 +294,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(expr.is_quasiconvex())
 
         problem = cp.Problem(cp.Maximize(expr), [x <= 4, y <= 9])
-        problem.solve(SOLVER, qcp=True)
+        problem.solve(cp.ECOS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 6, places=1)
         self.assertAlmostEqual(x.value, 4, places=1)
         self.assertAlmostEqual(y.value, 9, places=1)
@@ -306,7 +306,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(expr.is_quasiconvex())
 
         problem = cp.Problem(cp.Maximize(expr), [x <= 4, y <= 9])
-        problem.solve(SOLVER, qcp=True)
+        problem.solve(cp.ECOS, qcp=True)
         # (2 + 2) * (3 + 4) = 28
         self.assertAlmostEqual(problem.objective.value, 28, places=1)
         self.assertAlmostEqual(x.value, 4, places=1)
@@ -323,7 +323,7 @@ class TestDqcp(base_test.BaseTest):
         problem = cp.Problem(cp.Minimize(expr), [x == 12, y <= 6])
         self.assertTrue(problem.is_dqcp())
 
-        problem.solve(SOLVER, qcp=True)
+        problem.solve(cp.ECOS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 2.0, places=1)
         self.assertAlmostEqual(x.value, 12, places=1)
         self.assertAlmostEqual(y.value, 6, places=1)
@@ -338,7 +338,7 @@ class TestDqcp(base_test.BaseTest):
         problem = cp.Problem(cp.Maximize(expr), [x == 12, y >= -6])
         self.assertTrue(problem.is_dqcp())
 
-        problem.solve(SOLVER, qcp=True)
+        problem.solve(cp.ECOS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, -2.0, places=1)
         self.assertAlmostEqual(x.value, 12, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
@@ -369,7 +369,7 @@ class TestDqcp(base_test.BaseTest):
 
         problem = cp.Problem(cp.Maximize(concave_frac))
         self.assertTrue(problem.is_dqcp())
-        problem.solve(SOLVER, qcp=True)
+        problem.solve(cp.ECOS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 0.428, places=1)
         self.assertAlmostEqual(x.value, 0.5, places=1)
 
@@ -454,7 +454,7 @@ class TestDqcp(base_test.BaseTest):
         a = np.ones(2)
         b = np.zeros(2)
         problem = cp.Problem(cp.Minimize(cp.dist_ratio(x, a, b)), [x <= 0.8])
-        problem.solve(SOLVER, qcp=True)
+        problem.solve(cp.ECOS, qcp=True)
         np.testing.assert_almost_equal(problem.objective.value, 0.25)
         np.testing.assert_almost_equal(x.value, np.array([0.8, 0.8]))
 
@@ -613,7 +613,7 @@ class TestDqcp(base_test.BaseTest):
         objective_fn = -cp.sqrt(x) / y
         problem = cp.Problem(cp.Minimize(objective_fn), [cp.exp(x) <= y])
         # smoke test
-        problem.solve(SOLVER, qcp=True)
+        problem.solve(cp.ECOS, qcp=True)
 
     def test_curvature(self) -> None:
         x = cp.Variable(3)
@@ -654,7 +654,7 @@ class TestDqcp(base_test.BaseTest):
         obj = cp.max((1 - 2*cp.sqrt(x) + x) / x)
         problem = cp.Problem(cp.Minimize(obj), [x[0] <= 0.5, x[1] <= 0.9])
         self.assertTrue(problem.is_dqcp())
-        problem.solve(SOLVER, qcp=True)
+        problem.solve(cp.ECOS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 0.1715, places=3)
 
     def test_min(self) -> None:

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -800,7 +800,7 @@ class TestGrad(BaseTest):
         for obj in [Minimize((self.a)**-1), Maximize(cp.entr(self.a))]:
             prob = Problem(obj, [self.x + self.a >= [5, 8]])
             # Optimize over nothing.
-            expr = partial_optimize(prob, dont_opt_vars=[self.x, self.a], solver=cp.ECOS)
+            expr = partial_optimize(prob, dont_opt_vars=[self.x, self.a], solver=cp.CLARABEL)
             self.a.value = None
             self.x.value = None
             grad = expr.grad
@@ -820,22 +820,22 @@ class TestGrad(BaseTest):
             self.assertItemsAlmostEqual(grad[self.x].toarray(), [0, 0, 0, 0])
 
             # Optimize over x.
-            expr = partial_optimize(prob, opt_vars=[self.x], solver=cp.ECOS)
+            expr = partial_optimize(prob, opt_vars=[self.x], solver=cp.CLARABEL)
             self.a.value = 1
             grad = expr.grad
             self.assertAlmostEqual(grad[self.a], obj.args[0].grad[self.a] + 0)
 
             # Optimize over a.
             fix_prob = Problem(obj, [self.x + self.a >= [5, 8], self.x == 0])
-            fix_prob.solve(solver=cp.ECOS)
+            fix_prob.solve(solver=cp.CLARABEL)
             dual_val = fix_prob.constraints[0].dual_variables[0].value
-            expr = partial_optimize(prob, opt_vars=[self.a], solver=cp.ECOS)
+            expr = partial_optimize(prob, opt_vars=[self.a], solver=cp.CLARABEL)
             self.x.value = [0, 0]
             grad = expr.grad
             self.assertItemsAlmostEqual(grad[self.x].toarray(), dual_val)
 
             # Optimize over x and a.
-            expr = partial_optimize(prob, opt_vars=[self.x, self.a], solver=cp.ECOS)
+            expr = partial_optimize(prob, opt_vars=[self.x, self.a], solver=cp.CLARABEL)
             grad = expr.grad
             self.assertAlmostEqual(grad, {})
 

--- a/cvxpy/tests/test_monotonicity.py
+++ b/cvxpy/tests/test_monotonicity.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import cvxpy as cvx
+import cvxpy as cp
 import cvxpy.settings as s
 from cvxpy.tests.base_test import BaseTest
 
@@ -24,65 +24,65 @@ class TestMonotonicity(BaseTest):
     # Test application of DCP composition rules to determine curvature.
 
     def test_dcp_curvature(self) -> None:
-        expr = 1 + cvx.exp(cvx.Variable())
+        expr = 1 + cp.exp(cp.Variable())
         self.assertEqual(expr.curvature, s.CONVEX)
 
-        expr = cvx.Parameter()*cvx.Variable(nonneg=True)
+        expr = cp.Parameter()*cp.Variable(nonneg=True)
         self.assertEqual(expr.curvature, s.AFFINE)
 
         f = lambda x: x**2 + x**0.5  # noqa E731
-        expr = f(cvx.Constant(2))
+        expr = f(cp.Constant(2))
         self.assertEqual(expr.curvature, s.CONSTANT)
 
-        expr = cvx.exp(cvx.Variable())**2
+        expr = cp.exp(cp.Variable())**2
         self.assertEqual(expr.curvature, s.CONVEX)
 
-        expr = 1 - cvx.sqrt(cvx.Variable())
+        expr = 1 - cp.sqrt(cp.Variable())
         self.assertEqual(expr.curvature, s.CONVEX)
 
-        expr = cvx.log(cvx.sqrt(cvx.Variable()))
+        expr = cp.log(cp.sqrt(cp.Variable()))
         self.assertEqual(expr.curvature, s.CONCAVE)
 
-        expr = -(cvx.exp(cvx.Variable()))**2
+        expr = -(cp.exp(cp.Variable()))**2
         self.assertEqual(expr.curvature, s.CONCAVE)
 
-        expr = cvx.log(cvx.exp(cvx.Variable()))
+        expr = cp.log(cp.exp(cp.Variable()))
         self.assertEqual(expr.is_dcp(), False)
 
-        expr = cvx.entr(cvx.Variable(nonneg=True))
+        expr = cp.entr(cp.Variable(nonneg=True))
         self.assertEqual(expr.curvature, s.CONCAVE)
 
-        expr = ((cvx.Variable()**2)**0.5)**0
+        expr = ((cp.Variable()**2)**0.5)**0
         self.assertEqual(expr.curvature, s.CONSTANT)
 
     # Test DCP composition rules with signed monotonicity.
     def test_signed_curvature(self) -> None:
         # Convex argument.
-        expr = cvx.abs(1 + cvx.exp(cvx.Variable()))
+        expr = cp.abs(1 + cp.exp(cp.Variable()))
         self.assertEqual(expr.curvature, s.CONVEX)
 
-        expr = cvx.abs(-cvx.entr(cvx.Variable()))
+        expr = cp.abs(-cp.entr(cp.Variable()))
         self.assertEqual(expr.curvature, s.UNKNOWN)
 
-        expr = cvx.abs(-cvx.log(cvx.Variable()))
+        expr = cp.abs(-cp.log(cp.Variable()))
         self.assertEqual(expr.curvature, s.UNKNOWN)
 
         # Concave argument.
-        expr = cvx.abs(cvx.log(cvx.Variable()))
+        expr = cp.abs(cp.log(cp.Variable()))
         self.assertEqual(expr.curvature, s.UNKNOWN)
 
-        expr = cvx.abs(-cvx.square(cvx.Variable()))
+        expr = cp.abs(-cp.square(cp.Variable()))
         self.assertEqual(expr.curvature, s.CONVEX)
 
-        expr = cvx.abs(cvx.entr(cvx.Variable()))
+        expr = cp.abs(cp.entr(cp.Variable()))
         self.assertEqual(expr.curvature, s.UNKNOWN)
 
         # Affine argument.
-        expr = cvx.abs(cvx.Variable(nonneg=True))
+        expr = cp.abs(cp.Variable(nonneg=True))
         self.assertEqual(expr.curvature, s.CONVEX)
 
-        expr = cvx.abs(-cvx.Variable(nonneg=True))
+        expr = cp.abs(-cp.Variable(nonneg=True))
         self.assertEqual(expr.curvature, s.CONVEX)
 
-        expr = cvx.abs(cvx.Variable())
+        expr = cp.abs(cp.Variable())
         self.assertEqual(expr.curvature, s.CONVEX)

--- a/cvxpy/tests/test_nonlinear_atoms.py
+++ b/cvxpy/tests/test_nonlinear_atoms.py
@@ -18,7 +18,7 @@ import math
 
 import numpy as np
 
-import cvxpy as cvx
+import cvxpy as cp
 from cvxpy.tests.base_test import BaseTest
 
 
@@ -26,49 +26,49 @@ class TestNonlinearAtoms(BaseTest):
     """ Unit tests for the nonlinear atoms module. """
 
     def setUp(self) -> None:
-        self.x = cvx.Variable(2, name='x')
-        self.y = cvx.Variable(2, name='y')
+        self.x = cp.Variable(2, name='x')
+        self.y = cp.Variable(2, name='y')
 
-        self.A = cvx.Variable((2, 2), name='A')
-        self.B = cvx.Variable((2, 2), name='B')
-        self.C = cvx.Variable((3, 2), name='C')
+        self.A = cp.Variable((2, 2), name='A')
+        self.B = cp.Variable((2, 2), name='B')
+        self.C = cp.Variable((3, 2), name='C')
 
     def test_log_problem(self) -> None:
         # Log in objective.
-        obj = cvx.Maximize(cvx.sum(cvx.log(self.x)))
+        obj = cp.Maximize(cp.sum(cp.log(self.x)))
         constr = [self.x <= [1, math.e]]
-        p = cvx.Problem(obj, constr)
-        result = p.solve(solver=cvx.ECOS)
+        p = cp.Problem(obj, constr)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 1)
         self.assertItemsAlmostEqual(self.x.value, [1, math.e])
 
         # Log in constraint.
-        obj = cvx.Minimize(cvx.sum(self.x))
-        constr = [cvx.log(self.x) >= 0, self.x <= [1, 1]]
-        p = cvx.Problem(obj, constr)
-        result = p.solve(solver=cvx.ECOS)
+        obj = cp.Minimize(cp.sum(self.x))
+        constr = [cp.log(self.x) >= 0, self.x <= [1, 1]]
+        p = cp.Problem(obj, constr)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 2)
         self.assertItemsAlmostEqual(self.x.value, [1, 1])
 
         # Index into log.
-        obj = cvx.Maximize(cvx.log(self.x)[1])
+        obj = cp.Maximize(cp.log(self.x)[1])
         constr = [self.x <= [1, math.e]]
-        p = cvx.Problem(obj, constr)
-        result = p.solve(solver=cvx.ECOS)
+        p = cp.Problem(obj, constr)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 1)
 
         # Scalar log.
-        obj = cvx.Maximize(cvx.log(self.x[1]))
+        obj = cp.Maximize(cp.log(self.x[1]))
         constr = [self.x <= [1, math.e]]
-        p = cvx.Problem(obj, constr)
-        result = p.solve(solver=cvx.ECOS)
+        p = cp.Problem(obj, constr)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 1)
 
     def test_entr(self) -> None:
         """Test the entr atom.
         """
-        self.assertEqual(cvx.entr(0).value, 0)
-        assert np.isneginf(cvx.entr(-1).value)
+        self.assertEqual(cp.entr(0).value, 0)
+        assert np.isneginf(cp.entr(-1).value)
 
     def test_kl_div(self) -> None:
         """Test a problem with kl_div.
@@ -82,17 +82,17 @@ class TestNonlinearAtoms(BaseTest):
         npSPriors = npSPriors / sum(npSPriors)
 
         # Reference distribution
-        p_refProb = cvx.Parameter(kK, nonneg=True)
+        p_refProb = cp.Parameter(kK, nonneg=True)
         # Distribution to be estimated
-        v_prob = cvx.Variable(kK)
-        objkl = cvx.sum(cvx.kl_div(v_prob, p_refProb))
+        v_prob = cp.Variable(kK)
+        objkl = cp.sum(cp.kl_div(v_prob, p_refProb))
 
-        constrs = [cvx.sum(v_prob) == 1]
-        klprob = cvx.Problem(cvx.Minimize(objkl), constrs)
+        constrs = [cp.sum(v_prob) == 1]
+        klprob = cp.Problem(cp.Minimize(objkl), constrs)
         p_refProb.value = npSPriors
-        klprob.solve(solver=cvx.SCS, verbose=True)
+        klprob.solve(solver=cp.SCS, verbose=True)
         self.assertItemsAlmostEqual(v_prob.value, npSPriors, places=3)
-        klprob.solve(solver=cvx.ECOS, verbose=True)
+        klprob.solve(solver=cp.CLARABEL, verbose=True)
         self.assertItemsAlmostEqual(v_prob.value, npSPriors)
 
     def test_rel_entr(self) -> None:
@@ -107,32 +107,32 @@ class TestNonlinearAtoms(BaseTest):
         npSPriors = npSPriors / sum(npSPriors)
 
         # Reference distribution
-        p_refProb = cvx.Parameter(kK, nonneg=True)
+        p_refProb = cp.Parameter(kK, nonneg=True)
         # Distribution to be estimated
-        v_prob = cvx.Variable(kK)
-        obj_rel_entr = cvx.sum(cvx.rel_entr(v_prob, p_refProb))
+        v_prob = cp.Variable(kK)
+        obj_rel_entr = cp.sum(cp.rel_entr(v_prob, p_refProb))
 
-        constrs = [cvx.sum(v_prob) == 1]
-        rel_entr_prob = cvx.Problem(cvx.Minimize(obj_rel_entr), constrs)
+        constrs = [cp.sum(v_prob) == 1]
+        rel_entr_prob = cp.Problem(cp.Minimize(obj_rel_entr), constrs)
         p_refProb.value = npSPriors
-        rel_entr_prob.solve(solver=cvx.SCS, verbose=True)
+        rel_entr_prob.solve(solver=cp.SCS, verbose=True)
         self.assertItemsAlmostEqual(v_prob.value, npSPriors, places=3)
-        rel_entr_prob.solve(solver=cvx.ECOS, verbose=True)
+        rel_entr_prob.solve(solver=cp.CLARABEL, verbose=True)
         self.assertItemsAlmostEqual(v_prob.value, npSPriors)
 
     def test_difference_kl_div_rel_entr(self) -> None:
         """A test showing the difference between kl_div and rel_entr
         """
-        x = cvx.Variable()
-        y = cvx.Variable()
+        x = cp.Variable()
+        y = cp.Variable()
 
-        kl_div_prob = cvx.Problem(cvx.Minimize(cvx.kl_div(x, y)), constraints=[x + y <= 1])
-        kl_div_prob.solve(solver=cvx.ECOS)
+        kl_div_prob = cp.Problem(cp.Minimize(cp.kl_div(x, y)), constraints=[x + y <= 1])
+        kl_div_prob.solve(solver=cp.CLARABEL)
         self.assertItemsAlmostEqual(x.value, y.value)
         self.assertItemsAlmostEqual(kl_div_prob.value, 0)
 
-        rel_entr_prob = cvx.Problem(cvx.Minimize(cvx.rel_entr(x, y)), constraints=[x + y <= 1])
-        rel_entr_prob.solve(solver=cvx.ECOS)
+        rel_entr_prob = cp.Problem(cp.Minimize(cp.rel_entr(x, y)), constraints=[x + y <= 1])
+        rel_entr_prob.solve(solver=cp.CLARABEL)
 
         """
         Reference solution computed by passing the following command to Wolfram Alpha:
@@ -147,12 +147,12 @@ class TestNonlinearAtoms(BaseTest):
         """
         for n in [5, 10, 25]:
             print(n)
-            x = cvx.Variable(n)
-            obj = cvx.Maximize(cvx.sum(cvx.entr(x)))
-            p = cvx.Problem(obj, [cvx.sum(x) == 1])
-            p.solve(solver=cvx.ECOS, verbose=True)
+            x = cp.Variable(n)
+            obj = cp.Maximize(cp.sum(cp.entr(x)))
+            p = cp.Problem(obj, [cp.sum(x) == 1])
+            p.solve(solver=cp.CLARABEL, verbose=True)
             self.assertItemsAlmostEqual(x.value, n*[1./n])
-            p.solve(solver=cvx.SCS, verbose=True)
+            p.solve(solver=cp.SCS, verbose=True)
             self.assertItemsAlmostEqual(x.value, n*[1./n], places=3)
 
     def test_exp(self) -> None:
@@ -160,12 +160,12 @@ class TestNonlinearAtoms(BaseTest):
         """
         for n in [5, 10, 25]:
             print(n)
-            x = cvx.Variable(n)
-            obj = cvx.Minimize(cvx.sum(cvx.exp(x)))
-            p = cvx.Problem(obj, [cvx.sum(x) == 1])
-            p.solve(solver=cvx.SCS, verbose=True)
+            x = cp.Variable(n)
+            obj = cp.Minimize(cp.sum(cp.exp(x)))
+            p = cp.Problem(obj, [cp.sum(x) == 1])
+            p.solve(solver=cp.SCS, verbose=True)
             self.assertItemsAlmostEqual(x.value, n*[1./n], places=3)
-            p.solve(solver=cvx.ECOS, verbose=True)
+            p.solve(solver=cp.CLARABEL, verbose=True)
             self.assertItemsAlmostEqual(x.value, n*[1./n])
 
     def test_log(self) -> None:
@@ -173,10 +173,10 @@ class TestNonlinearAtoms(BaseTest):
         """
         for n in [5, 10, 25]:
             print(n)
-            x = cvx.Variable(n)
-            obj = cvx.Maximize(cvx.sum(cvx.log(x)))
-            p = cvx.Problem(obj, [cvx.sum(x) == 1])
-            p.solve(solver=cvx.ECOS, verbose=True)
+            x = cp.Variable(n)
+            obj = cp.Maximize(cp.sum(cp.log(x)))
+            p = cp.Problem(obj, [cp.sum(x) == 1])
+            p.solve(solver=cp.CLARABEL, verbose=True)
             self.assertItemsAlmostEqual(x.value, n*[1./n])
-            p.solve(solver=cvx.SCS, verbose=True)
+            p.solve(solver=cp.SCS, verbose=True)
             self.assertItemsAlmostEqual(x.value, n*[1./n], places=2)

--- a/cvxpy/tests/test_nonlinear_atoms.py
+++ b/cvxpy/tests/test_nonlinear_atoms.py
@@ -90,9 +90,9 @@ class TestNonlinearAtoms(BaseTest):
         constrs = [cp.sum(v_prob) == 1]
         klprob = cp.Problem(cp.Minimize(objkl), constrs)
         p_refProb.value = npSPriors
-        klprob.solve(solver=cp.SCS, verbose=True)
+        klprob.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(v_prob.value, npSPriors, places=3)
-        klprob.solve(solver=cp.CLARABEL, verbose=True)
+        klprob.solve(solver=cp.ECOS)
         self.assertItemsAlmostEqual(v_prob.value, npSPriors)
 
     def test_rel_entr(self) -> None:
@@ -115,9 +115,9 @@ class TestNonlinearAtoms(BaseTest):
         constrs = [cp.sum(v_prob) == 1]
         rel_entr_prob = cp.Problem(cp.Minimize(obj_rel_entr), constrs)
         p_refProb.value = npSPriors
-        rel_entr_prob.solve(solver=cp.SCS, verbose=True)
+        rel_entr_prob.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(v_prob.value, npSPriors, places=3)
-        rel_entr_prob.solve(solver=cp.CLARABEL, verbose=True)
+        rel_entr_prob.solve(solver=cp.CLARABEL)
         self.assertItemsAlmostEqual(v_prob.value, npSPriors)
 
     def test_difference_kl_div_rel_entr(self) -> None:
@@ -150,9 +150,9 @@ class TestNonlinearAtoms(BaseTest):
             x = cp.Variable(n)
             obj = cp.Maximize(cp.sum(cp.entr(x)))
             p = cp.Problem(obj, [cp.sum(x) == 1])
-            p.solve(solver=cp.CLARABEL, verbose=True)
+            p.solve(solver=cp.ECOS)
             self.assertItemsAlmostEqual(x.value, n*[1./n])
-            p.solve(solver=cp.SCS, verbose=True)
+            p.solve(solver=cp.SCS)
             self.assertItemsAlmostEqual(x.value, n*[1./n], places=3)
 
     def test_exp(self) -> None:
@@ -163,9 +163,9 @@ class TestNonlinearAtoms(BaseTest):
             x = cp.Variable(n)
             obj = cp.Minimize(cp.sum(cp.exp(x)))
             p = cp.Problem(obj, [cp.sum(x) == 1])
-            p.solve(solver=cp.SCS, verbose=True)
+            p.solve(solver=cp.SCS)
             self.assertItemsAlmostEqual(x.value, n*[1./n], places=3)
-            p.solve(solver=cp.CLARABEL, verbose=True)
+            p.solve(solver=cp.CLARABEL)
             self.assertItemsAlmostEqual(x.value, n*[1./n])
 
     def test_log(self) -> None:
@@ -176,7 +176,7 @@ class TestNonlinearAtoms(BaseTest):
             x = cp.Variable(n)
             obj = cp.Maximize(cp.sum(cp.log(x)))
             p = cp.Problem(obj, [cp.sum(x) == 1])
-            p.solve(solver=cp.CLARABEL, verbose=True)
+            p.solve(solver=cp.CLARABEL)
             self.assertItemsAlmostEqual(x.value, n*[1./n])
-            p.solve(solver=cp.SCS, verbose=True)
+            p.solve(solver=cp.SCS)
             self.assertItemsAlmostEqual(x.value, n*[1./n], places=2)

--- a/cvxpy/tests/test_nonlinear_atoms.py
+++ b/cvxpy/tests/test_nonlinear_atoms.py
@@ -127,7 +127,7 @@ class TestNonlinearAtoms(BaseTest):
         y = cp.Variable()
 
         kl_div_prob = cp.Problem(cp.Minimize(cp.kl_div(x, y)), constraints=[x + y <= 1])
-        kl_div_prob.solve(solver=cp.CLARABEL)
+        kl_div_prob.solve(solver=cp.ECOS)
         self.assertItemsAlmostEqual(x.value, y.value)
         self.assertItemsAlmostEqual(kl_div_prob.value, 0)
 

--- a/cvxpy/tests/test_nonlinear_atoms.py
+++ b/cvxpy/tests/test_nonlinear_atoms.py
@@ -118,7 +118,7 @@ class TestNonlinearAtoms(BaseTest):
         rel_entr_prob.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(v_prob.value, npSPriors, places=3)
         rel_entr_prob.solve(solver=cp.CLARABEL)
-        self.assertItemsAlmostEqual(v_prob.value, npSPriors)
+        self.assertItemsAlmostEqual(v_prob.value, npSPriors, places=3)
 
     def test_difference_kl_div_rel_entr(self) -> None:
         """A test showing the difference between kl_div and rel_entr

--- a/cvxpy/tests/test_perspective.py
+++ b/cvxpy/tests/test_perspective.py
@@ -125,11 +125,11 @@ def test_exp():
         ExpCone(ref_x, ref_s, ref_z),
         ref_x >= 1, ref_s >= 1]
     ref_prob = cp.Problem(cp.Minimize(obj), ref_constraints)
-    ref_prob.solve(solver=cp.ECOS)
+    ref_prob.solve(solver=SOLVER)
 
     assert np.isclose(prob.value, ref_prob.value)
     assert np.isclose(x.value, ref_x.value)
-    assert np.isclose(s.value, ref_s.value, atol=1.e-5)
+    assert np.isclose(s.value, ref_s.value, atol=1.e-4)
 
 
 @pytest.fixture

--- a/cvxpy/tests/test_perspective.py
+++ b/cvxpy/tests/test_perspective.py
@@ -113,7 +113,7 @@ def test_exp():
     obj = cp.perspective(f, s)
     constraints = [s >= 1, 1 <= x]
     prob = cp.Problem(cp.Minimize(obj), constraints)
-    prob.solve(solver=cp.ECOS)
+    prob.solve(solver=SOLVER)
 
     # reference problem
     ref_x = cp.Variable()
@@ -125,7 +125,7 @@ def test_exp():
         ExpCone(ref_x, ref_s, ref_z),
         ref_x >= 1, ref_s >= 1]
     ref_prob = cp.Problem(cp.Minimize(obj), ref_constraints)
-    ref_prob.solve(solver=cp.ECOS)
+    ref_prob.solve(solver=SOLVER)
 
     assert np.isclose(prob.value, ref_prob.value)
     assert np.isclose(x.value, ref_x.value)

--- a/cvxpy/tests/test_perspective.py
+++ b/cvxpy/tests/test_perspective.py
@@ -21,6 +21,8 @@ import cvxpy as cp
 from cvxpy.atoms.perspective import perspective
 from cvxpy.constraints.exponential import ExpCone
 
+SOLVER = cp.CLARABEL
+
 
 def test_monotonicity():
     x = cp.Variable(nonneg=True)
@@ -49,7 +51,7 @@ def quad_example(request):
     obj = cp.quad_over_lin(x, s) + r*x - 4*s
     constraints = [x >= 2, s <= .5]
     prob_ref = cp.Problem(cp.Minimize(obj), constraints)
-    prob_ref.solve(solver=cp.ECOS)
+    prob_ref.solve(solver=SOLVER)
 
     return prob_ref.value, s.value, x.value, r
 
@@ -62,7 +64,7 @@ def test_p_norms(p):
     obj = cp.perspective(f, s)
     constraints = [1 == s, x >= [1, 2, 3]]
     prob = cp.Problem(cp.Minimize(obj), constraints)
-    prob.solve(solver=cp.ECOS)
+    prob.solve(solver=SOLVER)
 
     # reference problem
     ref_x = cp.Variable(3, pos=True)
@@ -88,7 +90,7 @@ def test_rel_entr(cvx):
     obj = cp.perspective(f, s)
     constraints = [1 <= s, s <= 2, 1 <= x, x <= 2]
     prob = cp.Problem(cp.Minimize(obj) if cvx else cp.Maximize(obj), constraints)
-    prob.solve(solver=cp.ECOS)
+    prob.solve(solver=SOLVER)
 
     # reference problem
     ref_x = cp.Variable()
@@ -97,7 +99,7 @@ def test_rel_entr(cvx):
 
     ref_constraints = [1 <= ref_x, ref_x <= 2, 1 <= ref_s, ref_s <= 2]
     ref_prob = cp.Problem(cp.Minimize(obj) if cvx else cp.Maximize(obj), ref_constraints)
-    ref_prob.solve(solver=cp.ECOS)
+    ref_prob.solve(solver=SOLVER)
 
     assert np.isclose(prob.value, ref_prob.value)
     assert np.allclose(x.value, ref_x.value)
@@ -111,7 +113,7 @@ def test_exp():
     obj = cp.perspective(f, s)
     constraints = [s >= 1, 1 <= x]
     prob = cp.Problem(cp.Minimize(obj), constraints)
-    prob.solve(solver=cp.ECOS)
+    prob.solve(solver=SOLVER)
 
     # reference problem
     ref_x = cp.Variable()
@@ -123,7 +125,7 @@ def test_exp():
         ExpCone(ref_x, ref_s, ref_z),
         ref_x >= 1, ref_s >= 1]
     ref_prob = cp.Problem(cp.Minimize(obj), ref_constraints)
-    ref_prob.solve(solver=cp.ECOS)
+    ref_prob.solve(solver=SOLVER)
 
     assert np.isclose(prob.value, ref_prob.value)
     assert np.isclose(x.value, ref_x.value)
@@ -143,7 +145,7 @@ def lse_example():
         [1, 2, 3] <= ref_x, 1 <= ref_s, ref_s <= 2]
     ref_constraints += [ExpCone(ref_x[i]-ref_t, ref_s, ref_z[i]) for i in range(3)]
     ref_prob = cp.Problem(cp.Minimize(ref_t), ref_constraints)
-    ref_prob.solve(solver=cp.ECOS)
+    ref_prob.solve(solver=SOLVER)
 
     return ref_prob.value, ref_x.value, ref_s.value
 
@@ -156,7 +158,7 @@ def test_lse(lse_example):
     obj = cp.perspective(f, s)
     constraints = [1 <= s, s <= 2, [1, 2, 3] <= x]
     prob = cp.Problem(cp.Minimize(obj), constraints)
-    prob.solve(solver=cp.ECOS)
+    prob.solve(solver=SOLVER)
 
     ref_prob, ref_x, ref_s = lse_example
 
@@ -173,7 +175,7 @@ def test_lse_atom(lse_example):
     obj = cp.perspective(f_exp, s)
     constraints = [1 <= s, s <= 2, [1, 2, 3] <= x]
     prob = cp.Problem(cp.Minimize(obj), constraints)
-    prob.solve(solver=cp.ECOS)
+    prob.solve(solver=SOLVER)
 
     # reference problem
     ref_prob, ref_x, ref_s = lse_example
@@ -255,7 +257,7 @@ def test_quad_quad():
     constraints = [ref_x >= 5, ref_s <= 3]
     ref_prob = cp.Problem(cp.Minimize(obj), constraints)
 
-    ref_prob.solve(solver=cp.ECOS)
+    ref_prob.solve(solver=SOLVER)
 
     # perspective problem
     x = cp.Variable()
@@ -266,7 +268,7 @@ def test_quad_quad():
     constraints = [x >= 5, s <= 3]
 
     prob = cp.Problem(cp.Minimize(obj), constraints)
-    prob.solve(solver=cp.ECOS)
+    prob.solve(solver=SOLVER)
 
     assert np.isclose(prob.value, ref_prob.value)
     assert np.isclose(x.value, ref_x.value)
@@ -295,7 +297,7 @@ def test_power(n):
     constraints = [x >= 1, s <= .5]
 
     prob = cp.Problem(cp.Minimize(obj), constraints)
-    prob.solve(solver=cp.ECOS)
+    prob.solve(solver=SOLVER)
 
     assert np.isclose(prob.value, ref_prob.value)
     assert np.isclose(x.value, ref_x.value)

--- a/cvxpy/tests/test_perspective.py
+++ b/cvxpy/tests/test_perspective.py
@@ -125,11 +125,11 @@ def test_exp():
         ExpCone(ref_x, ref_s, ref_z),
         ref_x >= 1, ref_s >= 1]
     ref_prob = cp.Problem(cp.Minimize(obj), ref_constraints)
-    ref_prob.solve(solver=SOLVER)
+    ref_prob.solve(solver=cp.ECOS)
 
     assert np.isclose(prob.value, ref_prob.value)
     assert np.isclose(x.value, ref_x.value)
-    assert np.isclose(s.value, ref_s.value)
+    assert np.isclose(s.value, ref_s.value, atol=1.e-5)
 
 
 @pytest.fixture

--- a/cvxpy/tests/test_perspective.py
+++ b/cvxpy/tests/test_perspective.py
@@ -113,7 +113,7 @@ def test_exp():
     obj = cp.perspective(f, s)
     constraints = [s >= 1, 1 <= x]
     prob = cp.Problem(cp.Minimize(obj), constraints)
-    prob.solve(solver=SOLVER)
+    prob.solve(solver=cp.ECOS)
 
     # reference problem
     ref_x = cp.Variable()
@@ -125,7 +125,7 @@ def test_exp():
         ExpCone(ref_x, ref_s, ref_z),
         ref_x >= 1, ref_s >= 1]
     ref_prob = cp.Problem(cp.Minimize(obj), ref_constraints)
-    ref_prob.solve(solver=SOLVER)
+    ref_prob.solve(solver=cp.ECOS)
 
     assert np.isclose(prob.value, ref_prob.value)
     assert np.isclose(x.value, ref_x.value)

--- a/cvxpy/tests/test_perspective.py
+++ b/cvxpy/tests/test_perspective.py
@@ -117,7 +117,7 @@ def test_exp():
 
     # reference problem
     ref_x = cp.Variable()
-    ref_s = cp.Variable()
+    ref_s = cp.Variable(nonneg=True)
     ref_z = cp.Variable()
 
     obj = ref_z

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -581,19 +581,22 @@ class TestProblem(BaseTest):
         combo1 = prob1 + 2 * prob2
         combo1_ref = Problem(cp.Minimize(self.a + 4 * self.b),
                              [self.a >= self.b, self.a >= 1, self.b >= 2])
-        self.assertAlmostEqual(combo1.solve(solver=cp.ECOS), combo1_ref.solve(solver=cp.ECOS))
+        self.assertAlmostEqual(combo1.solve(solver=cp.CLARABEL), 
+                               combo1_ref.solve(solver=cp.CLARABEL))
 
         # division and subtraction
         combo2 = prob1 - prob3/2
         combo2_ref = Problem(cp.Minimize(self.a + pow(self.b + self.a, 2)/2),
                              [self.b >= 3, self.a >= self.b])
-        self.assertAlmostEqual(combo2.solve(solver=cp.ECOS), combo2_ref.solve(solver=cp.ECOS))
+        self.assertAlmostEqual(combo2.solve(solver=cp.CLARABEL), 
+                               combo2_ref.solve(solver=cp.CLARABEL))
 
         # multiplication with 0 (prob2's constraints should still hold)
         combo3 = prob1 + 0 * prob2 - 3 * prob3
         combo3_ref = Problem(cp.Minimize(self.a + 3 * pow(self.b + self.a, 2)),
                              [self.a >= self.b, self.a >= 1, self.b >= 3])
-        self.assertAlmostEqual(combo3.solve(solver=cp.ECOS), combo3_ref.solve(solver=cp.ECOS))
+        self.assertAlmostEqual(combo3.solve(solver=cp.CLARABEL), 
+                               combo3_ref.solve(solver=cp.CLARABEL))
 
     # Test scalar LP problems.
     def test_scalar_lp(self) -> None:
@@ -708,7 +711,7 @@ class TestProblem(BaseTest):
         T = Constant(numpy.ones((2, 3))*2).value
         p = Problem(cp.Minimize(1), [self.A >= T @ self.C,
                                      self.A == self.B, self.C == T.T])
-        result = p.solve(solver=cp.ECOS)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 1)
         self.assertItemsAlmostEqual(self.A.value, self.B.value)
         self.assertItemsAlmostEqual(self.C.value, T)
@@ -720,7 +723,7 @@ class TestProblem(BaseTest):
     # Test variable promotion.
     def test_variable_promotion(self) -> None:
         p = Problem(cp.Minimize(self.a), [self.x <= self.a, self.x == [1, 2]])
-        result = p.solve(solver=cp.ECOS)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 2)
         self.assertAlmostEqual(self.a.value, 2)
 
@@ -728,14 +731,14 @@ class TestProblem(BaseTest):
                     [self.A <= self.a,
                      self.A == [[1, 2], [3, 4]]
                      ])
-        result = p.solve(solver=cp.ECOS)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 4)
         self.assertAlmostEqual(self.a.value, 4)
 
         # Promotion must happen before the multiplication.
         p = Problem(cp.Minimize([[1], [1]] @ (self.x + self.a + 1)),
                     [self.a + self.x >= [1, 2]])
-        result = p.solve(solver=cp.ECOS)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 5)
 
     # Test parameter promotion.
@@ -791,7 +794,7 @@ class TestProblem(BaseTest):
         # Vector arguments.
         p = Problem(cp.Minimize(cp.norm_inf(self.x - self.z) + 5),
                     [self.x >= [2, 3], self.z <= [-1, -4]])
-        result = p.solve(solver=cp.ECOS)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(float(result), 12)
         self.assertAlmostEqual(float(list(self.x.value)[1] - list(self.z.value)[1]), 7)
 
@@ -1320,7 +1323,7 @@ class TestProblem(BaseTest):
         self.assertEqual(exp.value, 0)
         obj = cp.Minimize(exp)
         p = Problem(obj)
-        result = p.solve(solver=cp.ECOS)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 0)
         assert self.a.value is not None
 
@@ -1329,14 +1332,14 @@ class TestProblem(BaseTest):
         """
         obj = cp.Minimize(cp.norm_inf(self.A/5))
         p = Problem(obj, [self.A >= 5])
-        result = p.solve(solver=cp.ECOS)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 1)
 
         c = cp.Constant([[1., -1], [2, -2]])
         expr = self.A/(1./c)
         obj = cp.Minimize(cp.norm_inf(expr))
         p = Problem(obj, [self.A == 5])
-        result = p.solve(solver=cp.ECOS)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(expr.value, [5, -5] + [10, -10])
 
@@ -1348,7 +1351,7 @@ class TestProblem(BaseTest):
         expr = self.x[:, None]/(1/c)
         obj = cp.Minimize(cp.norm_inf(expr))
         p = Problem(obj, [self.x == 5])
-        result = p.solve(solver=cp.ECOS)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(expr.value, [5, 10])
 
@@ -1358,7 +1361,7 @@ class TestProblem(BaseTest):
         expr = self.a/(1/c)
         obj = cp.Minimize(cp.norm_inf(expr))
         p = Problem(obj, [self.a == 5])
-        result = p.solve(solver=cp.ECOS)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(expr.value, [5, -5] + [10, -10])
 
@@ -1369,7 +1372,7 @@ class TestProblem(BaseTest):
         expr = cp.multiply(c, self.A)
         obj = cp.Minimize(cp.norm_inf(expr))
         p = Problem(obj, [self.A == 5])
-        result = p.solve(solver=cp.ECOS)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(expr.value, [5, -5] + [10, -10])
 
@@ -1380,7 +1383,7 @@ class TestProblem(BaseTest):
         expr = cp.multiply(c, self.x[:, None])
         obj = cp.Minimize(cp.norm_inf(expr))
         p = Problem(obj, [self.x == 5])
-        result = p.solve(solver=cp.ECOS)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 10)
         self.assertItemsAlmostEqual(expr.value.toarray(), [5, 10])
 
@@ -1769,7 +1772,7 @@ class TestProblem(BaseTest):
 
         for p in (1, 1.6, 1.3, 2, 1.99, 3, 3.7, np.inf):
             prob = Problem(cp.Minimize(cp.pnorm(x, p=p)), [x.T @ a >= 1])
-            prob.solve(solver=cp.ECOS, verbose=True)
+            prob.solve(solver=cp.CLARABEL, verbose=True)
 
             # formula is true for any a >= 0 with p > 1
             if p == np.inf:
@@ -1794,14 +1797,14 @@ class TestProblem(BaseTest):
         a = np.array([-1.0, 2, 3])
         for p in (-1, .5, .3, -2.3):
             prob = Problem(cp.Minimize(cp.sum(cp.abs(x-a))), [cp.pnorm(x, p) >= 0])
-            prob.solve(solver=cp.ECOS)
+            prob.solve(solver=cp.CLARABEL)
 
             self.assertTrue(np.allclose(prob.value, 1))
 
         a = np.array([1.0, 2, 3])
         for p in (-1, .5, .3, -2.3):
             prob = Problem(cp.Minimize(cp.sum(cp.abs(x-a))), [cp.pnorm(x, p) >= 0])
-            prob.solve(solver=cp.ECOS)
+            prob.solve(solver=cp.CLARABEL)
 
             self.assertAlmostEqual(prob.value, 0, places=6)
 
@@ -1866,7 +1869,7 @@ class TestProblem(BaseTest):
         con = [expr <= 0]
         obj = cp.Maximize(cp.sum(X))
         prob = cp.Problem(obj, con)
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertItemsAlmostEqual(expr.value, numpy.zeros(2))
 
         b = numpy.arange(10)
@@ -1875,7 +1878,7 @@ class TestProblem(BaseTest):
         con = [expr <= 0]
         obj = cp.Maximize(cp.sum(X))
         prob = cp.Problem(obj, con)
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertItemsAlmostEqual(expr.value, numpy.zeros(10))
 
     def test_bool_constr(self) -> None:
@@ -1883,41 +1886,41 @@ class TestProblem(BaseTest):
         """
         x = cp.Variable(pos=True)
         prob = cp.Problem(cp.Minimize(x), [True])
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(x.value, 0)
 
         x = cp.Variable(pos=True)
         prob = cp.Problem(cp.Minimize(x), [True]*10)
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(x.value, 0)
 
         prob = cp.Problem(cp.Minimize(x), [42 <= x] + [True]*10)
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(x.value, 42)
 
         prob = cp.Problem(cp.Minimize(x), [True] + [42 <= x] + [True] * 10)
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(x.value, 42)
 
         prob = cp.Problem(cp.Minimize(x), [False])
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
         prob = cp.Problem(cp.Minimize(x), [False]*10)
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
         prob = cp.Problem(cp.Minimize(x), [True]*10 + [False] + [True]*10)
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
         prob = cp.Problem(cp.Minimize(x), [42 <= x] + [True]*10 + [False])
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
         # only Trues, but infeasible solution since x must be non-negative.
         prob = cp.Problem(cp.Minimize(x), [True] + [x <= -42] + [True]*10)
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertEqual(prob.status, s.INFEASIBLE)
 
     def test_invalid_constr(self) -> None:
@@ -1933,12 +1936,12 @@ class TestProblem(BaseTest):
         """
         x = cp.Variable(pos=True)
         prob = cp.Problem(cp.Minimize(x))
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(x.value, 0)
 
         x = cp.Variable(neg=True)
         prob = cp.Problem(cp.Maximize(x))
-        prob.solve(solver=cp.ECOS)
+        prob.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(x.value, 0)
 
     def test_pickle(self) -> None:

--- a/cvxpy/tests/test_semidefinite_vars.py
+++ b/cvxpy/tests/test_semidefinite_vars.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 import numpy as np
 
-import cvxpy as cvx
+import cvxpy as cp
 from cvxpy.expressions.variable import Variable
 from cvxpy.tests.base_test import BaseTest
 
@@ -39,15 +39,15 @@ class TestSemidefiniteVariable(BaseTest):
         x2 = Variable((3, 3), PSD=True)
         constraints = [M + C1 == x1]
         constraints += [M + C2 == x2]
-        objective = cvx.Minimize(cvx.trace(M))
-        prob = cvx.Problem(objective, constraints)
+        objective = cp.Minimize(cp.trace(M))
+        prob = cp.Problem(objective, constraints)
         prob.solve(solver="SCS")
         assert (M.value == M.T.value).all()
 
     def test_sdp_problem(self) -> None:
         # PSD in objective.
-        obj = cvx.Minimize(cvx.sum(cvx.square(self.X - self.F)))
-        p = cvx.Problem(obj, [])
+        obj = cp.Minimize(cp.sum(cp.square(self.X - self.F)))
+        p = cp.Problem(obj, [])
         result = p.solve(solver="SCS")
         self.assertAlmostEqual(result, 1, places=4)
 
@@ -58,8 +58,8 @@ class TestSemidefiniteVariable(BaseTest):
 
         # PSD in constraint.
         # ECHU: note to self, apparently this is a source of redundancy
-        obj = cvx.Minimize(cvx.sum(cvx.square(self.Y - self.F)))
-        p = cvx.Problem(obj, [self.Y == Variable((2, 2), PSD=True)])
+        obj = cp.Minimize(cp.sum(cp.square(self.Y - self.F)))
+        p = cp.Problem(obj, [self.Y == Variable((2, 2), PSD=True)])
         result = p.solve(solver="SCS")
         self.assertAlmostEqual(result, 1, places=2)
 
@@ -69,11 +69,11 @@ class TestSemidefiniteVariable(BaseTest):
         self.assertAlmostEqual(self.Y.value[1, 1], 0, places=3)
 
         # Index into semidef.
-        obj = cvx.Minimize(cvx.square(self.X[0, 0] - 1) +
-                           cvx.square(self.X[1, 0] - 2) +
+        obj = cp.Minimize(cp.square(self.X[0, 0] - 1) +
+                           cp.square(self.X[1, 0] - 2) +
                            # square(self.X[0,1] - 3) +
-                           cvx.square(self.X[1, 1] - 4))
-        p = cvx.Problem(obj, [])
+                           cp.square(self.X[1, 1] - 4))
+        p = cp.Problem(obj, [])
         result = p.solve(solver="SCS")
         print(self.X.value)
         self.assertAlmostEqual(result, 0)


### PR DESCRIPTION
## Description
Please include a short summary of the change.
Now that we are transitioning from ECOS to CLARABEL, I think it makes sense to change all our tests to use cp.CLARABEL by default. 

P.S. Some tests are failing (mostly in ``test_DQCP``), I believe this could be due to precision or some other missing parameter? 
I am not too familiar with Clarabel, @PTNobel could you have a look please?
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.