### PR TITLE
[CI] Updates macos version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-11, windows-2022 ]
+        os: [ ubuntu-20.04, macos-12, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]
         include:
           - os: ubuntu-20.04
@@ -36,7 +36,7 @@ jobs:
             openmp: "True"
           - os: ubuntu-20.04
             python-version: 3.8
-          - os: macos-11
+          - os: macos-12
             python-version: 3.8
             single_action_config: "True"
           - os: windows-2022
@@ -84,12 +84,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-11, windows-2022 ]
+        os: [ ubuntu-20.04, macos-12, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]
         include:
           - os: ubuntu-20.04
             python-version: 3.8
-          - os: macos-11
+          - os: macos-12
             python-version: 3.8
             single_action_config: "True"
           - os: windows-2022
@@ -163,13 +163,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-11, windows-2022 ]
+        os: [ ubuntu-20.04, macos-12, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]
         include:
           - os: ubuntu-20.04
             python-version: 3.8
             pip_intall: "True"
-          - os: macos-11
+          - os: macos-12
             python-version: 3.8
             pip_install: "True"
             single_action_config: "True"

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -35,7 +35,7 @@ if [[ "$PYTHON_VERSION" == "3.12" ]]; then
 elif [[ "$PYTHON_VERSION" == "3.11" ]]; then
   python -m pip install coptpy gurobipy cplex piqp osqp diffcp "ortools>=9.7,<9.10" clarabel
 # Python 3.8 on Windows and Linux will uninstall NumPy 1.16 and install NumPy 1.24 without the exception.
-elif [[ "$PYTHON_VERSION" == "3.8" ]] && [[ "$RUNNER_OS" != "macos-11" ]]; then
+elif [[ "$PYTHON_VERSION" == "3.8" ]] && [[ "$RUNNER_OS" != "macos-12" ]]; then
   python -m pip install gurobipy clarabel piqp
 else
   python -m pip install coptpy gurobipy cplex diffcp piqp clarabel


### PR DESCRIPTION
## Description
The macos-11 label has been deprecated and will no longer be available after 28 June 2024.

To be merged after the 1.5.2 release.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.