### PR TITLE
Deal with NumPy 2.0 compatibility breaker in gurobi interface

### DIFF
--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -181,7 +181,7 @@ class GUROBI(QpSolver):
                 x_grb[idx].start = data['init_value'][idx]
         model.update()
 
-        x = np.array(model.getVars(), copy=False)
+        x = np.array(model.getVars())
 
         if A.shape[0] > 0:
             if hasattr(model, 'addMConstr'):

--- a/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/gurobi_qpif.py
@@ -181,7 +181,7 @@ class GUROBI(QpSolver):
                 x_grb[idx].start = data['init_value'][idx]
         model.update()
 
-        x = np.array(model.getVars())
+        x = np.asarray(model.getVars())
 
         if A.shape[0] > 0:
             if hasattr(model, 'addMConstr'):


### PR DESCRIPTION
## Description
The Gurobi QP interface has an unnecessary `np.array(..., copy=False)` invocation that doesn't play well with NumPy 2.0

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.