### PR TITLE
adding hypothesis dependency for testing

### DIFF
--- a/.devcontainer/startup.sh
+++ b/.devcontainer/startup.sh
@@ -1,3 +1,3 @@
 pip install -e .
-pip install pytest pre-commit
+pip install pytest hypothesis pre-commit
 pre-commit install

--- a/.github/workflows/test_backends.yml
+++ b/.github/workflows/test_backends.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install cvxpy dependencies
         run: |
           pip install .
-          pip install pytest
+          pip install pytest hypothesis
       - name: Run tests for each non-default backend
         run : |
           export CVXPY_DEFAULT_CANON_BACKEND="SCIPY"

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ tags
 
 # Things specific to this project
 cvxpy/version.py
+
+# Hypothesis testing
+.hypothesis/

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -11,23 +11,23 @@ conda config --set remote_backoff_factor 2
 conda config --set remote_read_timeout_secs 120.0
 
 if [[ "$PYTHON_VERSION" == "3.8" ]]; then
-  conda install scipy=1.3 numpy=1.16 mkl pip pytest pytest-cov openblas ecos scs osqp cvxopt proxsuite daqp "setuptools>65.5.1"
+  conda install scipy=1.3 numpy=1.16 mkl pip pytest pytest-cov hypothesis openblas ecos scs osqp cvxopt proxsuite daqp "setuptools>65.5.1"
 elif [[ "$PYTHON_VERSION" == "3.9" ]]; then
   # The earliest version of numpy that works is 1.19.
   # Given numpy 1.19, the earliest version of scipy we can use is 1.5.
-  conda install scipy=1.5 numpy=1.19 mkl pip pytest openblas ecos scs osqp cvxopt proxsuite daqp "setuptools>65.5.1"
+  conda install scipy=1.5 numpy=1.19 mkl pip pytest hypothesis openblas ecos scs osqp cvxopt proxsuite daqp "setuptools>65.5.1"
 elif [[ "$PYTHON_VERSION" == "3.10" ]]; then
     # The earliest version of numpy that works is 1.21.
     # Given numpy 1.21, the earliest version of scipy we can use is 1.7.
-    conda install scipy=1.7 numpy=1.21 mkl pip pytest openblas ecos scs osqp cvxopt proxsuite daqp "setuptools>65.5.1"
+    conda install scipy=1.7 numpy=1.21 mkl pip pytest hypothesis openblas ecos scs osqp cvxopt proxsuite daqp "setuptools>65.5.1"
 elif [[ "$PYTHON_VERSION" == "3.11" ]]; then
     # The earliest version of numpy that works is 1.23.4.
     # Given numpy 1.23.4, the earliest version of scipy we can use is 1.9.3.
-    conda install scipy=1.9.3 numpy=1.23.4 mkl pip pytest openblas ecos scs cvxopt proxsuite daqp "setuptools>65.5.1"
+    conda install scipy=1.9.3 numpy=1.23.4 mkl pip pytest hypothesis openblas ecos scs cvxopt proxsuite daqp "setuptools>65.5.1"
 elif [[ "$PYTHON_VERSION" == "3.12" ]]; then
     # The earliest version of numpy that works is 1.26.4
     # Given numpy 1.26.4, the earliest version of scipy we can use is 1.9.3.
-    conda install scipy=1.11.3 numpy=1.26.4 mkl pip pytest openblas ecos scs cvxopt proxsuite daqp "setuptools>65.5.1"
+    conda install scipy=1.11.3 numpy=1.26.4 mkl pip pytest hypothesis openblas ecos scs cvxopt proxsuite daqp "setuptools>65.5.1"
 fi
 
 if [[ "$PYTHON_VERSION" == "3.12" ]]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,12 @@ SCIPY = ["scipy"]
 SCS = ["setuptools>65.5.1"]
 XPRESS = ["xpress"]
 DAQP = ["daqp"]
+testing = ["pytest", "hypothesis"]
+doc = ["sphinx",
+       "sphinxcontrib.jquery",
+       "sphinx-inline-tabs",
+       "sphinx-design",
+       "sphinx-immaterial>=0.11.7"]
 
 [project.readme]
 file = "README.md"


### PR DESCRIPTION
## Description
Please include a short summary of the change.
In light of future PRs for the n-dimensional cvxpy support, I would like to make use of [hypothesis](https://hypothesis.readthedocs.io/en/latest/index.html) for more extensive testing. In particular, hypothesis provides [numpy specific](https://hypothesis.readthedocs.io/en/latest/numpy.html#module-hypothesis.extra.numpy) test examples. NumPy also actually uses those tests (see image below).
<img width="802" alt="image" src="https://github.com/cvxpy/cvxpy/assets/89562186/2fa7d3f6-38dd-4ce7-b5c9-7043d6bd4e88">

I also updated the pyproject.toml to reflect this new optional dependency for the test suite (as well as adding one for the documentation). 
Users can now do the following to install everything at once:
```
pip install -e ".[testing]"
```
## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.