### PR TITLE
changing built-in divmod to numpy and specifying dtype=int64

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
+++ b/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
@@ -261,9 +261,8 @@ class ConicSolver(Solver):
             # this is equivalent to but _much_ faster than:
             #    restruct_mat_rep = sp.block_diag([restruct_mat]*(problem.x.size + 1))
             #    restruct_A = restruct_mat_rep * problem.A
-            unspecified, remainder = divmod(problem.A.shape[0] *
-                                            problem.A.shape[1],
-                                            restruct_mat.shape[1])
+            unspecified, _ = np.divmod(problem.A.shape[0] * problem.A.shape[1],
+                                        restruct_mat.shape[1], dtype=np.int64)
             reshaped_A = problem.A.reshape(restruct_mat.shape[1],
                                            unspecified, order='F').tocsr()
             restructured_A = restruct_mat(reshaped_A).tocoo()


### PR DESCRIPTION
## Description
Please include a short summary of the change.
Title explains what the PR is doing. (also, removing the ``remainder`` variable since it wasn't being used)
Issue link (if applicable): #2493 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.