### PR TITLE
updating numpy dependency to 1.20 and removing support for python 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,17 +30,6 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, macos-12, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]
-        include:
-          - os: ubuntu-20.04
-            python-version: 3.8
-            openmp: "True"
-          - os: ubuntu-20.04
-            python-version: 3.8
-          - os: macos-12
-            python-version: 3.8
-            single_action_config: "True"
-          - os: windows-2022
-            python-version: 3.8
 
     env:
       RUNNER_OS: ${{ matrix.os }}
@@ -86,14 +75,6 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, macos-12, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]
-        include:
-          - os: ubuntu-20.04
-            python-version: 3.8
-          - os: macos-12
-            python-version: 3.8
-            single_action_config: "True"
-          - os: windows-2022
-            python-version: 3.8
 
     env:
       RUNNER_OS: ${{ matrix.os }}
@@ -165,17 +146,6 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, macos-12, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]
-        include:
-          - os: ubuntu-20.04
-            python-version: 3.8
-            pip_intall: "True"
-          - os: macos-12
-            python-version: 3.8
-            pip_install: "True"
-            single_action_config: "True"
-          - os: windows-2022
-            python-version: 3.8
-            pip_install: "True"
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - uses: actions/checkout@v4
         with:
           ref: gh-pages

--- a/.github/workflows/test_backends.yml
+++ b/.github/workflows/test_backends.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - uses: actions/checkout@v4
       - name: Install cvxpy dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ CVXPY has the following dependencies:
 - OSQP >= 0.6.2
 - ECOS >= 2
 - SCS >= 3.2.4.post1
-- NumPy >= 1.20
+- NumPy >= 1.20.0
 - SciPy >= 1.1.0
 
 For detailed instructions, see the [installation

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ CVXPY has the following dependencies:
 - ECOS >= 2
 - SCS >= 3.2.4.post1
 - NumPy >= 1.20.0
-- SciPy >= 1.1.0
+- SciPy >= 1.6.0
 
 For detailed instructions, see the [installation
 guide](https://www.cvxpy.org/install/index.html).

--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ conda install -c conda-forge cvxpy
 
 CVXPY has the following dependencies:
 
-- Python >= 3.8
+- Python >= 3.9
 - Clarabel >= 0.5.0
 - OSQP >= 0.6.2
 - ECOS >= 2
 - SCS >= 3.2.4.post1
-- NumPy >= 1.15
+- NumPy >= 1.20
 - SciPy >= 1.1.0
 
 For detailed instructions, see the [installation

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -11,9 +11,9 @@ conda config --set remote_backoff_factor 2
 conda config --set remote_read_timeout_secs 120.0
 
 if [[ "$PYTHON_VERSION" == "3.9" ]]; then
-  # The earliest version of numpy that works is 1.19.
-  # Given numpy 1.19, the earliest version of scipy we can use is 1.5.
-  conda install scipy=1.5 numpy=1.19 mkl pip pytest hypothesis openblas ecos scs osqp cvxopt proxsuite daqp "setuptools>65.5.1"
+  # The earliest version of numpy that works is 1.20.
+  # Given numpy 1.20, the earliest version of scipy we can use is 1.5.
+  conda install scipy=1.5 numpy=1.20 mkl pip pytest hypothesis openblas ecos scs osqp cvxopt proxsuite daqp "setuptools>65.5.1"
 elif [[ "$PYTHON_VERSION" == "3.10" ]]; then
     # The earliest version of numpy that works is 1.21.
     # Given numpy 1.21, the earliest version of scipy we can use is 1.7.

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -10,9 +10,7 @@ conda config --set remote_max_retries 10
 conda config --set remote_backoff_factor 2
 conda config --set remote_read_timeout_secs 120.0
 
-if [[ "$PYTHON_VERSION" == "3.8" ]]; then
-  conda install scipy=1.3 numpy=1.16 mkl pip pytest pytest-cov hypothesis openblas ecos scs osqp cvxopt proxsuite daqp "setuptools>65.5.1"
-elif [[ "$PYTHON_VERSION" == "3.9" ]]; then
+if [[ "$PYTHON_VERSION" == "3.9" ]]; then
   # The earliest version of numpy that works is 1.19.
   # Given numpy 1.19, the earliest version of scipy we can use is 1.5.
   conda install scipy=1.5 numpy=1.19 mkl pip pytest hypothesis openblas ecos scs osqp cvxopt proxsuite daqp "setuptools>65.5.1"
@@ -34,20 +32,15 @@ if [[ "$PYTHON_VERSION" == "3.12" ]]; then
   python -m pip install coptpy gurobipy piqp osqp clarabel
 elif [[ "$PYTHON_VERSION" == "3.11" ]]; then
   python -m pip install coptpy gurobipy cplex piqp osqp diffcp "ortools>=9.7,<9.10" clarabel
-# Python 3.8 on Windows and Linux will uninstall NumPy 1.16 and install NumPy 1.24 without the exception.
-elif [[ "$PYTHON_VERSION" == "3.8" ]]; then
-  python -m pip install gurobipy clarabel piqp
 else
   python -m pip install coptpy gurobipy cplex diffcp piqp clarabel
 fi
 
-if [[ "$PYTHON_VERSION" != "3.8" ]]; then
-  if [[ "$RUNNER_OS" == "Windows" ]]; then
-    # SDPA with OpenBLAS backend does not pass LP5 on Windows
-    python -m pip install sdpa-multiprecision
-  else
-    python -m pip install sdpa-python
-  fi
+if [[ "$RUNNER_OS" == "Windows" ]]; then
+  # SDPA with OpenBLAS backend does not pass LP5 on Windows
+  python -m pip install sdpa-multiprecision
+else
+  python -m pip install sdpa-python
 fi
 
 if [[ "$PYTHON_VERSION" == "3.11" ]] && [[ "$RUNNER_OS" != "macOS" ]]; then

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -12,8 +12,8 @@ conda config --set remote_read_timeout_secs 120.0
 
 if [[ "$PYTHON_VERSION" == "3.9" ]]; then
   # The earliest version of numpy that works is 1.20.
-  # Given numpy 1.20, the earliest version of scipy we can use is 1.5.
-  conda install scipy=1.5 numpy=1.20 mkl pip pytest hypothesis openblas ecos scs osqp cvxopt proxsuite daqp "setuptools>65.5.1"
+  # Given numpy 1.20, the earliest version of scipy we can use is 1.6.
+  conda install scipy=1.6 numpy=1.20 mkl pip pytest hypothesis openblas ecos scs osqp cvxopt proxsuite daqp "setuptools>65.5.1"
 elif [[ "$PYTHON_VERSION" == "3.10" ]]; then
     # The earliest version of numpy that works is 1.21.
     # Given numpy 1.21, the earliest version of scipy we can use is 1.7.
@@ -24,7 +24,7 @@ elif [[ "$PYTHON_VERSION" == "3.11" ]]; then
     conda install scipy=1.9.3 numpy=1.23.4 mkl pip pytest hypothesis openblas ecos scs cvxopt proxsuite daqp "setuptools>65.5.1"
 elif [[ "$PYTHON_VERSION" == "3.12" ]]; then
     # The earliest version of numpy that works is 1.26.4
-    # Given numpy 1.26.4, the earliest version of scipy we can use is 1.9.3.
+    # Given numpy 1.26.4, the earliest version of scipy we can use is 1.11.3.
     conda install scipy=1.11.3 numpy=1.26.4 mkl pip pytest hypothesis openblas ecos scs cvxopt proxsuite daqp "setuptools>65.5.1"
 fi
 

--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -68,7 +68,7 @@ class reshape(AffAtom):
             unspecified_index = shape.index(-1)
             specified = shape[1 - unspecified_index]
             assert specified >= 0, "Specified dimension must be nonnegative."
-            unspecified, remainder = divmod(size, shape[1 - unspecified_index])
+            unspecified, remainder = np.divmod(size, shape[1 - unspecified_index])
             if remainder != 0:
                 raise ValueError(
                     f"Cannot reshape expression of size {size} into shape {shape}."

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -113,7 +113,7 @@ class Leaf(expression.Expression):
         for d in shape:
             if not isinstance(d, numbers.Integral) or d <= 0:
                 raise ValueError("Invalid dimensions %s." % (shape,))
-        shape = tuple(np.int32(d) for d in shape)
+        shape = tuple(shape)
         self._shape = shape
 
         if (PSD or NSD or symmetric or diag or hermitian) and (len(shape) != 2

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -64,7 +64,7 @@ or a conda environment.
          * `CLARABEL`_ >= 0.6.0
          * `SCS`_ >= 3.0
          * `NumPy`_ >= 1.20.0
-         * `SciPy`_ >= 1.1.0
+         * `SciPy`_ >= 1.6.0
 
         All required packages are installed automatically alongside CVXPY.
 

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -59,11 +59,11 @@ or a conda environment.
 
         CVXPY has the following dependencies:
 
-         * Python >= 3.7
+         * Python >= 3.9
          * `OSQP`_ >= 0.6.2
          * `CLARABEL`_ >= 0.6.0
          * `SCS`_ >= 3.0
-         * `NumPy`_ >= 1.15
+         * `NumPy`_ >= 1.20.0
          * `SciPy`_ >= 1.1.0
 
         All required packages are installed automatically alongside CVXPY.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ exclude = [
     "*__init__.py"
 ]
 # The minimum Python version that should be supported
-target-version = "py38"
+target-version = "py39"
 
 
 [tool.pytest.ini_options]
@@ -25,8 +25,7 @@ testpaths = [
 
 [build-system]
 requires = [
-    "numpy >= 2.0.0; python_version > '3.8'",
-    "oldest-supported-numpy; python_version <= '3.8'",
+    "numpy >= 2.0.0",
     "scipy >= 1.1.0",
     # 68.1.0 Promoted pyproject.toml's [tool.setuptools] out of beta.
     "setuptools >= 68.1.0",
@@ -47,10 +46,10 @@ dependencies = [
     "ecos >= 2",
     "clarabel >= 0.5.0",
     "scs >= 3.2.4.post1",
-    "numpy >= 1.15",
+    "numpy >= 1.20",
     "scipy >= 1.1.0",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 urls = {Homepage = "https://github.com/cvxpy/cvxpy"}
 license = {text = "Apache License, Version 2.0"}
 authors = [{name = "Steven Diamond", email = "stevend2@stanford.edu"},

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.organization=cvxpy
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=cvxpy
 sonar.language=py
-sonar.python.version= 3.9, 3.10, 3.11, 3.12
+sonar.python.version= 3.8, 3.9, 3.10, 3.11, 3.12
 sonar.c.file.suffixes=-
 sonar.cpp.file.suffixes=-
 sonar.objc.file.suffixes=-

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.organization=cvxpy
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=cvxpy
 sonar.language=py
-sonar.python.version= 3.8, 3.9, 3.10, 3.11, 3.12
+sonar.python.version= 3.9, 3.10, 3.11, 3.12
 sonar.c.file.suffixes=-
 sonar.cpp.file.suffixes=-
 sonar.objc.file.suffixes=-


### PR DESCRIPTION
## Description
Please include a short summary of the change.
In light of the following PR #2488 which requires ``numpy>=1.20`` for the API function ``broadcast_shapes``,
we are both dropping support for python 3.8 (EOL in October 2024) and also bumping the minimum numpy version from ``1.19.3`` to ``1.20``. Thanks to @PTNobel for the suggestions.
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.