### PR TITLE
sparse implementation for nd sums

### DIFF
--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -1237,12 +1237,22 @@ class SciPyCanonBackend(PythonCanonBackend):
         along a specified axis.
         
         Example:
-        shape = (2,2) and axis = (1)
-        out_axes = [True, False]
-        out_idx = [[[0, 0],
-                    [1, 1]]]
-        out_dims = [2]
-        row_idx.flatten(order='F') = [0, 1, 0, 1]
+        shape = (2,2,2) and axis = (1)
+        out_axes = [True, False, True]
+        out_idx[0] = [[[0, 0],
+                       [0, 0]],
+                      [[1, 1],
+                       [1, 1]]]
+        out_idx[1] = [[[0, 1],
+                       [0, 1]],
+                      [[0, 1],
+                       [0, 1]]]
+        out_dims = [2, 2]
+        row_idx = [[[0, 2],
+                    [0, 2]],
+                   [[1, 3],
+                    [1, 3]]]
+        row_idx.flatten(order='F') = [0, 1, 0, 1, 2, 3, 2, 3]
         """
         out_axes = np.isin(range(len(shape)), axis, invert=True)
         out_idx = np.indices(shape)[out_axes]

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -1205,7 +1205,8 @@ class SciPyCanonBackend(PythonCanonBackend):
         Here, since the slices are stacked, we sum over the rows corresponding
         to the same slice.
 
-        Note for sparse nd version: we compute the row indices using _get_sum_row_indices
+        Note: we form the sparse output directly using _get_sum_row_indices and 
+        column indices in column-major order.
         """
         row_idx_func = self._get_sum_row_indices
         def func(x, p):
@@ -1236,9 +1237,10 @@ class SciPyCanonBackend(PythonCanonBackend):
         Example:
         shape = (2,2) and axis = (1)
         out_axes = [True, False]
-        out_idx = np.indices(shape)[out_axes]
+        out_idx = [[[0, 0],
+                    [1, 1]]]
         out_dims = [2]
-        row_idx = np.indices(shape)[out_axes]
+        row_idx.flatten(order='F') = [0, 1, 0, 1]
         """
         out_axes = np.isin(range(len(shape)), axis, invert=True)
         out_idx = np.indices(shape)[out_axes]

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1576,3 +1576,12 @@ class TestND_Expressions():
         prob = cp.Problem(self.obj, [expr == y])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, y)
+
+    @pytest.mark.parametrize("axis", [(0,2,4,5),((4,5)),((0,2,3,1)),((5,3,1)), ((0,1,2,5))])
+    def test_nd_big_sum(self, axis) -> None:
+        in_shape = (6,5,4,3,2,1)
+        expr = cp.Variable(shape=in_shape).sum(axis=axis, keepdims=True)
+        y = np.ones(in_shape).sum(axis=axis, keepdims=True)
+        prob = cp.Problem(self.obj, [expr == y])
+        prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+        assert np.allclose(expr.value, y)


### PR DESCRIPTION
## Description
Please include a short summary of the change.
This PR addresses a TODO in the nd sum PR. It implements a function ``get_row_sum_idx`` which computes the summands of the sum operation (similar to NumPy but symbolic). The column indices are obtained by flattening a range in fortran order. 

The idea of ``get_sum_row_idx`` is to group the entries that would correspond to a sum with the corresponding axis input. First we compute the out_dims by deleting the dims corresponding to the axis argument. Then we compute the indices corresponding to these out_dims. There will be duplicate values corresponding to the size of axis, those are the values that will be summed together. Hence the goal is to assign the same row values to all the duplicate entries in ``indices[out_dims]``. NumPy provides a function ``ravel_multi_index`` that does exactly that. 

Issue link (if applicable):

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.