### PR TITLE
Fix scipy 1.14 incompatibilities

### DIFF
--- a/cvxpy/atoms/condition_number.py
+++ b/cvxpy/atoms/condition_number.py
@@ -34,8 +34,8 @@ class condition_number(Atom):
         Requires that A be a Positive Semidefinite Matrix.
         """
         lo = hi = self.args[0].shape[0]-1
-        max_eigen = LA.eigvalsh(values[0], eigvals=(lo, hi))[0]
-        min_eigen = -LA.eigvalsh(-values[0], eigvals=(lo, hi))[0]
+        max_eigen = LA.eigvalsh(values[0], subset_by_index=(lo, hi))[0]
+        min_eigen = -LA.eigvalsh(-values[0], subset_by_index=(lo, hi))[0]
         return max_eigen / min_eigen
 
     def _domain(self) -> List[Constraint]:

--- a/cvxpy/atoms/gen_lambda_max.py
+++ b/cvxpy/atoms/gen_lambda_max.py
@@ -37,7 +37,7 @@ class gen_lambda_max(Atom):
         return LA.eigh(a=values[0],
                        b=values[1],
                        eigvals_only=True,
-                       eigvals=(lo, hi))[0]
+                       subset_by_index=(lo, hi))[0]
 
     def _domain(self) -> List[Constraint]:
         """Returns constraints describing the domain of the node.

--- a/cvxpy/atoms/lambda_max.py
+++ b/cvxpy/atoms/lambda_max.py
@@ -36,7 +36,7 @@ class lambda_max(Atom):
         Requires that A be symmetric.
         """
         lo = hi = self.args[0].shape[0]-1
-        return LA.eigvalsh(values[0], eigvals=(lo, hi))[0]
+        return LA.eigvalsh(values[0], subset_by_index=(lo, hi))[0]
 
     def _domain(self) -> List[Constraint]:
         """Returns constraints describing the domain of the node.

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -338,7 +338,7 @@ class TestSCS(BaseTest):
             constr = [x >= 1]
             prob = cp.Problem(cp.Minimize(expr), constr)
             data = prob.get_problem_data(solver=cp.SCS)
-            self.assertItemsAlmostEqual(data[0]["P"].A, 2*np.eye(2))
+            self.assertItemsAlmostEqual(data[0]["P"].toarray(), 2*np.eye(2))
             solution1 = prob.solve(solver=cp.SCS)
 
             # When use_quad_obj = False, the quadratic objective is


### PR DESCRIPTION
## Description
- The eigvals named argument of the scipy.linalg.eigvalsh has been removed in favor of subset_by_index.
- The .A attribute of sparse matrices has been removed in favor of .torray()

cf https://docs.scipy.org/doc/scipy/release/1.14.0-notes.html

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.