### PR TITLE
Avoid integer overflow error for ``nconstr`` in ``canonInterface.py``

### DIFF
--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -127,7 +127,7 @@ def reduce_problem_data_tensor(A, var_length, quad_form: bool = False):
     # add one more column for the offset if not quad_form
     if not quad_form:
         n_cols += 1
-    n_constr = np.divide(A.shape[0], n_cols, dtype=np.int64)
+    n_constr = np.divide(A.shape[0], int(n_cols), dtype=np.int64)
     shape = (n_constr, n_cols)
     indices = nonzero_rows % (n_constr)
 

--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -127,7 +127,7 @@ def reduce_problem_data_tensor(A, var_length, quad_form: bool = False):
     # add one more column for the offset if not quad_form
     if not quad_form:
         n_cols += 1
-    n_constr = A.shape[0] // int(n_cols)
+    n_constr = np.divide(A.shape[0], n_cols, dtype=np.int64)
     shape = (n_constr, n_cols)
     indices = nonzero_rows % (n_constr)
 
@@ -136,7 +136,7 @@ def reduce_problem_data_tensor(A, var_length, quad_form: bool = False):
 
     # construction of the indptr: scan through cols, and find
     # the structure of the column index pointer
-    indptr = np.zeros(n_cols + 1, dtype=np.int32)
+    indptr = np.zeros(n_cols + 1, dtype=np.int64)
     positions, counts = np.unique(cols, return_counts=True)
     indptr[positions+1] = counts
     indptr = np.cumsum(indptr)

--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -127,7 +127,7 @@ def reduce_problem_data_tensor(A, var_length, quad_form: bool = False):
     # add one more column for the offset if not quad_form
     if not quad_form:
         n_cols += 1
-    n_constr, _ = np.divmod(A.shape[0], int(n_cols), dtype=np.int64)
+    n_constr, _ = np.divmod(A.shape[0], n_cols, dtype=np.int64)
     shape = (n_constr, n_cols)
     indices = nonzero_rows % (n_constr)
 

--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -127,7 +127,7 @@ def reduce_problem_data_tensor(A, var_length, quad_form: bool = False):
     # add one more column for the offset if not quad_form
     if not quad_form:
         n_cols += 1
-    n_constr = np.divide(A.shape[0], int(n_cols), dtype=np.int64)
+    n_constr, _ = np.divmod(A.shape[0], int(n_cols), dtype=np.int64)
     shape = (n_constr, n_cols)
     indices = nonzero_rows % (n_constr)
 

--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -127,7 +127,7 @@ def reduce_problem_data_tensor(A, var_length, quad_form: bool = False):
     # add one more column for the offset if not quad_form
     if not quad_form:
         n_cols += 1
-    n_constr = A.shape[0] // (n_cols)
+    n_constr = A.shape[0] // int(n_cols)
     shape = (n_constr, n_cols)
     indices = nonzero_rows % (n_constr)
 


### PR DESCRIPTION
## Description
Please include a short summary of the change.
This PR fixes a bug that caused some benchmarks to fail. 
See the logs from asv here:
```
 canonInterface.reduce_problem_data_tensor(
File "/Users/willizz/Documents/benchmarks/env/d7b296eeadace6ef7218f773ed071d5d/lib/python3.11/site-packages/cvxpy/cvxcore/python/canonInterface.py", line 130, in reduce_problem_data_tensor
 n_constr = A.shape[0] // (n_cols)
            ~~~~~~~~~~~^^~~~~~~~~~
OverflowError: Python integer 2738598423566 out of bounds for int32
asv: benchmark failed (exit status 1)
 ```
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.