### PR TITLE
Fix type mismatch in cvxcore ProblemData.hpp

### DIFF
--- a/cvxpy/cvxcore/python/cvxcore.py
+++ b/cvxpy/cvxcore/python/cvxcore.py
@@ -233,11 +233,11 @@ class ProblemData(object):
     def getLen(self):
         return _cvxcore.ProblemData_getLen(self)
 
-    def getV(self, values):
-        return _cvxcore.ProblemData_getV(self, values)
+    def getV(self, values, num_values):
+        return _cvxcore.ProblemData_getV(self, values, num_values)
 
-    def getI(self, values):
-        return _cvxcore.ProblemData_getI(self, values)
+    def getI(self, values, num_values):
+        return _cvxcore.ProblemData_getI(self, values, num_values)
 
     def getJ(self, values):
         return _cvxcore.ProblemData_getJ(self, values)

--- a/cvxpy/cvxcore/python/cvxcore_wrap.cxx
+++ b/cvxpy/cvxcore/python/cvxcore_wrap.cxx
@@ -3168,36 +3168,37 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_char swig_types[7]
 #define SWIGTYPE_p_difference_type swig_types[8]
 #define SWIGTYPE_p_double swig_types[9]
-#define SWIGTYPE_p_key_type swig_types[10]
-#define SWIGTYPE_p_mapped_type swig_types[11]
-#define SWIGTYPE_p_operatortype swig_types[12]
-#define SWIGTYPE_p_p_PyObject swig_types[13]
-#define SWIGTYPE_p_size_type swig_types[14]
-#define SWIGTYPE_p_std__allocatorT_LinOp_const_p_t swig_types[15]
-#define SWIGTYPE_p_std__allocatorT_LinOp_p_t swig_types[16]
-#define SWIGTYPE_p_std__allocatorT_double_t swig_types[17]
-#define SWIGTYPE_p_std__allocatorT_int_t swig_types[18]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_int_const_int_t_t swig_types[19]
-#define SWIGTYPE_p_std__allocatorT_std__vectorT_double_t_t swig_types[20]
-#define SWIGTYPE_p_std__allocatorT_std__vectorT_int_t_t swig_types[21]
-#define SWIGTYPE_p_std__invalid_argument swig_types[22]
-#define SWIGTYPE_p_std__lessT_int_t swig_types[23]
-#define SWIGTYPE_p_std__mapT_int_Eigen__SparseMatrixT_double_t_std__lessT_int_t_std__allocatorT_std__pairT_int_const_Eigen__SparseMatrixT_double_t_t_t_t swig_types[24]
-#define SWIGTYPE_p_std__mapT_int_int_t swig_types[25]
-#define SWIGTYPE_p_std__mapT_int_std__mapT_int_std__vectorT_Eigen__SparseMatrixT_double_t_std__allocatorT_Eigen__SparseMatrixT_double_t_t_t_std__lessT_int_t_std__allocatorT_std__pairT_int_const_std__vectorT_Eigen__SparseMatrixT_double_t_std__allocatorT_Eigen__SparseMatrixT_double_t_t_t_t_t_t_std__lessT_int_t_std__allocatorT_std__pairT_int_const_std__mapT_int_std__vectorT_Eigen__SparseMatrixT_double_t_std__allocatorT_Eigen__SparseMatrixT_double_t_t_t_std__lessT_int_t_std__allocatorT_std__pairT_int_const_std__vectorT_Eigen__SparseMatrixT_double_t_std__allocatorT_Eigen__SparseMatrixT_double_t_t_t_t_t_t_t_t_t swig_types[26]
-#define SWIGTYPE_p_std__mapT_int_std__vectorT_Eigen__SparseMatrixT_double_t_std__allocatorT_Eigen__SparseMatrixT_double_t_t_t_std__lessT_int_t_std__allocatorT_std__pairT_int_const_std__vectorT_Eigen__SparseMatrixT_double_t_std__allocatorT_Eigen__SparseMatrixT_double_t_t_t_t_t_t swig_types[27]
-#define SWIGTYPE_p_std__mapT_int_std__vectorT_std__vectorT_double_t_t_std__lessT_int_t_std__allocatorT_std__pairT_int_const_std__vectorT_std__vectorT_double_t_t_t_t_t swig_types[28]
-#define SWIGTYPE_p_std__mapT_int_std__vectorT_std__vectorT_int_t_t_std__lessT_int_t_std__allocatorT_std__pairT_int_const_std__vectorT_std__vectorT_int_t_t_t_t_t swig_types[29]
-#define SWIGTYPE_p_std__vectorT_LinOp_const_p_t swig_types[30]
-#define SWIGTYPE_p_std__vectorT_LinOp_p_t swig_types[31]
-#define SWIGTYPE_p_std__vectorT_double_t swig_types[32]
-#define SWIGTYPE_p_std__vectorT_int_t swig_types[33]
-#define SWIGTYPE_p_std__vectorT_std__vectorT_double_t_t swig_types[34]
-#define SWIGTYPE_p_std__vectorT_std__vectorT_int_t_t swig_types[35]
-#define SWIGTYPE_p_swig__SwigPyIterator swig_types[36]
-#define SWIGTYPE_p_value_type swig_types[37]
-static swig_type_info *swig_types[39];
-static swig_module_info swig_module = {swig_types, 38, 0, 0, 0, 0};
+#define SWIGTYPE_p_int swig_types[10]
+#define SWIGTYPE_p_key_type swig_types[11]
+#define SWIGTYPE_p_mapped_type swig_types[12]
+#define SWIGTYPE_p_operatortype swig_types[13]
+#define SWIGTYPE_p_p_PyObject swig_types[14]
+#define SWIGTYPE_p_size_type swig_types[15]
+#define SWIGTYPE_p_std__allocatorT_LinOp_const_p_t swig_types[16]
+#define SWIGTYPE_p_std__allocatorT_LinOp_p_t swig_types[17]
+#define SWIGTYPE_p_std__allocatorT_double_t swig_types[18]
+#define SWIGTYPE_p_std__allocatorT_int_t swig_types[19]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_int_const_int_t_t swig_types[20]
+#define SWIGTYPE_p_std__allocatorT_std__vectorT_double_t_t swig_types[21]
+#define SWIGTYPE_p_std__allocatorT_std__vectorT_int_t_t swig_types[22]
+#define SWIGTYPE_p_std__invalid_argument swig_types[23]
+#define SWIGTYPE_p_std__lessT_int_t swig_types[24]
+#define SWIGTYPE_p_std__mapT_int_Eigen__SparseMatrixT_double_t_std__lessT_int_t_std__allocatorT_std__pairT_int_const_Eigen__SparseMatrixT_double_t_t_t_t swig_types[25]
+#define SWIGTYPE_p_std__mapT_int_int_t swig_types[26]
+#define SWIGTYPE_p_std__mapT_int_std__mapT_int_std__vectorT_Eigen__SparseMatrixT_double_t_std__allocatorT_Eigen__SparseMatrixT_double_t_t_t_std__lessT_int_t_std__allocatorT_std__pairT_int_const_std__vectorT_Eigen__SparseMatrixT_double_t_std__allocatorT_Eigen__SparseMatrixT_double_t_t_t_t_t_t_std__lessT_int_t_std__allocatorT_std__pairT_int_const_std__mapT_int_std__vectorT_Eigen__SparseMatrixT_double_t_std__allocatorT_Eigen__SparseMatrixT_double_t_t_t_std__lessT_int_t_std__allocatorT_std__pairT_int_const_std__vectorT_Eigen__SparseMatrixT_double_t_std__allocatorT_Eigen__SparseMatrixT_double_t_t_t_t_t_t_t_t_t swig_types[27]
+#define SWIGTYPE_p_std__mapT_int_std__vectorT_Eigen__SparseMatrixT_double_t_std__allocatorT_Eigen__SparseMatrixT_double_t_t_t_std__lessT_int_t_std__allocatorT_std__pairT_int_const_std__vectorT_Eigen__SparseMatrixT_double_t_std__allocatorT_Eigen__SparseMatrixT_double_t_t_t_t_t_t swig_types[28]
+#define SWIGTYPE_p_std__mapT_int_std__vectorT_std__vectorT_double_t_t_std__lessT_int_t_std__allocatorT_std__pairT_int_const_std__vectorT_std__vectorT_double_t_t_t_t_t swig_types[29]
+#define SWIGTYPE_p_std__mapT_int_std__vectorT_std__vectorT_int_t_t_std__lessT_int_t_std__allocatorT_std__pairT_int_const_std__vectorT_std__vectorT_int_t_t_t_t_t swig_types[30]
+#define SWIGTYPE_p_std__vectorT_LinOp_const_p_t swig_types[31]
+#define SWIGTYPE_p_std__vectorT_LinOp_p_t swig_types[32]
+#define SWIGTYPE_p_std__vectorT_double_t swig_types[33]
+#define SWIGTYPE_p_std__vectorT_int_t swig_types[34]
+#define SWIGTYPE_p_std__vectorT_std__vectorT_double_t_t swig_types[35]
+#define SWIGTYPE_p_std__vectorT_std__vectorT_int_t_t swig_types[36]
+#define SWIGTYPE_p_swig__SwigPyIterator swig_types[37]
+#define SWIGTYPE_p_value_type swig_types[38]
+static swig_type_info *swig_types[40];
+static swig_module_info swig_module = {swig_types, 39, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -8418,42 +8419,35 @@ fail:
 SWIGINTERN PyObject *_wrap_ProblemData_getV(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   ProblemData *arg1 = (ProblemData *) 0 ;
-  double *arg2 = (double *) 0 ;
+  int *arg2 = (int *) 0 ;
   int arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  PyObject *array2 = NULL ;
-  PyObject *swig_obj[2] ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  PyObject *swig_obj[3] ;
   
   (void)self;
-  if (!SWIG_Python_UnpackTuple(args, "ProblemData_getV", 2, 2, swig_obj)) SWIG_fail;
+  if (!SWIG_Python_UnpackTuple(args, "ProblemData_getV", 3, 3, swig_obj)) SWIG_fail;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_ProblemData, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ProblemData_getV" "', argument " "1"" of type '" "ProblemData *""'"); 
   }
   arg1 = reinterpret_cast< ProblemData * >(argp1);
-  {
-    npy_intp dims[1];
-    if (!PyLong_Check(swig_obj[1]))
-    {
-      const char* typestring = pytype_string(swig_obj[1]);
-      PyErr_Format(PyExc_TypeError,
-        "Int dimension expected.  '%s' given.",
-        typestring);
-      SWIG_fail;
-    }
-    arg3 = (int) PyLong_AsSsize_t(swig_obj[1]);
-    if (arg3 == -1 && PyErr_Occurred()) SWIG_fail;
-    dims[0] = (npy_intp) arg3;
-    array2 = PyArray_SimpleNew(1, dims, NPY_DOUBLE);
-    if (!array2) SWIG_fail;
-    arg2 = (double*) array_data(array2);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ProblemData_getV" "', argument " "2"" of type '" "int *""'"); 
   }
+  arg2 = reinterpret_cast< int * >(argp2);
+  ecode3 = SWIG_AsVal_int(swig_obj[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "ProblemData_getV" "', argument " "3"" of type '" "int""'");
+  } 
+  arg3 = static_cast< int >(val3);
   (arg1)->getV(arg2,arg3);
   resultobj = SWIG_Py_Void();
-  {
-    resultobj = SWIG_Python_AppendOutput(resultobj,(PyObject*)array2);
-  }
   return resultobj;
 fail:
   return NULL;
@@ -8463,42 +8457,35 @@ fail:
 SWIGINTERN PyObject *_wrap_ProblemData_getI(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   ProblemData *arg1 = (ProblemData *) 0 ;
-  double *arg2 = (double *) 0 ;
+  int *arg2 = (int *) 0 ;
   int arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  PyObject *array2 = NULL ;
-  PyObject *swig_obj[2] ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  PyObject *swig_obj[3] ;
   
   (void)self;
-  if (!SWIG_Python_UnpackTuple(args, "ProblemData_getI", 2, 2, swig_obj)) SWIG_fail;
+  if (!SWIG_Python_UnpackTuple(args, "ProblemData_getI", 3, 3, swig_obj)) SWIG_fail;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_ProblemData, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ProblemData_getI" "', argument " "1"" of type '" "ProblemData *""'"); 
   }
   arg1 = reinterpret_cast< ProblemData * >(argp1);
-  {
-    npy_intp dims[1];
-    if (!PyLong_Check(swig_obj[1]))
-    {
-      const char* typestring = pytype_string(swig_obj[1]);
-      PyErr_Format(PyExc_TypeError,
-        "Int dimension expected.  '%s' given.",
-        typestring);
-      SWIG_fail;
-    }
-    arg3 = (int) PyLong_AsSsize_t(swig_obj[1]);
-    if (arg3 == -1 && PyErr_Occurred()) SWIG_fail;
-    dims[0] = (npy_intp) arg3;
-    array2 = PyArray_SimpleNew(1, dims, NPY_DOUBLE);
-    if (!array2) SWIG_fail;
-    arg2 = (double*) array_data(array2);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ProblemData_getI" "', argument " "2"" of type '" "int *""'"); 
   }
+  arg2 = reinterpret_cast< int * >(argp2);
+  ecode3 = SWIG_AsVal_int(swig_obj[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "ProblemData_getI" "', argument " "3"" of type '" "int""'");
+  } 
+  arg3 = static_cast< int >(val3);
   (arg1)->getI(arg2,arg3);
   resultobj = SWIG_Py_Void();
-  {
-    resultobj = SWIG_Python_AppendOutput(resultobj,(PyObject*)array2);
-  }
   return resultobj;
 fail:
   return NULL;
@@ -21531,6 +21518,7 @@ static swig_type_info _swigt__p_allocator_type = {"_p_allocator_type", "allocato
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_difference_type = {"_p_difference_type", "difference_type *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_double = {"_p_double", "double *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_int = {"_p_int", "int *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_key_type = {"_p_key_type", "key_type *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mapped_type = {"_p_mapped_type", "mapped_type *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_operatortype = {"_p_operatortype", "OperatorType *|enum operatortype *", 0, 0, (void*)0, 0};
@@ -21571,6 +21559,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_char,
   &_swigt__p_difference_type,
   &_swigt__p_double,
+  &_swigt__p_int,
   &_swigt__p_key_type,
   &_swigt__p_mapped_type,
   &_swigt__p_operatortype,
@@ -21611,6 +21600,7 @@ static swig_cast_info _swigc__p_allocator_type[] = {  {&_swigt__p_allocator_type
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_difference_type[] = {  {&_swigt__p_difference_type, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_double[] = {  {&_swigt__p_double, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_int[] = {  {&_swigt__p_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_key_type[] = {  {&_swigt__p_key_type, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mapped_type[] = {  {&_swigt__p_mapped_type, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_operatortype[] = {  {&_swigt__p_operatortype, 0, 0, 0},{0, 0, 0, 0}};
@@ -21651,6 +21641,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_char,
   _swigc__p_difference_type,
   _swigc__p_double,
+  _swigc__p_int,
   _swigc__p_key_type,
   _swigc__p_mapped_type,
   _swigc__p_operatortype,

--- a/cvxpy/cvxcore/src/ProblemData.hpp
+++ b/cvxpy/cvxcore/src/ProblemData.hpp
@@ -77,7 +77,7 @@ public:
   /**
    * Returns the data vector V as a contiguous 1D numpy array.
    */
-  void getV(double *values, int num_values) {
+  void getV(int *values, int num_values) {
     std::vector<double> V = TensorV[param_id][vec_idx];
     for (int i = 0; i < num_values; i++) {
       values[i] = V[i];
@@ -87,7 +87,7 @@ public:
   /**
    * Returns the row index vector I as a contiguous 1D numpy array.
    */
-  void getI(double *values, int num_values) {
+  void getI(int *values, int num_values) {
     std::vector<int> I = TensorI[param_id][vec_idx];
     for (int i = 0; i < num_values; i++) {
       values[i] = I[i];

--- a/setup/extensions.py
+++ b/setup/extensions.py
@@ -48,6 +48,7 @@ cvxcore = Extension(
                   'cvxpy/cvxcore/include/'],
     extra_compile_args=compiler_args,
     extra_link_args=['-O3'],
+    undef_macros = [ "NDEBUG" ],
 )
 
 sparsecholesky = Pybind11Extension(


### PR DESCRIPTION
Ints were being stuffed into doubles. 

PS. When I run the unittests, 2 fail, but I am not sure they are due to other reasons. I've attached the test transcript for review.

## Description
Please include a short summary of the change.
Issue link (if applicable): https://github.com/cvxpy/cvxpy/issues/2519

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
[unittests.txt](https://github.com/user-attachments/files/16434879/unittests.txt)
