### PR TITLE
adding warning for eventual change of default order

### DIFF
--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -486,6 +486,6 @@ def outer(x, y):
     if y.ndim > 1:
         raise ValueError("y must be a vector.")
     
-    x = reshape(x, (x.size, 1))
-    y = reshape(y, (1, y.size))
+    x = reshape(x, (x.size, 1), order='F')
+    y = reshape(y, (1, y.size), order='F')
     return x @ y

--- a/cvxpy/atoms/affine/diag.py
+++ b/cvxpy/atoms/affine/diag.py
@@ -46,7 +46,7 @@ def diag(expr, k: int = 0) -> Union["diag_mat", "diag_vec"]:
     """
     expr = AffAtom.cast_to_const(expr)
     if expr.is_vector():
-        return diag_vec(vec(expr), k)
+        return diag_vec(vec(expr, order='F'), k)
     elif expr.ndim == 2 and expr.shape[0] == expr.shape[1]:
         assert abs(k) < expr.shape[0], "Offset out of bounds."
         return diag_mat(expr, k)

--- a/cvxpy/atoms/affine/hstack.py
+++ b/cvxpy/atoms/affine/hstack.py
@@ -34,7 +34,7 @@ def hstack(arg_list) -> "Hstack":
     arg_list = [AffAtom.cast_to_const(arg) for arg in arg_list]
     for idx, arg in enumerate(arg_list):
         if arg.ndim == 0:
-            arg_list[idx] = arg.flatten()
+            arg_list[idx] = arg.flatten(order='F')
     return Hstack(*arg_list)
 
 

--- a/cvxpy/atoms/affine/index.py
+++ b/cvxpy/atoms/affine/index.py
@@ -169,7 +169,11 @@ class special_index(AffAtom):
         """
         select_vec = np.reshape(self._select_mat, self._select_mat.size, order='F')
         identity = sp.eye(self.args[0].size).tocsc()
-        lowered = reshape(identity[select_vec] @ vec(self.args[0]), self._shape, order='F')
+        lowered = reshape(
+            identity[select_vec] @ vec(self.args[0], order='F'),
+            self._shape,
+            order='F'
+        )
         return lowered.grad
 
     def graph_implementation(

--- a/cvxpy/atoms/affine/index.py
+++ b/cvxpy/atoms/affine/index.py
@@ -167,11 +167,9 @@ class special_index(AffAtom):
         Returns:
             A map of variable to SciPy CSC sparse matrix or None.
         """
-        select_vec = np.reshape(
-          self._select_mat, self._select_mat.size, order='F')
+        select_vec = np.reshape(self._select_mat, self._select_mat.size, order='F')
         identity = sp.eye(self.args[0].size).tocsc()
-        lowered = reshape(
-          identity[select_vec] @ vec(self.args[0]), self._shape)
+        lowered = reshape(identity[select_vec] @ vec(self.args[0]), self._shape, order='F')
         return lowered.grad
 
     def graph_implementation(

--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import numbers
 import warnings
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -48,7 +48,7 @@ class reshape(AffAtom):
     order : F(ortran) or C
     """
 
-    def __init__(self, expr, shape: int | Tuple[int, ...], order: str | None = None) -> None:
+    def __init__(self, expr, shape: int | Tuple[int, ...], order: Optional[str] = None) -> None:
         if isinstance(shape, numbers.Integral):
             shape = (int(shape),)
         if not s.ALLOW_ND_EXPR and len(shape) > 2:

--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -59,7 +59,8 @@ class reshape(AffAtom):
 
         self._shape = tuple(shape)
         if order is None:
-            warnings.warn(DEFAULT_ORDER_DEPRECATION_MSG, FutureWarning)
+            reshape_order_warning = DEFAULT_ORDER_DEPRECATION_MSG.replace("FUNC_NAME", "reshape")
+            warnings.warn(reshape_order_warning, FutureWarning)
             order = 'F'
         assert order in ['F', 'C']
         self.order = order

--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import numbers
 import warnings
-from typing import List, Optional, Tuple
+from typing import List, Literal, Tuple
 
 import numpy as np
 
@@ -48,7 +48,12 @@ class reshape(AffAtom):
     order : F(ortran) or C
     """
 
-    def __init__(self, expr, shape: int | Tuple[int, ...], order: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        expr,
+        shape: int | Tuple[int, ...],
+        order: Literal["F", "C", None] = None
+    ) -> None:
         if isinstance(shape, numbers.Integral):
             shape = (int(shape),)
         if not s.ALLOW_ND_EXPR and len(shape) > 2:

--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -16,6 +16,7 @@ limitations under the License.
 from __future__ import annotations
 
 import numbers
+import warnings
 from typing import List, Tuple
 
 import numpy as np
@@ -26,7 +27,7 @@ import cvxpy.settings as s
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.atoms.affine.hstack import hstack
 from cvxpy.constraints.constraint import Constraint
-from cvxpy.expressions.expression import Expression
+from cvxpy.expressions.expression import DEFAULT_ORDER_DEPRECATION_MSG, Expression
 from cvxpy.utilities.shape import size_from_shape
 
 
@@ -47,7 +48,7 @@ class reshape(AffAtom):
     order : F(ortran) or C
     """
 
-    def __init__(self, expr, shape: int | Tuple[int, ...], order: str = 'F') -> None:
+    def __init__(self, expr, shape: int | Tuple[int, ...], order = None) -> None:
         if isinstance(shape, numbers.Integral):
             shape = (int(shape),)
         if not s.ALLOW_ND_EXPR and len(shape) > 2:
@@ -57,6 +58,9 @@ class reshape(AffAtom):
             shape = self._infer_shape(shape, expr.size)
 
         self._shape = tuple(shape)
+        if order is None:
+            warnings.warn(DEFAULT_ORDER_DEPRECATION_MSG, FutureWarning)
+            order = 'F'
         assert order in ['F', 'C']
         self.order = order
         super(reshape, self).__init__(expr)

--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -48,7 +48,7 @@ class reshape(AffAtom):
     order : F(ortran) or C
     """
 
-    def __init__(self, expr, shape: int | Tuple[int, ...], order = None) -> None:
+    def __init__(self, expr, shape: int | Tuple[int, ...], order: str | None = None) -> None:
         if isinstance(shape, numbers.Integral):
             shape = (int(shape),)
         if not s.ALLOW_ND_EXPR and len(shape) > 2:

--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -161,10 +161,10 @@ def deep_flatten(x):
         if len(x.shape) == 1:
             return x
         else:
-            return x.flatten()
+            return x.flatten(order='F')
     elif isinstance(x, np.ndarray) or isinstance(x, (int, float)):
         x = Expression.cast_to_const(x)
-        return x.flatten()
+        return x.flatten(order='F')
     # recursion
     if isinstance(x, list):
         y = []

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -141,7 +141,7 @@ def vec_to_upper_tri(expr, strict: bool = False):
     P_cols = np.arange(ell)
     P_vals = np.ones(P_cols.size)
     P = sp.csc_matrix((P_vals, (P_rows, P_cols)), shape=(n * n, ell))
-    return reshape(P @ expr, (n, n)).T
+    return reshape(P @ expr, (n, n), order='F').T
 
 
 def upper_tri_to_full(n: int) -> sp.csc_matrix:

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -117,7 +117,7 @@ def vec_to_upper_tri(expr, strict: bool = False):
     if not expr.is_vector():
         raise ValueError("The input must be a vector.")
     if expr.ndim != 1:
-        expr = vec(expr)
+        expr = vec(expr, order='F')
 
     ell = expr.shape[0]
     if strict:

--- a/cvxpy/atoms/affine/vec.py
+++ b/cvxpy/atoms/affine/vec.py
@@ -15,13 +15,13 @@ limitations under the License.
 """
 
 import warnings
-from typing import Optional
+from typing import Literal
 
 from cvxpy.atoms.affine.reshape import reshape
 from cvxpy.expressions.expression import DEFAULT_ORDER_DEPRECATION_MSG, Expression
 
 
-def vec(X, order: Optional[str] = None):
+def vec(X, order: Literal["F", "C", None] = None):
     """Flattens the matrix X into a vector.
 
     Parameters

--- a/cvxpy/atoms/affine/vec.py
+++ b/cvxpy/atoms/affine/vec.py
@@ -36,7 +36,8 @@ def vec(X, order: Optional[str] = None):
         An Expression representing the flattened matrix.
     """
     if order is None:
-        warnings.warn(DEFAULT_ORDER_DEPRECATION_MSG, FutureWarning)
+        vec_order_warning = DEFAULT_ORDER_DEPRECATION_MSG.replace("FUNC_NAME", "vec")
+        warnings.warn(vec_order_warning, FutureWarning)
         order = 'F'
     assert order in ['F', 'C']
     X = Expression.cast_to_const(X)

--- a/cvxpy/atoms/affine/vec.py
+++ b/cvxpy/atoms/affine/vec.py
@@ -14,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import warnings
+
 from cvxpy.atoms.affine.reshape import reshape
-from cvxpy.expressions.expression import Expression
+from cvxpy.expressions.expression import DEFAULT_ORDER_DEPRECATION_MSG, Expression
 
 
-def vec(X, order: str = 'F'):
+def vec(X, order = None):
     """Flattens the matrix X into a vector.
 
     Parameters
@@ -32,6 +34,9 @@ def vec(X, order: str = 'F'):
     Expression
         An Expression representing the flattened matrix.
     """
+    if order is None:
+        warnings.warn(DEFAULT_ORDER_DEPRECATION_MSG, FutureWarning)
+        order = 'F'
     assert order in ['F', 'C']
     X = Expression.cast_to_const(X)
     return reshape(X, (X.size,), order)

--- a/cvxpy/atoms/affine/vec.py
+++ b/cvxpy/atoms/affine/vec.py
@@ -20,7 +20,7 @@ from cvxpy.atoms.affine.reshape import reshape
 from cvxpy.expressions.expression import DEFAULT_ORDER_DEPRECATION_MSG, Expression
 
 
-def vec(X, order = None):
+def vec(X, order: str | None = None):
     """Flattens the matrix X into a vector.
 
     Parameters

--- a/cvxpy/atoms/affine/vec.py
+++ b/cvxpy/atoms/affine/vec.py
@@ -15,12 +15,13 @@ limitations under the License.
 """
 
 import warnings
+from typing import Optional
 
 from cvxpy.atoms.affine.reshape import reshape
 from cvxpy.expressions.expression import DEFAULT_ORDER_DEPRECATION_MSG, Expression
 
 
-def vec(X, order: str | None = None):
+def vec(X, order: Optional[str] = None):
     """Flattens the matrix X into a vector.
 
     Parameters

--- a/cvxpy/atoms/elementwise/log_normcdf.py
+++ b/cvxpy/atoms/elementwise/log_normcdf.py
@@ -49,9 +49,9 @@ def log_normcdf(x):
     b = np.array([[3.0, 2.0, 1.0, 0.0, -1.0, -2.5, -3.5]]).reshape(-1, 1)
 
     x = Expression.cast_to_const(x)
-    flat_x = reshape(x, (1, x.size))
+    flat_x = reshape(x, (1, x.size), order='F')
 
     y = A @ (b @ np.ones(flat_x.shape) - np.ones(b.shape) @ flat_x)
     out = -sum_(maximum(y, 0) ** 2, axis=0)
 
-    return reshape(out, x.shape)
+    return reshape(out, x.shape, order='F')

--- a/cvxpy/atoms/norm.py
+++ b/cvxpy/atoms/norm.py
@@ -57,7 +57,7 @@ def norm(x, p: Union[int, str] = 2, axis=None, keepdims: bool = False):
             return cvxpy.atoms.max(norm1(x, axis=0))
         # Frobenius norm
         elif p == 'fro' or (p == 2 and num_nontrivial_idxs == 1):
-            return pnorm(vec(x), 2)
+            return pnorm(vec(x, order='F'), 2)
         elif p == 2:  # matrix 2-norm is largest singular value
             return sigma_max(x)
         elif p == 'nuc':  # the nuclear norm (sum of singular values)
@@ -73,7 +73,7 @@ def norm(x, p: Union[int, str] = 2, axis=None, keepdims: bool = False):
             return norm_inf(x, axis=axis, keepdims=keepdims)
         elif str(p).lower() == "fro":
             # TODO should not work for vectors.
-            return pnorm(vec(x), 2, axis)
+            return pnorm(vec(x, order='F'), 2, axis)
         elif isinstance(p, str):
             raise RuntimeError(f'Unsupported norm option {p} for non-matrix.')
         else:

--- a/cvxpy/atoms/stats.py
+++ b/cvxpy/atoms/stats.py
@@ -40,7 +40,7 @@ def std(x, axis=None, keepdims=False, ddof=0):
     `ddof` is the quantity to use in the Bessel correction.
     """
     if axis is None:
-        return norm((x - mean(x)).flatten(), 2) / np.sqrt(x.size - ddof)
+        return norm((x - mean(x)).flatten(order='F'), 2) / np.sqrt(x.size - ddof)
     elif axis in (0, 1):
         return norm(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims) \
                 / np.sqrt(x.shape[axis] - ddof)

--- a/cvxpy/atoms/suppfunc.py
+++ b/cvxpy/atoms/suppfunc.py
@@ -109,7 +109,7 @@ class SuppFuncAtom(Atom):
         from cvxpy.problems.objective import Maximize
         from cvxpy.problems.problem import Problem
         y_val = self.args[0].value.round(decimals=9).ravel(order='F')
-        x_flat = self._parent.x.flatten()
+        x_flat = self._parent.x.flatten(order='F')
         cons = self._parent.constraints
         if len(cons) == 0:
             dummy = Variable()

--- a/cvxpy/atoms/total_variation.py
+++ b/cvxpy/atoms/total_variation.py
@@ -57,5 +57,5 @@ def tv(value, *args):
                 mat[1:rows, 0:cols-1] - mat[0:rows-1, 0:cols-1],
             ]
         length = diffs[0].shape[0]*diffs[1].shape[1]
-        stacked = vstack([reshape(diff, (1, length)) for diff in diffs])
+        stacked = vstack([reshape(diff, (1, length), order='F') for diff in diffs])
         return sum(norm(stacked, p=2, axis=0))

--- a/cvxpy/constraints/finite_set.py
+++ b/cvxpy/constraints/finite_set.py
@@ -59,7 +59,7 @@ class FiniteSet(Constraint):
         Expression = cvxtypes.expression()
         if isinstance(vec, set):
             vec = list(vec)
-        vec = Expression.cast_to_const(vec).flatten()
+        vec = Expression.cast_to_const(vec).flatten(order='F')
         if not expre.is_affine() and not expre.is_log_log_affine():
             msg = """
             Provided Expression must be affine or log-log affine, but had curvature %s.
@@ -128,7 +128,7 @@ class FiniteSet(Constraint):
         -------
         float
         """
-        expr_val = np.array(self.expre.value).flatten()
+        expr_val = np.array(self.expre.value).flatten(order='F')
         vec_val = self.vec.value
         resids = [np.min(np.abs(val - vec_val)) for val in expr_val]
         res = max(resids)

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -213,7 +213,7 @@ class PowConeND(Cone):
         self.alpha = alpha
         self.axis = axis
         if z.ndim == 0:
-            z = z.flatten()
+            z = z.flatten(order='F')
         super(PowConeND, self).__init__([W, z], constr_id)
 
     def __str__(self) -> str:
@@ -237,8 +237,9 @@ class PowConeND(Cone):
         W = Variable(self.W.shape)
         z = Variable(self.z.shape)
         constr = [PowConeND(W, z, self.alpha, axis=self.axis)]
-        obj = Minimize(norm2(hstack([W.flatten(), z.flatten()]) -
-                             hstack([self.W.flatten().value, self.z.flatten().value])))
+        obj = Minimize(norm2(hstack([W.flatten(order='F'), z.flatten(order='F')]) -
+                             hstack([self.W.flatten(order='F').value, 
+                                     self.z.flatten(order='F').value])))
         problem = Problem(obj, constr)
         return problem.solve(solver='SCS', eps=1e-8)
 

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -49,7 +49,7 @@ class SOC(Cone):
             )
         self.axis = axis
         if len(t.shape) == 0:
-            t = t.flatten()
+            t = t.flatten(order='F')
         super(SOC, self).__init__([t, X], constr_id)
 
     def __str__(self) -> str:

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -864,10 +864,13 @@ class Expression(u.Canonical):
         from cvxpy import ptp
         return ptp(self, axis, keepdims)
 
-    def reshape(self, shape, order='F'):
+    def reshape(self, shape, order = None):
         """
         Equivalent to `cp.reshape(self, shape, order)`.
         """
+        if order is None:
+            warnings.warn(DEFAULT_ORDER_DEPRECATION_MSG, FutureWarning)
+            order = 'F'
         from cvxpy import reshape
         return reshape(self, shape, order)
 

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -17,7 +17,7 @@ limitations under the License.
 import abc
 import warnings
 from functools import wraps
-from typing import List, Optional, Tuple
+from typing import List, Literal, Tuple
 
 import numpy as np
 
@@ -488,8 +488,9 @@ class Expression(u.Canonical):
         """
         return len(self.shape)
 
-    def flatten(self, order: Optional[str] = None):
-        """Vectorizes the expression.
+    def flatten(self, order: Literal["F", "C", None] = None):
+        """
+        Vectorizes the expression.
 
         order: column-major ('F') or row-major ('C') order.
         """
@@ -865,7 +866,7 @@ class Expression(u.Canonical):
         from cvxpy import ptp
         return ptp(self, axis, keepdims)
 
-    def reshape(self, shape, order: Optional[str] = None):
+    def reshape(self, shape, order: Literal["F", "C", None] = None):
         """
         Equivalent to `cp.reshape(self, shape, order)`.
         """

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -488,7 +488,7 @@ class Expression(u.Canonical):
         """
         return len(self.shape)
 
-    def flatten(self, order = None):
+    def flatten(self, order: str | None = None):
         """Vectorizes the expression.
 
         order: column-major ('F') or row-major ('C') order.
@@ -864,7 +864,7 @@ class Expression(u.Canonical):
         from cvxpy import ptp
         return ptp(self, axis, keepdims)
 
-    def reshape(self, shape, order = None):
+    def reshape(self, shape, order: str | None = None):
         """
         Equivalent to `cp.reshape(self, shape, order)`.
         """

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -85,8 +85,8 @@ DEFAULT_ORDER_DEPRECATION_MSG = (
     """
     You didn't specify the order of the FUNC_NAME expression. The default order
     used in CVXPY is Fortran ('F') order. This default will change to match NumPy's
-    default order ('C') in a future version.
-    To suppress this warning, specify the order explicitly.
+    default order ('C') in a future version of CVXPY.
+    To suppress this warning, please specify the order explicitly.
     """
 )
 

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -81,6 +81,15 @@ You're calling the built-in abs function on a CVXPY expression. This is not
 supported. Consider using the abs function provided by CVXPY.
 """
 
+DEFAULT_ORDER_DEPRECATION_MSG = (
+    """
+    You didn't specify the order of the reshaped expression. The default order
+    used in CVXPY is Fortran ('F') order. This default will change to match NumPy's
+    default order ('C') in a future version.
+    To suppress this warning, specify the order explicitly.
+    """
+)
+
 __BINARY_EXPRESSION_UFUNCS__ = {
         np.add: lambda self, a: self.__radd__(a),
         np.subtract: lambda self, a: self.__rsub__(a),
@@ -442,7 +451,8 @@ class Expression(u.Canonical):
         """
         raise NotImplementedError()
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def shape(self) -> Tuple[int, ...]:
         """tuple : The expression dimensions.
         """
@@ -453,7 +463,8 @@ class Expression(u.Canonical):
         """
         return not self.is_complex()
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def is_imag(self) -> bool:
         """Is the Leaf imaginary?
         """
@@ -477,11 +488,14 @@ class Expression(u.Canonical):
         """
         return len(self.shape)
 
-    def flatten(self, order: str = 'F'):
+    def flatten(self, order = None):
         """Vectorizes the expression.
 
         order: column-major ('F') or row-major ('C') order.
         """
+        if order is None:
+            warnings.warn(DEFAULT_ORDER_DEPRECATION_MSG, FutureWarning)
+            order = 'F'
         assert order in ['F', 'C']
         return cvxtypes.vec()(self, order)
 

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -83,7 +83,7 @@ supported. Consider using the abs function provided by CVXPY.
 
 DEFAULT_ORDER_DEPRECATION_MSG = (
     """
-    You didn't specify the order of the reshaped expression. The default order
+    You didn't specify the order of the FUNC_NAME expression. The default order
     used in CVXPY is Fortran ('F') order. This default will change to match NumPy's
     default order ('C') in a future version.
     To suppress this warning, specify the order explicitly.
@@ -494,7 +494,8 @@ class Expression(u.Canonical):
         order: column-major ('F') or row-major ('C') order.
         """
         if order is None:
-            warnings.warn(DEFAULT_ORDER_DEPRECATION_MSG, FutureWarning)
+            flatten_order_warning = DEFAULT_ORDER_DEPRECATION_MSG.replace("FUNC_NAME", "flatten")
+            warnings.warn(flatten_order_warning, FutureWarning)
             order = 'F'
         assert order in ['F', 'C']
         return cvxtypes.vec()(self, order)
@@ -869,7 +870,8 @@ class Expression(u.Canonical):
         Equivalent to `cp.reshape(self, shape, order)`.
         """
         if order is None:
-            warnings.warn(DEFAULT_ORDER_DEPRECATION_MSG, FutureWarning)
+            reshape_order_warning = DEFAULT_ORDER_DEPRECATION_MSG.replace("FUNC_NAME", "reshape")
+            warnings.warn(reshape_order_warning, FutureWarning)
             order = 'F'
         from cvxpy import reshape
         return reshape(self, shape, order)

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -17,7 +17,7 @@ limitations under the License.
 import abc
 import warnings
 from functools import wraps
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -488,7 +488,7 @@ class Expression(u.Canonical):
         """
         return len(self.shape)
 
-    def flatten(self, order: str | None = None):
+    def flatten(self, order: Optional[str] = None):
         """Vectorizes the expression.
 
         order: column-major ('F') or row-major ('C') order.
@@ -864,7 +864,7 @@ class Expression(u.Canonical):
         from cvxpy import ptp
         return ptp(self, axis, keepdims)
 
-    def reshape(self, shape, order: str | None = None):
+    def reshape(self, shape, order: Optional[str] = None):
         """
         Equivalent to `cp.reshape(self, shape, order)`.
         """

--- a/cvxpy/reductions/complex2real/canonicalizers/abs_canon.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/abs_canon.py
@@ -24,8 +24,8 @@ def abs_canon(expr, real_args, imag_args, real2imag):
     elif imag_args[0] is None:  # Real
         output = abs(real_args[0])
     else:  # Complex.
-        real = real_args[0].flatten()
-        imag = imag_args[0].flatten()
+        real = real_args[0].flatten(order='F')
+        imag = imag_args[0].flatten(order='F')
         norms = pnorm(vstack([real, imag]), p=2, axis=0)
         output = reshape(norms, real_args[0].shape, order='F')
     return output, None

--- a/cvxpy/reductions/complex2real/canonicalizers/abs_canon.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/abs_canon.py
@@ -27,5 +27,5 @@ def abs_canon(expr, real_args, imag_args, real2imag):
         real = real_args[0].flatten()
         imag = imag_args[0].flatten()
         norms = pnorm(vstack([real, imag]), p=2, axis=0)
-        output = reshape(norms, real_args[0].shape)
+        output = reshape(norms, real_args[0].shape, order='F')
     return output, None

--- a/cvxpy/reductions/complex2real/canonicalizers/matrix_canon.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/matrix_canon.py
@@ -150,7 +150,7 @@ def at_least_2D(expr: Expression):
     """Upcast 0D and 1D to 2D.
     """
     if expr.ndim < 2:
-        return reshape(expr, (expr.size, 1))
+        return reshape(expr, (expr.size, 1), order='F')
     else:
         return expr
 

--- a/cvxpy/reductions/complex2real/canonicalizers/soc_canon.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/soc_canon.py
@@ -29,8 +29,8 @@ def soc_canon(expr, real_args, imag_args, real2imag):
                       axis=expr.axis, constr_id=expr.id)]
     else:  # Complex.
         orig_shape = real_args[1].shape
-        real = real_args[1].flatten()
-        imag = imag_args[1].flatten()
+        real = real_args[1].flatten(order='F')
+        imag = imag_args[1].flatten(order='F')
         flat_X = Variable(real.shape)
         inner_SOC = SOC(flat_X,
                         vstack([real, imag]),

--- a/cvxpy/reductions/complex2real/canonicalizers/soc_canon.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/soc_canon.py
@@ -35,7 +35,7 @@ def soc_canon(expr, real_args, imag_args, real2imag):
         inner_SOC = SOC(flat_X,
                         vstack([real, imag]),
                         axis=0)
-        real_X = reshape(flat_X, orig_shape)
+        real_X = reshape(flat_X, orig_shape, order='F')
         outer_SOC = SOC(real_args[0], real_X,
                         axis=expr.axis, constr_id=expr.id)
         output = [inner_SOC, outer_SOC]

--- a/cvxpy/reductions/cone2cone/approximations.py
+++ b/cvxpy/reductions/cone2cone/approximations.py
@@ -67,7 +67,7 @@ def rotated_quad_cone(X: cp.Expression, y: cp.Expression, z: cp.Expression):
     assert z.size == m
     assert X.shape[0] == m
     if len(X.shape) < 2:
-        X = cp.reshape(X, (m, 1))
+        X = cp.reshape(X, (m, 1), order='F')
     #####################################
     # Comments from quad_over_lin_canon:
     #   quad_over_lin := sum_{i} x^2_{i} / y
@@ -75,7 +75,7 @@ def rotated_quad_cone(X: cp.Expression, y: cp.Expression, z: cp.Expression):
     #   Becomes a constraint
     #   SOC(t=y + t, X=[y - t, 2*x])
     ####################################
-    soc_X_col0 = cp.reshape(y - z, (m, 1))
+    soc_X_col0 = cp.reshape(y - z, (m, 1), order='F')
     soc_X = cp.hstack((soc_X_col0, 2*X))
     soc_t = y + z
     con = cp.SOC(t=soc_t, X=soc_X, axis=1)

--- a/cvxpy/reductions/cone2cone/exotic2common.py
+++ b/cvxpy/reductions/cone2cone/exotic2common.py
@@ -49,7 +49,7 @@ def pow_nd_canon(con, args):
         W = W.T
         alpha = alpha.T
     if W.ndim == 1:
-        W = reshape(W, (W.size, 1))
+        W = reshape(W, (W.size, 1), order='F')
         alpha = np.reshape(alpha, (W.size, 1))
     n, k = W.shape
     if n == 2:

--- a/cvxpy/reductions/cone2cone/soc2psd.py
+++ b/cvxpy/reductions/cone2cone/soc2psd.py
@@ -74,14 +74,14 @@ class SOC2PSD(Reduction):
                 """
 
                 A = scalar_term * sparse.eye(1)
-                B = cp.reshape(X,[-1,1]).T
+                B = cp.reshape(X,[-1,1], order='F').T
                 C = scalar_term * sparse.eye(vector_term_len)
 
                 """
                 Another technique for reference
 
                 A = scalar_term * sparse.eye(vector_term_len)
-                B = cp.reshape(X,[-1,1])
+                B = cp.reshape(X,[-1,1], order='F')
                 C = scalar_term * sparse.eye(1)
                 """
 

--- a/cvxpy/reductions/cvx_attr2constr.py
+++ b/cvxpy/reductions/cvx_attr2constr.py
@@ -74,12 +74,12 @@ def attributes_present(variables, attr_map):
 
 def recover_value_for_variable(variable, lowered_value, project: bool = True):
     if variable.attributes['diag']:
-        return sp.diags(lowered_value.flatten())
+        return sp.diags(lowered_value.flatten(order='F'))
     elif attributes_present([variable], SYMMETRIC_ATTRIBUTES):
         n = variable.shape[0]
         value = np.zeros(variable.shape)
         idxs = np.triu_indices(n)
-        value[idxs] = lowered_value.flatten()
+        value[idxs] = lowered_value.flatten(order='F')
         return value + value.T - np.diag(value.diagonal())
     elif project:
         return variable.project(lowered_value)

--- a/cvxpy/reductions/cvx_attr2constr.py
+++ b/cvxpy/reductions/cvx_attr2constr.py
@@ -151,7 +151,7 @@ class CvxAttr2Constr(Reduction):
                     id2new_var[var.id] = upper_tri
                     fill_coeff = Constant(upper_tri_to_full(n))
                     full_mat = fill_coeff @ upper_tri
-                    obj = reshape(full_mat, (n, n))
+                    obj = reshape(full_mat, (n, n), order='F')
                 elif var.attributes['diag']:
                     diag_var = Variable(var.shape[0], var_id=var.id, **new_attr)
                     diag_var.set_variable_of_provenance(var)

--- a/cvxpy/reductions/dcp2cone/canonicalizers/log_sum_exp_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/log_sum_exp_canon.py
@@ -33,11 +33,9 @@ def log_sum_exp_canon(expr, args):
     if axis is None:  # shape = (1, 1)
         promoted_t = promote(t, x.shape)
     elif axis == 0:  # shape = (1, n)
-        promoted_t = Constant(np.ones((x.shape[0], 1))) @ reshape(
-                                                        t, (1,) + x.shape[1:])
+        promoted_t = Constant(np.ones((x.shape[0], 1))) @ reshape(t, (1,) + x.shape[1:], order='F')
     else:  # shape = (m, 1)
-        promoted_t = reshape(t, x.shape[:-1] + (1,)) @ Constant(
-                                                      np.ones((1, x.shape[1])))
+        promoted_t = reshape(t, x.shape[:-1] + (1,), order='F') @ Constant(np.ones((1, x.shape[1])))
 
     exp_expr = exp(x - promoted_t)
     obj, constraints = exp_canon(exp_expr, exp_expr.args)

--- a/cvxpy/reductions/dcp2cone/canonicalizers/matrix_frac_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/matrix_frac_canon.py
@@ -24,7 +24,7 @@ def matrix_frac_canon(expr, args):
     P = args[1]  # n by n matrix.
 
     if len(X.shape) == 1:
-        X = reshape(X, (X.shape[0], 1))
+        X = reshape(X, (X.shape[0], 1), order='F')
     n, m = X.shape
     T = Variable((m, m), symmetric=True)
     M = bmat([[P, X],

--- a/cvxpy/reductions/dcp2cone/canonicalizers/perspective_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/perspective_canon.py
@@ -88,6 +88,6 @@ def perspective_canon(expr, args):
             inds = np.triu_indices(n, k=0)  # includes diagonal
             constraints += [var[inds] == x_canon[start_ind:end_ind]]
         else:
-            constraints.append(vec(var) == x_canon[start_ind:end_ind])
+            constraints.append(vec(var, order='F') == x_canon[start_ind:end_ind])
 
     return (1 if expr.f.is_convex() else -1)*t, constraints

--- a/cvxpy/reductions/dcp2cone/canonicalizers/pnorm_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/pnorm_canon.py
@@ -38,9 +38,9 @@ def pnorm_canon(expr, args):
     if p == 2:
         if axis is None:
             assert shape == tuple()
-            return t, [SOC(t, vec(x))]
+            return t, [SOC(t, vec(x, order='F'))]
         else:
-            return t, [SOC(vec(t), x, axis)]
+            return t, [SOC(vec(t, order='F'), x, axis)]
 
     # we need an absolute value constraint for the symmetric convex branches
     # (p > 1)

--- a/cvxpy/reductions/dcp2cone/canonicalizers/quad_over_lin_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/quad_over_lin_canon.py
@@ -22,14 +22,11 @@ from cvxpy.expressions.variable import Variable
 def quad_over_lin_canon(expr, args):
     # quad_over_lin := sum_{ij} X^2_{ij} / y
     x = args[0]
-    y = args[1].flatten()
+    y = args[1].flatten(order='F')
     # precondition: shape == ()
     t = Variable(1,)
     # (y+t, y-t, 2*x) must lie in the second-order cone,
     # where y+t is the scalar part of the second-order
     # cone constraint.
-    constraints = [SOC(
-                       t=y+t,
-                       X=hstack([y-t, 2*x.flatten()]), axis=0
-                      )]
+    constraints = [SOC(t=y+t, X=hstack([y-t, 2*x.flatten(order='F')]), axis=0)]
     return t, constraints

--- a/cvxpy/reductions/dcp2cone/canonicalizers/suppfunc_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/suppfunc_canon.py
@@ -8,7 +8,7 @@ from cvxpy.reductions.solvers.conic_solvers.scs_conif import (
 
 
 def suppfunc_canon(expr, args):
-    y = args[0].flatten()
+    y = args[0].flatten(order='F')
     # ^ That's the user-supplied argument to the support function.
     parent = expr._parent
     A, b, K_sels = parent.conic_repr_of_set()

--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -360,11 +360,14 @@ class ConeMatrixStuffing(MatrixStuffing):
             elif isinstance(con, PowCone3D) and con.args[0].ndim > 1:
                 x, y, z = con.args
                 alpha = con.alpha
-                con = PowCone3D(x.flatten(), y.flatten(), z.flatten(), alpha.flatten(),
+                con = PowCone3D(x.flatten(order='F'),
+                                y.flatten(order='F'),
+                                z.flatten(order='F'),
+                                alpha.flatten(order='F'),
                                 constr_id=con.constr_id)
             elif isinstance(con, ExpCone) and con.args[0].ndim > 1:
                 x, y, z = con.args
-                con = ExpCone(x.flatten(), y.flatten(), z.flatten(),
+                con = ExpCone(x.flatten(order='F'), y.flatten(order='F'), z.flatten(order='F'),
                               constr_id=con.constr_id)
             cons.append(con)
         # Reorder constraints to Zero, NonNeg, SOC, PSD, EXP, PowCone3D

--- a/cvxpy/reductions/dgp2dcp/canonicalizers/add_canon.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/add_canon.py
@@ -1,3 +1,19 @@
+"""
+Copyright 2024 the CVXPY developers
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from cvxpy.atoms.affine.bmat import bmat
 from cvxpy.atoms.affine.hstack import hstack
 from cvxpy.atoms.affine.promote import promote
@@ -18,7 +34,7 @@ def add_canon(expr, args):
             row.append(
               log_sum_exp(hstack([summand[i] for summand in summands])))
             rows.append(row)
-        return reshape(bmat(rows), expr.shape), []
+        return reshape(bmat(rows), expr.shape, order='F'), []
     else:
         for i in range(expr.shape[0]):
             row = []
@@ -26,4 +42,4 @@ def add_canon(expr, args):
                 row.append(
                   log_sum_exp(hstack([summand[i, j] for summand in summands])))
             rows.append(row)
-        return reshape(bmat(rows), expr.shape), []
+        return reshape(bmat(rows), expr.shape, order='F'), []

--- a/cvxpy/reductions/dgp2dcp/canonicalizers/mulexpression_canon.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/mulexpression_canon.py
@@ -1,4 +1,18 @@
-"""Canonicalization for matrix multiplication."""
+"""
+Copyright 2024 the CVXPY developers
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
 
 from cvxpy.atoms.affine.bmat import bmat
 from cvxpy.atoms.affine.hstack import hstack
@@ -11,8 +25,8 @@ def mulexpression_canon(expr, args):
     lhs = args[0]
     rhs = args[1]
     lhs_shape, rhs_shape, _ = mul_shapes_promote(lhs.shape, rhs.shape)
-    lhs = reshape(lhs, lhs_shape)
-    rhs = reshape(rhs, rhs_shape)
+    lhs = reshape(lhs, lhs_shape, order='F')
+    rhs = reshape(rhs, rhs_shape, order='F')
     rows = []
     # TODO(akshayka): Parallelize this for large matrices.
     for i in range(lhs.shape[0]):

--- a/cvxpy/reductions/dgp2dcp/canonicalizers/pnorm_canon.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/pnorm_canon.py
@@ -11,7 +11,7 @@ def pnorm_canon(expr, args):
     if x.shape == tuple():
         x = promote(p, (1,))
     if expr.axis is None or len(x.shape) == 1:
-        x = vec(x)
+        x = vec(x, order='F')
         return (1.0/p) * log_sum_exp(hstack([xi * p for xi in x])), []
 
     if expr.axis == 0:

--- a/cvxpy/reductions/dgp2dcp/canonicalizers/sum_canon.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/sum_canon.py
@@ -1,3 +1,19 @@
+"""
+Copyright 2024 the CVXPY developers
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from cvxpy.atoms.affine.hstack import hstack
 from cvxpy.atoms.affine.reshape import reshape
 from cvxpy.reductions.dgp2dcp.canonicalizers.add_canon import add_canon
@@ -9,7 +25,7 @@ def sum_canon(expr, args):
     if expr.axis is None:
         summation = explicit_sum(X)
         canon, _ = add_canon(summation, summation.args)
-        return reshape(canon, expr.shape), []
+        return reshape(canon, expr.shape, order='F'), []
 
     if expr.axis == 0:
         X = X.T
@@ -20,4 +36,4 @@ def sum_canon(expr, args):
         canon, _ = add_canon(summation, summation.args)
         rows.append(canon)
     canon = hstack(rows)
-    return reshape(canon, expr.shape), []
+    return reshape(canon, expr.shape, order='F'), []

--- a/cvxpy/reductions/dgp2dcp/util.py
+++ b/cvxpy/reductions/dgp2dcp/util.py
@@ -1,10 +1,23 @@
+"""
+Copyright 2024 the CVXPY developers
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from cvxpy.atoms.affine.vec import vec
 
 
 # the Python `sum` function is a reduction with initial value 0.0,
 # resulting in a non-DGP expression
 def explicit_sum(expr):
-    x = vec(expr)
+    x = vec(expr, order='F')
     summation = x[0]
     for xi in x[1:]:
         summation += xi

--- a/cvxpy/reductions/discrete2mixedint/valinvec2mixedint.py
+++ b/cvxpy/reductions/discrete2mixedint/valinvec2mixedint.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Copyright, the CVXPY authors
 

--- a/cvxpy/reductions/eliminate_pwl/canonicalizers/dotsort_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/canonicalizers/dotsort_canon.py
@@ -39,6 +39,6 @@ def dotsort_canon(expr, args):
     q = Variable((1, w_unique.size))
 
     obj = sum(t) + q @ w_counts
-    x_w_unique_outer_product = outer(vec(x), vec(w_unique))
+    x_w_unique_outer_product = outer(vec(x, order='F'), vec(w_unique, order='F'))
     constraints = [x_w_unique_outer_product <= t + q]
     return obj, constraints

--- a/cvxpy/reductions/eliminate_pwl/canonicalizers/max_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/canonicalizers/max_canon.py
@@ -30,11 +30,9 @@ def max_canon(expr, args):
     if axis is None:  # shape = (1, 1)
         promoted_t = promote(t, x.shape)
     elif axis == 0:  # shape = (1, n)
-        promoted_t = Constant(np.ones((x.shape[0], 1))) @ reshape(
-                                                            t, (1, x.shape[1]))
+        promoted_t = Constant(np.ones((x.shape[0], 1))) @ reshape(t, (1, x.shape[1]), order='F')
     else:  # shape = (m, 1)
-        promoted_t = reshape(t, (x.shape[0], 1)) @ Constant(
-                                                      np.ones((1, x.shape[1])))
+        promoted_t = reshape(t, (x.shape[0], 1), order='F') @ Constant(np.ones((1, x.shape[1])))
 
     constraints = [x <= promoted_t]
     return t, constraints

--- a/cvxpy/reductions/eliminate_pwl/canonicalizers/norm_inf_canon.py
+++ b/cvxpy/reductions/eliminate_pwl/canonicalizers/norm_inf_canon.py
@@ -30,10 +30,8 @@ def norm_inf_canon(expr, args):
     if axis is None:  # shape = (1, 1)
         promoted_t = promote(t, x.shape)
     elif axis == 0:  # shape = (1, n)
-        promoted_t = Constant(np.ones((x.shape[0], 1))) @ reshape(
-                                                            t, (1, x.shape[1]))
+        promoted_t = Constant(np.ones((x.shape[0], 1))) @ reshape(t, (1, x.shape[1]), order='F')
     else:  # shape = (m, 1)
-        promoted_t = reshape(t, (x.shape[0], 1)) @ Constant(
-                                                      np.ones((1, x.shape[1])))
+        promoted_t = reshape(t, (x.shape[0], 1), order='F') @ Constant(np.ones((1, x.shape[1])))
 
     return t, [x <= promoted_t, x + promoted_t >= 0]

--- a/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
@@ -117,7 +117,7 @@ class CVXOPT(ConicSolver):
         data[s.A] = -A[:len_eq]
         if data[s.A].shape[0] == 0:
             data[s.A] = None
-        data[s.B] = b[:len_eq].flatten()
+        data[s.B] = b[:len_eq].flatten(order='F')
         if data[s.B].shape[0] == 0:
             data[s.B] = None
         if len_eq >= A.shape[0]:
@@ -127,7 +127,7 @@ class CVXOPT(ConicSolver):
             data[s.H] = None
         else:
             data[s.G] = -A[len_eq:]
-            data[s.H] = b[len_eq:].flatten()
+            data[s.H] = b[len_eq:].flatten(order='F')
         return data, inv_data
 
     def invert(self, solution, inverse_data):

--- a/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
@@ -115,13 +115,13 @@ class ECOS(ConicSolver):
         data[s.A] = -A[:len_eq]
         if data[s.A].shape[0] == 0:
             data[s.A] = None
-        data[s.B] = b[:len_eq].flatten()
+        data[s.B] = b[:len_eq].flatten(order='F')
         if data[s.B].shape[0] == 0:
             data[s.B] = None
         data[s.G] = -A[len_eq:]
         if 0 in data[s.G].shape:
             data[s.G] = None
-        data[s.H] = b[len_eq:].flatten()
+        data[s.H] = b[len_eq:].flatten(order='F')
         if 0 in data[s.H].shape:
             data[s.H] = None
         return data, inv_data

--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -92,13 +92,13 @@ class SCIPY(ConicSolver):
         data[s.A] = -A[:len_eq]
         if data[s.A].shape[0] == 0:
             data[s.A] = None
-        data[s.B] = b[:len_eq].flatten()
+        data[s.B] = b[:len_eq].flatten(order='F')
         if data[s.B].shape[0] == 0:
             data[s.B] = None
         data[s.G] = -A[len_eq:]
         if 0 in data[s.G].shape:
             data[s.G] = None
-        data[s.H] = b[len_eq:].flatten()
+        data[s.H] = b[len_eq:].flatten(order='F')
         if 0 in data[s.H].shape:
             data[s.H] = None
         return data, inv_data

--- a/cvxpy/reductions/solvers/conic_solvers/sdpa_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/sdpa_conif.py
@@ -104,7 +104,7 @@ class SDPA(ConicSolver):
         data[s.A] = A
         if data[s.A].shape[0] == 0:
             data[s.A] = None
-        data[s.B] = b.flatten()
+        data[s.B] = b.flatten(order='F')
         if data[s.B].shape[0] == 0:
             data[s.B] = None
 

--- a/cvxpy/reductions/utilities.py
+++ b/cvxpy/reductions/utilities.py
@@ -56,7 +56,7 @@ def special_index_canon(expr, args):
     # Select the chosen entries from expr.
     arg = args[0]
     identity = sp.eye(arg.size).tocsc()
-    lowered = reshape(identity[select_vec] @ vec(arg), final_shape, order='F')
+    lowered = reshape(identity[select_vec] @ vec(arg, order='F'), final_shape, order='F')
     return lowered, []
 
 

--- a/cvxpy/reductions/utilities.py
+++ b/cvxpy/reductions/utilities.py
@@ -56,7 +56,7 @@ def special_index_canon(expr, args):
     # Select the chosen entries from expr.
     arg = args[0]
     identity = sp.eye(arg.size).tocsc()
-    lowered = reshape(identity[select_vec] @ vec(arg), final_shape)
+    lowered = reshape(identity[select_vec] @ vec(arg), final_shape, order='F')
     return lowered, []
 
 

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -433,7 +433,7 @@ def socp_2() -> SolverTestHelper:
     """
     x = cp.Variable(shape=(2,), name='x')
     objective = cp.Minimize(-4 * x[0] - 5 * x[1])
-    expr = cp.reshape(x[0] + 2 * x[1], (1, 1))
+    expr = cp.reshape(x[0] + 2 * x[1], (1, 1), order='F')
     constraints = [2 * x[0] + x[1] <= 3,
                    cp.constraints.SOC(cp.Constant([3]), expr),
                    x[0] >= 0,

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -563,21 +563,21 @@ class TestAtoms(BaseTest):
     def test_reshape(self) -> None:
         """Test the reshape class.
         """
-        expr = cp.reshape(self.A, (4, 1))
+        expr = cp.reshape(self.A, (4, 1), order='F')
         self.assertEqual(expr.sign, s.UNKNOWN)
         self.assertEqual(expr.curvature, s.AFFINE)
         self.assertEqual(expr.shape, (4, 1))
 
-        expr = cp.reshape(expr, (2, 2))
+        expr = cp.reshape(expr, (2, 2), order='F')
         self.assertEqual(expr.shape, (2, 2))
 
-        expr = cp.reshape(cp.square(self.x), (1, 2))
+        expr = cp.reshape(cp.square(self.x), (1, 2), order='F')
         self.assertEqual(expr.sign, s.NONNEG)
         self.assertEqual(expr.curvature, s.CONVEX)
         self.assertEqual(expr.shape, (1, 2))
 
         with self.assertRaises(Exception) as cm:
-            cp.reshape(self.C, (5, 4))
+            cp.reshape(self.C, (5, 4), order='F')
         self.assertEqual(str(cm.exception),
                          "Invalid reshape dimensions (5, 4).")
 
@@ -628,23 +628,23 @@ class TestAtoms(BaseTest):
         expected_shapes = [(6, 1), (1, 6), (3, 2), (6,), (6,)]
 
         for shape, expected_shape in zip(shapes, expected_shapes):
-            expr_reshaped = cp.reshape(expr, shape)
+            expr_reshaped = cp.reshape(expr, shape, order='F')
             self.assertEqual(expr_reshaped.shape, expected_shape)
 
             numpy_expr_reshaped = np.reshape(numpy_expr, shape)
             self.assertEqual(numpy_expr_reshaped.shape, expected_shape)
 
         with pytest.raises(ValueError, match="Cannot reshape expression"):
-            cp.reshape(expr, (8, -1))
+            cp.reshape(expr, (8, -1), order='F')
 
         with pytest.raises(AssertionError, match="Only one"):
-            cp.reshape(expr, (-1, -1))
+            cp.reshape(expr, (-1, -1), order='F')
 
         with pytest.raises(ValueError, match="Invalid reshape dimensions"):
-            cp.reshape(expr, (-1, 0))
+            cp.reshape(expr, (-1, 0), order='F')
 
         with pytest.raises(AssertionError, match="Specified dimension must be nonnegative"):
-            cp.reshape(expr, (-1, -2))
+            cp.reshape(expr, (-1, -2), order='F')
 
         A = np.array([[1, 2, 3], [4, 5, 6]])
         A_reshaped = cp.reshape(A, -1, order='C')
@@ -807,7 +807,7 @@ class TestAtoms(BaseTest):
         for n in range(3, 8):
             A = upper_tri_to_full(n)
             v = np.arange(n * (n+1) // 2)
-            M = (A @ v).reshape((n, n))
+            M = (A @ v).reshape((n, n), order='F')
             assert np.allclose(M, M.T)
 
     def test_huber(self) -> None:
@@ -1494,7 +1494,6 @@ class TestAtoms(BaseTest):
 
         # Test with matrices
         A = np.arange(4).reshape((2, 2))
-        np.arange(4, 8).reshape((2, 2))
 
         with pytest.raises(ValueError, match="x must be a vector"):
             cp.outer(A, d)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -655,15 +655,15 @@ class TestAtoms(BaseTest):
     def test_vec(self) -> None:
         """Test the vec atom.
         """
-        expr = cp.vec(self.C)
+        expr = cp.vec(self.C, order='F')
         self.assertEqual(expr.sign, s.UNKNOWN)
         self.assertEqual(expr.curvature, s.AFFINE)
         self.assertEqual(expr.shape, (6,))
 
-        expr = cp.vec(self.x)
+        expr = cp.vec(self.x, order='F')
         self.assertEqual(expr.shape, (2,))
 
-        expr = cp.vec(cp.square(self.a))
+        expr = cp.vec(cp.square(self.a), order='F')
         self.assertEqual(expr.sign, s.NONNEG)
         self.assertEqual(expr.curvature, s.CONVEX)
         self.assertEqual(expr.shape, (1,))
@@ -1501,7 +1501,8 @@ class TestAtoms(BaseTest):
             cp.outer(d, A)
 
         # allow 2D inputs once row-major flattening is the default
-        assert np.allclose(cp.vec(np.array([[1, 2], [3, 4]])).value, np.array([1, 3, 2, 4]))
+        assert np.allclose(cp.vec(np.array([[1, 2], [3, 4]]), order='F').value, 
+                           np.array([1, 3, 2, 4]))
 
     def test_conj(self) -> None:
         """Test conj.
@@ -1705,7 +1706,7 @@ class TestAtoms(BaseTest):
         self.assertItemsAlmostEqual(x.value, reshaped)
 
         reshaped = np.reshape(A, (2, 5), order='F')
-        expr = cp.vec(x)
+        expr = cp.vec(x, order='F')
         cp.Problem(cp.Minimize(0), [expr == A]).solve()
         self.assertItemsAlmostEqual(x.value, reshaped)
         expr = cp.Constant(A).flatten()

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1681,12 +1681,6 @@ class TestAtoms(BaseTest):
         expr = cp.Constant(reshaped).flatten(order='C')
         self.assertItemsAlmostEqual(expr.value, A)
 
-        reshaped = np.reshape(A, (2, 5), order='F')
-        expr = cp.vec(reshaped, order='F')
-        self.assertItemsAlmostEqual(expr.value, A)
-        expr = cp.Constant(reshaped).flatten()
-        self.assertItemsAlmostEqual(expr.value, A)
-
         # Variable argument.
         x = Variable((2, 5))
         reshaped = np.reshape(A, (2, 5), order='F')
@@ -1702,14 +1696,6 @@ class TestAtoms(BaseTest):
         cp.Problem(cp.Minimize(0), [expr == A]).solve()
         self.assertItemsAlmostEqual(x.value, reshaped)
         expr = cp.Constant(A).flatten(order='C')
-        cp.Problem(cp.Minimize(0), [expr == A]).solve()
-        self.assertItemsAlmostEqual(x.value, reshaped)
-
-        reshaped = np.reshape(A, (2, 5), order='F')
-        expr = cp.vec(x, order='F')
-        cp.Problem(cp.Minimize(0), [expr == A]).solve()
-        self.assertItemsAlmostEqual(x.value, reshaped)
-        expr = cp.Constant(A).flatten()
         cp.Problem(cp.Minimize(0), [expr == A]).solve()
         self.assertItemsAlmostEqual(x.value, reshaped)
 

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -526,7 +526,7 @@ class TestComplex(BaseTest):
         constraints = [f >> 0]
         for k in range(1, n):
             indices = [(i * n) + i - (n - k) for i in range(n - k, n)]
-            constraints += [cp.sum(cp.vec(f)[indices]) == c[n - k]]
+            constraints += [cp.sum(cp.vec(f, order='F')[indices]) == c[n - k]]
         # Form objective.
         obj = cp.Maximize(c[0] - cp.real(cp.trace(f)))
         # Form and solve problem.

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -326,7 +326,7 @@ class TestConstraints(BaseTest):
             con = PowConeND(W, z, alpha.reshape((n, 1)))
         with self.assertRaises(ValueError):
             # wrong axis
-            con = PowConeND(reshape_atom(W, (n, 1)), z,
+            con = PowConeND(reshape_atom(W, (n, 1), order='F'), z,
                             alpha.reshape((n, 1)),
                             axis=1)
         # Compute a violation

--- a/cvxpy/tests/test_derivative.py
+++ b/cvxpy/tests/test_derivative.py
@@ -539,7 +539,7 @@ class TestBackwardDgp(BaseTest):
     def test_matrix_constraint(self) -> None:
         X = cp.Variable((2, 2), pos=True)
         a = cp.Parameter(pos=True, value=0.1)
-        obj = cp.Minimize(cp.geo_mean(cp.vec(X)))
+        obj = cp.Minimize(cp.geo_mean(cp.vec(X, order='F')))
         constr = [cp.diag(X) == a,
                   cp.hstack([X[0, 1], X[1, 0]]) == 2*a]
         problem = cp.Problem(obj, constr)

--- a/cvxpy/tests/test_expression_methods.py
+++ b/cvxpy/tests/test_expression_methods.py
@@ -148,21 +148,21 @@ class TestExpressionMethods():
         a = np.arange(10)
         A_np = np.reshape(a, (5, 2), order='C')
         A_cp = Constant(a).reshape((5, 2), order='C')
-        np.allclose(A_np, A_cp.value)
+        assert np.allclose(A_np, A_cp.value)
 
         X = cp.Variable((5, 2))
         prob = cp.Problem(cp.Minimize(0), [X == A_cp])
         prob.solve(solver=cp.SCS)
-        np.allclose(A_np, X.value)
+        assert np.allclose(A_np, X.value)
 
         a_np = np.reshape(A_np, 10, order='C')
         a_cp = A_cp.reshape(10, order='C')
-        np.allclose(a_np, a_cp.value)
+        assert np.allclose(a_np, a_cp.value)
 
         x = cp.Variable(10)
         prob = cp.Problem(cp.Minimize(0), [x == a_cp])
         prob.solve(solver=cp.SCS)
-        np.allclose(a_np, x.value)
+        assert np.allclose(a_np, x.value)
 
         # Test more complex C-style reshape: matrix to another matrix
         b = np.array([
@@ -176,8 +176,8 @@ class TestExpressionMethods():
         X_reshaped = X.reshape((2, 6), order='C')
         prob = cp.Problem(cp.Minimize(0), [X_reshaped == b_reshaped])
         prob.solve(solver=cp.SCS)
-        np.allclose(b_reshaped, X_reshaped.value)
-        np.allclose(b, X.value)
+        assert np.allclose(b_reshaped, X_reshaped.value)
+        assert np.allclose(b, X.value)
 
         b_reshaped = b.reshape((2, 6), order='F')
         X = cp.Variable(b.shape)
@@ -191,8 +191,8 @@ class TestExpressionMethods():
             cp.reshape(X, (2, 6))
         prob = cp.Problem(cp.Minimize(0), [X_reshaped == b_reshaped])
         prob.solve(solver=cp.SCS)
-        np.allclose(b_reshaped, X_reshaped.value)
-        np.allclose(b, X.value)
+        assert np.allclose(b_reshaped, X_reshaped.value)
+        assert np.allclose(b, X.value)
 
     def test_reshape_negative_one(self) -> None:
         """Test the reshape class with -1 in the shape."""

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -387,7 +387,7 @@ class TestGrad(BaseTest):
         lin_expr = linearize(expr)
         manual = expr.value + 2*cp.reshape(
             cp.diag(cp.vec(self.A)).value @ cp.vec(self.A - self.A.value),
-            (2, 2)
+            (2, 2), order='F'
         )
         self.assertItemsAlmostEqual(lin_expr.value, expr.value)
         self.A.value = [[-5, -5], [8.2, 4.4]]

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -386,8 +386,9 @@ class TestGrad(BaseTest):
         self.A.value = [[1, 2], [3, 4]]
         lin_expr = linearize(expr)
         manual = expr.value + 2*cp.reshape(
-            cp.diag(cp.vec(self.A)).value @ cp.vec(self.A - self.A.value),
-            (2, 2), order='F'
+            cp.diag(cp.vec(self.A, order='F')).value @ cp.vec(self.A - self.A.value, order='F'), 
+            (2, 2), 
+            order='F'
         )
         self.assertItemsAlmostEqual(lin_expr.value, expr.value)
         self.A.value = [[-5, -5], [8.2, 4.4]]

--- a/cvxpy/tests/test_kron_canon.py
+++ b/cvxpy/tests/test_kron_canon.py
@@ -127,13 +127,13 @@ class TestKronLeftVar(TestKron):
         U = np.array([[10, 11], [12, 13]])
         kronX = cp.kron(X, b)  # should be equal to X
 
-        objective = cp.Minimize(cp.sum(X.flatten()))
+        objective = cp.Minimize(cp.sum(X.flatten(order='F')))
         constraints = [U >= kronX, kronX >= L]
         prob = cp.Problem(objective, constraints)
         prob.solve()
 
         self.assertItemsAlmostEqual(X.value, np.array([[0.5, 2], [2, 3]]) / 1.5)
-        objective = cp.Maximize(cp.sum(X.flatten()))
+        objective = cp.Maximize(cp.sum(X.flatten(order='F')))
         prob = cp.Problem(objective, constraints)
         prob.solve()
         self.assertItemsAlmostEqual(X.value, np.array([[10, 11], [11, 13]]) / 1.5)

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -316,7 +316,7 @@ class TestProblem(BaseTest):
                         p.solve(verbose=verbose, solver=solver)
 
                     if PSD in SOLVER_MAP_CONIC[solver].SUPPORTED_CONSTRAINTS:
-                        a_mat = cp.reshape(self.a, shape=(1, 1))
+                        a_mat = cp.reshape(self.a, shape=(1, 1), order='F')
                         p = Problem(cp.Minimize(self.a), [cp.lambda_min(a_mat) >= 2])
                         p.solve(verbose=verbose, solver=solver)
 
@@ -363,7 +363,7 @@ class TestProblem(BaseTest):
                         p.solve(solver_verbose=solver_verbose, solver=solver)
 
                     if PSD in SOLVER_MAP_CONIC[solver].SUPPORTED_CONSTRAINTS:
-                        a_mat = cp.reshape(self.a, shape=(1, 1))
+                        a_mat = cp.reshape(self.a, shape=(1, 1), order='F')
                         p = Problem(cp.Minimize(self.a), [cp.lambda_min(a_mat) >= 2])
                         p.solve(solver_verbose=solver_verbose, solver=solver)
 
@@ -1466,14 +1466,14 @@ class TestProblem(BaseTest):
         """Tests problems with reshape.
         """
         # Test on scalars.
-        self.assertEqual(cp.reshape(1, (1, 1)).value, 1)
+        self.assertEqual(cp.reshape(1, (1, 1), order='F').value, 1)
 
         # Test vector to matrix.
         x = Variable(4)
         mat = numpy.array([[1, -1], [2, -2]]).T
         vec = numpy.array([[1, 2, 3, 4]]).T
         vec_mat = numpy.array([[1, 2], [3, 4]]).T
-        expr = cp.reshape(x, (2, 2))
+        expr = cp.reshape(x, (2, 2), order='F')
         obj = cp.Minimize(cp.sum(mat @ expr))
         prob = Problem(obj, [x[:, None] == vec])
         result = prob.solve(solver=cp.SCS)
@@ -1481,17 +1481,17 @@ class TestProblem(BaseTest):
 
         # Test on matrix to vector.
         c = [1, 2, 3, 4]
-        expr = cp.reshape(self.A, (4, 1))
+        expr = cp.reshape(self.A, (4, 1), order='F')
         obj = cp.Minimize(expr.T @ c)
         constraints = [self.A == [[-1, -2], [3, 4]]]
         prob = Problem(obj, constraints)
         result = prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 20)
         self.assertItemsAlmostEqual(expr.value, [-1, -2, 3, 4])
-        self.assertItemsAlmostEqual(cp.reshape(expr, (2, 2)).value, [-1, -2, 3, 4])
+        self.assertItemsAlmostEqual(cp.reshape(expr, (2, 2), order='F').value, [-1, -2, 3, 4])
 
         # Test matrix to matrix.
-        expr = cp.reshape(self.C, (2, 3))
+        expr = cp.reshape(self.C, (2, 3), order='F')
         mat = numpy.array([[1, -1], [2, -2]])
         C_mat = numpy.array([[1, 4], [2, 5], [3, 6]])
         obj = cp.Minimize(cp.sum(mat @ expr))
@@ -1503,14 +1503,14 @@ class TestProblem(BaseTest):
 
         # Test promoted expressions.
         c = numpy.array([[1, -1], [2, -2]]).T
-        expr = cp.reshape(c * self.a, (1, 4))
+        expr = cp.reshape(c * self.a, (1, 4), order='F')
         obj = cp.Minimize(expr @ [1, 2, 3, 4])
         prob = Problem(obj, [self.a == 2])
         result = prob.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, -6)
         self.assertItemsAlmostEqual(expr.value, 2*c)
 
-        expr = cp.reshape(c * self.a, (4, 1))
+        expr = cp.reshape(c * self.a, (4, 1), order='F')
         obj = cp.Minimize(expr.T @ [1, 2, 3, 4])
         prob = Problem(obj, [self.a == 2])
         result = prob.solve(solver=cp.SCS)
@@ -2102,7 +2102,7 @@ class TestProblem(BaseTest):
 
         stacked_flattened = cp.vstack([cp.vec(x), cp.vec(y)])  # (2, 10)
         minimum = cp.min(stacked_flattened, axis=0)  # (10,)
-        reshaped_minimum = cp.reshape(minimum, (5, 2))  # (5, 2)
+        reshaped_minimum = cp.reshape(minimum, (5, 2), order='F')  # (5, 2)
 
         obj = cp.sum(reshaped_minimum)
         problem = cp.Problem(cp.Maximize(obj), [x == 1, y == 2])

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1539,7 +1539,7 @@ class TestProblem(BaseTest):
         """Tests problems with vec.
         """
         c = [1, 2, 3, 4]
-        expr = cp.vec(self.A)
+        expr = cp.vec(self.A, order='F')
         obj = cp.Minimize(expr.T @ c)
         constraints = [self.A == [[-1, -2], [3, 4]]]
         prob = Problem(obj, constraints)
@@ -2100,7 +2100,7 @@ class TestProblem(BaseTest):
         x = cp.Variable((5, 2))
         y = cp.Variable((5, 2))
 
-        stacked_flattened = cp.vstack([cp.vec(x), cp.vec(y)])  # (2, 10)
+        stacked_flattened = cp.vstack([cp.vec(x, order='F'), cp.vec(y, order='F')])  # (2, 10)
         minimum = cp.min(stacked_flattened, axis=0)  # (10,)
         reshaped_minimum = cp.reshape(minimum, (5, 2), order='F')  # (5, 2)
 

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -147,8 +147,7 @@ class TestQp(BaseTest):
         p = Problem(Minimize(sum_squares(A @ self.x - b)))
         self.solve_QP(p, solver)
         for var in p.variables():
-            self.assertItemsAlmostEqual(lstsq(A, b)[0].flatten(),
-                                        var.value,
+            self.assertItemsAlmostEqual(lstsq(A, b)[0].flatten(order='F'), var.value,
                                         places=1)
 
     def quad_form(self, solver) -> None:
@@ -202,7 +201,7 @@ class TestQp(BaseTest):
         p = Problem(Minimize(norm(A @ self.w - b, 2)))
         self.solve_QP(p, solver)
         for var in p.variables():
-            self.assertItemsAlmostEqual(lstsq(A, b)[0].flatten(), var.value,
+            self.assertItemsAlmostEqual(lstsq(A, b)[0].flatten(order='F'), var.value,
                                         places=1)
 
     def mat_norm_2(self, solver) -> None:

--- a/cvxpy/tests/test_shape.py
+++ b/cvxpy/tests/test_shape.py
@@ -57,7 +57,7 @@ class TestShape():
         n = 2
         a = Variable([n, n])
         b = Variable(n**2)
-        c = reshape(b, [n, n])
+        c = reshape(b, [n, n], order='F')
         assert (a + c).shape == (n, n)
-        d = reshape(b, (n, n))
+        d = reshape(b, (n, n), order='F')
         assert (a + d).shape == (n, n)

--- a/cvxpy/tests/test_suppfunc.py
+++ b/cvxpy/tests/test_suppfunc.py
@@ -89,7 +89,7 @@ class TestSupportFunctions(BaseTest):
         sigma = cp.suppfunc(x, [x[:, 0] == 0])
         y = cp.Variable(shape=(rows, cols))
         cons = [sigma(y - a) <= 0]
-        objective = cp.Minimize(cp.sum_squares(y.flatten()))
+        objective = cp.Minimize(cp.sum_squares(y.flatten(order='F')))
         prob = cp.Problem(objective, cons)
         prob.solve(solver='ECOS')
         expect = np.hstack([np.zeros(shape=(rows, 1)), a[:, [1]]])
@@ -105,7 +105,7 @@ class TestSupportFunctions(BaseTest):
         sigma = cp.suppfunc(X, [X >> 0])
         A = np.random.randn(n, n)
         Y = cp.Variable(shape=(n, n))
-        objective = cp.Minimize(cp.norm(A.ravel(order='F') + Y.flatten()))
+        objective = cp.Minimize(cp.norm(A.ravel(order='F') + Y.flatten(order='F')))
         cons = [sigma(Y) <= 0]  # Y is negative definite.
         prob = cp.Problem(objective, cons)
         prob.solve(solver='SCS', eps=1e-8)

--- a/cvxpy/tests/test_valinvec2mixedint.py
+++ b/cvxpy/tests/test_valinvec2mixedint.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Copyright, the CVXPY authors
 

--- a/cvxpy/transforms/linearize.py
+++ b/cvxpy/transforms/linearize.py
@@ -55,8 +55,8 @@ def linearize(expr):
             if grad_map[var] is None:
                 return None
             elif var.is_matrix():
-                flattened = Constant(grad_map[var]).T @ vec(var - var.value)
-                tangent = tangent + reshape(flattened, expr.shape)
+                flattened = Constant(grad_map[var]).T @ vec(var - var.value, order='F')
+                tangent = tangent + reshape(flattened, expr.shape, order='F')
             else:
                 tangent = tangent + Constant(grad_map[var]).T @ (var - var.value)
         return tangent

--- a/cvxpy/utilities/perspective_utils.py
+++ b/cvxpy/utilities/perspective_utils.py
@@ -50,7 +50,7 @@ def form_cone_constraint(z: Variable, constraint: Constraint) -> Constraint:
         N = z.shape[0]
         n = int(N**.5)
         assert N == n**2, "argument is not a vectorized square matrix"
-        z_mat = cp.reshape(z, (n, n))
+        z_mat = cp.reshape(z, (n, n), order='F')
         return PSD(z_mat)  # do we need constraint_id?
     elif isinstance(constraint, PowCone3D):
         raise NotImplementedError

--- a/cvxpy/utilities/power_tools.py
+++ b/cvxpy/utilities/power_tools.py
@@ -28,8 +28,11 @@ from cvxpy.expressions.variable import Variable
 
 def gm(t, x, y):
     length = t.size
-    return SOC(t=reshape(x+y, (length,)),
-               X=vstack([reshape(x-y, (1, length)), reshape(2*t, (1, length))]),
+    return SOC(t=reshape(x+y, (length,), order='F'),
+               X=vstack([
+                   reshape(x-y, (1, length), order='F'),
+                   reshape(2*t, (1, length), order='F')
+               ]),
                axis=0)
 
 


### PR DESCRIPTION
## Description
Please include a short summary of the change.
adding warning for not specifying order in reshape, vec and flatten. Also updated the cvxpy internal codebase to ensure that every operation above is specifying the order and wouldn't raise a warning for the user.
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.