### PR TITLE
Remove Python 2 compatibility code

### DIFF
--- a/cvxpy/atoms/affine/affine_atom.py
+++ b/cvxpy/atoms/affine/affine_atom.py
@@ -27,7 +27,7 @@ from cvxpy.expressions.constants import Constant
 from cvxpy.utilities import performance_utils as perf
 
 
-class AffAtom(Atom, metaclass=abc.ABCMeta):
+class AffAtom(Atom):
     """ Abstract base class for affine atoms. """
     _allow_complex = True
 

--- a/cvxpy/atoms/affine/affine_atom.py
+++ b/cvxpy/atoms/affine/affine_atom.py
@@ -27,9 +27,8 @@ from cvxpy.expressions.constants import Constant
 from cvxpy.utilities import performance_utils as perf
 
 
-class AffAtom(Atom):
+class AffAtom(Atom, metaclass=abc.ABCMeta):
     """ Abstract base class for affine atoms. """
-    __metaclass__ = abc.ABCMeta
     _allow_complex = True
 
     def sign_from_args(self) -> Tuple[bool, bool]:

--- a/cvxpy/atoms/affine/affine_atom.py
+++ b/cvxpy/atoms/affine/affine_atom.py
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import abc
 from typing import Any, List, Tuple
 
 import scipy.sparse as sp

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import division
-
 import operator as op
 from functools import reduce
 from typing import List, Tuple

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -33,7 +33,7 @@ from cvxpy.utilities import performance_utils as perf
 from cvxpy.utilities.deterministic import unique_list
 
 
-class Atom(Expression, metaclass=abc.ABCMeta):
+class Atom(Expression):
     """ Abstract base class for atoms. """
     _allow_complex = False
     # args are the expressions passed into the Atom constructor.

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -33,9 +33,8 @@ from cvxpy.utilities import performance_utils as perf
 from cvxpy.utilities.deterministic import unique_list
 
 
-class Atom(Expression):
+class Atom(Expression, metaclass=abc.ABCMeta):
     """ Abstract base class for atoms. """
-    __metaclass__ = abc.ABCMeta
     _allow_complex = False
     # args are the expressions passed into the Atom constructor.
 

--- a/cvxpy/atoms/axis_atom.py
+++ b/cvxpy/atoms/axis_atom.py
@@ -23,12 +23,10 @@ import scipy.sparse as sp
 from cvxpy.atoms.atom import Atom
 
 
-class AxisAtom(Atom):
+class AxisAtom(Atom, metaclass=abc.ABCMeta):
     """
     An abstract base class for atoms that can be applied along an axis.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, expr, axis: Optional[int] = None, keepdims: bool = False) -> None:
         self.axis = axis

--- a/cvxpy/atoms/axis_atom.py
+++ b/cvxpy/atoms/axis_atom.py
@@ -23,7 +23,7 @@ import scipy.sparse as sp
 from cvxpy.atoms.atom import Atom
 
 
-class AxisAtom(Atom, metaclass=abc.ABCMeta):
+class AxisAtom(Atom):
     """
     An abstract base class for atoms that can be applied along an axis.
     """

--- a/cvxpy/atoms/axis_atom.py
+++ b/cvxpy/atoms/axis_atom.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import abc
 from typing import List, Optional, Tuple
 
 import numpy as np

--- a/cvxpy/atoms/elementwise/elementwise.py
+++ b/cvxpy/atoms/elementwise/elementwise.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import abc
 from typing import Tuple
 
 import numpy as np

--- a/cvxpy/atoms/elementwise/elementwise.py
+++ b/cvxpy/atoms/elementwise/elementwise.py
@@ -25,7 +25,7 @@ import cvxpy.utilities as u
 from cvxpy.atoms.atom import Atom
 
 
-class Elementwise(Atom, metaclass=abc.ABCMeta):
+class Elementwise(Atom):
     """ Abstract base class for elementwise atoms. """
 
     def shape_from_args(self) -> Tuple[int, ...]:

--- a/cvxpy/atoms/elementwise/elementwise.py
+++ b/cvxpy/atoms/elementwise/elementwise.py
@@ -25,9 +25,8 @@ import cvxpy.utilities as u
 from cvxpy.atoms.atom import Atom
 
 
-class Elementwise(Atom):
+class Elementwise(Atom, metaclass=abc.ABCMeta):
     """ Abstract base class for elementwise atoms. """
-    __metaclass__ = abc.ABCMeta
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Shape is the same as the sum of the arguments.

--- a/cvxpy/atoms/elementwise/kl_div.py
+++ b/cvxpy/atoms/elementwise/kl_div.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import division
-
 from typing import List, Optional, Tuple
 
 import numpy as np

--- a/cvxpy/atoms/elementwise/maximum.py
+++ b/cvxpy/atoms/elementwise/maximum.py
@@ -14,15 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sys
+from functools import reduce
 from typing import Any, List, Tuple
 
 import numpy as np
 
 from cvxpy.atoms.elementwise.elementwise import Elementwise
-
-if sys.version_info >= (3, 0):
-    from functools import reduce
 
 
 class maximum(Elementwise):

--- a/cvxpy/atoms/elementwise/minimum.py
+++ b/cvxpy/atoms/elementwise/minimum.py
@@ -13,15 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sys
+from functools import reduce
 from typing import Any, List, Tuple
 
 import numpy as np
 
 from cvxpy.atoms.elementwise.elementwise import Elementwise
-
-if sys.version_info >= (3, 0):
-    from functools import reduce
 
 
 class minimum(Elementwise):

--- a/cvxpy/atoms/elementwise/rel_entr.py
+++ b/cvxpy/atoms/elementwise/rel_entr.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import division
-
 from typing import List, Optional, Tuple
 
 import numpy as np

--- a/cvxpy/atoms/perspective.py
+++ b/cvxpy/atoms/perspective.py
@@ -136,3 +136,17 @@ class perspective(Atom):
         """Returns the (row, col) shape of the expression.
         """
         return self.f.shape
+
+    def _grad(self, values):
+        """Gives the (sub/super)gradient of the atom w.r.t. each argument.
+
+        Matrix expressions are vectorized, so the gradient is a matrix.
+
+        Args:
+            values: A list of numeric values for the arguments.
+
+        Returns:
+            A list of SciPy CSC sparse matrices or None.
+        """
+        # TODO
+        raise NotImplementedError()

--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import division
-
 import warnings
 from typing import Tuple
 

--- a/cvxpy/constraints/cones.py
+++ b/cvxpy/constraints/cones.py
@@ -19,7 +19,7 @@ import abc
 from cvxpy.constraints.constraint import Constraint
 
 
-class Cone(Constraint, metaclass=abc.ABCMeta):
+class Cone(Constraint):
     """A base class for all conic constraints in CVXPY
 
     These are special constraints imposing set membership in convex cones

--- a/cvxpy/constraints/cones.py
+++ b/cvxpy/constraints/cones.py
@@ -19,7 +19,7 @@ import abc
 from cvxpy.constraints.constraint import Constraint
 
 
-class Cone(Constraint):
+class Cone(Constraint, metaclass=abc.ABCMeta):
     """A base class for all conic constraints in CVXPY
 
     These are special constraints imposing set membership in convex cones
@@ -39,8 +39,6 @@ class Cone(Constraint):
     constr_id : int
         A unique id for the constraint.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, args, constr_id=None) -> None:
         super(Cone, self).__init__(args, constr_id)

--- a/cvxpy/constraints/cones.py
+++ b/cvxpy/constraints/cones.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import abc
-
 from cvxpy.constraints.constraint import Constraint
 
 

--- a/cvxpy/constraints/constraint.py
+++ b/cvxpy/constraints/constraint.py
@@ -23,7 +23,7 @@ import cvxpy.utilities as u
 from cvxpy.expressions import cvxtypes
 
 
-class Constraint(u.Canonical):
+class Constraint(u.Canonical, metaclass=abc.ABCMeta):
     """The base class for constraints.
 
     A constraint is an equality, inequality, or more generally a generalized
@@ -37,8 +37,6 @@ class Constraint(u.Canonical):
     constr_id : int
         A unique id for the constraint.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, args, constr_id=None) -> None:
         # TODO cast constants.
@@ -212,16 +210,6 @@ class Constraint(u.Canonical):
         """Data needed to copy.
         """
         return [self.id]
-
-    def __nonzero__(self):
-        """Raises an exception when called.
-
-        Python 2 version.
-
-        Called when evaluating the truth value of the constraint.
-        Raising an error here prevents writing chained constraints.
-        """
-        return self._chain_constraints()
 
     def _chain_constraints(self):
         """Raises an error due to chained constraints.

--- a/cvxpy/constraints/constraint.py
+++ b/cvxpy/constraints/constraint.py
@@ -23,7 +23,7 @@ import cvxpy.utilities as u
 from cvxpy.expressions import cvxtypes
 
 
-class Constraint(u.Canonical, metaclass=abc.ABCMeta):
+class Constraint(u.Canonical):
     """The base class for constraints.
 
     A constraint is an equality, inequality, or more generally a generalized
@@ -127,7 +127,8 @@ class Constraint(u.Canonical, metaclass=abc.ABCMeta):
         else:
             raise ValueError("Unsupported context ", context)
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def residual(self):
         """The residual of the constraint.
 

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -103,14 +103,12 @@ __BINARY_EXPRESSION_UFUNCS__ = {
 ExpressionLike = "Expression | np.typing.ArrayLike"
 
 
-class Expression(u.Canonical):
+class Expression(u.Canonical, metaclass=abc.ABCMeta):
     """A mathematical expression in a convex optimization problem.
 
     Overloads many operators to allow for convenient creation of compound
     expressions (e.g., the sum of two expressions) and constraints.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     # Handles arithmetic operator overloading with Numpy.
     __array_priority__ = 100

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -103,7 +103,7 @@ __BINARY_EXPRESSION_UFUNCS__ = {
 ExpressionLike = "Expression | np.typing.ArrayLike"
 
 
-class Expression(u.Canonical, metaclass=abc.ABCMeta):
+class Expression(u.Canonical):
     """A mathematical expression in a convex optimization problem.
 
     Overloads many operators to allow for convenient creation of compound

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -440,7 +440,8 @@ class Expression(u.Canonical):
         """
         raise NotImplementedError()
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def shape(self) -> Tuple[int, ...]:
         """tuple : The expression dimensions.
         """
@@ -451,7 +452,8 @@ class Expression(u.Canonical):
         """
         return not self.is_complex()
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def is_imag(self) -> bool:
         """Is the Leaf imaginary?
         """

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 from __future__ import annotations
 
-import abc
 from typing import TYPE_CHECKING, Iterable
 
 if TYPE_CHECKING:
@@ -39,7 +38,7 @@ from cvxpy.settings import (
 )
 
 
-class Leaf(expression.Expression, metaclass=abc.ABCMeta):
+class Leaf(expression.Expression):
     """
     A leaf node of an expression tree; i.e., a Variable, Constant, or Parameter.
 

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -39,7 +39,7 @@ from cvxpy.settings import (
 )
 
 
-class Leaf(expression.Expression):
+class Leaf(expression.Expression, metaclass=abc.ABCMeta):
     """
     A leaf node of an expression tree; i.e., a Variable, Constant, or Parameter.
 
@@ -94,8 +94,6 @@ class Leaf(expression.Expression):
     bounds : Iterable
         An iterable of length two specifying lower and upper bounds.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def __init__(
         self, shape: int | tuple[int, ...], value=None, nonneg: bool = False,

--- a/cvxpy/expressions/variable.py
+++ b/cvxpy/expressions/variable.py
@@ -29,7 +29,7 @@ class Variable(Leaf):
     """
 
     def __init__(
-        self, shape: int | Iterable[int, ...] = (), name: str | None = None,
+        self, shape: int | Iterable[int] = (), name: str | None = None,
         var_id: int | None = None, **kwargs: Any
     ):
         if var_id is None:

--- a/cvxpy/interface/base_matrix_interface.py
+++ b/cvxpy/interface/base_matrix_interface.py
@@ -21,12 +21,11 @@ import numpy as np
 import cvxpy.interface.matrix_utilities
 
 
-class BaseMatrixInterface:
+class BaseMatrixInterface(metaclass=abc.ABCMeta):
     """
     An interface between constants' internal values
     and the target matrix used internally.
     """
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
     def const_to_matrix(self, value, convert_scalars: bool = False):

--- a/cvxpy/performance_tests/test_warmstart.py
+++ b/cvxpy/performance_tests/test_warmstart.py
@@ -18,8 +18,6 @@ THIS FILE IS DEPRECATED AND MAY BE REMOVED WITHOUT WARNING!
 DO NOT CALL THESE FUNCTIONS IN YOUR CODE!
 """
 
-from __future__ import print_function
-
 import time
 import unittest
 

--- a/cvxpy/problems/param_prob.py
+++ b/cvxpy/problems/param_prob.py
@@ -16,20 +16,19 @@ limitations under the License.
 import abc
 
 
-class ParamProb:
+class ParamProb(metaclass=abc.ABCMeta):
     """An abstract base class for parameterized problems.
 
     Parameterized problems are produced during the first canonicalization
     and allow canonicalization to be short-circuited for future solves.
     """
-    __metaclass__ = abc.ABCMeta
 
-    @abc.abstractproperty
+    @abc.abstractmethod
     def is_mixed_integer(self) -> bool:
         """Is the problem mixed-integer?"""
         raise NotImplementedError()
 
-    @abc.abstractproperty
+    @abc.abstractmethod
     def apply_parameters(self, id_to_param_value=None, zero_offset: bool = False,
                          keep_zeros: bool = False):
         """Returns A, b after applying parameters (and reshaping).

--- a/cvxpy/reductions/matrix_stuffing.py
+++ b/cvxpy/reductions/matrix_stuffing.py
@@ -103,10 +103,8 @@ def extract_mip_idx(variables) -> Tuple[List[int], List[int]]:
     return boolean_idx, integer_idx
 
 
-class MatrixStuffing(Reduction):
+class MatrixStuffing(Reduction, metaclass=abc.ABCMeta):
     """Stuffs a problem into a standard form for a family of solvers."""
-
-    __metaclass__ = abc.ABCMeta
 
     def apply(self, problem) -> None:
         """Returns a stuffed problem.

--- a/cvxpy/reductions/matrix_stuffing.py
+++ b/cvxpy/reductions/matrix_stuffing.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 
-import abc
 from typing import List, Optional, Tuple
 
 import numpy as np

--- a/cvxpy/reductions/matrix_stuffing.py
+++ b/cvxpy/reductions/matrix_stuffing.py
@@ -103,7 +103,7 @@ def extract_mip_idx(variables) -> Tuple[List[int], List[int]]:
     return boolean_idx, integer_idx
 
 
-class MatrixStuffing(Reduction, metaclass=abc.ABCMeta):
+class MatrixStuffing(Reduction):
     """Stuffs a problem into a standard form for a family of solvers."""
 
     def apply(self, problem) -> None:

--- a/cvxpy/reductions/reduction.py
+++ b/cvxpy/reductions/reduction.py
@@ -17,7 +17,7 @@ limitations under the License.
 from abc import ABCMeta, abstractmethod
 
 
-class Reduction:
+class Reduction(metaclass=ABCMeta):
     """Abstract base class for reductions.
 
     A reduction is an actor that transforms a problem into an
@@ -45,8 +45,6 @@ class Reduction:
     problem : Problem
         A problem owned by this reduction; possibly None.
     """
-
-    __metaclass__ = ABCMeta
 
     def __init__(self, problem=None) -> None:
         """Construct a reduction for reducing `problem`.

--- a/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
+++ b/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
@@ -165,7 +165,8 @@ class ConicSolver(Solver):
         # Default is identity.
         return sp.eye(constr.size, format='csc')
 
-    def format_constraints(self, problem, exp_cone_order):
+    @classmethod
+    def format_constraints(cls, problem, exp_cone_order):
         """
         Returns a ParamConeProg whose problem data tensors will yield the
         coefficient "A" and offset "b" for the constraint in the following
@@ -249,7 +250,7 @@ class ConicSolver(Solver):
                     arg_mats.append(space_mat)
                 restruct_mat.append(sp.hstack(arg_mats))
             elif type(constr) == PSD:
-                restruct_mat.append(self.psd_format_mat(constr))
+                restruct_mat.append(cls.psd_format_mat(constr))
             else:
                 raise ValueError("Unsupported constraint type.")
 

--- a/cvxpy/reductions/solvers/solver.py
+++ b/cvxpy/reductions/solvers/solver.py
@@ -20,7 +20,7 @@ from cvxpy import settings as s
 from cvxpy.reductions.reduction import Reduction
 
 
-class Solver(Reduction):
+class Solver(Reduction, metaclass=abc.ABCMeta):
     """Generic interface for a solver that uses reduction semantics
     """
 
@@ -29,8 +29,6 @@ class Solver(Reduction):
     #
     #   There are separate ConeDims classes for cone programs vs QPs.
     #   See cone_matrix_stuffing.py and qp_matrix_stuffing.py for details.
-
-    __metaclass__ = abc.ABCMeta
 
     # Solver capabilities.
     MIP_CAPABLE = False

--- a/cvxpy/reductions/solvers/solver.py
+++ b/cvxpy/reductions/solvers/solver.py
@@ -20,7 +20,7 @@ from cvxpy import settings as s
 from cvxpy.reductions.reduction import Reduction
 
 
-class Solver(Reduction, metaclass=abc.ABCMeta):
+class Solver(Reduction):
     """Generic interface for a solver that uses reduction semantics
     """
 

--- a/cvxpy/tests/test_base_classes.py
+++ b/cvxpy/tests/test_base_classes.py
@@ -1,0 +1,27 @@
+import inspect
+
+import pytest
+
+from cvxpy.atoms.affine.affine_atom import AffAtom
+from cvxpy.atoms.atom import Atom
+from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions.expression import Expression
+from cvxpy.expressions.leaf import Leaf
+from cvxpy.interface.base_matrix_interface import BaseMatrixInterface
+from cvxpy.problems.param_prob import ParamProb
+from cvxpy.reductions.reduction import Reduction
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from cvxpy.reductions.solvers.solver import Solver
+from cvxpy.utilities.canonical import Canonical
+
+
+@pytest.mark.parametrize("expected_abc", [
+    Canonical,
+    Expression, Atom, AffAtom, Leaf,
+    Constraint,
+    Reduction, Solver, ConicSolver,
+    ParamProb,
+    BaseMatrixInterface,
+])
+def test_is_abstract(expected_abc):
+    assert inspect.isabstract(expected_abc)

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -49,7 +49,7 @@ class TestDualize(BaseTest):
 
         # Dualize the problem, reconstruct a high-level cvxpy problem for the dual.
         # Solve the problem, invert the dualize reduction.
-        cone_prog = ConicSolver().format_constraints(cone_prog, exp_cone_order=[0, 1, 2])
+        cone_prog = ConicSolver.format_constraints(cone_prog, exp_cone_order=[0, 1, 2])
         data, inv_data = a2d.Dualize.apply(cone_prog)
         A, b, c, K_dir = data[s.A], data[s.B], data[s.C], data['K_dir']
         y = cp.Variable(shape=(A.shape[1],))
@@ -205,7 +205,7 @@ class TestSlacks(BaseTest):
 
         # apply the Slacks reduction, reconstruct a high-level problem,
         # solve the problem, invert the reduction.
-        cone_prog = ConicSolver().format_constraints(cone_prog, exp_cone_order=[0, 1, 2])
+        cone_prog = ConicSolver.format_constraints(cone_prog, exp_cone_order=[0, 1, 2])
         data, inv_data = a2d.Slacks.apply(cone_prog, affine)
         G, h, f, K_dir, K_aff = data[s.A], data[s.B], data[s.C], data['K_dir'], data['K_aff']
         G = sp.sparse.csc_matrix(G)

--- a/cvxpy/tests/test_examples.py
+++ b/cvxpy/tests/test_examples.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import print_function
-
 import unittest
 
 import numpy as np

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import division
-
 import numpy as np
 
 import cvxpy as cp

--- a/cvxpy/tests/test_matrices.py
+++ b/cvxpy/tests/test_matrices.py
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import sys
 import unittest
 from typing import Tuple
 
@@ -24,8 +23,6 @@ import cvxpy.interface.matrix_utilities as intf
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions.expression import Expression
 from cvxpy.expressions.variable import Variable
-
-PY35 = sys.version_info >= (3, 5)
 
 
 class TestMatrices(unittest.TestCase):
@@ -130,8 +127,7 @@ class TestMatrices(unittest.TestCase):
         self.assertExpression(B @ var, (4, 2))
         self.assertExpression(var - A, (4, 2))
         self.assertExpression(A - A - var, (4, 2))
-        if PY35:
-            self.assertExpression(var.__rmatmul__(B), (4, 2))
+        self.assertExpression(var.__rmatmul__(B), (4, 2))
         # self.assertExpression(var <= A, (4, 2))
         # self.assertExpression(A <= var, (4, 2))
         # self.assertExpression(var == A, (4, 2))

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -985,13 +985,8 @@ class TestProblem(BaseTest):
     def test_non_python_int_index(self) -> None:
         """Test problems that have special types as indices.
         """
-        import sys
-        if sys.version_info > (3,):
-            my_long = int
-        else:
-            my_long = long  # noqa: F821
-        # Test with long indices.
-        cost = self.x[0:my_long(2)][0]
+        # Test with int indices.
+        cost = self.x[0:int(2)][0]
         p = Problem(cp.Minimize(cost), [self.x == 1])
         result = p.solve(solver=cp.SCS)
         self.assertAlmostEqual(result, 1)

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import absolute_import, division, print_function
-
 import warnings
 
 import numpy as np

--- a/cvxpy/transforms/indicator.py
+++ b/cvxpy/transforms/indicator.py
@@ -94,6 +94,11 @@ class indicator(Expression):
         """
         return ()
 
+    def is_dpp(self, context: str = 'dcp') -> bool:
+        """The expression is a disciplined parameterized expression.
+        """
+        return False
+
     def name(self) -> str:
         """Returns the string representation of the expression.
         """

--- a/cvxpy/utilities/canonical.py
+++ b/cvxpy/utilities/canonical.py
@@ -159,6 +159,10 @@ class Canonical(metaclass=abc.ABCMeta):
         """
         return max([self.ndim] + [arg._max_ndim() for arg in self.args])
 
+    @abc.abstractmethod
+    def __str__(self) -> str:
+        raise NotImplementedError()
+
 
 _MISSING = object()
 

--- a/cvxpy/utilities/canonical.py
+++ b/cvxpy/utilities/canonical.py
@@ -22,12 +22,10 @@ from cvxpy.utilities import performance_utils as pu
 from cvxpy.utilities.deterministic import unique_list
 
 
-class Canonical:
+class Canonical(metaclass=abc.ABCMeta):
     """
     An interface for objects that can be canonicalized.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     @property
     def expr(self):

--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import annotations, division
+from __future__ import annotations
 
 import operator
 from typing import List

--- a/cvxpy/utilities/key_utils.py
+++ b/cvxpy/utilities/key_utils.py
@@ -16,8 +16,6 @@ limitations under the License.
 
 # Utility functions to handle indexing/slicing into an expression.
 
-from __future__ import division
-
 import numbers
 from typing import Optional, Tuple
 

--- a/examples/advanced/circuits.py
+++ b/examples/advanced/circuits.py
@@ -35,8 +35,7 @@ class Ground(Node):
     def constraints(self):
         return [self.voltage == 0] + super(Ground, self).constraints()
 
-class Device:
-    __metaclass__ = abc.ABCMeta
+class Device(metaclass=abc.ABCMeta):
     """ A device on a circuit. """
     def __init__(self, pos_node, neg_node) -> None:
         self.pos_node = pos_node

--- a/examples/advanced/test.py
+++ b/examples/advanced/test.py
@@ -74,8 +74,7 @@ import numpy as np
 a = np.random.random((2,2))
 
 
-class Bar1:
-    __metaclass__ = MyMeta
+class Bar1(metaclass=MyMeta):
     def __add__(self, rhs): return 0
     def __radd__(self, rhs): return 1
     def __lt__(self, rhs): return 0

--- a/examples/extensions/mixed_integer/noncvx_variable.py
+++ b/examples/extensions/mixed_integer/noncvx_variable.py
@@ -23,7 +23,6 @@ import cvxpy.interface as intf
 
 
 class NonCvxVariable(cvxpy.Variable):
-    __metaclass__ = abc.ABCMeta
     def __init__(self, *args, **kwargs) -> None:
         super(NonCvxVariable, self).__init__(*args, **kwargs)
         self.noncvx = True


### PR DESCRIPTION
Hi there 👋 

I noticed there was still quite a bit of code that uses some constructs from Python 2 in the code base, even though Python 2 is not supported anymore. I used the 2to3 tool (while it still exists) to make the bulk of the changes, and then I adapted a little the result.

The most noticeable change comes from the Abstract Base Classes. The old syntax:
```python
class X:
    __metaclass__ = abc.ABCMeta
```
has no effect in Python 3, so all of these were just plain classes. Fixing that revealed a couple errors with some unimplemented methods, so I added some dummy implementations.

I wanted to add a test that the abstract-ness is working, something like:
```python
for expected_abc in (Canonical, Expression, Atom, Leaf, Reduction, Solver, Constraint):
    assert inspect.isabstract(expected_abc)
```
All of these fail before this PR. Do you have an idea where this test could fit? Looking at the `tests` directory, I couldn't figure out if there were similar tests somewhere or not.

Let me know your thoughts about this!