### PR TITLE
Allow expressions with multiple attributes

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -142,15 +142,6 @@ class Leaf(expression.Expression):
         else:
             self.integer_idx = []
 
-        # Only one attribute be True (except can be boolean and integer).
-        true_attr = sum(1 for k, v in self.attributes.items() if v)
-        # HACK we should remove this feature or allow multiple attributes in general.
-        if boolean and integer:
-            true_attr -= 1
-        if true_attr > 1:
-            raise ValueError("Cannot set more than one special attribute in %s."
-                             % self.__class__.__name__)
-
         if value is not None:
             self.value = value
 

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+import cvxpy as cp
+from cvxpy.constraints.psd import PSD
+from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
+
+
+class Test_Attributes():
+
+    def test_multiple_attributes(self) -> None:
+        x = cp.Variable(shape=(2,2), symmetric=True, nonneg=True, integer=True)
+        target = np.array(np.eye(2) * 5)
+        prob = cp.Problem(cp.Minimize(0), [x == target])
+        prob.solve()
+        assert np.allclose(x.value, target)
+
+    def test_nonneg_PSD(self) -> None:
+        x = cp.Variable(shape=(2,2), PSD=True, nonneg=True)
+        target = np.array(np.eye(2) * 5)
+        prob = cp.Problem(cp.Minimize(0), [x == target])
+        prob.solve()
+        assert np.allclose(x.value, target)
+
+    def test_nonneg_NSD(self) -> None:
+        x = cp.Variable(shape=(2,2), NSD=True, nonpos=True)
+        target = np.array(np.eye(2) * 5)
+        prob = cp.Problem(cp.Minimize(0), [x == -target])
+
+        new_prob = CvxAttr2Constr(prob)
+        assert type(new_prob.apply(prob)[0].constraints[0]) is PSD

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -1,7 +1,9 @@
 import numpy as np
 
 import cvxpy as cp
+from cvxpy.constraints.nonpos import Inequality
 from cvxpy.constraints.psd import PSD
+from cvxpy.constraints.zero import Equality
 from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
 
 
@@ -11,6 +13,10 @@ class Test_Attributes():
         x = cp.Variable(shape=(2,2), symmetric=True, nonneg=True, integer=True)
         target = np.array(np.eye(2) * 5)
         prob = cp.Problem(cp.Minimize(0), [x == target])
+        new_prob = CvxAttr2Constr(prob, reduce_bounds=True)
+        assert type(new_prob.apply(prob)[0].constraints[0]) is Inequality
+        assert type(new_prob.apply(prob)[0].constraints[1]) is Equality
+
         prob.solve()
         assert np.allclose(x.value, target)
 
@@ -18,13 +24,37 @@ class Test_Attributes():
         x = cp.Variable(shape=(2,2), PSD=True, nonneg=True)
         target = np.array(np.eye(2) * 5)
         prob = cp.Problem(cp.Minimize(0), [x == target])
+        new_prob = CvxAttr2Constr(prob, reduce_bounds=True)
+        assert type(new_prob.apply(prob)[0].constraints[0]) is PSD
+        assert type(new_prob.apply(prob)[0].constraints[1]) is Inequality
+        assert type(new_prob.apply(prob)[0].constraints[2]) is Equality
+
         prob.solve()
         assert np.allclose(x.value, target)
 
-    def test_nonneg_NSD(self) -> None:
+    def test_nonpos_NSD(self) -> None:
         x = cp.Variable(shape=(2,2), NSD=True, nonpos=True)
         target = np.array(np.eye(2) * 5)
         prob = cp.Problem(cp.Minimize(0), [x == -target])
 
-        new_prob = CvxAttr2Constr(prob)
+        new_prob = CvxAttr2Constr(prob, reduce_bounds=True)
         assert type(new_prob.apply(prob)[0].constraints[0]) is PSD
+        assert type(new_prob.apply(prob)[0].constraints[1]) is Inequality
+        assert type(new_prob.apply(prob)[0].constraints[2]) is Equality
+
+        prob.solve()
+        assert np.allclose(x.value, -target)
+
+    def test_integer_bounds(self) -> None:
+        x = cp.Variable(shape=(2,2), integer=True, bounds=[0, 2])
+        target = np.array(np.eye(2))
+        prob = cp.Problem(cp.Minimize(0), [x == target])
+
+        new_prob = CvxAttr2Constr(prob, reduce_bounds=True)
+        assert type(new_prob.apply(prob)[0].constraints[0]) is Inequality
+        assert type(new_prob.apply(prob)[0].constraints[1]) is Inequality
+        assert type(new_prob.apply(prob)[0].constraints[2]) is Equality
+
+        prob.solve()
+        assert np.allclose(x.value, target)
+        

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 import warnings
-from itertools import combinations
 
 import numpy as np
 import pytest
@@ -1610,31 +1609,3 @@ class TestND_Expressions():
         prob = cp.Problem(self.obj, [expr == y])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, y)
-
-class Test_Attributes():
-
-    def test_multiple_attributes(self) -> None:
-        x = cp.Variable(shape=(2,2), symmetric=True, nonneg=True, integer=True, boolean=True)
-        target = np.array(np.eye(2))
-        prob = cp.Problem(cp.Minimize(0), [x == target])
-        prob.solve()
-        assert np.allclose(x.value, target)
-            
-    # Define the attributes to test
-    attributes = [
-    'nonneg', 'pos', 'nonpos', 'neg', 'diag', 'PSD', 'NSD', 'imag', 'boolean', 'integer'
-    ]
-
-    # Generate combinations of attributes
-    combinations_of_attributes = []
-    for r in range(1, len(attributes) + 1):
-        combinations_of_attributes.extend(combinations(attributes, r))
-
-    @pytest.mark.parametrize("attributes", combinations_of_attributes)
-    def test_variable_combinations(self, attributes):
-        kwargs = {attr: True for attr in attributes}
-        var = cp.Variable(shape=(2, 2), **kwargs)
-        target = np.array([[0, 1], [1, 0]])
-        prob = cp.Problem(cp.Minimize(0), [var == target])
-        prob.solve()
-        assert np.allclose(var.value, target)


### PR DESCRIPTION
## Description
This PR attempts to tackle a long-standing TODO for CVXPY, which is enabling users to specify more than one special attribute for variables and parameters. 
Note: I don't think the PR is ready by any means yet, but I would like some feedback and potentially start a discussion on what tests can be added (which combinations of attributes, what sorts of feasibility problems, etc.).

I have imported the ``cvxattr2constr`` reduction to ensure that the attributes are in fact able to create all the expected new constraints. It seems like many things are working by default (for example, bounds and integer/boolean and also PSD with nonneg). 
Issue link (if applicable): #566 

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.