### PR TITLE
update nd-sum to be general for sparse variables

### DIFF
--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -1219,11 +1219,12 @@ class SciPyCanonBackend(PythonCanonBackend):
                 else:
                     shape = tuple(_lin.args[0].shape)
                     axis = axis if isinstance(axis, tuple) else (axis,)
-                    n = x.shape[-1]
+                    n = x.shape[0]
                     d = np.prod([shape[i] for i in axis], dtype=int)
                     row_idx = row_idx_func(shape=shape, axis=axis)
-                    col_idx = np.arange(n).reshape(shape, order='F').flatten(order='F')
-                    return sp.csr_matrix((x.data, (row_idx, col_idx)), shape=(n//d, n))
+                    col_idx = np.arange(n)
+                    A = sp.csr_matrix((np.ones(n), (row_idx, col_idx)), shape=(n//d, n))
+                    return A @ x
             else:
                 m = x.shape[0] // p
                 return (sp.kron(sp.eye(p, format="csc"), np.ones(m)) @ x).tocsc()

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1621,3 +1621,10 @@ class TestND_Expressions():
         prob = cp.Problem(self.obj, [expr == y])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, y)
+
+    def test_nd_index_sum(self) -> None:
+        expr = self.x[:,:,0].sum(axis=0)
+        y = self.target[:,:,0].sum(axis=0)
+        prob = cp.Problem(self.obj, [expr == y])
+        prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+        assert np.allclose(expr.value, y)


### PR DESCRIPTION
## Description
Please include a short summary of the change.
nd sums were not working in conjunction with sparse variables and it was because I had previously assumed that the tensor was always an identity matrix. @PTNobel gave the suggestion to form a sparse coefficient matrix to multiply the tensor with, thanks!
Issue link (if applicable):

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.