### PR TITLE
Removes support for old CLARABEL versions

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
@@ -25,7 +25,6 @@ from cvxpy.expressions.expression import Expression
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
-from cvxpy.utilities.versioning import Version
 
 
 def dims_to_solver_cones(cone_dims):
@@ -133,16 +132,7 @@ class CLARABEL(ConicSolver):
     # Solver capabilities.
     MIP_CAPABLE = False
     SUPPORTED_CONSTRAINTS = ConicSolver.SUPPORTED_CONSTRAINTS \
-        + [SOC, ExpCone, PowCone3D]
-    
-    # TODO remove try-catch when minimum required version >= 0.5.0.
-    try:
-        import clarabel
-        if Version(clarabel.__version__) >= Version('0.5.0'):
-            SUPPORTED_CONSTRAINTS.append(PSD)
-    except (ModuleNotFoundError, TypeError):
-        pass
-    
+        + [SOC, ExpCone, PowCone3D, PSD]
 
     STATUS_MAP = {
                     "Solved": s.OPTIMAL,


### PR DESCRIPTION
## Description

We stopped officially supporting code for Clarabel v<0.5.0 a few releases ago, so we can drop this extra code.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.