### PR TITLE
`np.reshape` needs order as keyword argument

### DIFF
--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -102,7 +102,7 @@ class reshape(AffAtom):
     def numeric(self, values):
         """Reshape the value.
         """
-        return np.reshape(values[0], self.shape, self.order)
+        return np.reshape(values[0], shape=self.shape, order=self.order)
 
     def validate_arguments(self) -> None:
         """Checks that the new shape has the same number of entries as the old.

--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -102,7 +102,7 @@ class reshape(AffAtom):
     def numeric(self, values):
         """Reshape the value.
         """
-        return np.reshape(values[0], shape=self.shape, order=self.order)
+        return np.reshape(values[0], self.shape, order=self.order)
 
     def validate_arguments(self) -> None:
         """Checks that the new shape has the same number of entries as the old.

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -138,10 +138,10 @@ class ExpCone(Cone):
 
     def save_dual_value(self, value) -> None:
         # TODO(akshaya,SteveDiamond): verify that reshaping below works correctly
-        value = np.reshape(value, shape=(-1, 3))
-        dv0 = np.reshape(value[:, 0], shape=self.x.shape)
-        dv1 = np.reshape(value[:, 1], shape=self.y.shape)
-        dv2 = np.reshape(value[:, 2], shape=self.z.shape)
+        value = np.reshape(value, (-1, 3))
+        dv0 = np.reshape(value[:, 0], self.x.shape)
+        dv1 = np.reshape(value[:, 1], self.y.shape)
+        dv2 = np.reshape(value[:, 2], self.z.shape)
         self.dual_variables[0].save_value(dv0)
         self.dual_variables[1].save_value(dv1)
         self.dual_variables[2].save_value(dv2)

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -138,10 +138,10 @@ class ExpCone(Cone):
 
     def save_dual_value(self, value) -> None:
         # TODO(akshaya,SteveDiamond): verify that reshaping below works correctly
-        value = np.reshape(value, newshape=(-1, 3))
-        dv0 = np.reshape(value[:, 0], newshape=self.x.shape)
-        dv1 = np.reshape(value[:, 1], newshape=self.y.shape)
-        dv2 = np.reshape(value[:, 2], newshape=self.z.shape)
+        value = np.reshape(value, shape=(-1, 3))
+        dv0 = np.reshape(value[:, 0], shape=self.x.shape)
+        dv1 = np.reshape(value[:, 1], shape=self.y.shape)
+        dv2 = np.reshape(value[:, 2], shape=self.z.shape)
         self.dual_variables[0].save_value(dv0)
         self.dual_variables[1].save_value(dv1)
         self.dual_variables[2].save_value(dv2)

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -129,10 +129,10 @@ class PowCone3D(Cone):
         return s
 
     def save_dual_value(self, value) -> None:
-        value = np.reshape(value, shape=(3, -1))
-        dv0 = np.reshape(value[0, :], shape=self.x.shape)
-        dv1 = np.reshape(value[1, :], shape=self.y.shape)
-        dv2 = np.reshape(value[2, :], shape=self.z.shape)
+        value = np.reshape(value, (3, -1))
+        dv0 = np.reshape(value[0, :], self.x.shape)
+        dv1 = np.reshape(value[1, :], self.y.shape)
+        dv2 = np.reshape(value[2, :], self.z.shape)
         self.dual_variables[0].save_value(dv0)
         self.dual_variables[1].save_value(dv1)
         self.dual_variables[2].save_value(dv2)

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -129,10 +129,10 @@ class PowCone3D(Cone):
         return s
 
     def save_dual_value(self, value) -> None:
-        value = np.reshape(value, newshape=(3, -1))
-        dv0 = np.reshape(value[0, :], newshape=self.x.shape)
-        dv1 = np.reshape(value[1, :], newshape=self.y.shape)
-        dv2 = np.reshape(value[2, :], newshape=self.z.shape)
+        value = np.reshape(value, shape=(3, -1))
+        dv0 = np.reshape(value[0, :], shape=self.x.shape)
+        dv1 = np.reshape(value[1, :], shape=self.y.shape)
+        dv2 = np.reshape(value[2, :], shape=self.z.shape)
         self.dual_variables[0].save_value(dv0)
         self.dual_variables[1].save_value(dv1)
         self.dual_variables[2].save_value(dv2)

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -158,7 +158,7 @@ class SOC(Cone):
 
     def save_dual_value(self, value) -> None:
         cone_size = 1 + self.args[1].shape[self.axis]
-        value = np.reshape(value, shape=(-1, cone_size))
+        value = np.reshape(value, (-1, cone_size))
         t = value[:, 0]
         X = value[:, 1:]
         if self.axis == 0:

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -158,7 +158,7 @@ class SOC(Cone):
 
     def save_dual_value(self, value) -> None:
         cone_size = 1 + self.args[1].shape[self.axis]
-        value = np.reshape(value, newshape=(-1, cone_size))
+        value = np.reshape(value, shape=(-1, cone_size))
         t = value[:, 0]
         X = value[:, 1:]
         if self.axis == 0:

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1497,7 +1497,7 @@ class TestProblem(BaseTest):
         obj = cp.Minimize(cp.sum(mat @ expr))
         prob = Problem(obj, [self.C == C_mat])
         result = prob.solve(solver=cp.SCS)
-        reshaped = numpy.reshape(C_mat, (2, 3), 'F')
+        reshaped = numpy.reshape(C_mat, (2, 3), order='F')
         self.assertAlmostEqual(result, (mat.dot(reshaped)).sum())
         self.assertItemsAlmostEqual(expr.value, C_mat)
 


### PR DESCRIPTION
## Description
In the latest release of NumPy (v2.1.0), the `order` argument to `np.reshape` became keyword-only, so the `cp.reshape` atom is failing.

The `newshape` argument is also deprecated, `shape` is preferred to align with the Array API.

### Note

I think the `order` change was unintended and might be reverted in a patch release (reported in numpy/numpy#27256). However, it is still worth fixing this in cvxpy to guard against future changes.

Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.