### PR TITLE
adding support for nd sum in parametrized expressions

### DIFF
--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1574,7 +1574,7 @@ class TestND_Expressions():
     @pytest.mark.parametrize("axis", [(0),(1),(2),((0,1)),((0,2)),((2,1))])
     def test_nd_parametrized_sum(self, axis) -> None:
         param = cp.Parameter((2,2,2))
-        param.value = np.ones((2,2,2))
+        param.value = np.arange(8).reshape(2,2,2)
         expr = cp.multiply(self.x, param).sum(axis=axis)
         target = self.target.sum(axis=axis)
         prob = cp.Problem(self.obj, [expr == target])

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1571,6 +1571,16 @@ class TestND_Expressions():
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, y)
 
+    @pytest.mark.parametrize("axis", [(0),(1),(2),((0,1)),((0,2)),((2,1))])
+    def test_nd_parametrized_sum(self, axis) -> None:
+        param = cp.Parameter((2,2,2))
+        param.value = np.ones((2,2,2))
+        expr = cp.multiply(self.x, param).sum(axis=axis)
+        target = self.target.sum(axis=axis)
+        prob = cp.Problem(self.obj, [expr == target])
+        prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+        assert np.allclose(expr.value, target)
+
     @pytest.mark.parametrize("axis", [(0,2,4,5),((4,5)),((0,2,3,1)),((5,3,1)), ((0,1,2,5))])
     def test_nd_big_sum(self, axis) -> None:
         in_shape = (6,5,4,3,2,1)


### PR DESCRIPTION
## Description
Please include a short summary of the change.
This PR adapts the SciPy backend sum function to support parametrized sums. 
I introduced a new helper function ``get_sum_coeff_matrix`` since I noticed that it was being reused for both cases (non-dpp and dpp). 
This PR keeps the old functionality the same and adds a general case for when ``axis != None``.
Issue link (if applicable):

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.