### PR TITLE
Fix: `value.A` has been removed and is still used for large problems

### DIFF
--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -249,7 +249,7 @@ class ParamConeProg(ParamProb):
             # slow path.
             # TODO: make this faster by intelligently operating on the
             # sparse matrix data / making use of reduced_A
-            del_param_vec += np.squeeze((delAb.T @ self.A).A)
+            del_param_vec += np.squeeze((delAb.T @ self.A).toarray())
         del_param_vec = np.squeeze(del_param_vec)
 
         param_id_to_delta_param = {}


### PR DESCRIPTION
## Description
Please include a short summary of the change.
Issue link (if applicable): `value.A` has been removed from scipy sparse arrays. This bug only happens when solving large problems. 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests: No. My personal computer doesn't have enough memory to enter the branch in which the bug exists.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.