### PR TITLE
New CVaR atom

### DIFF
--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -40,6 +40,7 @@ from cvxpy.atoms.affine.wraps import (hermitian_wrap, psd_wrap,
                                       skew_symmetric_wrap, symmetric_wrap,)
 from cvxpy.atoms.condition_number import condition_number
 from cvxpy.atoms.cummax import cummax
+from cvxpy.atoms.cvar import cvar
 from cvxpy.atoms.dist_ratio import dist_ratio
 from cvxpy.atoms.dotsort import dotsort
 from cvxpy.atoms.elementwise.abs import abs

--- a/cvxpy/atoms/cvar.py
+++ b/cvxpy/atoms/cvar.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 import numpy as np
 
-import cvxpy as cp
 from cvxpy.atoms.dotsort import dotsort
 
 
@@ -37,21 +36,18 @@ def cvar(x, beta):
 
     Parameters
     ----------
-    x : cvxpy.Expression
+    x : Expression or numeric constant.
         The vector of samples.
     beta : float
         The probability level, must be in the range :math:`[0, 1)`.
 
     Returns
     -------
-    cvxpy.Expression
+    Expression
         The CVaR of :math:`x` at probability level :math:`\beta`.
     """
     if not 0 <= beta < 1:
         raise ValueError(f"The probability level beta must be in the range [0, 1), got {beta}")
-
-    if not isinstance(x, cp.Expression):
-        raise TypeError("Input must be a CVXPY expression")
 
     if len(x.shape) > 1 and x.shape[1] != 1:
         raise ValueError(f"Input must be a vector, got shape {x.shape}")

--- a/cvxpy/atoms/cvar.py
+++ b/cvxpy/atoms/cvar.py
@@ -14,13 +14,41 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from cvxpy.atoms.dotsort import dotsort
 import numpy as np
+
+from cvxpy.atoms.dotsort import dotsort
 
 
 def cvar(x, beta):
-    """
-    The conditional value at risk (CVaR) of x at quantile level (1 - beta).
+    r"""The Conditional Value at Risk (CVaR) of a discrete random variable.
+
+    CVaR at level beta is a risk measure that captures the expected value over 
+    the worst (1-beta) fraction of outcomes of a real-valued random variable. 
+    For a random variable X representing losses, CVaR at level beta is defined as:
+
+    .. math::
+        \phi_\beta(X) = \mathbb{E}[X | X \geq \psi_\beta(X)]
+
+    where psi_beta(X) is the Value at Risk (VaR) at level beta.
+
+    For a discrete distribution represented by samples z_1, ..., z_m, 
+    CVaR can be computed as:
+
+    .. math::
+        \phi_\beta(z) = \inf_{\alpha \in \mathbb{R}} \left\{ \alpha + 
+        \frac{1}{(1-\beta)m}\sum_{i=1}^m(z_i-\alpha)_+ \right\}
+
+    where (z-alpha)_+ = max(z-alpha, 0) is the positive part of z-alpha.
+
+    This function is a wrapper around the dotsort atom, providing an efficient 
+    computation of CVaR for discrete distributions.
+
+    Parameters
+    ----------
+    x : cvxpy.Expression
+        The vector of sample losses.
+    beta : float
+        The probability level, between 0 and 1.
     """
     k = (1 - beta) * x.shape[0]
     w = np.append(np.ones(int(k)), k - int(k))

--- a/cvxpy/atoms/cvar.py
+++ b/cvxpy/atoms/cvar.py
@@ -1,0 +1,28 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from cvxpy.atoms.dotsort import dotsort
+import numpy as np
+
+
+def cvar(x, beta):
+    """
+    The conditional value at risk (CVaR) of x at quantile level (1 - beta).
+    """
+    k = (1 - beta) * x.shape[0]
+    w = np.append(np.ones(int(k)), k - int(k))
+    return 1/k * dotsort(x, w)
+    

--- a/cvxpy/atoms/cvar.py
+++ b/cvxpy/atoms/cvar.py
@@ -20,35 +20,31 @@ from cvxpy.atoms.dotsort import dotsort
 
 
 def cvar(x, beta):
-    r"""The Conditional Value at Risk (CVaR) of a discrete random variable.
-
-    CVaR at level beta is a risk measure that captures the expected value over 
-    the worst (1-beta) fraction of outcomes of a real-valued random variable. 
-    For a random variable X representing losses, CVaR at level beta is defined as:
-
-    .. math::
-        \phi_\beta(X) = \mathbb{E}[X | X \geq \psi_\beta(X)]
-
-    where psi_beta(X) is the Value at Risk (VaR) at level beta.
-
-    For a discrete distribution represented by samples z_1, ..., z_m, 
-    CVaR can be computed as:
+    r"""Conditional value at risk (CVaR) at probability level :math:`\beta` of a vector :math:`x`.
+    
+    It represents the average of the :math:`(1-\beta)` fraction of largest values in :math:`x`. 
+    If a probability distribution is represented by a finite set of samples 
+    :math:`x_1, \ldots, x_m \in \mathbb{R}`, the CVaR at level :math:`\beta`, denoted as 
+    :math:`\phi_\beta(x): \mathbb{R}^m \rightarrow \mathbb{R}`, can be computed as: 
 
     .. math::
-        \phi_\beta(z) = \inf_{\alpha \in \mathbb{R}} \left\{ \alpha + 
-        \frac{1}{(1-\beta)m}\sum_{i=1}^m(z_i-\alpha)_+ \right\}
+        \phi_\beta(x) = \inf_{\alpha \in \mathbb{R}} \left\{ \alpha + 
+        \frac{1}{(1-\beta)m}\sum_{i=1}^m(x_i-\alpha)_+ \right\}
 
-    where (z-alpha)_+ = max(z-alpha, 0) is the positive part of z-alpha.
+    where :math:`(x-\alpha)_+ = \max(x-\alpha, 0)` is the positive part of :math:`x-\alpha`.
 
-    This function is a wrapper around the dotsort atom, providing an efficient 
-    computation of CVaR for discrete distributions.
 
     Parameters
     ----------
     x : cvxpy.Expression
-        The vector of sample losses.
+        The vector of samples.
     beta : float
-        The probability level, between 0 and 1.
+        The probability level, must be in the range :math:`(0, 1)`.
+
+    Returns
+    -------
+    cvxpy.Expression
+        The CVaR of :math:`x` at probability level :math:`\beta`.
     """
     k = (1 - beta) * x.shape[0]
     w = np.append(np.ones(int(k)), k - int(k))

--- a/cvxpy/atoms/cvar.py
+++ b/cvxpy/atoms/cvar.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import numpy as np
 
+import cvxpy as cp
 from cvxpy.atoms.dotsort import dotsort
 
 
@@ -39,13 +40,22 @@ def cvar(x, beta):
     x : cvxpy.Expression
         The vector of samples.
     beta : float
-        The probability level, must be in the range :math:`(0, 1)`.
+        The probability level, must be in the range :math:`[0, 1)`.
 
     Returns
     -------
     cvxpy.Expression
         The CVaR of :math:`x` at probability level :math:`\beta`.
     """
+    if not 0 <= beta < 1:
+        raise ValueError(f"The probability level beta must be in the range [0, 1), got {beta}")
+
+    if not isinstance(x, cp.Expression):
+        raise TypeError("Input must be a CVXPY expression")
+
+    if len(x.shape) > 1 and x.shape[1] != 1:
+        raise ValueError(f"Input must be a vector, got shape {x.shape}")
+    
     k = (1 - beta) * x.shape[0]
     w = np.append(np.ones(int(k)), k - int(k))
     return 1/k * dotsort(x, w)

--- a/cvxpy/atoms/cvar.py
+++ b/cvxpy/atoms/cvar.py
@@ -49,8 +49,8 @@ def cvar(x, beta):
     if not 0 <= beta < 1:
         raise ValueError(f"The probability level beta must be in the range [0, 1), got {beta}")
 
-    if len(x.shape) > 1 and x.shape[1] != 1:
-        raise ValueError(f"Input must be a vector, got shape {x.shape}")
+    if len(x.shape) != 1:
+        raise ValueError(f"Input must be a vector (1D array), got shape {x.shape}")
     
     k = (1 - beta) * x.shape[0]
     w = np.append(np.ones(int(k)), k - int(k))

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -955,7 +955,31 @@ class TestAtoms(BaseTest):
         # Check that sum_smallest is PWL so can be canonicalized as a QP.
         atom = cp.sum_smallest(self.x, 2)
         assert atom.is_pwl()
+    
+    def test_cvar(self) -> None:
+        """Test the cvar atom.
+        """
+        # Set random seed for reproducibility
+        np.random.seed(1)
 
+        # Generate problem data
+        m = 100  # Size of random vector
+        x = np.random.randn(m)  # Random vector
+        beta = 0.9  # Probability level
+        
+        # Evaluate using cvar atom
+        cvar_atom = cp.cvar(x, beta)
+        cvar_value = cvar_atom.value
+        
+        # Evaluate using alternative optimization problem
+        alpha = cp.Variable()
+        objective = alpha + 1/((1-beta)*m) * cp.sum(cp.pos(x - alpha))
+        prob_alt = cp.Problem(cp.Minimize(objective))
+        cvar_alt_value = prob_alt.solve()
+        
+        # Check that the results are equal (within numerical tolerance)
+        self.assertAlmostEqual(cvar_value, cvar_alt_value)
+        
     def test_index(self) -> None:
         """Test the copy function for index.
         """

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -965,20 +965,21 @@ class TestAtoms(BaseTest):
         # Generate problem data
         m = 100  # Size of random vector
         x = np.random.randn(m)  # Random vector
-        beta = 0.9  # Probability level
+        betas = [0.1, 0.5, 0.9, 0.95, 0.99] # Probability levels
         
-        # Evaluate using cvar atom
-        cvar_atom = cp.cvar(x, beta)
-        cvar_value = cvar_atom.value
-        
-        # Evaluate using alternative optimization problem
-        alpha = cp.Variable()
-        objective = alpha + 1/((1-beta)*m) * cp.sum(cp.pos(x - alpha))
-        prob_alt = cp.Problem(cp.Minimize(objective))
-        cvar_alt_value = prob_alt.solve()
-        
-        # Check that the results are equal (within numerical tolerance)
-        self.assertAlmostEqual(cvar_value, cvar_alt_value)
+        for beta in betas:
+            # Evaluate using cvar atom
+            cvar_atom = cp.cvar(x, beta)
+            cvar_value = cvar_atom.value
+            
+            # Evaluate using alternative optimization problem
+            alpha = cp.Variable()
+            objective = alpha + 1/((1-beta)*m) * cp.sum(cp.pos(x - alpha))
+            prob_alt = cp.Problem(cp.Minimize(objective))
+            cvar_alt_value = prob_alt.solve()
+            
+            # Check that the results are equal (within numerical tolerance)
+            self.assertAlmostEqual(cvar_value, cvar_alt_value)
         
     def test_index(self) -> None:
         """Test the copy function for index.

--- a/doc/source/api_reference/cvxpy.atoms.other_atoms.rst
+++ b/doc/source/api_reference/cvxpy.atoms.other_atoms.rst
@@ -12,6 +12,13 @@ cummax
 .. autoclass:: cvxpy.atoms.cummax.cummax
     :show-inheritance:
 
+.. _cvar:
+
+cvar
+--------
+
+.. autofunction:: cvxpy.atoms.cvar.cvar
+
 .. _diff_pos:
 
 diff_pos

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -83,10 +83,12 @@ and returns a scalar.
 
    * - :ref:`cvar(x, beta) <cvar>`
      - average of the :math:`(1-\beta)`
-      
-       fraction of largest
        
-       losses in :math:`x`
+       fraction of largest values
+       
+       in :math:`x`, where :math:`x`
+       
+       is a vector of losses
      - :math:`x \in \mathbf{R}^m`
       
        :math:`\beta \in (0,1)`

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -81,15 +81,19 @@ and returns a scalar.
      - Curvature |_|
      - Monotonicity
 
-  * - :ref:`cvar(x, beta) <cvar>`
-      - average of the :math:`(1-\beta)` fraction of worst outcomes in :math:`x`
-      - :math:`x \in \mathbf{R}^m`
-        
-        :math:`\beta \in (0,1)`
-      - depends on :math:`x`
-      - |convex| convex
-      - |incr| incr.
-
+   * - :ref:`cvar(x, beta) <cvar>`
+     - average of the :math:`(1-\beta)`
+      
+       fraction of worst
+       
+       outcomes in :math:`x`
+     - :math:`x \in \mathbf{R}^m`
+      
+       :math:`\beta \in (0,1)`
+     - depends on :math:`x`
+     - |convex| convex
+     - |incr| incr.
+     
    * - :ref:`dotsort(X,W) <dotsort>`
 
        constant :math:`W \in \mathbf{R}^{o \times p}`

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -84,16 +84,16 @@ and returns a scalar.
    * - :ref:`cvar(x, beta) <cvar>`
      - average of the :math:`(1-\beta)`
       
-       fraction of worst
+       fraction of largest
        
-       outcomes in :math:`x`
+       losses in :math:`x`
      - :math:`x \in \mathbf{R}^m`
       
        :math:`\beta \in (0,1)`
      - depends on :math:`x`
      - |convex| convex
      - |incr| incr.
-     
+
    * - :ref:`dotsort(X,W) <dotsort>`
 
        constant :math:`W \in \mathbf{R}^{o \times p}`

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -86,9 +86,7 @@ and returns a scalar.
        
        fraction of largest values
        
-       in :math:`x`, where :math:`x`
-       
-       is a vector of losses
+       in :math:`x`
      - :math:`x \in \mathbf{R}^m`
       
        :math:`\beta \in (0,1)`

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -81,6 +81,15 @@ and returns a scalar.
      - Curvature |_|
      - Monotonicity
 
+  * - :ref:`cvar(x, beta) <cvar>`
+      - average of the :math:`(1-\beta)` fraction of worst outcomes in :math:`x`
+      - :math:`x \in \mathbf{R}^m`
+        
+        :math:`\beta \in (0,1)`
+      - depends on :math:`x`
+      - |convex| convex
+      - |incr| incr.
+
    * - :ref:`dotsort(X,W) <dotsort>`
 
        constant :math:`W \in \mathbf{R}^{o \times p}`


### PR DESCRIPTION
## Description
This PR creates the `cvar` atom (conditonal value at risk), which is implemented as a wrapper around the existing `dotsort` atom.

## Type of change
- [X] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [X] Add our license to new files.
- [X] Check that your code adheres to our coding style.
- [X] Write unittests.
- [X] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.