### PR TITLE
improve sum_largest to use partitionsort instead of standard sort

### DIFF
--- a/cvxpy/atoms/sum_largest.py
+++ b/cvxpy/atoms/sum_largest.py
@@ -42,8 +42,6 @@ class sum_largest(Atom):
     def numeric(self, values):
         """
         Returns the sum of the k largest entries of the matrix.
-
-        New in 1.6.0: sum_largest uses np.argpartition instead of np.argsort
         """
         value = values[0].flatten()
         k = int(self.k)

--- a/cvxpy/atoms/sum_largest.py
+++ b/cvxpy/atoms/sum_largest.py
@@ -24,10 +24,11 @@ from cvxpy.atoms.atom import Atom
 
 
 class sum_largest(Atom):
-    """Sum of the largest k values in the matrix X.
+    """
+    Sum of the largest k values in the expression X
     """
 
-    def __init__(self, x, k) -> None:
+    def __init__(self, x, k: int) -> None:
         self.k = k
         super(sum_largest, self).__init__(x)
 
@@ -39,10 +40,14 @@ class sum_largest(Atom):
         super(sum_largest, self).validate_arguments()
 
     def numeric(self, values):
-        """Returns the sum of the k largest entries of the matrix.
+        """
+        Returns the sum of the k largest entries of the matrix.
+
+        New in 1.6.0: sum_largest uses np.argpartition instead of np.argsort
         """
         value = values[0].flatten()
-        indices = np.argsort(-value)[:int(self.k)]
+        k = int(self.k)
+        indices = np.argpartition(-value, kth=k)[:k]
         return value[indices].sum()
 
     def _grad(self, values):
@@ -58,7 +63,8 @@ class sum_largest(Atom):
         """
         # Grad: 1 for each of k largest indices.
         value = intf.from_2D_to_1D(values[0].flatten().T)
-        indices = np.argsort(-value)[:int(self.k)]
+        k = int(self.k)
+        indices = np.argpartition(-value, kth=k)[:k]
         D = np.zeros((self.args[0].shape[0]*self.args[0].shape[1], 1))
         D[indices] = 1
         return [sp.csc_matrix(D)]

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -939,6 +939,14 @@ class TestAtoms(BaseTest):
         atom = cp.sum_largest(self.x, 2)
         assert atom.is_pwl()
 
+        # New in 1.6.0: sum_largest now uses np.argpartition instead of np.argsort
+        v = np.random.randn(10000)
+        x = Constant(v)
+        for i in [5, 50, 100, 250, 500, 1000]:
+            expr = cp.sum_largest(x, i)
+            prev_idx = np.argsort(-v)[:i]
+            self.assertAlmostEqual(expr.value, v[prev_idx].sum())
+
     def test_sum_smallest(self) -> None:
         """Test the sum_smallest atom and related atoms.
         """


### PR DESCRIPTION
## Description
Please include a short summary of the change.
This PR takes advantage of numpy's [argpartition](https://numpy.org/doc/stable/reference/generated/numpy.argpartition.html) function to partially sort the expression X. 
Since we only care about the $k$ largest (resp. smallest) values, we just need to make sure that the k-th element is sorted and all the values to its right (resp. left) are larger (resp. smaller). 

Algorithmic improvement (worst-case): ``O(nlogn)`` to ``O(nlogk)``.
Some small benchmarks:
 ```py
import time
import numpy as np
def new(x, k):
    indices = np.argpartition(-x, k)[:k]
    return x[indices].sum()
def prev(x, k):
    indices = np.argsort(-x)[:k]
    return x[indices].sum()

# compare prev with new for time
x = np.random.rand(10_000_000)
for k in [100, 1000, 10_000]:
    print('k:', k)
    start = time.time()
    prev(x, k)
    print('prev:', time.time() - start)
    start = time.time()
    new(x, k)
    print('new:', time.time() - start)
```
Output:
```
k: 100
prev: 1.1751160621643066
new: 0.10212492942810059
k: 1000
prev: 1.080510139465332
new: 0.10003519058227539
k: 10000
prev: 1.0831398963928223
new: 0.10057806968688965
```
Issue link (if applicable):

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.