### PR TITLE
improving special indexing string representation

### DIFF
--- a/cvxpy/atoms/affine/index.py
+++ b/cvxpy/atoms/affine/index.py
@@ -63,14 +63,13 @@ class index(AffAtom):
         """
         return True
 
-    # The string representation of the atom.
     def name(self):
-        # TODO string should be orig_key
+        """String representation of the index expression."""
         inner_str = "[%s" + ", %s"*(len(self.key)-1) + "]"
         return self.args[0].name() + inner_str % ku.to_str(self.key)
 
     def numeric(self, values):
-        """ Returns the index/slice into the given value.
+        """Returns the index/slice into the given value.
         """
         return values[0][self._orig_key]
 
@@ -138,12 +137,13 @@ class special_index(AffAtom):
         """
         return True
 
-    # The string representation of the atom.
     def name(self):
-        return self.args[0].name() + str(self.key)
+        """String representation of the special index expression."""
+        key_str = ku.special_key_to_str(self.key)
+        return f"{self.args[0].name()}[{key_str}]"
 
     def numeric(self, values):
-        """ Returns the index/slice into the given value.
+        """Returns the index/slice into the given value.
         """
         return values[0][self.key]
 

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1007,13 +1007,9 @@ class TestExpressions(BaseTest):
         self.assertEqual(exp.shape, (1,))
 
     def test_special_idx_str_repr(self) -> None:
-        idx = np.arange(178, dtype=int)
+        idx = [i for i in range(178)]
         exp = cp.Variable((200, 10), name="exp")[idx, 6]
         self.assertEqual("exp[[0, 1, 2, '...', 175, 176, 177], 6]", str(exp))
-
-        idx = [i for i in range(115)]
-        exp = cp.Variable((200, 10), name="exp")[idx, 2:5]
-        self.assertEqual("exp[[0, 1, 2, '...', 112, 113, 114], 2:5]", str(exp))
 
     def test_none_idx(self) -> None:
         """Test None as index.

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1007,7 +1007,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(exp.shape, (1,))
 
     def test_special_idx_str_repr(self) -> None:
-        idx = np.arange(178)
+        idx = np.arange(178, dtype=int)
         exp = cp.Variable((200, 10), name="exp")[idx, 6]
         self.assertEqual("exp[[0, 1, 2, '...', 175, 176, 177], 6]", str(exp))
 

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1006,6 +1006,15 @@ class TestExpressions(BaseTest):
         self.assertEqual(exp.curvature, s.AFFINE)
         self.assertEqual(exp.shape, (1,))
 
+    def test_special_idx_str_repr(self) -> None:
+        idx = np.arange(178)
+        exp = cp.Variable((200, 10), name="exp")[idx, 6]
+        self.assertEqual("exp[[0, 1, 2, '...', 175, 176, 177], 6]", str(exp))
+
+        idx = [i for i in range(115)]
+        exp = cp.Variable((200, 10), name="exp")[idx, 2:5]
+        self.assertEqual("exp[[0, 1, 2, '...', 112, 113, 114], 2:5]", str(exp))
+
     def test_none_idx(self) -> None:
         """Test None as index.
         """

--- a/cvxpy/utilities/key_utils.py
+++ b/cvxpy/utilities/key_utils.py
@@ -209,3 +209,23 @@ def is_special_slice(key) -> bool:
             return True
 
     return False
+
+
+def special_key_to_str(key):
+    """Converts a special key to a string representation."""
+    key_strs = []
+    for k in key:
+        if isinstance(k, (np.ndarray, list)):
+            key_strs.append(str(pprint_sequence(k)))
+        elif isinstance(k, slice):
+            key_strs.append(slice_to_str(k))
+        else:
+            key_strs.append(str(k))
+    return ", ".join(key_strs)
+
+
+def pprint_sequence(seq, max_elems=6):
+    """Shorten the sequence (array or list) for pretty-printing."""
+    if len(seq) > max_elems:
+        return list(seq[:3]) + ['...'] + list(seq[-3:])
+    return seq


### PR DESCRIPTION
## Description
Please include a short summary of the change.
When passing a list or an ndarray as an index, cvxpy currently shows the entire constant in the string representation which can get quite messy (example below):
```py
>>> import numpy as np
>>> import cvxpy as cp
>>> idx = np.arange(178)
>>> exp = cp.Variable((200, 10), name="exp")[idx, 6]
>>> print(exp)
exp(array([  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,
        13,  14,  15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,
        26,  27,  28,  29,  30,  31,  32,  33,  34,  35,  36,  37,  38,
        39,  40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  50,  51,
        52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  63,  64,
        65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,
        78,  79,  80,  81,  82,  83,  84,  85,  86,  87,  88,  89,  90,
        91,  92,  93,  94,  95,  96,  97,  98,  99, 100, 101, 102, 103,
       104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116,
       117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129,
       130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142,
       143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155,
       156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168,
       169, 170, 171, 172, 173, 174, 175, 176, 177]), 6)
```
This PR aims to fix this by introducing two helper functions in the ``key_utils`` module.
The new output now looks like this:
```py
exp[[0, 1, 2, '...', 175, 176, 177], 6]
```
Issue link (if applicable):

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.