### PR TITLE
improving performance of diff_matrix for cumsum

### DIFF
--- a/cvxpy/atoms/affine/cumsum.py
+++ b/cvxpy/atoms/affine/cumsum.py
@@ -43,25 +43,10 @@ def get_diff_mat(dim: int, axis: int) -> sp.csc_matrix:
     SciPy CSC matrix
         A square matrix representing first order difference.
     """
-    # Construct a sparse matrix representation.
-    val_arr = []
-    row_arr = []
-    col_arr = []
-    for i in range(dim):
-        val_arr.append(1.)
-        row_arr.append(i)
-        col_arr.append(i)
-        if i > 0:
-            val_arr.append(-1.)
-            row_arr.append(i)
-            col_arr.append(i-1)
-
-    mat = sp.csc_matrix((val_arr, (row_arr, col_arr)),
-                        (dim, dim))
-    if axis == 0:
-        return mat
-    else:
-        return mat.T
+    mat = sp.diags([np.ones(dim), -np.ones(dim - 1)], [0, -1], 
+                   shape=(dim, dim), 
+                   format='csc')
+    return mat if axis == 0 else mat.T
 
 
 class cumsum(AffAtom, AxisAtom):

--- a/cvxpy/atoms/affine/cumsum.py
+++ b/cvxpy/atoms/affine/cumsum.py
@@ -40,7 +40,7 @@ def get_diff_mat(dim: int, axis: int) -> sp.csc_matrix:
 
     Returns
     -------
-    SciPy CSC matrix
+    sp.csc_matrix
         A square matrix representing first order difference.
     """
     mat = sp.diags([np.ones(dim), -np.ones(dim - 1)], [0, -1], 
@@ -50,7 +50,8 @@ def get_diff_mat(dim: int, axis: int) -> sp.csc_matrix:
 
 
 class cumsum(AffAtom, AxisAtom):
-    """Cumulative sum.
+    """
+    Cumulative sum of the elements of an expression.
 
     Attributes
     ----------
@@ -64,13 +65,13 @@ class cumsum(AffAtom, AxisAtom):
 
     @AffAtom.numpy_numeric
     def numeric(self, values):
-        """Convolve the two values.
+        """
+        Returns the cumulative product of elements of an expression over an axis.
         """
         return np.cumsum(values[0], axis=self.axis)
 
     def shape_from_args(self) -> Tuple[int, ...]:
-        """The same as the input.
-        """
+        """The same as the input."""
         return self.args[0].shape
 
     def _grad(self, values):
@@ -84,12 +85,8 @@ class cumsum(AffAtom, AxisAtom):
         Returns:
             A list of SciPy CSC sparse matrices or None.
         """
-        # TODO inefficient
         dim = values[0].shape[self.axis]
-        mat = np.zeros((dim, dim))
-        for i in range(dim):
-            for j in range(i+1):
-                mat[i, j] = 1
+        mat = sp.tril(np.ones((dim, dim)))
         var = Variable(self.args[0].shape)
         if self.axis == 0:
             grad = MulExpression(mat, var)._grad(values)[1]
@@ -98,8 +95,7 @@ class cumsum(AffAtom, AxisAtom):
         return [grad]
 
     def get_data(self):
-        """Returns the axis being summed.
-        """
+        """Returns the axis being summed."""
         return [self.axis]
 
     def graph_implementation(

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1026,7 +1026,16 @@ class TestAtoms(BaseTest):
             problem.solve(enforce_dpp=True)
 
     def test_cumsum(self) -> None:
-        pass
+        for axis in [0, 1]:
+            x = cp.Variable((4, 3))
+            expr = cp.cumsum(x, axis=axis)
+            x_val = np.arange(12).reshape((4, 3))
+            target = np.cumsum(x_val, axis=axis)
+            
+            prob = cp.Problem(cp.Minimize(0), [x == x_val])
+            prob.solve()
+            
+            assert np.allclose(expr.value, target)
     
     def test_kron_expr(self) -> None:
         """Test the kron atom.

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1025,6 +1025,9 @@ class TestAtoms(BaseTest):
         with pytest.raises(cp.DPPError):
             problem.solve(enforce_dpp=True)
 
+    def test_cumsum(self) -> None:
+        pass
+    
     def test_kron_expr(self) -> None:
         """Test the kron atom.
         """


### PR DESCRIPTION
## Description
This PR introduces some slight speedups for the formation of the diff_matrix used in the cumsum atom. 
Also added tests and improved something for _grad of the atom as well. 
Issue link (if applicable):

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.