### PR TITLE
Re-enable sdist publishing + clean up build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
         os: [ ubuntu-20.04, macos-12, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]
         include:
+          # These are intended to just add their extra parameter to existing matrix combinations;
+          # see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
           - os: ubuntu-20.04
             python-version: 3.12
             openmp: "True"
@@ -84,6 +86,8 @@ jobs:
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]
         build-cvxpy-base: [ true, false ]  # whether to build cvxpy-base (true) or regular cvxpy (false)
         include:
+          # This is intended to just add the single_action_config parameter to one existing combination;
+          # see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
           - os: ubuntu-20.04
             python-version: 3.12
             single_action_config: "True"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.19.1
 
       - name: Build source
-        if: ${{github.event_name == 'push' && env.SINGLE_ACTION_CONFIG == 'True'}}
+        if: ${{env.SINGLE_ACTION_CONFIG == 'True'}}
         run: |
           pip install build
           python -m build --sdist -o wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.19.1
 
       - name: Build source
-        if: ${{env.SINGLE_ACTION_CONFIG == 'True'}}
+        if: ${{github.event_name == 'push' && env.SINGLE_ACTION_CONFIG == 'True'}}
         run: |
           pip install build
           python -m build --sdist -o wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,7 @@ jobs:
       PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
       PYPI_USER: ${{ secrets.PYPI_USER }}
       PYPI_PASSWORD: ${{ matrix.build-cvxpy-base && secrets.PYPI_BASE_PASSWORD || secrets.PYPI_PASSWORD }}
+      CVXPY_BASE_SUFFIX: ${{ matrix.build-cvxpy-base && "base-" || "" }}
 
     steps:
       - uses: actions/checkout@v4
@@ -126,7 +127,6 @@ jobs:
           sed -i.bak '/scs >= /d' pyproject.toml
           sed -i.bak -e 's/name="cvxpy",/name="cvxpy-base",/g' setup.py
           rm -rf pyproject.toml.bak setup.py.bak
-          echo "CVXPY_BASE_SUFFIX=base-" >> "$GITHUB_ENV"
 
       - name: Verify that we can build by pip-install on each OS.
         if: ${{matrix.build-cvxpy-base && env.PIP_INSTALL == 'True'}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
       RUNNER_OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}
       SINGLE_ACTION_CONFIG: "${{ matrix.single_action_config == 'True' }}"
-      PIP_INSTALL: "${{ matrix.python-version == '3.12' }}"
+      PIP_INSTALL: "${{ matrix.python-version == '3.11' }}"
       PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
       PYPI_USER: ${{ secrets.PYPI_USER }}
       PYPI_PASSWORD: ${{ matrix.build-cvxpy-base && secrets.PYPI_BASE_PASSWORD || secrets.PYPI_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,13 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, macos-12, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]
+        exclude:
+          - os: ubuntu-20.04
+            python-version: 3.12
+        include:
+          - os: ubuntu-20.04
+            python-version: 3.12
+            single_action_config: "True"
 
     env:
       RUNNER_OS: ${{ matrix.os }}
@@ -76,12 +83,21 @@ jobs:
         os: [ ubuntu-20.04, macos-12, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]
         base: [ true, false ]
+        exclude:
+          - os: ubuntu-20.04
+            python-version: 3.12
+            base: true
+        include:
+          - os: ubuntu-20.04
+            python-version: 3.12
+            base: true
+            single_action_config: "True"
 
     env:
       RUNNER_OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}
       SINGLE_ACTION_CONFIG: "${{ matrix.single_action_config == 'True' }}"
-      PIP_INSTALL: "${{ matrix.pip_install == 'True' }}"
+      PIP_INSTALL: "${{ matrix.python-version == '3.12' }}"
       PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
       PYPI_USER: ${{ secrets.PYPI_USER }}
       PYPI_PASSWORD: ${{ matrix.base && secrets.PYPI_BASE_PASSWORD || secrets.PYPI_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,14 +148,14 @@ jobs:
           python -m build --sdist -o wheelhouse
 
       - name: Check wheels
-        if: ${{github.event_name == 'push' &&  env.USE_OPENMP != 'True'}}
+        if: ${{github.event_name == 'push' && env.USE_OPENMP != 'True'}}
         shell: bash
         run: |
           python -m pip install --upgrade twine
           twine check wheelhouse/*
 
-      - name:  Release to pypi
-        if: ${{env.DEPLOY == 'True' &&  env.USE_OPENMP != 'True'}}
+      - name: Release to pypi
+        if: ${{env.DEPLOY == 'True' && env.USE_OPENMP != 'True'}}
         shell: bash
         run: |
           twine upload --skip-existing --repository-url $PYPI_SERVER wheelhouse/* -u $PYPI_USER -p $PYPI_PASSWORD

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, macos-12, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]
-        base: [ true, false ]
+        build-cvxpy-base: [ true, false ]  # whether to build cvxpy-base (true) or regular cvxpy (false)
         include:
           - os: ubuntu-20.04
             python-version: 3.12
@@ -95,7 +95,7 @@ jobs:
       PIP_INSTALL: "${{ matrix.python-version == '3.12' }}"
       PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
       PYPI_USER: ${{ secrets.PYPI_USER }}
-      PYPI_PASSWORD: ${{ matrix.base && secrets.PYPI_BASE_PASSWORD || secrets.PYPI_PASSWORD }}
+      PYPI_PASSWORD: ${{ matrix.build-cvxpy-base && secrets.PYPI_BASE_PASSWORD || secrets.PYPI_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v4
@@ -110,7 +110,7 @@ jobs:
           echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
 
       - name: Adapt pyproject.toml
-        if: ${{matrix.base}}
+        if: ${{matrix.build-cvxpy-base}}
         shell: bash
         run: |
           # Mac has a different syntax for sed -i, this works across oses
@@ -124,7 +124,7 @@ jobs:
           echo "CVXPY_BASE_SUFFIX=base-" >> "$GITHUB_ENV"
 
       - name: Verify that we can build by pip-install on each OS.
-        if: ${{matrix.base && env.PIP_INSTALL == 'True'}}
+        if: ${{matrix.build-cvxpy-base && env.PIP_INSTALL == 'True'}}
         run: |
           pip install . pytest cplex
           pytest cvxpy/tests/test_conic_solvers.py -k 'TestCPLEX'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,6 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, macos-12, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]
-        exclude:
-          - os: ubuntu-20.04
-            python-version: 3.12
         include:
           - os: ubuntu-20.04
             python-version: 3.12
@@ -83,14 +80,9 @@ jobs:
         os: [ ubuntu-20.04, macos-12, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]
         base: [ true, false ]
-        exclude:
-          - os: ubuntu-20.04
-            python-version: 3.12
-            base: true
         include:
           - os: ubuntu-20.04
             python-version: 3.12
-            base: true
             single_action_config: "True"
 
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,9 @@ jobs:
         include:
           - os: ubuntu-20.04
             python-version: 3.12
+            openmp: "True"
+          - os: macos-12
+            python-version: 3.12
             single_action_config: "True"
 
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,14 +36,15 @@ jobs:
           - os: ubuntu-20.04
             python-version: 3.12
             openmp: "True"
+            single_action_config: false
           - os: macos-12
             python-version: 3.12
-            single_action_config: "True"
+            single_action_config: true
 
     env:
       RUNNER_OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}
-      SINGLE_ACTION_CONFIG: "${{ matrix.single_action_config == 'True' && 'True' || 'False' }}"
+      SINGLE_ACTION_CONFIG: "${{ matrix.single_action_config && 'True' || 'False' }}"
       USE_OPENMP: "${{ matrix.openmp == 'True' && 'True' || 'False' }}"
       MOSEK_CI_BASE64: ${{ secrets.MOSEK_CI_BASE64 }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
       PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
       PYPI_USER: ${{ secrets.PYPI_USER }}
       PYPI_PASSWORD: ${{ matrix.build-cvxpy-base && secrets.PYPI_BASE_PASSWORD || secrets.PYPI_PASSWORD }}
-      CVXPY_BASE_SUFFIX: ${{ matrix.build-cvxpy-base && "base-" || "" }}
+      CVXPY_BASE_SUFFIX: ${{ matrix.build-cvxpy-base && 'base-' || '' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,14 +75,16 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, macos-12, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]
+        base: [ true, false ]
 
     env:
       RUNNER_OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}
       SINGLE_ACTION_CONFIG: "${{ matrix.single_action_config == 'True' }}"
+      PIP_INSTALL: "${{ matrix.pip_install == 'True' }}"
       PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
       PYPI_USER: ${{ secrets.PYPI_USER }}
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      PYPI_PASSWORD: ${{ matrix.base && secrets.PYPI_BASE_PASSWORD || secrets.PYPI_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v4
@@ -95,6 +97,26 @@ jobs:
         run: |
           echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
           echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
+
+      - name: Adapt pyproject.toml
+        if: ${{matrix.base}}
+        shell: bash
+        run: |
+          # Mac has a different syntax for sed -i, this works across oses
+          sed -i.bak -e 's/name = "cvxpy"/name = "cvxpy-base"/g' pyproject.toml
+          sed -i.bak '/clarabel >= /d' pyproject.toml
+          sed -i.bak '/osqp >= /d' pyproject.toml
+          sed -i.bak '/ecos >= /d' pyproject.toml
+          sed -i.bak '/scs >= /d' pyproject.toml
+          sed -i.bak -e 's/name="cvxpy",/name="cvxpy-base",/g' setup.py
+          rm -rf pyproject.toml.bak setup.py.bak
+          echo "CVXPY_BASE_SUFFIX=base-" >> "$GITHUB_ENV"
+
+      - name: Verify that we can build by pip-install on each OS.
+        if: ${{matrix.base && env.PIP_INSTALL == 'True'}}
+        run: |
+          pip install . pytest cplex
+          pytest cvxpy/tests/test_conic_solvers.py -k 'TestCPLEX'
 
       - name: Set up QEMU  # For aarch64, see https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation
         if: runner.os == 'Linux'
@@ -134,93 +156,5 @@ jobs:
         if: ${{github.event_name == 'push' && env.USE_OPENMP != 'True'}}
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}-${{ matrix.python-version }}
-          path: ./wheelhouse
-
-  build_cvxpy-base:
-    needs: build
-
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-20.04, macos-12, windows-2022 ]
-        python-version: [ 3.9, "3.10", "3.11", "3.12" ]
-
-    env:
-      PYTHON_VERSION: ${{ matrix.python-version }}
-      SINGLE_ACTION_CONFIG: "${{ matrix.single_action_config == 'True' }}"
-      PIP_INSTALL: "${{ matrix.pip_install == 'True' }}"
-      PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
-      PYPI_USER: ${{ secrets.PYPI_USER }}
-      PYPI_BASE_PASSWORD: ${{ secrets.PYPI_BASE_PASSWORD }}
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Set Additional Envs
-        shell: bash
-        run: |
-          echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
-          echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
-
-      - name: Adapt pyproject.toml
-        shell: bash
-        run: |
-          # Mac has a different syntax for sed -i, this works across oses
-          sed -i.bak -e 's/name = "cvxpy"/name = "cvxpy-base"/g' pyproject.toml
-          sed -i.bak '/clarabel >= /d' pyproject.toml
-          sed -i.bak '/osqp >= /d' pyproject.toml
-          sed -i.bak '/ecos >= /d' pyproject.toml
-          sed -i.bak '/scs >= /d' pyproject.toml
-          sed -i.bak -e 's/name="cvxpy",/name="cvxpy-base",/g' setup.py
-          rm -rf pyproject.toml.bak setup.py.bak
-
-      - name: Verify that we can build by pip-install on each OS.
-        if: ${{env.PIP_INSTALL == 'True'}}
-        run: |
-          pip install . pytest cplex
-          pytest cvxpy/tests/test_conic_solvers.py -k 'TestCPLEX'
-
-      - name: Set up QEMU  # For aarch64, see https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
-      - name: Build wheels
-        if: ${{github.event_name == 'push'}}
-        env:
-          CIBW_BUILD: "cp3${{env.PYTHON_SUBVERSION}}-*"
-          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
-          CIBW_ARCHS_MACOS: x86_64 universal2
-          CIBW_ARCHS_LINUX: auto aarch64
-        uses: pypa/cibuildwheel@v2.19.1
-
-      - name: Build source
-        if: ${{github.event_name == 'push' && env.SINGLE_ACTION_CONFIG == 'True'}}
-        run: |
-          pip install build
-          python -m build --sdist -o wheelhouse
-
-      - name: Check wheels
-        shell: bash
-        if: ${{github.event_name == 'push'}}
-        run: |
-          python -m pip install --upgrade twine
-          twine check wheelhouse/*
-
-      - name: Release to pypi
-        shell: bash
-        if: ${{env.DEPLOY == 'True'}}
-        run: |
-          twine upload --skip-existing --repository-url $PYPI_SERVER wheelhouse/* -u $PYPI_USER -p $PYPI_BASE_PASSWORD
-
-      - name: Upload artifacts to github
-        if: ${{github.event_name == 'push'}}
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-base-${{ matrix.os }}-${{ matrix.python-version }}
+          name: wheels-${CVXPY_BASE_SUFFIX}${{ matrix.os }}-${{ matrix.python-version }}
           path: ./wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,12 +91,12 @@ jobs:
           # see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
           - os: ubuntu-20.04
             python-version: 3.12
-            single_action_config: "True"
+            single_action_config: true
 
     env:
       RUNNER_OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}
-      SINGLE_ACTION_CONFIG: "${{ matrix.single_action_config == 'True' }}"
+      SINGLE_ACTION_CONFIG: "${{ matrix.single_action_config }}"
       PIP_INSTALL: "${{ matrix.python-version == '3.11' }}"
       PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
       PYPI_USER: ${{ secrets.PYPI_USER }}

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -9,7 +9,7 @@ conda config --set remote_connect_timeout_secs 30.0
 conda config --set remote_max_retries 10
 conda config --set remote_backoff_factor 2
 conda config --set remote_read_timeout_secs 120.0
-conda install mkl pip pytest hypothesis openblas "setuptools>65.5.1"
+conda install mkl pip pytest pytest-cov hypothesis openblas "setuptools>65.5.1"
 conda install ecos scs osqp cvxopt proxsuite daqp
 python -m pip install coptpy gurobipy piqp clarabel
 


### PR DESCRIPTION
## Description
Reduce duplication in github actions workflow for builds, and re-add "single action" configurations that produce coverage uploads and Source Distribution (sdist) files.

Fixes #2584.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.