### PR TITLE
Pin coptpy version to 7.1.7

### DIFF
--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -11,7 +11,7 @@ conda config --set remote_backoff_factor 2
 conda config --set remote_read_timeout_secs 120.0
 conda install mkl pip pytest pytest-cov hypothesis openblas "setuptools>65.5.1"
 conda install ecos scs osqp cvxopt proxsuite daqp
-python -m pip install coptpy gurobipy piqp clarabel
+python -m pip install coptpy==7.1.7 gurobipy piqp clarabel
 
 if [[ "$PYTHON_VERSION" == "3.9" ]]; then
   # The earliest version of numpy that works is 1.20.


### PR DESCRIPTION
## Description
Please include a short summary of the change.
coptpy version 7.2.1 was released yesterday and it is causing failures on all our CI. (see logs below).
This PR pins the version that is being installed to avoid these CI failures.
P.S. We should probably reach out to the COPT team about this.
```bash
Fatal Python error: Segmentation fault

Current thread 0x00007fbb3e2f6180 (most recent call first):
  File "/home/runner/work/cvxpy/cvxpy/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py", line 166 in solve_via_data
  File "/home/runner/work/cvxpy/cvxpy/cvxpy/reductions/solvers/solving_chain.py", line 516 in solve_via_data
  File "/home/runner/work/cvxpy/cvxpy/cvxpy/problems/problem.py", line 1157 in _solve
  File "/home/runner/work/cvxpy/cvxpy/cvxpy/problems/problem.py", line 573 in solve
  File "/home/runner/work/cvxpy/cvxpy/cvxpy/tests/test_qp_solvers.py", line 77 in solve_QP
  File "/home/runner/work/cvxpy/cvxpy/cvxpy/tests/test_qp_solvers.py", line 133 in power
  File "/home/runner/work/cvxpy/cvxpy/cvxpy/tests/test_qp_solvers.py", line 82 in test_all_solvers
  File "/usr/share/miniconda/envs/test/lib/python3.9/unittest/case.py", line 550 in _callTestMethod
  File "/usr/share/miniconda/envs/test/lib/python3.9/unittest/case.py", line 592 in run
  File "/usr/share/miniconda/envs/test/lib/python3.9/unittest/case.py", line 651 in __call__
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/_pytest/unittest.py", line 351 in runtest
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/_pytest/runner.py", line 174 in pytest_runtest_call
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/pluggy/_callers.py", line 103 in _multicall
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/pluggy/_hooks.py", line 513 in __call__
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/_pytest/runner.py", line 242 in <lambda>
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/_pytest/runner.py", line 341 in from_call
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/_pytest/runner.py", line 241 in call_and_report
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/_pytest/runner.py", line 132 in runtestprotocol
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/_pytest/runner.py", line 113 in pytest_runtest_protocol
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/pluggy/_callers.py", line 103 in _multicall
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/pluggy/_hooks.py", line 513 in __call__
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/_pytest/main.py", line 362 in pytest_runtestloop
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/pluggy/_callers.py", line 103 in _multicall
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/pluggy/_hooks.py", line 513 in __call__
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/_pytest/main.py", line 337 in _main
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/_pytest/main.py", line 283 in wrap_session
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/_pytest/main.py", line 330 in pytest_cmdline_main
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/pluggy/_callers.py", line 103 in _multicall
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/pluggy/_hooks.py", line 513 in __call__
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/_pytest/config/__init__.py", line [175](https://github.com/cvxpy/cvxpy/actions/runs/11395906012/job/31708867320#step:6:176) in main
  File "/usr/share/miniconda/envs/test/lib/python3.9/site-packages/_pytest/config/__init__.py", line 201 in console_main
  File "/usr/share/miniconda/envs/test/bin/pytest", line 10 in <module>
continuous_integration/test_script.sh: line 26:  2626 Segmentation fault      (core dumped) pytest cvxpy/tests
cvxpy/tests/test_qp_solvers.py
```
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.