### PR TITLE
Support concatenate on atoms

### DIFF
--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -31,7 +31,7 @@ from cvxpy.atoms.affine.partial_transpose import partial_transpose
 from cvxpy.atoms.affine.promote import promote
 from cvxpy.atoms.affine.real import real
 from cvxpy.atoms.affine.reshape import deep_flatten, reshape
-# TODO: Remove comment once concatenated is enabledf
+# TODO: Remove comment once concatenated is enabled
 # from cvxpy.atoms.affine.concatenate import concatenate
 from cvxpy.atoms.affine.sum import sum
 from cvxpy.atoms.affine.trace import trace

--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -31,7 +31,8 @@ from cvxpy.atoms.affine.partial_transpose import partial_transpose
 from cvxpy.atoms.affine.promote import promote
 from cvxpy.atoms.affine.real import real
 from cvxpy.atoms.affine.reshape import deep_flatten, reshape
-from cvxpy.atoms.affine.concatenate import concatenate
+# TODO: Remove comment once concatenated is enabledf
+# from cvxpy.atoms.affine.concatenate import concatenate
 from cvxpy.atoms.affine.sum import sum
 from cvxpy.atoms.affine.trace import trace
 from cvxpy.atoms.affine.transpose import transpose

--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -31,6 +31,7 @@ from cvxpy.atoms.affine.partial_transpose import partial_transpose
 from cvxpy.atoms.affine.promote import promote
 from cvxpy.atoms.affine.real import real
 from cvxpy.atoms.affine.reshape import deep_flatten, reshape
+from cvxpy.atoms.affine.concatenate import concatenate
 from cvxpy.atoms.affine.sum import sum
 from cvxpy.atoms.affine.trace import trace
 from cvxpy.atoms.affine.transpose import transpose

--- a/cvxpy/atoms/affine/concatenate.py
+++ b/cvxpy/atoms/affine/concatenate.py
@@ -25,7 +25,7 @@ from cvxpy.constraints.constraint import Constraint
 
 
 def concatenate(arg_list, axis: Optional[int] = 0):
-    assert axis is None or (isinstance(axis,int) and axis >=0)
+    assert axis is None or (isinstance(axis, int) and axis >= 0)
     return Concatenate(*(arg_list + [axis]))
 
 
@@ -56,36 +56,12 @@ class Concatenate(AffAtom):
         return [self.axis]
 
     def validate_arguments(self) -> None:
-        # If axis is None, arrays are flattened, so no validation is necessary.
-        if self.axis is None:
-            return
-        axis = self.axis
-        ref_shape = self.args[0].shape
-        # Zero-dimensional arrays cannot be concatenated along a specified axis.
-        if ref_shape == ():
-            raise ValueError("Zero-dimensional arrays cannot be concatenated along an axis")
-        ndim = len(ref_shape)
-        if axis >= ndim:
-            raise ValueError(f"Axis {axis} is out of bounds for array of dimension {ndim}")
-
-        for idx, arg in enumerate(self.args[1:], start=1):
-            arg_shape = arg.shape
-            if arg_shape == ():
-                raise ValueError("Zero-dimensional arrays cannot be concatenated along an axis")
-            if len(arg_shape) != ndim:
-                raise ValueError(
-                    f"all the input arrays must have same number of dimensions, but the array "
-                    f"at index 0 has {ndim} dimension(s) and the array at index {idx} has "
-                    f"{len(arg_shape)} dimension(s)"
-                )
-            for i in range(ndim):
-                if i != axis and ref_shape[i] != arg_shape[i]:
-                    raise ValueError(
-                        "All the input array dimensions except for the concatenation axis "
-                        f"must match exactly, but along dimension {i}, the array at index 0 "
-                        f"has size {ref_shape[i]} and the array at index {idx} has "
-                        f"size {arg_shape[i]}"
-                    )
+        # Validates that the input shapes in `self.args` are suitable for
+        # concatenation along a specified axis using numpy API with empty arrays
+        np.concatenate(
+            [np.empty(arg.shape, dtype=np.dtype([])) for arg in self.args],
+            axis=self.axis,
+        )
 
     def shape_from_args(self) -> Tuple[int, ...]:
         if self.axis is None:

--- a/cvxpy/atoms/affine/concatenate.py
+++ b/cvxpy/atoms/affine/concatenate.py
@@ -1,5 +1,5 @@
 """
-Copyright 2013 Steven Diamond
+Copyright, the CVXPY authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
 
 
-def concatenate(arg_list, axis: Optional[int] = None):
+def concatenate(arg_list, axis: Optional[int] = 0):
     assert axis is None or (isinstance(axis,int) and axis >=0)
     return Concatenate(*(arg_list + [axis]))
 

--- a/cvxpy/atoms/affine/concatenate.py
+++ b/cvxpy/atoms/affine/concatenate.py
@@ -64,17 +64,10 @@ class Concatenate(AffAtom):
         )
 
     def shape_from_args(self) -> Tuple[int, ...]:
-        if self.axis is None:
-            # Flatten all arrays and sum their sizes
-            total_size = sum(arg.size for arg in self.args)
-            return (total_size,)
-        axis = self.axis
-        ref_shape = self.args[0].shape
-        # Initialize the output shape with the reference shape
-        output_shape = list(ref_shape)
-        # Sum sizes along the specified axis
-        output_shape[axis] = sum(arg.shape[axis] for arg in self.args)
-        return tuple(output_shape)
+        return np.concatenate(
+            [np.empty(arg.shape, dtype=np.dtype([])) for arg in self.args],
+            axis=self.axis,
+        ).shape
 
     def graph_implementation(
         self,

--- a/cvxpy/atoms/affine/concatenate.py
+++ b/cvxpy/atoms/affine/concatenate.py
@@ -1,0 +1,125 @@
+"""
+Copyright 2013 Steven Diamond
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+import cvxpy.lin_ops.lin_op as lo
+import cvxpy.lin_ops.lin_utils as lu
+from cvxpy.atoms.affine.affine_atom import AffAtom
+from cvxpy.constraints.constraint import Constraint
+
+
+def concatenate(arg_list, axis: Optional[int] = None):
+    assert axis is None or (isinstance(axis,int) and axis >=0)
+    return Concatenate(*(arg_list + [axis]))
+
+
+class Concatenate(AffAtom):
+    """Concatenate along an existing axis"""
+
+    def __init__(self, *args) -> None:
+        if isinstance(args[-1], int) or args[-1] is None:
+            # Assume the last positional argument is axis
+            axis = args[-1]
+            args = args[:-1]
+            self.axis = axis
+        else:
+            self.axis = None
+        super().__init__(*args)
+
+    def is_atom_log_log_convex(self) -> bool:
+        return True
+
+    def is_atom_log_log_concave(self) -> bool:
+        return True
+
+    # Returns the concatenation of the values along the specified axis.
+    def numeric(self, values):
+        return np.concatenate(values, axis=self.axis)
+
+    def get_data(self) -> List[Optional[int]]:
+        return [self.axis]
+
+    def validate_arguments(self) -> None:
+        # If axis is None, arrays are flattened, so no validation is necessary.
+        if self.axis is None:
+            return
+        axis = self.axis
+        ref_shape = self.args[0].shape
+        # Zero-dimensional arrays cannot be concatenated along a specified axis.
+        if ref_shape == ():
+            raise ValueError("Zero-dimensional arrays cannot be concatenated along an axis")
+        ndim = len(ref_shape)
+        if axis >= ndim:
+            raise ValueError(f"Axis {axis} is out of bounds for array of dimension {ndim}")
+
+        for idx, arg in enumerate(self.args[1:], start=1):
+            arg_shape = arg.shape
+            if arg_shape == ():
+                raise ValueError("Zero-dimensional arrays cannot be concatenated along an axis")
+            if len(arg_shape) != ndim:
+                raise ValueError(
+                    f"all the input arrays must have same number of dimensions, but the array "
+                    f"at index 0 has {ndim} dimension(s) and the array at index {idx} has "
+                    f"{len(arg_shape)} dimension(s)"
+                )
+            for i in range(ndim):
+                if i != axis and ref_shape[i] != arg_shape[i]:
+                    raise ValueError(
+                        "All the input array dimensions except for the concatenation axis "
+                        f"must match exactly, but along dimension {i}, the array at index 0 "
+                        f"has size {ref_shape[i]} and the array at index {idx} has "
+                        f"size {arg_shape[i]}"
+                    )
+
+    def shape_from_args(self) -> Tuple[int, ...]:
+        if self.axis is None:
+            # Flatten all arrays and sum their sizes
+            total_size = sum(arg.size for arg in self.args)
+            return (total_size,)
+        axis = self.axis
+        ref_shape = self.args[0].shape
+        # Initialize the output shape with the reference shape
+        output_shape = list(ref_shape)
+        # Sum sizes along the specified axis
+        output_shape[axis] = sum(arg.shape[axis] for arg in self.args)
+        return tuple(output_shape)
+
+    def graph_implementation(
+        self,
+        arg_objs,
+        shape: Tuple[int, ...],
+        data=None,
+    ) -> Tuple[lo.LinOp, List[Constraint]]:
+        """Concatenate the expressions along an existing axis.
+
+        Parameters
+        ----------
+        arg_objs : list
+            LinOp for each argument.
+        shape : tuple
+            The shape of the resulting expression.
+        data :
+            Additional data required by the atom. In this case data wraps axis
+
+        Returns
+        -------
+        tuple
+            (LinOp for the objective, list of constraints)
+        """
+        return (lu.concatenate(arg_objs, shape, data[0]), [])

--- a/cvxpy/lin_ops/lin_op.py
+++ b/cvxpy/lin_ops/lin_op.py
@@ -94,6 +94,9 @@ HSTACK = "hstack"
 # Vertically concatenating operators.
 # Data: None
 VSTACK = "vstack"
+# Stack concatenating operators.
+# Data: None
+CONCATENATE = "concatenate"
 # A scalar constant.
 # Data: Python float.
 SCALAR_CONST = "scalar_const"

--- a/cvxpy/lin_ops/lin_utils.py
+++ b/cvxpy/lin_ops/lin_utils.py
@@ -16,7 +16,7 @@ limitations under the License.
 THIS FILE IS DEPRECATED AND MAY BE REMOVED WITHOUT WARNING!
 DO NOT CALL THESE FUNCTIONS IN YOUR CODE!
 """
-from typing import Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 
@@ -572,7 +572,7 @@ def vstack(operators, shape: Tuple[int, ...]):
     """
     return lo.LinOp(lo.VSTACK, shape, operators, None)
 
-def concatenate(operators, shape: Tuple[int, ...], axis: int):
+def concatenate(operators, shape: Tuple[int, ...], axis: Optional[int] = 0):
     """Concatenate operators on axis.
 
     Parameters
@@ -581,6 +581,8 @@ def concatenate(operators, shape: Tuple[int, ...], axis: int):
         The operators to concatenate.
     shape : tuple
         The (rows, cols) of the concatenated operators.
+    axis : int, optional
+        The axis along which the operators will be joined.
 
     Returns
     -------

--- a/cvxpy/lin_ops/lin_utils.py
+++ b/cvxpy/lin_ops/lin_utils.py
@@ -572,6 +572,22 @@ def vstack(operators, shape: Tuple[int, ...]):
     """
     return lo.LinOp(lo.VSTACK, shape, operators, None)
 
+def concatenate(operators, shape: Tuple[int, ...], axis: int):
+    """Concatenate operators on axis.
+
+    Parameters
+    ----------
+    operator : list
+        The operators to concatenate.
+    shape : tuple
+        The (rows, cols) of the concatenated operators.
+
+    Returns
+    -------
+    LinOp
+       LinOp representing the stacked expression.
+    """
+    return lo.LinOp(lo.CONCATENATE, shape, operators, [axis])
 
 def get_constr_expr(lh_op, rh_op):
     """Returns the operator in the constraint.

--- a/cvxpy/reductions/complex2real/canonicalizers/__init__.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/__init__.py
@@ -30,6 +30,7 @@ from cvxpy.atoms.affine.sum import Sum
 from cvxpy.atoms.affine.transpose import transpose
 from cvxpy.atoms.affine.unary_operators import NegExpression
 from cvxpy.atoms.affine.vstack import Vstack
+from cvxpy.atoms.affine.concatenate import Concatenate
 from cvxpy.atoms.affine.wraps import hermitian_wrap
 from cvxpy.atoms.norm_nuc import normNuc
 from cvxpy.constraints import (PSD, SOC, Equality, Inequality,
@@ -76,6 +77,7 @@ CANON_METHODS = {
     NegExpression: separable_canon,
     upper_tri: separable_canon,
     Vstack: separable_canon,
+    Concatenate: separable_canon,
 
     conv: binary_canon,
     DivExpression: binary_canon,

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -561,23 +561,26 @@ class TestAtoms(BaseTest):
         self.assertEqual(expr.shape, (2, 1))
 
     def test_concatenate(self):
-        atom = cp.concatenate([self.x, self.y], axis=0)
+        # TODO: concatenated is not exposed in cp.concatenated yet. Use cp.concatenate in
+        # this test once it is available
+        from cvxpy.atoms.affine.concatenate import concatenate
+        atom = concatenate([self.x, self.y], axis=0)
         self.assertEqual(atom.name(), "Concatenate(x, y, 0)")
         self.assertEqual(atom.shape, (4,))  # (2 vectors are concatenated on axis 0)
 
         with self.assertRaises(ValueError) as cm:
             # x and y are 1D arrays, so they can't be concatenated on axis 1
-            atom = cp.concatenate([self.x, self.y], axis=1)
+            atom = concatenate([self.x, self.y], axis=1)
         self.assertEqual(str(cm.exception), "axis 1 is out of bounds for array of dimension 1")
 
-        atom = cp.concatenate([self.A, self.C], axis=None)
+        atom = concatenate([self.A, self.C], axis=None)
         self.assertEqual(atom.shape, (10,))
 
-        atom = cp.concatenate([self.A, self.C], axis=0)
+        atom = concatenate([self.A, self.C], axis=0)
         self.assertEqual(atom.shape, (5, 2))
 
         with self.assertRaises(ValueError) as cm:
-            atom = cp.concatenate([self.A, self.C], axis=1)
+            atom = concatenate([self.A, self.C], axis=1)
         self.assertEqual(
             str(cm.exception),
             "all the input array dimensions except for the concatenation axis "
@@ -585,27 +588,27 @@ class TestAtoms(BaseTest):
             "has size 2 and the array at index 1 has size 3",
         )
 
-        atom = cp.concatenate([self.A, self.B], axis=1)
+        atom = concatenate([self.A, self.B], axis=1)
         self.assertEqual(atom.shape, (2, 4))
 
-        atom = cp.concatenate([self.A, self.B], axis=0)
+        atom = concatenate([self.A, self.B], axis=0)
         self.assertEqual(atom.shape, (4, 2))
 
-        atom = cp.concatenate([self.A, self.B], axis=None)
+        atom = concatenate([self.A, self.B], axis=None)
         self.assertEqual(atom.shape, (8,))
 
         with self.assertRaises(ValueError) as cm:
-            cp.concatenate([self.a, self.A], axis=0)
+            concatenate([self.a, self.A], axis=0)
         self.assertEqual(
             str(cm.exception), "zero-dimensional arrays cannot be concatenated"
         )
 
         with self.assertRaises(ValueError) as cm:
-            cp.concatenate([self.A, self.C], axis=2)
+            concatenate([self.A, self.C], axis=2)
         self.assertEqual(str(cm.exception), "axis 2 is out of bounds for array of dimension 2")
 
         with self.assertRaises(ValueError) as cm:
-            cp.concatenate([self.C, self.x], axis=1)
+            concatenate([self.C, self.x], axis=1)
         self.assertEqual(
             str(cm.exception),
             "all the input arrays must have same number of dimensions, but the array at index "

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -568,7 +568,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(ValueError) as cm:
             # x and y are 1D arrays, so they can't be concatenated on axis 1
             atom = cp.concatenate([self.x, self.y], axis=1)
-        self.assertEqual(str(cm.exception), "Axis 1 is out of bounds for array of dimension 1")
+        self.assertEqual(str(cm.exception), "axis 1 is out of bounds for array of dimension 1")
 
         atom = cp.concatenate([self.A, self.C], axis=None)
         self.assertEqual(atom.shape, (10,))
@@ -580,7 +580,7 @@ class TestAtoms(BaseTest):
             atom = cp.concatenate([self.A, self.C], axis=1)
         self.assertEqual(
             str(cm.exception),
-            "All the input array dimensions except for the concatenation axis "
+            "all the input array dimensions except for the concatenation axis "
             "must match exactly, but along dimension 0, the array at index 0 "
             "has size 2 and the array at index 1 has size 3",
         )
@@ -595,14 +595,14 @@ class TestAtoms(BaseTest):
         self.assertEqual(atom.shape, (8,))
 
         with self.assertRaises(ValueError) as cm:
-            cp.concatenate([self.A, self.a], axis=0)
+            cp.concatenate([self.a, self.A], axis=0)
         self.assertEqual(
-            str(cm.exception), "Zero-dimensional arrays cannot be concatenated along an axis"
+            str(cm.exception), "zero-dimensional arrays cannot be concatenated"
         )
 
         with self.assertRaises(ValueError) as cm:
             cp.concatenate([self.A, self.C], axis=2)
-        self.assertEqual(str(cm.exception), "Axis 2 is out of bounds for array of dimension 2")
+        self.assertEqual(str(cm.exception), "axis 2 is out of bounds for array of dimension 2")
 
         with self.assertRaises(ValueError) as cm:
             cp.concatenate([self.C, self.x], axis=1)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -568,10 +568,10 @@ class TestAtoms(BaseTest):
         self.assertEqual(atom.name(), "Concatenate(x, y, 0)")
         self.assertEqual(atom.shape, (4,))  # (2 vectors are concatenated on axis 0)
 
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ValueError):
             # x and y are 1D arrays, so they can't be concatenated on axis 1
             atom = concatenate([self.x, self.y], axis=1)
-        self.assertEqual(str(cm.exception), "axis 1 is out of bounds for array of dimension 1")
+        # Expected ValueError due to invalid axis for 1D arrays
 
         atom = concatenate([self.A, self.C], axis=None)
         self.assertEqual(atom.shape, (10,))
@@ -579,14 +579,9 @@ class TestAtoms(BaseTest):
         atom = concatenate([self.A, self.C], axis=0)
         self.assertEqual(atom.shape, (5, 2))
 
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ValueError):
             atom = concatenate([self.A, self.C], axis=1)
-        self.assertEqual(
-            str(cm.exception),
-            "all the input array dimensions except for the concatenation axis "
-            "must match exactly, but along dimension 0, the array at index 0 "
-            "has size 2 and the array at index 1 has size 3",
-        )
+        # Expected ValueError due to mismatched dimensions along dimension 0
 
         atom = concatenate([self.A, self.B], axis=1)
         self.assertEqual(atom.shape, (2, 4))
@@ -597,23 +592,17 @@ class TestAtoms(BaseTest):
         atom = concatenate([self.A, self.B], axis=None)
         self.assertEqual(atom.shape, (8,))
 
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ValueError):
             concatenate([self.a, self.A], axis=0)
-        self.assertEqual(
-            str(cm.exception), "zero-dimensional arrays cannot be concatenated"
-        )
+        # Expected ValueError due to zero-dimensional arrays cannot be concatenated
 
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ValueError):
             concatenate([self.A, self.C], axis=2)
-        self.assertEqual(str(cm.exception), "axis 2 is out of bounds for array of dimension 2")
+        # Expected ValueError due to axis 2 being out of bounds for 2D arrays
 
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ValueError):
             concatenate([self.C, self.x], axis=1)
-        self.assertEqual(
-            str(cm.exception),
-            "all the input arrays must have same number of dimensions, but the array at index "
-            "0 has 2 dimension(s) and the array at index 1 has 1 dimension(s)",
-        )
+        # Expected ValueError due to mismatched number of dimensions between arrays
 
     def test_reshape(self) -> None:
         """Test the reshape class.

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -208,7 +208,7 @@ class TestAtoms(BaseTest):
 
         # Error message when geo_mean used incorrectly.
         with pytest.raises(
-                TypeError, 
+                TypeError,
                 match=SECOND_ARG_SHOULD_NOT_BE_EXPRESSION_ERROR_MESSAGE
             ):
             cp.geo_mean(self.x, self.y)
@@ -560,6 +560,58 @@ class TestAtoms(BaseTest):
         expr = cp.vstack([2, Variable((1,))])
         self.assertEqual(expr.shape, (2, 1))
 
+    def test_concatenate(self):
+        atom = cp.concatenate([self.x, self.y], axis=0)
+        self.assertEqual(atom.name(), "Concatenate(x, y, 0)")
+        self.assertEqual(atom.shape, (4,))  # (2 vectors are concatenated on axis 0)
+
+        with self.assertRaises(ValueError) as cm:
+            # x and y are 1D arrays, so they can't be concatenated on axis 1
+            atom = cp.concatenate([self.x, self.y], axis=1)
+        self.assertEqual(str(cm.exception), "Axis 1 is out of bounds for array of dimension 1")
+
+        atom = cp.concatenate([self.A, self.C], axis=None)
+        self.assertEqual(atom.shape, (10,))
+
+        atom = cp.concatenate([self.A, self.C], axis=0)
+        self.assertEqual(atom.shape, (5, 2))
+
+        with self.assertRaises(ValueError) as cm:
+            atom = cp.concatenate([self.A, self.C], axis=1)
+        self.assertEqual(
+            str(cm.exception),
+            "All the input array dimensions except for the concatenation axis "
+            "must match exactly, but along dimension 0, the array at index 0 "
+            "has size 2 and the array at index 1 has size 3",
+        )
+
+        atom = cp.concatenate([self.A, self.B], axis=1)
+        self.assertEqual(atom.shape, (2, 4))
+
+        atom = cp.concatenate([self.A, self.B], axis=0)
+        self.assertEqual(atom.shape, (4, 2))
+
+        atom = cp.concatenate([self.A, self.B], axis=None)
+        self.assertEqual(atom.shape, (8,))
+
+        with self.assertRaises(ValueError) as cm:
+            cp.concatenate([self.A, self.a], axis=0)
+        self.assertEqual(
+            str(cm.exception), "Zero-dimensional arrays cannot be concatenated along an axis"
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            cp.concatenate([self.A, self.C], axis=2)
+        self.assertEqual(str(cm.exception), "Axis 2 is out of bounds for array of dimension 2")
+
+        with self.assertRaises(ValueError) as cm:
+            cp.concatenate([self.C, self.x], axis=1)
+        self.assertEqual(
+            str(cm.exception),
+            "all the input arrays must have same number of dimensions, but the array at index "
+            "0 has 2 dimension(s) and the array at index 1 has 1 dimension(s)",
+        )
+
     def test_reshape(self) -> None:
         """Test the reshape class.
         """
@@ -796,7 +848,7 @@ class TestAtoms(BaseTest):
 
         # works with row vectors
         assert np.allclose(
-            cp.vec_to_upper_tri(np.arange(6)).value, 
+            cp.vec_to_upper_tri(np.arange(6)).value,
             cp.vec_to_upper_tri(np.arange(6).reshape(1, 6)).value
         )
 
@@ -963,7 +1015,7 @@ class TestAtoms(BaseTest):
         # Check that sum_smallest is PWL so can be canonicalized as a QP.
         atom = cp.sum_smallest(self.x, 2)
         assert atom.is_pwl()
-    
+
     def test_cvar(self) -> None:
         """Test the cvar atom and its use in a linear program."""
         # Check that CVaR is correctly computed
@@ -973,18 +1025,18 @@ class TestAtoms(BaseTest):
         m = 100  # Size of random vector
         x = np.random.randn(m)  # Random vector
         betas = [0.1, 0.5, 0.9, 0.95, 0.99] # Probability levels
-        
+
         for beta in betas:
             # Evaluate using cvar atom
             cvar_atom = cp.cvar(x, beta)
             cvar_value = cvar_atom.value
-            
+
             # Evaluate CVaR using alternative formulation
             alpha = cp.Variable()
             objective = alpha + 1/((1-beta)*m) * cp.sum(cp.pos(x - alpha))
             prob_alt = cp.Problem(cp.Minimize(objective))
             cvar_alt_value = prob_alt.solve()
-            
+
             # Check that the results are equal (within numerical tolerance)
             self.assertAlmostEqual(cvar_value, cvar_alt_value)
 
@@ -1102,7 +1154,7 @@ class TestAtoms(BaseTest):
             target = np.cumsum(x_val, axis=axis)
             prob = cp.Problem(cp.Minimize(cp.sum(expr)), [x == x_val])
             prob.solve()
-            
+
             assert np.allclose(expr.value, target)
 
     def test_cumprod(self) -> None:
@@ -1111,13 +1163,13 @@ class TestAtoms(BaseTest):
             expr = cp.cumprod(x, axis=axis)
             # constant needs to be elementwise positive
             x_val = (np.arange(12)+1).reshape((4, 3))
-            
+
             target = np.cumprod(x_val, axis=axis)
             prob = cp.Problem(cp.Minimize(cp.sum(expr)), [x == x_val])
             prob.solve(gp=True)
-            
+
             assert np.allclose(expr.value, target)
-    
+
     def test_kron_expr(self) -> None:
         """Test the kron atom.
         """
@@ -1594,7 +1646,7 @@ class TestAtoms(BaseTest):
             cp.outer(d, A)
 
         # allow 2D inputs once row-major flattening is the default
-        assert np.allclose(cp.vec(np.array([[1, 2], [3, 4]]), order='F').value, 
+        assert np.allclose(cp.vec(np.array([[1, 2], [3, 4]]), order='F').value,
                            np.array([1, 3, 2, 4]))
 
     def test_conj(self) -> None:

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1525,7 +1525,7 @@ class TestND_Expressions():
         self.x = Variable((2,2,2), name='x')
         self.target = (1+np.arange(8)).reshape(2,2,2)
         self.obj = cp.Minimize(0)
-    
+
     def test_nd_variable(self) -> None:
         prob = cp.Problem(self.obj, [self.x == self.target])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
@@ -1565,6 +1565,14 @@ class TestND_Expressions():
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, self.target)
 
+    def test_nd_concatenate(self) -> None:
+        x = Variable((1, 2, 2))
+        z = Variable((1, 2, 2))
+        expr = cp.concatenate([x,z], axis = 0)
+        prob = cp.Problem(self.obj, [expr == self.target])
+        prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+        assert np.allclose(expr.value, self.target)
+
     def test_nd_sum_expr(self) -> None:
         x = [cp.Variable((2,2,2)) for _ in range(10)]
         expr = sum(x)
@@ -1598,7 +1606,7 @@ class TestND_Expressions():
         prob = cp.Problem(self.obj, [expr == y])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, y)
-    
+
     @given(integer_array_indices(shape=(2,2,2)))
     def test_nd_integer_index(self, s) -> None:
         expr = self.x[s]
@@ -1612,7 +1620,7 @@ class TestND_Expressions():
         # Skip examples with 0-d output. TODO allow 0-d expressions in cvxpy.
         def is_zero_dim_output(axis):
             return 0 in self.target[axis].shape
-        
+
         assume(is_zero_dim_output(axis) is False)
         expr = self.x[axis]
         y = self.target[axis]
@@ -1633,7 +1641,7 @@ class TestND_Expressions():
     def test_nd_bool_index(self, axis) -> None:
         def is_zero_dim_output(axis):
             return 0 in self.target[axis].shape
-        
+
         assume(is_zero_dim_output(axis) is False)
         expr = self.x[axis]
         y = self.target[axis]
@@ -1649,7 +1657,7 @@ class TestND_Expressions():
         assert np.allclose(expr.value, y)
 
     @pytest.mark.parametrize("order", ['C', 'F'])
-    @pytest.mark.parametrize("shape", [(20, 2, 30), (300, 2, 2), 
+    @pytest.mark.parametrize("shape", [(20, 2, 30), (300, 2, 2),
                                        (1, 24, 5, 10), (240, 5, 1)])
     def test_nd_reshape(self, order, shape) -> None:
         var = cp.Variable((5, 24, 10))
@@ -1659,7 +1667,7 @@ class TestND_Expressions():
         prob = cp.Problem(self.obj, [expr == y])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, y)
-    
+
     def test_nd_transpose(self) -> None:
         var = cp.Variable((5, 24, 10))
         target = np.arange(1200).reshape((5, 24, 10))
@@ -1668,4 +1676,3 @@ class TestND_Expressions():
         prob = cp.Problem(self.obj, [expr == y])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, y)
-    

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1566,9 +1566,12 @@ class TestND_Expressions():
         assert np.allclose(expr.value, self.target)
 
     def test_nd_concatenate(self) -> None:
+        # TODO: concatenated is not exposed in cp.concatenated yet. Use cp.concatenate
+        # in this test once it is available
+        from cvxpy.atoms.affine.concatenate import concatenate
         x = Variable((1, 2, 2))
         z = Variable((1, 2, 2))
-        expr = cp.concatenate([x,z], axis = 0)
+        expr = concatenate([x,z], axis = 0)
         prob = cp.Problem(self.obj, [expr == self.target])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, self.target)

--- a/cvxpy/tests/test_python_backends.py
+++ b/cvxpy/tests/test_python_backends.py
@@ -610,6 +610,166 @@ class TestBackends:
         expected = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
         assert np.all(A == expected)
 
+    def test_concatenate(self, backend):
+        """
+        Define x,y = Variable((1,2)), Variable((1,2)) with
+        [[x1, x2]]
+        and
+        [[y1, y2]]
+
+        concatenate([x, y], axis = 0) yields
+
+        [[x1, x2],
+         [y1, y2]]
+
+        which maps to
+
+         x1   x2  y1  y2
+        [[1   0   0   0],
+         [0   0   1   0],
+         [0   1   0   0],
+         [0   0   0   1]]
+
+        Note that in this case concatenate is equivalent to vstack
+
+        Applying concatenate([x, y], axis=1) yields:
+
+        [[x1, x2, y1, y2]]
+
+        Which is equivalent to hstack([x, y]) in this context.
+
+        The mapping to the matrix A would be:
+
+          x1  x2  y1  y2
+         [[1   0   0  0],
+          [0   1   0  0],
+          [0   0   1  0],
+          [0   0   0  1]]
+
+        """
+        # See InverseData.get_var_offsets method for references to this map
+        backend.id_to_col = {1: 0, 2: 2}
+
+        # Axis = 1
+        lin_op_x = linOpHelper((1, 2), type="variable", data=1)
+        lin_op_y = linOpHelper((1, 2), type="variable", data=2)
+
+        concatenate_lin_op = linOpHelper(args=[lin_op_x, lin_op_y], data = [1])
+        backend.id_to_col = {1: 0, 2: 2}
+        out_view = backend.concatenate(concatenate_lin_op, backend.get_empty_view())
+        A = out_view.get_tensor_representation(0, 4)
+
+        # cast to numpy
+        A = sp.coo_matrix((A.data, (A.row, A.col)), shape=(4, 4)).toarray()
+        expected = np.eye(4)
+        assert np.all(A == expected)
+
+        # Axis = 0
+        concatenate_lin_op = linOpHelper(args=[lin_op_x, lin_op_y], data = [0])
+        out_view = backend.concatenate(concatenate_lin_op, backend.get_empty_view())
+        A = out_view.get_tensor_representation(0, 4)
+
+        # cast to numpy
+        A = sp.coo_matrix((A.data, (A.row, A.col)), shape=(4, 4)).toarray()
+        expected = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+        assert np.all(A == expected)
+
+
+    @pytest.mark.parametrize("axis, variable_indices", [
+        # Axis 0
+        (0, [0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15]),
+        # Axis 1
+        (1, [0, 1, 2, 3, 8, 9, 10, 11, 4, 5, 6, 7, 12, 13, 14, 15]),
+        # Axis 2
+        (2, list(range(16))),
+        # Axis None
+        (None, list(range(16))),
+    ])
+    def test_concatenate_nd(self, backend, axis, variable_indices):
+        """
+        Test the concatenate operation with variables of shape (2, 2, 2)
+        along different axes
+
+        Define variables x and y, each of shape (2, 2, 2):
+
+        x = [
+            [[x000, x001],
+            [x010, x011]],
+            [[x100, x101],
+            [x110, x111]]
+            ]
+
+        y = [
+            [[y000, y001],
+            [y010, y011]],
+            [[y100, y101],
+            [y110, y111]]
+            ]
+
+        The variables are assigned indices as follows:
+
+        Indices for x:
+            x000: 0, x001: 1, x010: 2, x011: 3,
+            x100: 4, x101: 5, x110: 6, x111: 7
+
+        Indices for y:
+            y000: 8, y001: 9, y010: 10, y011: 11,
+            y100: 12, y101: 13, y110: 14, y111: 15
+
+        How we chose the list of variable_indices:
+
+        - For each axis, we perform the concatenation of x and y along that axis.
+        - We assign indices to the variables in x and y as per their positions.
+        - For each argument, we generate an array of indices from 0 to the number of
+        elements minus one, reshaped to the argument's shape with 'F' order
+        (column-major order), and offset by the cumulative
+        number of elements from previous arguments.
+
+        - We concatenate these indices along the specified axis.
+        - We flatten the concatenated indices with 'F' order to obtain the variable_indices,
+        which represent the order of variables in the flattened concatenated tensor.
+
+        The expected variable_indices are:
+
+        For axis=0:
+            [0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15]
+
+        For axis=1:
+            [0, 1, 2, 3, 8, 9, 10, 11, 4, 5, 6, 7, 12, 13, 14, 15]
+
+        For axis=2:
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+
+        For axis=None:
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+
+        axis=None follows NumPy; arrays are flattened in 'C' order before concatenating,
+        so the resulting array is [x000, x001, x010, x011, x100, x101, x110, x111,
+                                y000, y001, y010, y011, y100, y101, y110, y111]
+        """
+        def get_expected_matrix(variable_indices):
+            A = np.zeros((16, 16), dtype=int)
+            positions = np.arange(16)
+            for pos, var_idx in zip(positions, variable_indices):
+                A[pos, var_idx] = 1
+            return A
+
+        # Map variable IDs to column indices
+        backend.id_to_col = {1: 0, 2: 8}
+
+        # Define lin_op_x and lin_op_y with shape (2, 2, 2)
+        lin_op_x = linOpHelper((2, 2, 2), type="variable", data=1)
+        lin_op_y = linOpHelper((2, 2, 2), type="variable", data=2)
+
+        # Perform concatenation along the specified axis
+        concatenate_lin_op = linOpHelper(args=[lin_op_x, lin_op_y], data = [axis])
+        out_view = backend.concatenate(concatenate_lin_op, backend.get_empty_view())
+        A = out_view.get_tensor_representation(0, 16)
+        # Convert to numpy array
+        A = sp.coo_matrix((A.data, (A.row, A.col)), shape=(16, 16)).toarray()
+        expected_A = get_expected_matrix(variable_indices)
+        assert np.all(A == expected_A)
+
     def test_mul(self, backend):
         """
         define x = Variable((2,2)) with
@@ -1035,7 +1195,7 @@ class TestBackends:
 
         """
         kron(l,r)
-        with 
+        with
         l = [[x1],  r = [[a, c],
              [x2]]       [b, d]]
 
@@ -1044,13 +1204,13 @@ class TestBackends:
          [bx1, dx1],
          [ax2, cx2],
          [bx2, dx2]]
-        
+
         Here, we have to swap the row indices of the resulting matrix.
-        Immediately applying kron(l,r) gives to eye(2) and r reshaped to 
+        Immediately applying kron(l,r) gives to eye(2) and r reshaped to
         a column vector gives.
-                 
+
         So we have:
-        kron(l,r) = 
+        kron(l,r) =
         [[a, 0],
          [b, 0],
          [c, 0],
@@ -1789,7 +1949,7 @@ class TestND_Backends:
         backend = CanonBackend.get_backend(request.param, **kwargs)
         assert isinstance(backend, PythonCanonBackend)
         return backend
-    
+
 
     def test_nd_sum_entries(self, backend):
         """
@@ -1815,7 +1975,7 @@ class TestND_Backends:
         sum(x, axis = 0) means we only consider entries in a given axis (axes)
 
         which, when using the same columns as before, now maps to
-        
+
         sum(x, axis = 0)
         x111 x211 x121 x221 x112 x212 x122 x222
         [[1   1   0   0   0   0   0   0],
@@ -1836,9 +1996,9 @@ class TestND_Backends:
          [0   1   0   0   0   1   0   0],
          [0   0   1   0   0   0   1   0],
          [0   0   0   1   0   0   0   1]]
-        
+
         To reproduce the outputs above, eliminate the given axis
-        and put ones where the remaining axes (axis) match. 
+        and put ones where the remaining axes (axis) match.
 
         Note: sum(x, keepdims=True) is equivalent to sum(x, keepdims=False)
         with a reshape, which is NO-OP in the backend.
@@ -1955,7 +2115,7 @@ class TestND_Backends:
          [0   0   0   0   0   1   0   0],
          [0   0   0   0   0   0   1   0],
          [0   0   0   0   0   0   0   1]]
-        
+
         index() returns the subset of rows corresponding to the slicing of variables.
 
         e.g. x[0:2, 0, 0:2] yields
@@ -2017,7 +2177,7 @@ class TestParametrizedND_Backends:
         backend = CanonBackend.get_backend(request.param, **kwargs)
         assert isinstance(backend, PythonCanonBackend)
         return backend
-        
+
     def test_parametrized_nd_sum_entries(self, param_backend):
         """
         starting with a (2,2,2) parametrized expression


### PR DESCRIPTION
## Description
Thank you for this amazing project!, I've been using it for a while and I decided to contribute. This PR aims to add `cp.concatenate` support as mentioned in here #2567. Note that so far I added it to the atoms and to the numpy/scipy backends. I haven't added it yet to the cpp/rust backends. I'd love to add it there, but before going too far, i'd like to know if this is needed/wanted and if my PR is in a good spot. I tried to follow numpy concatenate convention. I added several unit tests and also docstring documentation you can check to follow my ideas. 

**I pushed my changes after runnning ruff format command**, so as you can see there are some format changes that i'd like to avoid --- Do you have a command to do formatting that will sync with master branch?


## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.