### PR TITLE
CI: pin xpress version to 9.4.3

### DIFF
--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -60,7 +60,7 @@ if [[ "$PYTHON_VERSION" == "3.10" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then
 fi
 
 if [[ "$PYTHON_VERSION" == "3.11" ]] && [[ "$RUNNER_OS" != "macOS" ]]; then
-  python -m pip install xpress
+  python -m pip install xpress==9.4.3
 fi
 
 # Only install Mosek if license is available (secret is not copied to forks)


### PR DESCRIPTION
## Description
Please include a short summary of the change.
CI was failing because of the recently released xpress version 9.5.0.
Here is a copy of the test summary for future reference:
```sh
=========================== short test summary info ============================
FAILED cvxpy/tests/test_conic_solvers.py::TestXPRESS::test_xpress_lp_3 - xpress.ModelError: Solution is not available
FAILED cvxpy/tests/test_conic_solvers.py::TestXPRESS::test_xpress_lp_4 - xpress.ModelError: Solution is not available
FAILED cvxpy/tests/test_conic_solvers.py::TestXPRESS::test_xpress_mi_lp_3 - xpress.ModelError: Solution is not available
FAILED cvxpy/tests/test_conic_solvers.py::TestXPRESS::test_xpress_mi_lp_5 - xpress.ModelError: Solution is not available
FAILED cvxpy/tests/test_mip_vars.py::TestMIPVariable::test_all_solvers - xpress.ModelError: Solution is not available
FAILED cvxpy/tests/test_qp_solvers.py::TestQp::test_all_solvers - xpress.ModelError: Dual values are not available
========== 6 failed, 1411 passed, 47 skipped, 1217 warnings in 47.91s ==========
```
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.