### PR TITLE
removing ECOS dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ CVXPY has the following dependencies:
 - Python >= 3.9
 - Clarabel >= 0.5.0
 - OSQP >= 0.6.2
-- ECOS >= 2
 - SCS >= 3.2.4.post1
 - NumPy >= 1.20.0
 - SciPy >= 1.6.0

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -16,7 +16,7 @@ if [[ "$PYTHON_VERSION" != "3.13" ]]; then
   python -m pip install coptpy==7.1.7 gurobipy piqp clarabel osqp
 else
   # only install the essential solvers for Python 3.13.
-  conda install ecos scs
+  conda install scs
   python -m pip install clarabel osqp
 fi
 

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -13,7 +13,7 @@ conda install mkl pip pytest pytest-cov hypothesis openblas "setuptools>65.5.1"
 
 if [[ "$PYTHON_VERSION" != "3.13" ]]; then
   conda install ecos scs cvxopt proxsuite daqp
-  python -m pip install coptpy==7.1.7 gurobipy piqp clarabel osqp
+  python -m pip install coptpy==7.1.7 gurobipy piqp clarabel osqp highs
 else
   # only install the essential solvers for Python 3.13.
   conda install scs

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -13,7 +13,7 @@ conda install mkl pip pytest pytest-cov hypothesis openblas "setuptools>65.5.1"
 
 if [[ "$PYTHON_VERSION" != "3.13" ]]; then
   conda install ecos scs cvxopt proxsuite daqp
-  python -m pip install coptpy==7.1.7 gurobipy piqp clarabel osqp highs
+  python -m pip install coptpy==7.1.7 gurobipy piqp clarabel osqp highspy
 else
   # only install the essential solvers for Python 3.13.
   conda install scs

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -483,7 +483,7 @@ class Problem(u.Canonical):
         Arguments
         ---------
         solver : str, optional
-            The solver to use. For example, 'ECOS', 'SCS', or 'OSQP'.
+            The solver to use. For example, 'CLARABEL', 'SCS', or 'OSQP'.
         solver_path : list of (str, dict) tuples or strings, optional
             The solvers to use with optional arguments.
             The function tries the solvers in the given order and

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -46,7 +46,6 @@ from cvxpy.reductions.solvers.solver import Solver
 from cvxpy.settings import (
     CLARABEL,
     CPP_CANON_BACKEND,
-    ECOS,
     NUMPY_CANON_BACKEND,
     PARAM_THRESHOLD,
     SCIPY_CANON_BACKEND,
@@ -360,10 +359,6 @@ def construct_solving_chain(problem, candidates,
                 CvxAttr2Constr(reduce_bounds=not solver_instance.BOUNDED_VARIABLES),
             ]
             if all(c in supported_constraints for c in cones):
-                if solver == ECOS and specified_solver == ECOS:
-                    warnings.warn(ECOS_DEP_DEPRECATION_MSG, FutureWarning)
-                elif solver == ECOS and specified_solver is None:
-                    warnings.warn(ECOS_DEPRECATION_MSG, FutureWarning)
                 # Return the reduction chain.
                 reductions += [
                     ConeMatrixStuffing(quad_obj=quad_obj, canon_backend=canon_backend),

--- a/cvxpy/tests/test_KKT.py
+++ b/cvxpy/tests/test_KKT.py
@@ -11,7 +11,7 @@ class TestKKT_LPs(BaseTest):
     def test_lp_1(self, places=4):
         # typical LP
         sth = STH.lp_1()
-        sth.solve(solver='ECOS')
+        sth.solve(solver='CLARABEL')
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
@@ -20,7 +20,7 @@ class TestKKT_LPs(BaseTest):
     def test_lp_2(self, places=4):
         # typical LP
         sth = STH.lp_2()
-        sth.solve(solver='ECOS')
+        sth.solve(solver='CLARABEL')
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
@@ -29,7 +29,7 @@ class TestKKT_LPs(BaseTest):
     def test_lp_5(self, places=4):
         # LP with redundant constraints
         sth = STH.lp_5()
-        sth.solve(solver='ECOS')
+        sth.solve(solver='CLARABEL')
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
@@ -40,7 +40,7 @@ class TestKKT_QPs(BaseTest):
 
     def test_qp_0(self, places=4):
         sth = STH.qp_0()
-        sth.solve(solver='ECOS')
+        sth.solve(solver='CLARABEL')
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
@@ -52,7 +52,7 @@ class TestKKT_SOCPs(BaseTest):
 
     def test_socp_0(self, places=4):
         sth = STH.socp_0()
-        sth.solve(solver='ECOS')
+        sth.solve(solver='CLARABEL')
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
@@ -61,7 +61,7 @@ class TestKKT_SOCPs(BaseTest):
 
     def test_socp_1(self, places=4):
         sth = STH.socp_1()
-        sth.solve(solver='ECOS')
+        sth.solve(solver='CLARABEL')
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
@@ -70,7 +70,7 @@ class TestKKT_SOCPs(BaseTest):
 
     def test_socp_2(self, places=4):
         sth = STH.socp_2()
-        sth.solve(solver='ECOS')
+        sth.solve(solver='CLARABEL')
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
@@ -79,7 +79,7 @@ class TestKKT_SOCPs(BaseTest):
 
     def test_socp_3ax0(self, places=4):
         sth = STH.socp_3(axis=0)
-        sth.solve(solver='ECOS')
+        sth.solve(solver='CLARABEL')
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
@@ -89,7 +89,7 @@ class TestKKT_SOCPs(BaseTest):
 
     def test_socp_3ax1(self, places=4):
         sth = STH.socp_3(axis=1)
-        sth.solve(solver='ECOS')
+        sth.solve(solver='CLARABEL')
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
@@ -101,7 +101,7 @@ class TestKKT_ECPs(BaseTest):
 
     def test_expcone_1(self, places = 4):
         sth = STH.expcone_1()
-        sth.solve(solver='ECOS')
+        sth.solve(solver='CLARABEL')
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1342,13 +1342,13 @@ class TestAtoms(BaseTest):
         # Solve the (simple) two-stage problem by "combining" the two stages
         # (i.e., by solving a single linear program)
         p1 = Problem(Minimize(x+y), [x+y >= 3, y >= 4, x >= 5])
-        p1.solve(solver=cp.SCIPY)
+        p1.solve(solver=cp.HIGHS)
 
         # Solve the two-stage problem via partial_optimize
         p2 = Problem(Minimize(y), [x+y >= 3, y >= 4])
         g = partial_optimize(p2, [y], [x])
         p3 = Problem(Minimize(x+g), [x >= 5])
-        p3.solve(solver=cp.SCIPY)
+        p3.solve(solver=cp.HIGHS)
         self.assertAlmostEqual(p1.value, p3.value)
 
     def test_partial_optimize_special_constr(self) -> None:

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1342,13 +1342,13 @@ class TestAtoms(BaseTest):
         # Solve the (simple) two-stage problem by "combining" the two stages
         # (i.e., by solving a single linear program)
         p1 = Problem(Minimize(x+y), [x+y >= 3, y >= 4, x >= 5])
-        p1.solve(solver=cp.ECOS_BB)
+        p1.solve(solver=cp.SCIPY)
 
         # Solve the two-stage problem via partial_optimize
         p2 = Problem(Minimize(y), [x+y >= 3, y >= 4])
         g = partial_optimize(p2, [y], [x])
         p3 = Problem(Minimize(x+g), [x >= 5])
-        p3.solve(solver=cp.ECOS_BB)
+        p3.solve(solver=cp.SCIPY)
         self.assertAlmostEqual(p1.value, p3.value)
 
     def test_partial_optimize_special_constr(self) -> None:

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1335,7 +1335,7 @@ class TestAtoms(BaseTest):
         p3.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(p1.value, p3.value)
 
-    @unittest.skipUnless(len(INSTALLED_MI_SOLVERS) > 0, 'No mixed-integer solver is installed.')
+    @unittest.skipUnless("HIGHS" in INSTALLED_MI_SOLVERS, 'HiGHS solver is not installed.')
     def test_partial_optimize_special_var(self) -> None:
         x, y = Variable(boolean=True), Variable(integer=True)
 

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1263,44 +1263,44 @@ class TestAtoms(BaseTest):
         x, t = Variable(dims), Variable(dims)
         xval = [-5]*dims
         p1 = Problem(cp.Minimize(cp.sum(t)), [-t <= xval, xval <= t])
-        p1.solve(solver='ECOS')
+        p1.solve()
 
         # Minimize the 1-norm via partial_optimize.
         p2 = Problem(cp.Minimize(cp.sum(t)), [-t <= x, x <= t])
-        g = partial_optimize(p2, [t], [x], solver='ECOS')
+        g = partial_optimize(p2, [t], [x])
         p3 = Problem(cp.Minimize(g), [x == xval])
-        p3.solve(solver='ECOS')
+        p3.solve()
         self.assertAlmostEqual(p1.value, p3.value)
 
         # Minimize the 1-norm using maximize.
         p2 = Problem(cp.Maximize(cp.sum(-t)), [-t <= x, x <= t])
-        g = partial_optimize(p2, opt_vars=[t], solver='ECOS')
+        g = partial_optimize(p2, opt_vars=[t])
         p3 = Problem(cp.Maximize(g), [x == xval])
-        p3.solve(solver='ECOS')
+        p3.solve()
         self.assertAlmostEqual(p1.value, -p3.value)
 
         # Try leaving out args.
 
         # Minimize the 1-norm via partial_optimize.
         p2 = Problem(cp.Minimize(cp.sum(t)), [-t <= x, x <= t])
-        g = partial_optimize(p2, opt_vars=[t], solver='ECOS')
+        g = partial_optimize(p2, opt_vars=[t])
         p3 = Problem(cp.Minimize(g), [x == xval])
-        p3.solve(solver='ECOS')
+        p3.solve()
         self.assertAlmostEqual(p1.value, p3.value)
 
         # Minimize the 1-norm via partial_optimize.
-        g = partial_optimize(p2, dont_opt_vars=[x], solver='ECOS')
+        g = partial_optimize(p2, dont_opt_vars=[x])
         p3 = Problem(cp.Minimize(g), [x == xval])
-        p3.solve(solver='ECOS')
+        p3.solve()
         self.assertAlmostEqual(p1.value, p3.value)
 
         with self.assertRaises(Exception) as cm:
-            g = partial_optimize(p2, solver='ECOS')
+            g = partial_optimize(p2)
         self.assertEqual(str(cm.exception),
                          "partial_optimize called with neither opt_vars nor dont_opt_vars.")
 
         with self.assertRaises(Exception) as cm:
-            g = partial_optimize(p2, [], [x], solver='ECOS')
+            g = partial_optimize(p2, [], [x])
         self.assertEqual(str(cm.exception),
                          ("If opt_vars and new_opt_vars are both specified, "
                           "they must contain all variables in the problem.")
@@ -1313,11 +1313,11 @@ class TestAtoms(BaseTest):
         p1 = Problem(Minimize(cp.sum(t)), [-t <= x, x <= t])
 
         # Minimize the 1-norm via partial_optimize
-        g = partial_optimize(p1, [t], [x], solver='ECOS')
+        g = partial_optimize(p1, [t], [x])
         p2 = Problem(Minimize(g))
-        p2.solve(solver='ECOS')
+        p2.solve()
 
-        p1.solve(solver='ECOS')
+        p1.solve()
         self.assertAlmostEqual(p1.value, p2.value)
 
     def test_partial_optimize_simple_problem(self) -> None:
@@ -1330,7 +1330,7 @@ class TestAtoms(BaseTest):
 
         # Solve the two-stage problem via partial_optimize
         p2 = Problem(Minimize(y), [x+y >= 3, y >= 4])
-        g = partial_optimize(p2, [y], [x], solver='ECOS')
+        g = partial_optimize(p2, [y], [x])
         p3 = Problem(Minimize(x+g), [x >= 5])
         p3.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(p1.value, p3.value)
@@ -1426,12 +1426,12 @@ class TestAtoms(BaseTest):
         p1 = Problem(Minimize(cp.sum(t)), [-t <= x, x <= t])
 
         # Minimize the 1-norm via partial_optimize
-        g = partial_optimize(p1, [t], [x], solver='ECOS')
-        g2 = partial_optimize(Problem(Minimize(g)), [x], solver='ECOS')
+        g = partial_optimize(p1, [t], [x])
+        g2 = partial_optimize(Problem(Minimize(g)), [x], )
         p2 = Problem(Minimize(g2))
-        p2.solve(solver='ECOS')
+        p2.solve()
 
-        p1.solve(solver='ECOS')
+        p1.solve()
         self.assertAlmostEqual(p1.value, p2.value)
 
     def test_nonnegative_variable(self) -> None:

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -15,12 +15,14 @@ limitations under the License.
 """
 
 import numpy as np
+import pytest
 import scipy.sparse as sp
 
 import cvxpy as cp
 from cvxpy import Minimize, Problem
 from cvxpy.expressions.constants import Constant, Parameter
 from cvxpy.expressions.variable import Variable
+from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS
 from cvxpy.tests.base_test import BaseTest
 
 
@@ -637,6 +639,10 @@ class TestComplex(BaseTest):
         print("P2 is complex:", cp.quad_form(x, P2).curvature)
         assert cp.quad_form(x, P2).is_dcp()
 
+    @pytest.mark.skipif(
+        len(INSTALLED_MI_SOLVERS) == 0, 
+        reason='No mixed-integer solver is installed.'
+    )
     def test_bool(self) -> None:
         # The purpose of this test is to make sure
         # that we don't try to recover dual variables
@@ -652,7 +658,7 @@ class TestComplex(BaseTest):
 
         obj = cp.Maximize(cp.real(complex_var))
         prob = cp.Problem(obj, constraints)
-        prob.solve(solver=cp.SCIPY)
+        prob.solve(solver=cp.HIGHS)
         self.assertAlmostEqual(prob.value, 1, places=4)
 
     def test_partial_trace(self) -> None:

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -291,7 +291,7 @@ class TestComplex(BaseTest):
         """
         x = Variable((1, 2), complex=True)
         prob = Problem(cp.Maximize(cp.sum(cp.imag(x) + cp.real(x))), [cp.norm1(x) <= 2])
-        result = prob.solve(solver="ECOS")
+        result = prob.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 2*np.sqrt(2))
         val = np.ones(2)*np.sqrt(2)/2
         # self.assertItemsAlmostEqual(x.value, val + 1j*val)
@@ -299,7 +299,7 @@ class TestComplex(BaseTest):
         x = Variable((2, 2), complex=True)
         prob = Problem(cp.Maximize(cp.sum(cp.imag(x) + cp.real(x))),
                        [cp.pnorm(x, p=2) <= np.sqrt(8)])
-        result = prob.solve(solver="ECOS")
+        result = prob.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 8)
         val = np.ones((2, 2))
         self.assertItemsAlmostEqual(x.value, val + 1j*val)
@@ -388,7 +388,7 @@ class TestComplex(BaseTest):
         x = Variable(3, complex=False)
         value = cp.quad_form(b, P).value
         prob = Problem(cp.Minimize(cp.quad_form(x, P)), [x == b])
-        result = prob.solve(solver="ECOS")
+        result = prob.solve(solver="CLARABEL")
         self.assertAlmostEqual(result, value)
 
         # Solve a problem with complex variable
@@ -396,7 +396,7 @@ class TestComplex(BaseTest):
         x = Variable(3, complex=True)
         value = cp.quad_form(b, P).value
         prob = Problem(cp.Minimize(cp.quad_form(x, P)), [x == b])
-        result = prob.solve(solver="ECOS")
+        result = prob.solve(solver="CLARABEL")
         normalization = max(abs(result), abs(value))
         self.assertAlmostEqual(result / normalization, value / normalization, places=5)
 
@@ -406,7 +406,7 @@ class TestComplex(BaseTest):
         value = cp.quad_form(b, P).value
         expr = cp.quad_form(x, P)
         prob = Problem(cp.Minimize(expr), [x == b])
-        result = prob.solve(solver="ECOS")
+        result = prob.solve(solver="CLARABEL")
         normalization = max(abs(result), abs(value))
         self.assertAlmostEqual(result / normalization, value / normalization)
 
@@ -484,7 +484,7 @@ class TestComplex(BaseTest):
         obj = cp.Maximize(cp.real(cp.sum(v * np.ones((2, 2)))))
         con = [cp.norm(v) <= 1]
         prob = cp.Problem(obj, con)
-        result = prob.solve(solver="ECOS")
+        result = prob.solve(solver="CLARABEL")
         self.assertAlmostEqual(result, 4.0)
 
     def test_sparse(self) -> None:
@@ -652,7 +652,7 @@ class TestComplex(BaseTest):
 
         obj = cp.Maximize(cp.real(complex_var))
         prob = cp.Problem(obj, constraints)
-        prob.solve(solver='ECOS_BB')
+        prob.solve(solver=cp.SCIPY)
         self.assertAlmostEqual(prob.value, 1, places=4)
 
     def test_partial_trace(self) -> None:

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -640,8 +640,8 @@ class TestComplex(BaseTest):
         assert cp.quad_form(x, P2).is_dcp()
 
     @pytest.mark.skipif(
-        len(INSTALLED_MI_SOLVERS) == 0, 
-        reason='No mixed-integer solver is installed.'
+        "HIGHS" not in INSTALLED_MI_SOLVERS, 
+        reason='HiGHS solver is not installed.'
     )
     def test_bool(self) -> None:
         # The purpose of this test is to make sure

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -352,8 +352,8 @@ class TestSlacks(BaseTest):
             sth.verify_primal_values(places=3)
 
     @pytest.mark.skipif(
-        len(INSTALLED_MI) == 0, 
-        reason='No mixed-integer solver is installed.'
+        "HIGHS" not in INSTALLED_MI, 
+        reason='HiGHS solver is not installed.'
     )
     def test_mi_lp_1(self):
         sth = STH.mi_lp_1()

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -291,7 +291,7 @@ class TestSlacks(BaseTest):
         # typical LP
         sth = STH.lp_2()
         for affine in TestSlacks.AFF_LP_CASES:
-            TestSlacks.simulate_chain(sth.prob, affine, solver='ECOS')
+            TestSlacks.simulate_chain(sth.prob, affine, solver='CLARABEL')
             sth.verify_objective(places=4)
             sth.verify_primal_values(places=4)
 
@@ -299,41 +299,41 @@ class TestSlacks(BaseTest):
         # unbounded LP
         sth = STH.lp_3()
         for affine in TestSlacks.AFF_LP_CASES:
-            TestSlacks.simulate_chain(sth.prob, affine, solver='ECOS')
+            TestSlacks.simulate_chain(sth.prob, affine, solver='CLARABEL')
             sth.verify_objective(places=4)
 
     def test_lp_4(self):
         # infeasible LP
         sth = STH.lp_4()
         for affine in TestSlacks.AFF_LP_CASES:
-            TestSlacks.simulate_chain(sth.prob, affine, solver='ECOS')
+            TestSlacks.simulate_chain(sth.prob, affine, solver='CLARABEL')
             sth.verify_objective(places=4)
 
     def test_socp_2(self):
         sth = STH.socp_2()
         for affine in TestSlacks.AFF_SOCP_CASES:
-            TestSlacks.simulate_chain(sth.prob, affine, solver='ECOS')
+            TestSlacks.simulate_chain(sth.prob, affine, solver='CLARABEL')
             sth.verify_objective(places=4)
             sth.verify_primal_values(places=4)
 
     def test_socp_3(self):
         for axis in [0, 1]:
             sth = STH.socp_3(axis)
-            TestSlacks.simulate_chain(sth.prob, [], solver='ECOS')
+            TestSlacks.simulate_chain(sth.prob, [], solver='CLARABEL')
             sth.verify_objective(places=4)
             sth.verify_primal_values(places=4)
 
     def test_expcone_1(self):
         sth = STH.expcone_1()
         for affine in TestSlacks.AFF_EXP_CASES:
-            TestSlacks.simulate_chain(sth.prob, affine, solver='ECOS')
+            TestSlacks.simulate_chain(sth.prob, affine, solver='CLARABEL')
             sth.verify_objective(places=4)
             sth.verify_primal_values(places=4)
 
     def test_expcone_socp_1(self):
         sth = STH.expcone_socp_1()
         for affine in TestSlacks.AFF_MIXED_CASES:
-            TestSlacks.simulate_chain(sth.prob, affine, solver='ECOS')
+            TestSlacks.simulate_chain(sth.prob, affine, solver='CLARABEL')
             sth.verify_objective(places=4)
             sth.verify_primal_values(places=4)
 
@@ -354,7 +354,7 @@ class TestSlacks(BaseTest):
     def test_mi_lp_1(self):
         sth = STH.mi_lp_1()
         for affine in TestSlacks.AFF_LP_CASES:
-            TestSlacks.simulate_chain(sth.prob, affine, solver='ECOS_BB')
+            TestSlacks.simulate_chain(sth.prob, affine, solver=cp.SCIPY)
             sth.verify_objective(places=4)
             sth.verify_primal_values(places=4)
 
@@ -362,7 +362,7 @@ class TestSlacks(BaseTest):
     def test_mi_socp_1(self):
         sth = STH.mi_socp_1()
         for affine in TestSlacks.AFF_SOCP_CASES:
-            TestSlacks.simulate_chain(sth.prob, affine, solver='ECOS_BB')
+            TestSlacks.simulate_chain(sth.prob, affine, solver=cp.SCIPY)
             sth.verify_objective(places=4)
             sth.verify_primal_values(places=4)
 
@@ -520,7 +520,7 @@ class TestRelEntrQuad(BaseTest):
 
     def test_expcone_1(self):
         sth = self.expcone_1()
-        sth.solve(solver='ECOS')
+        sth.solve(solver='CLARABEL')
         sth.verify_primal_values(places=2)
         sth.verify_objective(places=2)
 
@@ -558,9 +558,9 @@ class TestRelEntrQuad(BaseTest):
 
     def test_expcone_socp_1(self):
         sth = self.expcone_socp_1()
-        sth.solve(solver='ECOS')
-        sth.verify_primal_values(places=2)
-        sth.verify_objective(places=2)
+        sth.solve(solver=cp.SCS)
+        sth.verify_primal_values(places=6)
+        sth.verify_objective(places=6)
 
 
 def sdp_ipm_installed():

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -351,10 +351,14 @@ class TestSlacks(BaseTest):
             sth.verify_objective(places=3)
             sth.verify_primal_values(places=3)
 
+    @pytest.mark.skipif(
+        len(INSTALLED_MI) == 0, 
+        reason='No mixed-integer solver is installed.'
+    )
     def test_mi_lp_1(self):
         sth = STH.mi_lp_1()
         for affine in TestSlacks.AFF_LP_CASES:
-            TestSlacks.simulate_chain(sth.prob, affine, solver=cp.SCIPY)
+            TestSlacks.simulate_chain(sth.prob, affine, solver=cp.HIGHS)
             sth.verify_objective(places=4)
             sth.verify_primal_values(places=4)
 
@@ -366,7 +370,7 @@ class TestSlacks(BaseTest):
             sth.verify_objective(places=4)
             sth.verify_primal_values(places=4)
 
-    @unittest.skipUnless([svr for svr in INSTALLED_MI if svr in MI_SOCP and svr != 'ECOS_BB'],
+    @unittest.skipUnless([svr for svr in INSTALLED_MI if svr in MI_SOCP],
                          'No appropriate mixed-integer SOCP solver is installed.')
     def test_mi_socp_2(self):
         sth = STH.mi_socp_2()

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -333,7 +333,7 @@ class TestSlacks(BaseTest):
     def test_expcone_socp_1(self):
         sth = STH.expcone_socp_1()
         for affine in TestSlacks.AFF_MIXED_CASES:
-            TestSlacks.simulate_chain(sth.prob, affine, solver='CLARABEL')
+            TestSlacks.simulate_chain(sth.prob, affine, solver='SCS')
             sth.verify_objective(places=4)
             sth.verify_primal_values(places=4)
 
@@ -559,8 +559,8 @@ class TestRelEntrQuad(BaseTest):
     def test_expcone_socp_1(self):
         sth = self.expcone_socp_1()
         sth.solve(solver=cp.SCS)
-        sth.verify_primal_values(places=6)
-        sth.verify_objective(places=6)
+        sth.verify_primal_values(places=3)
+        sth.verify_objective(places=3)
 
 
 def sdp_ipm_installed():

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -41,6 +41,7 @@ from cvxpy.tests.solver_test_helpers import (
 from cvxpy.utilities.versioning import Version
 
 
+@unittest.skipUnless('ECOS' in INSTALLED_SOLVERS, 'ECOS is not installed.')
 class TestECOS(BaseTest):
 
     def setUp(self) -> None:
@@ -2130,6 +2131,7 @@ class TestAllSolvers(BaseTest):
             self.assertItemsAlmostEqual(x.value, [0, 0])
 
 
+@unittest.skipUnless('ECOS' in INSTALLED_SOLVERS, 'ECOS_BB is not installed.')
 class TestECOS_BB(unittest.TestCase):
 
     def test_ecos_bb_explicit_only(self) -> None:

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -532,9 +532,9 @@ class TestDgp2Dcp(BaseTest):
                                 [cvxpy.multiply(w, h) >= 10,
                                 cvxpy.sum(w) <= 10])
         problem.solve(SOLVER, gp=True)
-        np.testing.assert_almost_equal(problem.value, 4)
-        np.testing.assert_almost_equal(h.value, np.array([2, 2]))
-        np.testing.assert_almost_equal(w.value, np.array([5, 5]))
+        np.testing.assert_almost_equal(problem.value, 4, decimal=3)
+        np.testing.assert_almost_equal(h.value, np.array([2, 2]), decimal=3)
+        np.testing.assert_almost_equal(w.value, np.array([5, 5]), decimal=3)
 
     def test_sum_squares_vector(self) -> None:
         w = cvxpy.Variable(2, pos=True)

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -9,7 +9,7 @@ from cvxpy.reductions import solution
 from cvxpy.settings import SOLVER_ERROR
 from cvxpy.tests.base_test import BaseTest
 
-SOLVER = cvxpy.ECOS
+SOLVER = cvxpy.CLARABEL
 
 
 class TestDgp2Dcp(BaseTest):

--- a/cvxpy/tests/test_dgp2dcp.py
+++ b/cvxpy/tests/test_dgp2dcp.py
@@ -402,7 +402,7 @@ class TestDgp2Dcp(BaseTest):
         problem = cvxpy.Problem(cvxpy.Minimize(x))
         error_msg = ("When `gp=True`, `solver` must be a conic solver "
                      "(received 'OSQP'); try calling `solve()` with "
-                     "`solver=cvxpy.ECOS`.")
+                     "`solver=cvxpy.CLARABEL`.")
         with self.assertRaises(error.SolverError) as err:
             problem.solve(solver="OSQP", gp=True)
             self.assertEqual(error_msg, str(err))
@@ -436,7 +436,7 @@ class TestDgp2Dcp(BaseTest):
         constr = [cvxpy.geo_mean(cvxpy.diag(X)) == 0.1,
                   cvxpy.geo_mean(cvxpy.hstack([X[0, 1], X[1, 0]])) == 0.1]
         problem = cvxpy.Problem(obj, constr)
-        problem.solve(gp=True, solver="ECOS")
+        problem.solve(gp=True, solver="SCS")
         np.testing.assert_almost_equal(X.value, 0.1*np.ones((2, 2)), decimal=3)
         self.assertAlmostEqual(problem.value, 2.25)
 
@@ -446,7 +446,7 @@ class TestDgp2Dcp(BaseTest):
         constr = [cvxpy.diag(X) == 0.1,
                   cvxpy.hstack([X[0, 1], X[1, 0]]) == 0.1]
         problem = cvxpy.Problem(obj, constr)
-        problem.solve(gp=True, solver="ECOS")
+        problem.solve(gp=True, solver="CLARABEL")
         np.testing.assert_almost_equal(X.value, 0.1*np.ones((2, 2)), decimal=3)
         self.assertAlmostEqual(problem.value, 2.25)
 
@@ -543,9 +543,9 @@ class TestDgp2Dcp(BaseTest):
                                 [cvxpy.multiply(w, h) >= 10,
                                 cvxpy.sum(w) <= 10])
         problem.solve(SOLVER, gp=True)
-        np.testing.assert_almost_equal(problem.value, 8)
-        np.testing.assert_almost_equal(h.value, np.array([2, 2]))
-        np.testing.assert_almost_equal(w.value, np.array([5, 5]))
+        np.testing.assert_almost_equal(problem.value, 8, decimal=3)
+        np.testing.assert_almost_equal(h.value, np.array([2, 2]), decimal=3)
+        np.testing.assert_almost_equal(w.value, np.array([5, 5]), decimal=3)
 
     def test_sum_matrix(self) -> None:
         w = cvxpy.Variable((2, 2), pos=True)
@@ -554,9 +554,9 @@ class TestDgp2Dcp(BaseTest):
                                 [cvxpy.multiply(w, h) >= 10,
                                 cvxpy.sum(w) <= 20])
         problem.solve(SOLVER, gp=True)
-        np.testing.assert_almost_equal(problem.value, 8)
-        np.testing.assert_almost_equal(h.value, np.array([[2, 2], [2, 2]]))
-        np.testing.assert_almost_equal(w.value, np.array([[5, 5], [5, 5]]))
+        np.testing.assert_almost_equal(problem.value, 8, decimal=3)
+        np.testing.assert_almost_equal(h.value, np.array([[2, 2], [2, 2]]), decimal=3)
+        np.testing.assert_almost_equal(w.value, np.array([[5, 5], [5, 5]]), decimal=3)
 
     def test_trace(self) -> None:
         w = cvxpy.Variable((1, 1), pos=True)

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -799,7 +799,7 @@ class TestDgp(BaseTest):
         np.testing.assert_almost_equal(w.value, np.array([4, 4]), decimal=3)
 
         alpha.value = [4.0, 4.0]
-        problem.solve(cp.ECOS, gp=True, enforce_dpp=True)
+        problem.solve(cp.CLARABEL, gp=True, enforce_dpp=True)
         self.assertAlmostEqual(problem.value, 40)
         np.testing.assert_almost_equal(h.value, np.array([20, 20]), decimal=3)
         np.testing.assert_almost_equal(w.value, np.array([1, 1]), decimal=3)

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -800,7 +800,7 @@ class TestDgp(BaseTest):
 
         alpha.value = [4.0, 4.0]
         problem.solve(cp.CLARABEL, gp=True, enforce_dpp=True)
-        self.assertAlmostEqual(problem.value, 40)
+        self.assertAlmostEqual(problem.value, 40, places=3)
         np.testing.assert_almost_equal(h.value, np.array([20, 20]), decimal=3)
         np.testing.assert_almost_equal(w.value, np.array([1, 1]), decimal=3)
 

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -223,7 +223,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(problem.is_dcp())
         self.assertFalse(problem.is_dgp())
 
-        problem.solve(cp.CLARABEL, qcp=True)
+        problem.solve(cp.SCS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 72, places=1)
         self.assertAlmostEqual(x.value, 12, places=1)
         self.assertAlmostEqual(y.value, 6, places=1)
@@ -242,7 +242,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(problem.is_dcp())
         self.assertFalse(problem.is_dgp())
 
-        problem.solve(cp.CLARABEL, qcp=True)
+        problem.solve(cp.SCS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 72, places=1)
         self.assertAlmostEqual(x.value, -12, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
@@ -262,7 +262,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(problem.is_dcp())
         self.assertFalse(problem.is_dgp())
 
-        problem.solve(cp.CLARABEL, qcp=True)
+        problem.solve(cp.SCS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, -42, places=1)
         self.assertAlmostEqual(x.value, 7, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
@@ -281,7 +281,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(problem.is_dcp())
         self.assertFalse(problem.is_dgp())
 
-        problem.solve(cp.CLARABEL, qcp=True)
+        problem.solve(cp.SCS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, -42, places=1)
         self.assertAlmostEqual(x.value, 7, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
@@ -294,7 +294,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(expr.is_quasiconvex())
 
         problem = cp.Problem(cp.Maximize(expr), [x <= 4, y <= 9])
-        problem.solve(cp.CLARABEL, qcp=True)
+        problem.solve(cp.SCS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 6, places=1)
         self.assertAlmostEqual(x.value, 4, places=1)
         self.assertAlmostEqual(y.value, 9, places=1)
@@ -306,7 +306,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(expr.is_quasiconvex())
 
         problem = cp.Problem(cp.Maximize(expr), [x <= 4, y <= 9])
-        problem.solve(cp.CLARABEL, qcp=True)
+        problem.solve(cp.SCS, qcp=True)
         # (2 + 2) * (3 + 4) = 28
         self.assertAlmostEqual(problem.objective.value, 28, places=1)
         self.assertAlmostEqual(x.value, 4, places=1)
@@ -323,7 +323,7 @@ class TestDqcp(base_test.BaseTest):
         problem = cp.Problem(cp.Minimize(expr), [x == 12, y <= 6])
         self.assertTrue(problem.is_dqcp())
 
-        problem.solve(cp.CLARABEL, qcp=True)
+        problem.solve(cp.SCS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 2.0, places=1)
         self.assertAlmostEqual(x.value, 12, places=1)
         self.assertAlmostEqual(y.value, 6, places=1)
@@ -338,7 +338,7 @@ class TestDqcp(base_test.BaseTest):
         problem = cp.Problem(cp.Maximize(expr), [x == 12, y >= -6])
         self.assertTrue(problem.is_dqcp())
 
-        problem.solve(cp.CLARABEL, qcp=True)
+        problem.solve(cp.SCS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, -2.0, places=1)
         self.assertAlmostEqual(x.value, 12, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
@@ -369,7 +369,7 @@ class TestDqcp(base_test.BaseTest):
 
         problem = cp.Problem(cp.Maximize(concave_frac))
         self.assertTrue(problem.is_dqcp())
-        problem.solve(cp.CLARABEL, qcp=True)
+        problem.solve(cp.SCS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 0.428, places=1)
         self.assertAlmostEqual(x.value, 0.5, places=1)
 
@@ -454,9 +454,9 @@ class TestDqcp(base_test.BaseTest):
         a = np.ones(2)
         b = np.zeros(2)
         problem = cp.Problem(cp.Minimize(cp.dist_ratio(x, a, b)), [x <= 0.8])
-        problem.solve(cp.CLARABEL, qcp=True)
-        np.testing.assert_almost_equal(problem.objective.value, 0.25)
-        np.testing.assert_almost_equal(x.value, np.array([0.8, 0.8]))
+        problem.solve(cp.SCS, qcp=True)
+        np.testing.assert_almost_equal(problem.objective.value, 0.25, decimal=3)
+        np.testing.assert_almost_equal(x.value, np.array([0.8, 0.8]), decimal=3)
 
     def test_infeasible_exp_constr(self) -> None:
         x = cp.Variable()
@@ -613,7 +613,7 @@ class TestDqcp(base_test.BaseTest):
         objective_fn = -cp.sqrt(x) / y
         problem = cp.Problem(cp.Minimize(objective_fn), [cp.exp(x) <= y])
         # smoke test
-        problem.solve(cp.CLARABEL, qcp=True)
+        problem.solve(cp.SCS, qcp=True)
 
     def test_curvature(self) -> None:
         x = cp.Variable(3)
@@ -654,7 +654,7 @@ class TestDqcp(base_test.BaseTest):
         obj = cp.max((1 - 2*cp.sqrt(x) + x) / x)
         problem = cp.Problem(cp.Minimize(obj), [x[0] <= 0.5, x[1] <= 0.9])
         self.assertTrue(problem.is_dqcp())
-        problem.solve(cp.CLARABEL, qcp=True)
+        problem.solve(cp.SCS, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 0.1715, places=3)
 
     def test_min(self) -> None:

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -223,7 +223,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(problem.is_dcp())
         self.assertFalse(problem.is_dgp())
 
-        problem.solve(cp.ECOS, qcp=True)
+        problem.solve(cp.CLARABEL, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 72, places=1)
         self.assertAlmostEqual(x.value, 12, places=1)
         self.assertAlmostEqual(y.value, 6, places=1)
@@ -242,7 +242,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(problem.is_dcp())
         self.assertFalse(problem.is_dgp())
 
-        problem.solve(cp.ECOS, qcp=True)
+        problem.solve(cp.CLARABEL, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 72, places=1)
         self.assertAlmostEqual(x.value, -12, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
@@ -262,7 +262,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(problem.is_dcp())
         self.assertFalse(problem.is_dgp())
 
-        problem.solve(cp.ECOS, qcp=True)
+        problem.solve(cp.CLARABEL, qcp=True)
         self.assertAlmostEqual(problem.objective.value, -42, places=1)
         self.assertAlmostEqual(x.value, 7, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
@@ -281,7 +281,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(problem.is_dcp())
         self.assertFalse(problem.is_dgp())
 
-        problem.solve(cp.ECOS, qcp=True)
+        problem.solve(cp.CLARABEL, qcp=True)
         self.assertAlmostEqual(problem.objective.value, -42, places=1)
         self.assertAlmostEqual(x.value, 7, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
@@ -294,7 +294,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(expr.is_quasiconvex())
 
         problem = cp.Problem(cp.Maximize(expr), [x <= 4, y <= 9])
-        problem.solve(cp.ECOS, qcp=True)
+        problem.solve(cp.CLARABEL, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 6, places=1)
         self.assertAlmostEqual(x.value, 4, places=1)
         self.assertAlmostEqual(y.value, 9, places=1)
@@ -306,7 +306,7 @@ class TestDqcp(base_test.BaseTest):
         self.assertFalse(expr.is_quasiconvex())
 
         problem = cp.Problem(cp.Maximize(expr), [x <= 4, y <= 9])
-        problem.solve(cp.ECOS, qcp=True)
+        problem.solve(cp.CLARABEL, qcp=True)
         # (2 + 2) * (3 + 4) = 28
         self.assertAlmostEqual(problem.objective.value, 28, places=1)
         self.assertAlmostEqual(x.value, 4, places=1)
@@ -323,7 +323,7 @@ class TestDqcp(base_test.BaseTest):
         problem = cp.Problem(cp.Minimize(expr), [x == 12, y <= 6])
         self.assertTrue(problem.is_dqcp())
 
-        problem.solve(cp.ECOS, qcp=True)
+        problem.solve(cp.CLARABEL, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 2.0, places=1)
         self.assertAlmostEqual(x.value, 12, places=1)
         self.assertAlmostEqual(y.value, 6, places=1)
@@ -338,7 +338,7 @@ class TestDqcp(base_test.BaseTest):
         problem = cp.Problem(cp.Maximize(expr), [x == 12, y >= -6])
         self.assertTrue(problem.is_dqcp())
 
-        problem.solve(cp.ECOS, qcp=True)
+        problem.solve(cp.CLARABEL, qcp=True)
         self.assertAlmostEqual(problem.objective.value, -2.0, places=1)
         self.assertAlmostEqual(x.value, 12, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
@@ -369,7 +369,7 @@ class TestDqcp(base_test.BaseTest):
 
         problem = cp.Problem(cp.Maximize(concave_frac))
         self.assertTrue(problem.is_dqcp())
-        problem.solve(cp.ECOS, qcp=True)
+        problem.solve(cp.CLARABEL, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 0.428, places=1)
         self.assertAlmostEqual(x.value, 0.5, places=1)
 
@@ -454,7 +454,7 @@ class TestDqcp(base_test.BaseTest):
         a = np.ones(2)
         b = np.zeros(2)
         problem = cp.Problem(cp.Minimize(cp.dist_ratio(x, a, b)), [x <= 0.8])
-        problem.solve(cp.ECOS, qcp=True)
+        problem.solve(cp.CLARABEL, qcp=True)
         np.testing.assert_almost_equal(problem.objective.value, 0.25)
         np.testing.assert_almost_equal(x.value, np.array([0.8, 0.8]))
 
@@ -613,7 +613,7 @@ class TestDqcp(base_test.BaseTest):
         objective_fn = -cp.sqrt(x) / y
         problem = cp.Problem(cp.Minimize(objective_fn), [cp.exp(x) <= y])
         # smoke test
-        problem.solve(cp.ECOS, qcp=True)
+        problem.solve(cp.CLARABEL, qcp=True)
 
     def test_curvature(self) -> None:
         x = cp.Variable(3)
@@ -654,7 +654,7 @@ class TestDqcp(base_test.BaseTest):
         obj = cp.max((1 - 2*cp.sqrt(x) + x) / x)
         problem = cp.Problem(cp.Minimize(obj), [x[0] <= 0.5, x[1] <= 0.9])
         self.assertTrue(problem.is_dqcp())
-        problem.solve(cp.ECOS, qcp=True)
+        problem.solve(cp.CLARABEL, qcp=True)
         self.assertAlmostEqual(problem.objective.value, 0.1715, places=3)
 
     def test_min(self) -> None:

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -655,7 +655,7 @@ class TestDqcp(base_test.BaseTest):
         problem = cp.Problem(cp.Minimize(obj), [x[0] <= 0.5, x[1] <= 0.9])
         self.assertTrue(problem.is_dqcp())
         problem.solve(cp.SCS, qcp=True)
-        self.assertAlmostEqual(problem.objective.value, 0.1715, places=3)
+        self.assertAlmostEqual(problem.objective.value, 0.1715, places=1)
 
     def test_min(self) -> None:
         x = cp.Variable(2)

--- a/cvxpy/tests/test_examples.py
+++ b/cvxpy/tests/test_examples.py
@@ -20,7 +20,6 @@ import numpy as np
 
 import cvxpy as cvx
 import cvxpy.interface as intf
-from cvxpy.reductions.solvers.conic_solvers import ecos_conif
 from cvxpy.tests.base_test import BaseTest
 
 
@@ -279,9 +278,9 @@ class TestExamples(BaseTest):
         constraints = [x >= 2]
         prob = cvx.Problem(obj, constraints)
 
-        # Solve with ECOS.
-        prob.solve(solver=cvx.ECOS)
-        print("optimal value with ECOS:", prob.value)
+        # Solve with CLARABEL.
+        prob.solve(solver=cvx.CLARABEL)
+        print("optimal value with CLARABEL:", prob.value)
         self.assertAlmostEqual(prob.value, 6)
 
         # Solve with CVXOPT.
@@ -472,7 +471,7 @@ class TestExamples(BaseTest):
 
         # An unbounded problem.
         prob = cvx.Problem(cvx.Minimize(x))
-        prob.solve(solver=cvx.ECOS)
+        prob.solve(solver=cvx.CLARABEL)
         print("status:", prob.status)
         print("optimal value", prob.value)
 
@@ -608,32 +607,6 @@ class TestExamples(BaseTest):
         constraints = [cvx.multiply(Known, U) == cvx.multiply(Known, Ucorr)]
         prob = cvx.Problem(obj, constraints)
         prob.solve(solver=cvx.SCS)
-
-    def test_advanced2(self) -> None:
-        """Test code from the advanced section of the tutorial.
-        """
-        x = cvx.Variable()
-        prob = cvx.Problem(cvx.Minimize(cvx.square(x)), [x == 2])
-        # Get ECOS arguments.
-        data, chain, inverse = prob.get_problem_data(cvx.ECOS)
-
-        # Get CVXOPT arguments.
-        if cvx.CVXOPT in cvx.installed_solvers():
-            data, chain, inverse = prob.get_problem_data(cvx.CVXOPT)
-
-        # Get SCS arguments.
-        data, chain, inverse = prob.get_problem_data(cvx.SCS)
-
-        import ecos
-
-        # Get ECOS arguments.
-        data, chain, inverse = prob.get_problem_data(cvx.ECOS)
-        # Call ECOS solver.
-        solution = ecos.solve(data["c"], data["G"], data["h"],
-                              ecos_conif.dims_to_solver_dict(data["dims"]),
-                              data["A"], data["b"])
-        # Unpack raw solver output.
-        prob.unpack_results(solution, chain, inverse)
 
     def test_log_sum_exp(self) -> None:
         """Test log_sum_exp function that failed in Github issue.

--- a/cvxpy/tests/test_linear_cone.py
+++ b/cvxpy/tests/test_linear_cone.py
@@ -25,7 +25,7 @@ from cvxpy.expressions.variable import Variable
 from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
 from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
 from cvxpy.reductions.flip_objective import FlipObjective
-from cvxpy.reductions.solvers.conic_solvers.ecos_conif import ECOS
+from cvxpy.reductions.solvers.conic_solvers.clarabel_conif import CLARABEL
 from cvxpy.tests.base_test import BaseTest
 from cvxpy.tests.solver_test_helpers import SolverTestHelper
 
@@ -52,7 +52,7 @@ class TestLinearCone(BaseTest):
         self.B = Variable((2, 2), name='B')
         self.C = Variable((3, 2), name='C')
 
-        self.solvers = [ECOS()]
+        self.solvers = [CLARABEL()]
 
     def test_scalar_lp(self) -> None:
         """Test scalar LP problems.
@@ -334,7 +334,7 @@ class TestLinearCone(BaseTest):
         # Check that the problem compiles correctly, and that
         # dual variables are recovered correctly.
         sth = SolverTestHelper(obj_pair, var_pairs, con_pairs)
-        sth.solve(solver='ECOS')
+        sth.solve(solver='CLARABEL')
         sth.verify_primal_values(places=4)
         sth.verify_dual_values(places=4)
         # Check that violations are computed properly

--- a/cvxpy/tests/test_nonlinear_atoms.py
+++ b/cvxpy/tests/test_nonlinear_atoms.py
@@ -128,7 +128,7 @@ class TestNonlinearAtoms(BaseTest):
 
         kl_div_prob = cp.Problem(cp.Minimize(cp.kl_div(x, y)), constraints=[x + y <= 1])
         kl_div_prob.solve(solver=cp.CLARABEL)
-        self.assertItemsAlmostEqual(x.value, y.value)
+        self.assertItemsAlmostEqual(x.value, y.value, places=3)
         self.assertItemsAlmostEqual(kl_div_prob.value, 0)
 
         rel_entr_prob = cp.Problem(cp.Minimize(cp.rel_entr(x, y)), constraints=[x + y <= 1])

--- a/cvxpy/tests/test_nonlinear_atoms.py
+++ b/cvxpy/tests/test_nonlinear_atoms.py
@@ -92,7 +92,7 @@ class TestNonlinearAtoms(BaseTest):
         p_refProb.value = npSPriors
         klprob.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(v_prob.value, npSPriors, places=3)
-        klprob.solve(solver=cp.ECOS)
+        klprob.solve(solver=cp.CLARABEL)
         self.assertItemsAlmostEqual(v_prob.value, npSPriors)
 
     def test_rel_entr(self) -> None:
@@ -127,7 +127,7 @@ class TestNonlinearAtoms(BaseTest):
         y = cp.Variable()
 
         kl_div_prob = cp.Problem(cp.Minimize(cp.kl_div(x, y)), constraints=[x + y <= 1])
-        kl_div_prob.solve(solver=cp.ECOS)
+        kl_div_prob.solve(solver=cp.CLARABEL)
         self.assertItemsAlmostEqual(x.value, y.value)
         self.assertItemsAlmostEqual(kl_div_prob.value, 0)
 
@@ -150,7 +150,7 @@ class TestNonlinearAtoms(BaseTest):
             x = cp.Variable(n)
             obj = cp.Maximize(cp.sum(cp.entr(x)))
             p = cp.Problem(obj, [cp.sum(x) == 1])
-            p.solve(solver=cp.ECOS)
+            p.solve(solver=cp.CLARABEL)
             self.assertItemsAlmostEqual(x.value, n*[1./n])
             p.solve(solver=cp.SCS)
             self.assertItemsAlmostEqual(x.value, n*[1./n], places=3)

--- a/cvxpy/tests/test_nonlinear_atoms.py
+++ b/cvxpy/tests/test_nonlinear_atoms.py
@@ -93,7 +93,7 @@ class TestNonlinearAtoms(BaseTest):
         klprob.solve(solver=cp.SCS)
         self.assertItemsAlmostEqual(v_prob.value, npSPriors, places=3)
         klprob.solve(solver=cp.CLARABEL)
-        self.assertItemsAlmostEqual(v_prob.value, npSPriors)
+        self.assertItemsAlmostEqual(v_prob.value, npSPriors, places=3)
 
     def test_rel_entr(self) -> None:
         """Test a problem with rel_entr.
@@ -151,7 +151,7 @@ class TestNonlinearAtoms(BaseTest):
             obj = cp.Maximize(cp.sum(cp.entr(x)))
             p = cp.Problem(obj, [cp.sum(x) == 1])
             p.solve(solver=cp.CLARABEL)
-            self.assertItemsAlmostEqual(x.value, n*[1./n])
+            self.assertItemsAlmostEqual(x.value, n*[1./n], places=3)
             p.solve(solver=cp.SCS)
             self.assertItemsAlmostEqual(x.value, n*[1./n], places=3)
 

--- a/cvxpy/tests/test_power_tools.py
+++ b/cvxpy/tests/test_power_tools.py
@@ -35,7 +35,7 @@ class TestGeoMean(BaseTest):
         if 'MOSEK' in cp.installed_solvers():
             log_solve_args = {'solver': 'MOSEK'}
         else:
-            log_solve_args = {'solver': 'ECOS'}
+            log_solve_args = {'solver': 'CLARABEL'}
         n_buyer = 5
         n_items = 7
         np.random.seed(0)

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1993,7 +1993,7 @@ class TestProblem(BaseTest):
             constraints = [a >= 0., -alpha <= D.T @ a, D.T @ a <= alpha]
 
             prob = cp.Problem(obj, constraints)
-            prob.solve(solver=s.OSQP)
+            prob.solve(solver=s.CLARABEL)
             assert prob.status == 'optimal'
             return prob
 
@@ -2003,11 +2003,11 @@ class TestProblem(BaseTest):
 
         make_problem(D_dense)
         coef_dense = a.value.T.dot(D_dense)
-        np.testing.assert_almost_equal(expected_coef, coef_dense)
+        np.testing.assert_almost_equal(expected_coef, coef_dense, decimal=4)
 
         make_problem(D_sparse)
         coef_sparse = a.value.T @ D_sparse
-        np.testing.assert_almost_equal(expected_coef, coef_sparse)
+        np.testing.assert_almost_equal(expected_coef, coef_sparse, decimal=4)
 
     def test_special_index(self) -> None:
         """Test QP code path with special indexing.

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -193,9 +193,7 @@ class TestProblem(BaseTest):
         prob.solve(solver=s.CLARABEL)
         stats = prob.solver_stats
         self.assertGreater(stats.solve_time, 0)
-        self.assertGreater(stats.setup_time, 0)
         self.assertGreater(stats.num_iters, 0)
-        self.assertIn('info', stats.extra_stats)
 
         prob = Problem(cp.Minimize(cp.norm(self.x)), [self.x == 0])
         prob.solve(solver=s.SCS)
@@ -233,8 +231,7 @@ class TestProblem(BaseTest):
         dims = data[ConicSolver.DIMS]
         self.assertEqual(dims.soc, [3])
         self.assertEqual(data["c"].shape, (3,))
-        self.assertIsNone(data["A"])
-        self.assertEqual(data["G"].shape, (3, 3))
+        self.assertEqual(data["A"].shape, (3, 3))
 
         # caching use_quad_obj
         p = Problem(cp.Minimize(cp.sum_squares(self.x) + 2))
@@ -1242,17 +1239,6 @@ class TestProblem(BaseTest):
         result = p.solve(solver=s.SCS)
         self.assertAlmostEqual(result, 0)
 
-        with self.assertRaises(ValueError) as cm:
-            obj = cp.Minimize(cp.sum(cp.square(self.x)))
-            constraints = [self.x == self.x]
-            problem = Problem(obj, constraints)
-            problem.solve(solver=s.CLARABEL)
-        self.assertEqual(
-            str(cm.exception),
-            "CLARABEL cannot handle sparse data with nnz == 0; "
-            "this is a bug in CLARABEL, and it indicates that your problem "
-            "might have redundant constraints.")
-
     # Test that symmetry is enforced.
     def test_sdp_symmetry(self) -> None:
         p = Problem(cp.Minimize(cp.lambda_max(self.A)), [self.A >= 2])
@@ -1383,10 +1369,10 @@ class TestProblem(BaseTest):
         """Tests that errors occur when you use an invalid solver.
         """
         with self.assertRaises(SolverError):
-            Problem(cp.Minimize(Variable(boolean=True))).solve(solver=s.CLARABEL)
+            Problem(cp.Minimize(Variable(boolean=True))).solve(solver=s.OSQP)
 
         with self.assertRaises(SolverError):
-            Problem(cp.Minimize(cp.lambda_max(self.A))).solve(solver=s.CLARABEL)
+            Problem(cp.Minimize(cp.lambda_max(self.A))).solve(solver=s.OSQP)
 
         with self.assertRaises(SolverError):
             Problem(cp.Minimize(self.a)).solve(solver=s.SCS)
@@ -2007,7 +1993,7 @@ class TestProblem(BaseTest):
             constraints = [a >= 0., -alpha <= D.T @ a, D.T @ a <= alpha]
 
             prob = cp.Problem(obj, constraints)
-            prob.solve(solver=s.CLARABEL)
+            prob.solve(solver=s.OSQP)
             assert prob.status == 'optimal'
             return prob
 

--- a/cvxpy/tests/test_suppfunc.py
+++ b/cvxpy/tests/test_suppfunc.py
@@ -41,7 +41,7 @@ class TestSupportFunctions(BaseTest):
         cons = [sigma(y - a) <= 0]  # "<= num" for any num >= 0 is valid.
         objective = cp.Minimize(a @ y)
         prob = cp.Problem(objective, cons)
-        prob.solve(solver='ECOS')
+        prob.solve(solver='CLARABEL')
         actual = prob.value
         expected = np.dot(a, a)
         self.assertLessEqual(abs(actual - expected), 1e-6)
@@ -60,7 +60,7 @@ class TestSupportFunctions(BaseTest):
         y = np.random.randn(n,)
         y_var = cp.Variable(shape=(n,))
         prob = cp.Problem(cp.Minimize(sigma(y_var)), [y == y_var])
-        prob.solve(solver='ECOS')
+        prob.solve(solver='CLARABEL')
         actual = prob.value
         expected = a @ y + np.linalg.norm(y, ord=np.inf)
         self.assertLessEqual(abs(actual - expected), 1e-5)
@@ -75,7 +75,7 @@ class TestSupportFunctions(BaseTest):
         y = np.random.randn(n,)
         y_var = cp.Variable(shape=(n,))
         prob = cp.Problem(cp.Minimize(sigma(y_var)), [y == y_var])
-        prob.solve(solver='ECOS')
+        prob.solve(solver='CLARABEL')
         actual = prob.value
         expected = a @ y + np.linalg.norm(y, ord=2)
         self.assertLessEqual(abs(actual - expected), 1e-6)
@@ -91,7 +91,7 @@ class TestSupportFunctions(BaseTest):
         cons = [sigma(y - a) <= 0]
         objective = cp.Minimize(cp.sum_squares(y.flatten(order='F')))
         prob = cp.Problem(objective, cons)
-        prob.solve(solver='ECOS')
+        prob.solve(solver='CLARABEL')
         expect = np.hstack([np.zeros(shape=(rows, 1)), a[:, [1]]])
         actual = y.value
         self.assertLessEqual(np.linalg.norm(actual - expect, ord=2), 1e-6)
@@ -138,7 +138,7 @@ class TestSupportFunctions(BaseTest):
         cons = [sigma(y) <= 1]
         # ^ That just means -1 <= y[0] <= 1
         prob = cp.Problem(cp.Minimize(obj_expr), cons)
-        prob.solve(solver='ECOS')
+        prob.solve(solver='CLARABEL')
         viol = cons[0].violation()
         self.assertLessEqual(viol, 1e-6)
         self.assertLessEqual(abs(y.value - (-1)), 1e-6)
@@ -154,7 +154,7 @@ class TestSupportFunctions(BaseTest):
         objective = cp.Maximize(expr)
         cons = [y == a]
         prob = cp.Problem(objective, cons)
-        prob.solve(solver='ECOS')
+        prob.solve(solver='CLARABEL')
         # Check for expected objective value
         epi_actual = prob.value
         direct_actual = expr.value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ name = "cvxpy"
 description = "A domain-specific language for modeling convex optimization problems in Python."
 dependencies = [
     "osqp >= 0.6.2",
-    "ecos >= 2",
     "clarabel >= 0.5.0",
     "scs >= 3.2.4.post1",
     "numpy >= 1.20",
@@ -64,8 +63,8 @@ CBC = ["cylp>=0.91.5"]
 CLARABEL = []
 CVXOPT = ["cvxopt"]
 DIFFCP = ["diffcp"]
-ECOS = []
-ECOS_BB = []
+ECOS = ["ecos"]
+ECOS_BB = ["ecos"]
 GLOP = ["ortools>=9.7,<9.10"]
 GLPK = ["cvxopt"]
 GLPK_MI = ["cvxopt"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 clarabel
 osqp
-ecos
 scs
 numpy
 scipy


### PR DESCRIPTION
## Description
Please include a short summary of the change.
This PR deletes ECOS as a dependency, as discussed in the release of version 1.5 (which changed its default solver from ecos to clarabel). 
There are currently some minor regressions from this default solver change in our test suite (especially in a few DQCP tests). However, we believe it is not a big change for users to add, if necessary, an installation step for ecos. 
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.