### PR TITLE
Bug/geo mean

### DIFF
--- a/cvxpy/tests/test_dgp.py
+++ b/cvxpy/tests/test_dgp.py
@@ -54,7 +54,7 @@ class TestDgp(BaseTest):
         div = x / y
         self.assertTrue(div.is_log_log_affine())
 
-        div = posynomial / (3.0 * x * y**(-0.1))
+        div = posynomial / (3.0 * x * y ** (-0.1))
         self.assertTrue(div.is_log_log_convex())
         self.assertFalse(div.is_log_log_concave())
         self.assertTrue(div.is_dgp())
@@ -169,17 +169,26 @@ class TestDgp(BaseTest):
     def test_inv_prod(self) -> None:
         x = cvxpy.Variable(2)
         # # test inv_prod with scalar value
-        prob1 = cvxpy.Problem(cvxpy.Minimize(cvxpy.inv_prod(x[0])+cvxpy.inv_prod(x[:2])), [cvxpy.sum(x)==2])
+        prob1 = cvxpy.Problem(
+            cvxpy.Minimize(cvxpy.inv_prod(x[0]) + cvxpy.inv_prod(x[:2])),
+            [cvxpy.sum(x) == 2],
+        )
         prob1.solve()
 
         # compare inv_prod with inv_pos
-        prob2 = cvxpy.Problem(cvxpy.Minimize(cvxpy.inv_prod(x[:1])+cvxpy.inv_prod(x[:2])), [cvxpy.sum(x)==2])
+        prob2 = cvxpy.Problem(
+            cvxpy.Minimize(cvxpy.inv_prod(x[:1]) + cvxpy.inv_prod(x[:2])),
+            [cvxpy.sum(x) == 2],
+        )
         prob2.solve()
 
-        prob3 = cvxpy.Problem(cvxpy.Minimize(cvxpy.inv_pos(x[0])+cvxpy.inv_prod(x[:2])), [cvxpy.sum(x)==2])
+        prob3 = cvxpy.Problem(
+            cvxpy.Minimize(cvxpy.inv_pos(x[0]) + cvxpy.inv_prod(x[:2])),
+            [cvxpy.sum(x) == 2],
+        )
         prob3.solve()
         self.assertAlmostEqual(prob2.value, prob3.value, 4)
-    
+
     def test_builtin_sum(self) -> None:
         x = cvxpy.Variable(2, pos=True)
         self.assertTrue(sum(x).is_log_log_convex())

--- a/cvxpy/tests/test_dgp.py
+++ b/cvxpy/tests/test_dgp.py
@@ -160,6 +160,26 @@ class TestDgp(BaseTest):
         self.assertTrue(geo_mean.is_log_log_convex())
         self.assertTrue(geo_mean.is_log_log_concave())
 
+    def test_geo_mean_scalar(self) -> None:
+        x = cvxpy.Variable(pos=True)
+        p = np.array([2])
+        geo_mean = cvxpy.geo_mean(x, p)
+        self.assertTrue(geo_mean.is_dgp())
+
+    def test_inv_prod(self) -> None:
+        x = cvxpy.Variable(2)
+        # # test inv_prod with scalar value
+        prob1 = cvxpy.Problem(cvxpy.Minimize(cvxpy.inv_prod(x[0])+cvxpy.inv_prod(x[:2])), [cvxpy.sum(x)==2])
+        prob1.solve()
+
+        # compare inv_prod with inv_pos
+        prob2 = cvxpy.Problem(cvxpy.Minimize(cvxpy.inv_prod(x[:1])+cvxpy.inv_prod(x[:2])), [cvxpy.sum(x)==2])
+        prob2.solve()
+
+        prob3 = cvxpy.Problem(cvxpy.Minimize(cvxpy.inv_pos(x[0])+cvxpy.inv_prod(x[:2])), [cvxpy.sum(x)==2])
+        prob3.solve()
+        self.assertAlmostEqual(prob2.value, prob3.value, 4)
+    
     def test_builtin_sum(self) -> None:
         x = cvxpy.Variable(2, pos=True)
         self.assertTrue(sum(x).is_log_log_convex())

--- a/cvxpy/tests/test_dgp.py
+++ b/cvxpy/tests/test_dgp.py
@@ -160,7 +160,13 @@ class TestDgp(BaseTest):
         self.assertTrue(geo_mean.is_log_log_convex())
         self.assertTrue(geo_mean.is_log_log_concave())
 
-    def test_geo_mean_scalar(self) -> None:
+    def test_geo_mean_scalar1(self) -> None:
+        x = cvxpy.Variable(1, pos=True)
+        p = np.array([2])
+        geo_mean = cvxpy.geo_mean(x, p)
+        self.assertTrue(geo_mean.is_dgp())
+    
+    def test_geo_mean_scalar2(self) -> None:
         x = cvxpy.Variable(pos=True)
         p = np.array([2])
         geo_mean = cvxpy.geo_mean(x, p)

--- a/cvxpy/utilities/power_tools.py
+++ b/cvxpy/utilities/power_tools.py
@@ -90,7 +90,7 @@ def gm_constrs(t, x_list, p):
     if len(x_list) == 1:
         # Assuming p[0] = 1 for geometric mean
         x = x_list[0]
-        constraints += [t <= x]
+        constraints += [t == x]
 
     return constraints
 

--- a/cvxpy/utilities/power_tools.py
+++ b/cvxpy/utilities/power_tools.py
@@ -86,6 +86,12 @@ def gm_constrs(t, x_list, p):
         if 1 not in elem:
             constraints += [gm(d[elem], d[children[0]], d[children[1]])]
 
+    # Handle single-variable case
+    if len(x_list) == 1:
+        # Assuming p[0] = 1 for geometric mean
+        x = x_list[0]
+        constraints += [t <= x]
+
     return constraints
 
 


### PR DESCRIPTION
## Description
Please include a short summary of the change.
Issue link (if applicable): [Issue #2583](https://github.com/cvxpy/cvxpy/issues/2583)
As discussed in the linked issue, when a variable x of shape (1,) is passed to inv_prod, it is not properly modeled it as 1/x.
This issue seems to be caused by the geo_mean (in `gm_constrs` function) which for x variable with the shape of (1,) it does not include a constraint to bind the epigraph variable t with x.

@Transurgeon has nicely provided some tests which I added to `test_dgp.py ` to make sure we properly support scalar inputs.
Currently, test_geo_mean_scalar2 is not passing.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [x] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.