### PR TITLE
CI: change pyscipopt installation to use pip and pin version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-12, windows-2022 ]
+        os: [ ubuntu-20.04, macos-13, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13" ]
         include:
           # These are intended to just add their extra parameter to existing matrix combinations;
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-12, windows-2022 ]
+        os: [ ubuntu-20.04, macos-13, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13" ]
         build-cvxpy-base: [ true, false ]  # whether to build cvxpy-base (true) or regular cvxpy (false)
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
             python-version: 3.12
             openmp: "True"
             single_action_config: false
-          - os: macos-12
+          - os: macos-13
             python-version: 3.12
             single_action_config: true
 

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -50,8 +50,7 @@ if [[ "$RUNNER_OS" == "Windows" ]] && [[ "$PYTHON_VERSION" != "3.13" ]]; then
   python -m pip install sdpa-multiprecision
 elif [[ "$PYTHON_VERSION" != "3.13" ]]; then
   # cylp has no wheels for Windows
-  conda install pyscipopt
-  python -m pip install cylp
+  python -m pip install cylp pyscipopt==5.2.1
 fi
 
 if [[ "$PYTHON_VERSION" == "3.10" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then


### PR DESCRIPTION
## Description
Please include a short summary of the change.
Pyscipopt 5.2.1 is the latest version (released october 31 :ghost: 2024).
Also update the mac-os version to 13 in CI due to encountering the following error:
```
The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15.
```
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.