### PR TITLE
- Select scipy if any problem atom is not supported in cpp.

### DIFF
--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -31,8 +31,7 @@ from cvxpy.atoms.affine.partial_transpose import partial_transpose
 from cvxpy.atoms.affine.promote import promote
 from cvxpy.atoms.affine.real import real
 from cvxpy.atoms.affine.reshape import deep_flatten, reshape
-# TODO: Remove comment once concatenated is enabled
-# from cvxpy.atoms.affine.concatenate import concatenate
+from cvxpy.atoms.affine.concatenate import concatenate
 from cvxpy.atoms.affine.sum import sum
 from cvxpy.atoms.affine.trace import trace
 from cvxpy.atoms.affine.transpose import transpose

--- a/cvxpy/atoms/affine/concatenate.py
+++ b/cvxpy/atoms/affine/concatenate.py
@@ -42,7 +42,7 @@ class Concatenate(AffAtom):
             self.axis = None
         super().__init__(*args)
 
-    def supports_cpp(self) -> bool:
+    def _supports_cpp(self) -> bool:
         return False
 
     def is_atom_log_log_convex(self) -> bool:

--- a/cvxpy/atoms/affine/concatenate.py
+++ b/cvxpy/atoms/affine/concatenate.py
@@ -42,6 +42,9 @@ class Concatenate(AffAtom):
             self.axis = None
         super().__init__(*args)
 
+    def supports_cpp(self) -> bool:
+        return False
+
     def is_atom_log_log_convex(self) -> bool:
         return True
 

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -269,7 +269,7 @@ class Problem(u.Canonical):
         """
         Returns True if all the arguments in the problem support cpp backend.
         """
-        return all(expr._all_cpp_support() for expr in self.constraints + [self.objective.expr])
+        return all(expr._all_support_cpp() for expr in self.constraints + [self.objective.expr])
 
     @perf.compute_once
     def is_dgp(self, dpp: bool = False) -> bool:

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -408,11 +408,10 @@ def _get_canon_backend(problem, canon_backend):
                 f"The problem includes expressions that don't support {CPP_CANON_BACKEND} backend. "
                 f"Defaulting to the {SCIPY_CANON_BACKEND} backend for canonicalization."))
             return SCIPY_CANON_BACKEND
-        elif canon_backend == CPP_CANON_BACKEND:
+        if canon_backend == CPP_CANON_BACKEND:
             raise ValueError(f"The {CPP_CANON_BACKEND} backend cannot be used with problems "
-                             f"that expressions which do not support it.")
-        else:
-            return canon_backend  # Use the specified backend (e.g., SCIPY_CANON_BACKEND)
+                             f"that have expressions which do not support it.")
+        return canon_backend  # Use the specified backend (e.g., SCIPY_CANON_BACKEND)
 
     if problem._max_ndim() > 2:
         if canon_backend is None:
@@ -420,7 +419,7 @@ def _get_canon_backend(problem, canon_backend):
                 f"The problem has an expression with dimension greater than 2. "
                 f"Defaulting to the {SCIPY_CANON_BACKEND} backend for canonicalization."))
             return SCIPY_CANON_BACKEND
-        elif canon_backend == CPP_CANON_BACKEND:
+        if canon_backend == CPP_CANON_BACKEND:
             raise ValueError(f"Only the {SCIPY_CANON_BACKEND} and {NUMPY_CANON_BACKEND} "
                              f"backends are supported for problems with expressions of "
                              f"dimension greater than 2.")

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -561,47 +561,44 @@ class TestAtoms(BaseTest):
         self.assertEqual(expr.shape, (2, 1))
 
     def test_concatenate(self):
-        # TODO: concatenated is not exposed in cp.concatenated yet. Use cp.concatenate in
-        # this test once it is available
-        from cvxpy.atoms.affine.concatenate import concatenate
-        atom = concatenate([self.x, self.y], axis=0)
+        atom = cp.concatenate([self.x, self.y], axis=0)
         self.assertEqual(atom.name(), "Concatenate(x, y, 0)")
         self.assertEqual(atom.shape, (4,))  # (2 vectors are concatenated on axis 0)
 
         with self.assertRaises(ValueError):
             # x and y are 1D arrays, so they can't be concatenated on axis 1
-            atom = concatenate([self.x, self.y], axis=1)
+            atom = cp.concatenate([self.x, self.y], axis=1)
         # Expected ValueError due to invalid axis for 1D arrays
 
-        atom = concatenate([self.A, self.C], axis=None)
+        atom = cp.concatenate([self.A, self.C], axis=None)
         self.assertEqual(atom.shape, (10,))
 
-        atom = concatenate([self.A, self.C], axis=0)
+        atom = cp.concatenate([self.A, self.C], axis=0)
         self.assertEqual(atom.shape, (5, 2))
 
         with self.assertRaises(ValueError):
-            atom = concatenate([self.A, self.C], axis=1)
+            atom = cp.concatenate([self.A, self.C], axis=1)
         # Expected ValueError due to mismatched dimensions along dimension 0
 
-        atom = concatenate([self.A, self.B], axis=1)
+        atom = cp.concatenate([self.A, self.B], axis=1)
         self.assertEqual(atom.shape, (2, 4))
 
-        atom = concatenate([self.A, self.B], axis=0)
+        atom = cp.concatenate([self.A, self.B], axis=0)
         self.assertEqual(atom.shape, (4, 2))
 
-        atom = concatenate([self.A, self.B], axis=None)
+        atom = cp.concatenate([self.A, self.B], axis=None)
         self.assertEqual(atom.shape, (8,))
 
         with self.assertRaises(ValueError):
-            concatenate([self.a, self.A], axis=0)
+            cp.concatenate([self.a, self.A], axis=0)
         # Expected ValueError due to zero-dimensional arrays cannot be concatenated
 
         with self.assertRaises(ValueError):
-            concatenate([self.A, self.C], axis=2)
+            cp.concatenate([self.A, self.C], axis=2)
         # Expected ValueError due to axis 2 being out of bounds for 2D arrays
 
         with self.assertRaises(ValueError):
-            concatenate([self.C, self.x], axis=1)
+            cp.concatenate([self.C, self.x], axis=1)
         # Expected ValueError due to mismatched number of dimensions between arrays
 
     def test_reshape(self) -> None:

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1517,6 +1517,42 @@ class TestExpressions(BaseTest):
         expr = hermitian_wrap(U)
         assert expr.is_hermitian()
 
+    def test_expr_does_not_support_cpp_warning(self):
+        from cvxpy.atoms.affine.sum import Sum
+
+        class SumNotSupportedInCPP(Sum):
+            def _supports_cpp(self):
+                return False
+
+        x = Variable(2)
+        prob = Problem(Minimize(0), [SumNotSupportedInCPP(x) == 1])
+
+        with pytest.warns(
+            UserWarning,
+            match="The problem includes expressions that don't support "
+            "CPP backend. Defaulting to the SCIPY backend "
+            "for canonicalization.",
+        ):
+            prob.solve()
+
+
+    def test_expr_does_not_support_cpp_error(self):
+        from cvxpy.atoms.affine.sum import Sum
+
+        class SumNotSupportedInCPP(Sum):
+            def _supports_cpp(self):
+                return False
+
+        x = Variable(2)
+        prob = Problem(Minimize(0), [SumNotSupportedInCPP(x) == 1])
+
+        with pytest.raises(
+            ValueError,
+            match="The CPP backend cannot be used with problems "
+            "that have expressions which do not support it",
+        ):
+            prob.solve(canon_backend=cp.CPP_CANON_BACKEND)
+
 
 class TestND_Expressions():
 

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1566,12 +1566,9 @@ class TestND_Expressions():
         assert np.allclose(expr.value, self.target)
 
     def test_nd_concatenate(self) -> None:
-        # TODO: concatenated is not exposed in cp.concatenated yet. Use cp.concatenate
-        # in this test once it is available
-        from cvxpy.atoms.affine.concatenate import concatenate
-        x = Variable((1, 2, 2))
-        z = Variable((1, 2, 2))
-        expr = concatenate([x,z], axis = 0)
+        x = cp.Variable((1, 2, 2))
+        z = cp.Variable((1, 2, 2))
+        expr = cp.concatenate([x,z], axis = 0)
         prob = cp.Problem(self.obj, [expr == self.target])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, self.target)

--- a/cvxpy/utilities/canonical.py
+++ b/cvxpy/utilities/canonical.py
@@ -100,7 +100,11 @@ class Canonical(metaclass=abc.ABCMeta):
         else:
             return type(self)(*args)
 
-    def supports_cpp(self):
+    def _supports_cpp(self) -> bool:
+        """
+        Determines whether the current atom is implemented in C++. This method should be
+        overridden in derived atom classes that are not implemented in C++.
+        """
         return True
 
     def __copy__(self):
@@ -158,14 +162,17 @@ class Canonical(metaclass=abc.ABCMeta):
     @pu.compute_once
     def _aggregate_metrics(self) -> dict:
         """
-        Aggregates multiple metrics based on sub-expressions.
+        Aggregates and caches metrics for expression trees in self.args. So far
+        metrics include the maximum dimensionality ('max_ndim') and whether
+        all sub-expressions support C++ ('all_support_cpp').
+
         """
         max_ndim = self.ndim
-        cpp_support = self.supports_cpp()
+        cpp_support = self._supports_cpp()
 
         for arg in self.args:
             max_ndim = max(max_ndim, arg._max_ndim())
-            cpp_support = cpp_support and arg.supports_cpp()
+            cpp_support = cpp_support and arg._supports_cpp()
 
         metrics = {
             "max_ndim": max_ndim,
@@ -178,7 +185,7 @@ class Canonical(metaclass=abc.ABCMeta):
         """
         return self._aggregate_metrics()["max_ndim"]
 
-    def _all_cpp_support(self) -> bool:
+    def _all_support_cpp(self) -> bool:
         """
         Returns True if all sub-expressions support C++, False otherwise.
         """


### PR DESCRIPTION


## Description

If an operator is not supported in CPP then select SCIPY backend. This allows you to define operators in numpy/scipy versions without having to program their analogue in cpp.

Also enables concatenate operator in the top level module.

**WIP**

Issue link : #2597  See for details

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.