### PR TITLE
Fixes failing `quantum_rel_entr` tests

### DIFF
--- a/cvxpy/atoms/quantum_cond_entr.py
+++ b/cvxpy/atoms/quantum_cond_entr.py
@@ -13,8 +13,8 @@ def quantum_cond_entr(rho: Expression , dim: list[int], sys: Optional[int]=0):
     if sys == 0:
         composite_arg = kron(np.eye(dim[0]),
                              partial_trace(rho, dim, sys))
-        return -quantum_rel_entr(hermitian_wrap(rho), hermitian_wrap(composite_arg))
+        return -quantum_rel_entr(rho, hermitian_wrap(composite_arg))
     elif sys == 1:
         composite_arg = kron(partial_trace(rho, dim, sys),
                              np.eye(dim[1]))
-        return -quantum_rel_entr(hermitian_wrap(rho), hermitian_wrap(composite_arg))
+        return -quantum_rel_entr(rho, hermitian_wrap(composite_arg))

--- a/cvxpy/atoms/quantum_cond_entr.py
+++ b/cvxpy/atoms/quantum_cond_entr.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from cvxpy.atoms.affine.kron import kron
 from cvxpy.atoms.affine.partial_trace import partial_trace
+from cvxpy.atoms.affine.wraps import hermitian_wrap
 from cvxpy.atoms.quantum_rel_entr import quantum_rel_entr
 from cvxpy.expressions.expression import Expression
 
@@ -12,8 +13,8 @@ def quantum_cond_entr(rho: Expression , dim: list[int], sys: Optional[int]=0):
     if sys == 0:
         composite_arg = kron(np.eye(dim[0]),
                              partial_trace(rho, dim, sys))
-        return -quantum_rel_entr(rho, composite_arg)
+        return -quantum_rel_entr(hermitian_wrap(rho), hermitian_wrap(composite_arg))
     elif sys == 1:
         composite_arg = kron(partial_trace(rho, dim, sys),
                              np.eye(dim[1]))
-        return -quantum_rel_entr(rho, composite_arg)
+        return -quantum_rel_entr(hermitian_wrap(rho), hermitian_wrap(composite_arg))

--- a/cvxpy/tests/test_quantum_rel_entr.py
+++ b/cvxpy/tests/test_quantum_rel_entr.py
@@ -4,6 +4,7 @@ import pytest
 import cvxpy as cp
 from cvxpy.atoms.affine.kron import kron
 from cvxpy.atoms.affine.partial_trace import partial_trace
+from cvxpy.atoms.affine.wraps import hermitian_wrap
 from cvxpy.tests import solver_test_helpers as STH
 
 
@@ -125,7 +126,7 @@ class TestQuantumRelEntr:
 
         def Ic(rho: cp.Variable):
             return cp.quantum_cond_entr(
-                        W @ applychan(U, rho, 'isom', (na, nb)) @ W.conj().T,
+                        hermitian_wrap(W @ applychan(U, rho, 'isom', (na, nb)) @ W.conj().T),
                         [ne, nf], 1
                     )/np.log(2)
 


### PR DESCRIPTION
## Description
Minor fix to ensure `quantum_cond_entr` test passes

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.