### PR TITLE
Fix breaking tests due to gurobi interface update

### DIFF
--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1569,7 +1569,7 @@ class TestGUROBI(BaseTest):
                 self.skipTest("Gurobi has found a solution, the test is not relevant anymore.")
 
             solver_status = getattr(extra_stats, "Status", None)
-            if solver_status != gurobipy.StatusConstClass.TIME_LIMIT:
+            if solver_status != gurobipy.GRB.TIME_LIMIT:
                 self.skipTest("Gurobi terminated for a different reason than reaching time limit, "
                               "the test is not relevant anymore.")
 

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -586,7 +586,7 @@ class TestQp(BaseTest):
                 self.skipTest("Gurobi has found a solution, the test is not relevant anymore.")
 
             solver_status = getattr(extra_stats, "Status", None)
-            if solver_status != gurobipy.StatusConstClass.TIME_LIMIT:
+            if solver_status != gurobipy.GRB.TIME_LIMIT:
                 self.skipTest("Gurobi terminated for a different reason than reaching time limit, "
                               "the test is not relevant anymore.")
 


### PR DESCRIPTION
## Description
Please include a short summary of the change.
Thanks a lot for @simonbowly for pointing the fix.
Quote:
"So in cvxpy these cases:

```python
if solver_status != gurobipy.StatusConstClass.TIME_LIMIT:
```

should be replaced with just":

```python
if solver_status != gurobipy.GRB.TIME_LIMIT
```

Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.