### PR TITLE
build(pre-commit): Update ruff from 0.1.11 -> 0.8.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.1.11'
+    rev: 'v0.8.1'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,18 @@
 [tool.ruff]
+# The minimum Python version that should be supported
+target-version = "py39"
+
+line-length = 100
+
+extend-exclude = [
+    "build",
+    "examples",
+    "doc",
+    "cvxpy/cvxcore/*",
+    "*__init__.py"
+]
+
+[tool.ruff.lint]
 select = [
     "E",
     "F",
@@ -6,16 +20,10 @@ select = [
     "NPY201",
     "W605",  # Check for invalid escape sequences in docstrings (errors in py >= 3.11)
 ]
-line-length = 100
-exclude = [
-    "build",
-    "examples",
-    "doc",
-    "cvxpy/cvxcore/*",
-    "*__init__.py"
+
+ignore = [
+    "E721" # Do not compare types, use 'isinstance()'
 ]
-# The minimum Python version that should be supported
-target-version = "py39"
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
[changelog for ruff](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#081)

This updates ruff and also removes a deprecation warning about select not being in a `lint` section of the `pyproject.toml`

Also migrate to `extend-exclude` as the default exclude is [pretty decent](https://docs.astral.sh/ruff/configuration/)

Also ignore [E721](https://docs.astral.sh/ruff/rules/type-comparison/); This is a newer check and fails in many files.
Keeping it ignored mimic behavior pre-upgrade.
Another PR seems appropriate to fix `is / is not` vs `==/!=`

## Description
Please include a short summary of the change.
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.