### PR TITLE
removing some test deprecation warnings

### DIFF
--- a/cvxpy/reductions/dgp2dcp/canonicalizers/mulexpression_canon.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/mulexpression_canon.py
@@ -37,5 +37,5 @@ def mulexpression_canon(expr, args):
         rows.append(row)
     mat = bmat(rows)
     if mat.shape != expr.shape:
-        mat = reshape(mat, expr.shape)
+        mat = reshape(mat, expr.shape, order='F')
     return mat, []

--- a/cvxpy/tests/test_KKT.py
+++ b/cvxpy/tests/test_KKT.py
@@ -45,7 +45,6 @@ class TestKKT_QPs(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
 
 class TestKKT_SOCPs(BaseTest):
@@ -57,7 +56,6 @@ class TestKKT_SOCPs(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
     def test_socp_1(self, places=4):
         sth = STH.socp_1()
@@ -66,7 +64,6 @@ class TestKKT_SOCPs(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
     def test_socp_2(self, places=4):
         sth = STH.socp_2()
@@ -75,7 +72,6 @@ class TestKKT_SOCPs(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
     def test_socp_3ax0(self, places=4):
         sth = STH.socp_3(axis=0)
@@ -84,7 +80,6 @@ class TestKKT_SOCPs(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
 
     def test_socp_3ax1(self, places=4):
@@ -94,7 +89,6 @@ class TestKKT_SOCPs(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
 
 class TestKKT_ECPs(BaseTest):
@@ -106,7 +100,6 @@ class TestKKT_ECPs(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
 class TestKKT_SDPs(BaseTest):
 
@@ -117,7 +110,6 @@ class TestKKT_SDPs(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
     def test_sdp_1max(self, places=4):
         sth = STH.sdp_1('max')
@@ -126,7 +118,6 @@ class TestKKT_SDPs(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
     def test_sdp_2(self, places=4):
         sth = STH.sdp_2()
@@ -135,7 +126,6 @@ class TestKKT_SDPs(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
 
 class TestKKT_PCPs(BaseTest):
@@ -190,7 +180,6 @@ class TestKKT_PCPs(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
     def test_pcp_2(self, places: int = 4):
         sth = STH.pcp_2()
@@ -199,7 +188,6 @@ class TestKKT_PCPs(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
     def test_pcp_3(self, places: int = 4):
         sth = STH.pcp_3()
@@ -208,7 +196,6 @@ class TestKKT_PCPs(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
     # Tests for verifying the dual value implementation of `PowConeND`
     def test_pcp_4(self, places: int=3):
@@ -218,7 +205,6 @@ class TestKKT_PCPs(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
     def test_pcp_5(self, places: int=3):
         sth = self.vec_pow_nd()
@@ -227,14 +213,12 @@ class TestKKT_PCPs(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
     def test_pcp_6(self, places: int=3):
         sth = TestPowND.pcp_4()
         sth.solve(solver='SCS', eps=1e-6)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
 class TestKKT_Flags(BaseTest):
     """
@@ -363,7 +347,6 @@ class TestKKT_Flags(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
     def test_kkt_psd_var(self, places=4):
         sth = TestKKT_Flags.psd_flag()
@@ -372,7 +355,6 @@ class TestKKT_Flags(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
     def test_kkt_symmetric_var(self, places=4):
         sth = TestKKT_Flags.symmetric_flag()
@@ -381,7 +363,6 @@ class TestKKT_Flags(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
     def test_kkt_nonneg_var(self, places=4):
         sth = TestKKT_Flags.nonneg_flag()
@@ -390,7 +371,6 @@ class TestKKT_Flags(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth
 
     def test_kkt_nonpos_var(self, places=4):
         sth = TestKKT_Flags.nonpos_flag()
@@ -399,4 +379,3 @@ class TestKKT_Flags(BaseTest):
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
         sth.check_stationary_lagrangian(places)
-        return sth

--- a/cvxpy/tests/test_errors.py
+++ b/cvxpy/tests/test_errors.py
@@ -115,6 +115,7 @@ class TestErrors(BaseTest):
         self.assertEqual(vstack.shape, (1, 1))
         self.assertEqual(vstack.dtype, object)
 
+    @pytest.mark.filterwarnings("ignore:DeprecationWarning")
     def test_broken_numpy_functions(self) -> None:
         with pytest.raises(RuntimeError, match=__NUMPY_UFUNC_ERROR__):
             np.linalg.norm(self.x)

--- a/cvxpy/tests/test_errors.py
+++ b/cvxpy/tests/test_errors.py
@@ -115,7 +115,6 @@ class TestErrors(BaseTest):
         self.assertEqual(vstack.shape, (1, 1))
         self.assertEqual(vstack.dtype, object)
 
-    @pytest.mark.filterwarnings("ignore:DeprecationWarning")
     def test_broken_numpy_functions(self) -> None:
         with pytest.raises(RuntimeError, match=__NUMPY_UFUNC_ERROR__):
             np.linalg.norm(self.x)

--- a/cvxpy/tests/test_interfaces.py
+++ b/cvxpy/tests/test_interfaces.py
@@ -71,31 +71,6 @@ class TestInterfaces(BaseTest):
         # shape.
         self.assertEqual(interface.shape(np.array([1, 2, 3])), (3,))
 
-    # Test numpy matrix interface.
-    def test_numpy_matrix(self) -> None:
-        interface = intf.get_matrix_interface(np.matrix)
-        # const_to_matrix
-        mat = interface.const_to_matrix([1, 2, 3])
-        self.assertEqual(interface.shape(mat), (3, 1))
-        mat = interface.const_to_matrix([[1], [2], [3]])
-        self.assertEqual(mat[0, 0], 1)
-        mat = interface.scalar_matrix(2, (4, 3))
-        self.assertEqual(interface.shape(mat), (4, 3))
-        self.assertEqual(interface.index(mat, (1, 2)), 2)
-        # reshape
-        mat = interface.const_to_matrix([[1, 2, 3], [3, 4, 5]])
-        mat = interface.reshape(mat, (6, 1))
-        self.assertEqual(interface.index(mat, (4, 0)), 4)
-        mat = interface.const_to_matrix(1, convert_scalars=True)
-        self.assertEqual(type(interface.reshape(mat, (1, 1))), type(mat))
-        # index
-        mat = interface.const_to_matrix([[1, 2, 3, 4], [3, 4, 5, 6]])
-        self.assertEqual(interface.index(mat, (0, 1)), 3)
-        mat = interface.index(mat, (slice(1, 4, 2), slice(0, 2, None)))
-        self.assertFalse((mat - np.array([[2, 4], [4, 6]])).any())
-        # Sign
-        self.sign_for_intf(interface)
-
     def test_scipy_sparse(self) -> None:
         """Test cvxopt sparse interface.
         """
@@ -148,7 +123,6 @@ class TestInterfaces(BaseTest):
         """Test conversion between every pair of interfaces.
         """
         interfaces = [intf.get_matrix_interface(np.ndarray),
-                      intf.get_matrix_interface(np.matrix),
                       intf.get_matrix_interface(sp.csc_matrix)]
         cmp_mat = [[1, 2, 3, 4], [3, 4, 5, 6], [-1, 0, 2, 4]]
         for i in range(len(interfaces)):


### PR DESCRIPTION
## Description
Please include a short summary of the change.
This PR shortens the output of running ``pytest`` and is a small QoL improvement for developers.
Example of output caused by the tests in ``test_KKT.py``.
```bash
cvxpy/tests/test_KKT.py::TestKKT_QPs::test_qp_0
  /opt/anaconda3/envs/cvxpy_env/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_QPs.test_qp_0 of <cvxpy.tests.test_KKT.TestKKT_QPs testMethod=test_qp_0>>)
    return self.run(*args, **kwds)

cvxpy/tests/test_KKT.py::TestKKT_SOCPs::test_socp_0
  /opt/anaconda3/envs/cvxpy_env/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method TestKKT_SOCPs.test_socp_0 of <cvxpy.tests.test_KKT.TestKKT_SOCPs testMethod=test_socp_0>>)
    return self.run(*args, **kwds)
```
Also removed tests for the ``np.matrix`` interface since there were also deprecation warnings there from NumPy.
Finally, there is one last fix on a missed internal usage of reshape with explicit order.
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.