### PR TITLE
Updating scipy and numpy versions for python < 3.12

### DIFF
--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -13,7 +13,7 @@ conda install mkl pip pytest pytest-cov hypothesis openblas "setuptools>65.5.1"
 
 if [[ "$PYTHON_VERSION" != "3.13" ]]; then
   conda install ecos scs cvxopt proxsuite daqp
-  python -m pip install coptpy==7.1.7 gurobipy piqp clarabel osqp highspy==1.8.1
+  python -m pip install coptpy==7.1.7 gurobipy piqp clarabel osqp highspy
 else
   # only install the essential solvers for Python 3.13.
   conda install scs

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -13,7 +13,7 @@ conda install mkl pip pytest pytest-cov hypothesis openblas "setuptools>65.5.1"
 
 if [[ "$PYTHON_VERSION" != "3.13" ]]; then
   conda install ecos scs cvxopt proxsuite daqp
-  python -m pip install coptpy==7.1.7 gurobipy piqp clarabel osqp highspy
+  python -m pip install coptpy==7.1.7 gurobipy piqp clarabel osqp highspy==1.8.1
 else
   # only install the essential solvers for Python 3.13.
   conda install scs

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -31,6 +31,7 @@ else
   # Lower versions of Python all install scipy 1.9.3 and numpy 1.23.4.
   # This change is necessary for compatibility with the scipy.array interface.
   conda install scipy=1.9.3 numpy=1.23.4
+fi
 
 if [[ "$PYTHON_VERSION" == "3.11" ]]; then
   python -m pip install cplex "ortools>=9.7,<9.12"

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -20,26 +20,17 @@ else
   python -m pip install clarabel osqp
 fi
 
-if [[ "$PYTHON_VERSION" == "3.9" ]]; then
-  # The earliest version of numpy that works is 1.20.
-  # Given numpy 1.20, the earliest version of scipy we can use is 1.6.
-  conda install scipy=1.6 numpy=1.20
-elif [[ "$PYTHON_VERSION" == "3.10" ]]; then
-  # The earliest version of numpy that works is 1.21.
-  # Given numpy 1.21, the earliest version of scipy we can use is 1.7.
-  conda install scipy=1.7 numpy=1.21
-elif [[ "$PYTHON_VERSION" == "3.11" ]]; then
-  # The earliest version of numpy that works is 1.23.4.
-  # Given numpy 1.23.4, the earliest version of scipy we can use is 1.9.3.
-  conda install scipy=1.9.3 numpy=1.23.4
-elif [[ "$PYTHON_VERSION" == "3.12" ]]; then
+if [[ "$PYTHON_VERSION" == "3.12" ]]; then
   # The earliest version of numpy that works is 1.26.4
   # Given numpy 1.26.4, the earliest version of scipy we can use is 1.11.3.
   conda install scipy=1.11.3 numpy=1.26.4
-else
+elif [[ "$PYTHON_VERSION" == "3.13" ]]; then
   # Install newest versions for Python 3.13.
   conda install scipy numpy
-fi
+else
+  # Lower versions of Python all install scipy 1.9.3 and numpy 1.23.4.
+  # This change is necessary for compatibility with the scipy.array interface.
+  conda install scipy=1.9.3 numpy=1.23.4
 
 if [[ "$PYTHON_VERSION" == "3.11" ]]; then
   python -m pip install cplex "ortools>=9.7,<9.12"


### PR DESCRIPTION
## Description
Please include a short summary of the change.
CI is failing on master for python 3.10 and 3.9 on MacOS. The error is odd because the tests crashes without any error messages on python's side. I did a bit of digging and found that the most likely solver that is causing this is [highspy](https://pypi.org/project/highspy/) which new version 1.9.0 was released two days ago (December 20th, 2024).

Update: instead of pinning highspy to 1.8, updating the scipy and numpy versions somehow fixes the issue.
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.