### PR TITLE
Fixed a coding typo in socp.ipynb

### DIFF
--- a/examples/notebooks/WWW/socp.ipynb
+++ b/examples/notebooks/WWW/socp.ipynb
@@ -98,7 +98,7 @@
     "    A.append(np.random.randn(n_i, n))\n",
     "    b.append(np.random.randn(n_i))\n",
     "    c.append(np.random.randn(n))\n",
-    "    d.append(np.linalg.norm(A[i]@x0 + b, 2) - c[i].T@x0)\n",
+    "    d.append(np.linalg.norm(A[i]@x0 + b[i], 2) - c[i].T@x0)\n",
     "F = np.random.randn(p, n)\n",
     "g = F@x0\n",
     "\n",


### PR DESCRIPTION
L101: change b to b[i]
