### PR TITLE
Updating SciPy dependency to >=1.11.0 and version for wheels to >=1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ CVXPY has the following dependencies:
 - Clarabel >= 0.5.0
 - OSQP >= 0.6.2
 - SCS >= 3.2.4.post1
-- NumPy >= 1.20.0
-- SciPy >= 1.6.0
+- NumPy >= 1.21.6
+- SciPy >= 1.11.0
 
 For detailed instructions, see the [installation
 guide](https://www.cvxpy.org/install/index.html).

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -36,7 +36,7 @@ if [[ "$RUNNER_OS" == "Windows" ]] && [[ "$PYTHON_VERSION" != "3.13" ]]; then
   python -m pip install sdpa-multiprecision
 fi
 
-if [[ "$RUNNER_OS" != "Windows" ]]; then
+if [[ "$RUNNER_OS" != "Windows" ]] && [[ "$PYTHON_VERSION" != "3.13" ]]; then
   conda install cvxopt
 fi
 

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -38,7 +38,7 @@ fi
 
 if [[ "$PYTHON_VERSION" == "3.12" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then
   # cylp has no wheels for Windows
-  python -m pip install cylp pyscipopt==5.2.1 diffcp
+  python -m pip install cylp pyscipopt==5.2.1
 fi
 
 if [[ "$PYTHON_VERSION" == "3.10" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -37,7 +37,7 @@ if [[ "$RUNNER_OS" == "Windows" ]] && [[ "$PYTHON_VERSION" != "3.13" ]]; then
 fi
 
 if [[ "$RUNNER_OS" != "Windows" ]]; then
-  python -m pip install cvxopt
+  conda install cvxopt
 fi
 
 if [[ "$PYTHON_VERSION" == "3.12" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -12,7 +12,7 @@ conda config --set remote_read_timeout_secs 120.0
 conda install mkl pip pytest pytest-cov hypothesis openblas "setuptools>65.5.1"
 
 if [[ "$PYTHON_VERSION" != "3.13" ]]; then
-  conda install ecos scs cvxopt proxsuite daqp
+  conda install ecos scs proxsuite daqp
   python -m pip install coptpy==7.1.7 gurobipy piqp clarabel osqp highspy
 else
   # only install the essential solvers for Python 3.13.
@@ -34,6 +34,10 @@ fi
 if [[ "$RUNNER_OS" == "Windows" ]] && [[ "$PYTHON_VERSION" != "3.13" ]]; then
   # SDPA with OpenBLAS backend does not pass LP5 on Windows
   python -m pip install sdpa-multiprecision
+fi
+
+if [[ "$RUNNER_OS" != "Windows" ]]; then
+  python -m pip install cvxopt
 fi
 
 if [[ "$PYTHON_VERSION" == "3.12" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -20,17 +20,11 @@ else
   python -m pip install clarabel osqp
 fi
 
-if [[ "$PYTHON_VERSION" == "3.12" ]]; then
-  # The earliest version of numpy that works is 1.26.4
-  # Given numpy 1.26.4, the earliest version of scipy we can use is 1.11.3.
-  conda install scipy=1.11.3 numpy=1.26.4
-elif [[ "$PYTHON_VERSION" == "3.13" ]]; then
-  # Install newest versions for Python 3.13.
+# Install newest stable versions for Python 3.13.
+if [[ "$PYTHON_VERSION" == "3.13" ]]; then
   conda install scipy numpy
 else
-  # Lower versions of Python all install scipy 1.9.3 and numpy 1.23.4.
-  # This change is necessary for compatibility with the scipy.array interface.
-  conda install scipy=1.9.3 numpy=1.23.4
+  conda install scipy=1.13.0 numpy=1.26.4
 fi
 
 if [[ "$PYTHON_VERSION" == "3.11" ]]; then

--- a/cvxpy/tests/test_quantum_rel_entr.py
+++ b/cvxpy/tests/test_quantum_rel_entr.py
@@ -151,9 +151,8 @@ class TestQuantumRelEntr:
         return sth
 
     @pytest.mark.skipif(
-        platform.system() == "Windows"
-        and sys.version_info.major == 3 and sys.version_info.minor == 13,
-        reason="This test is skipped on Windows with Python version 3.13",
+        platform.system() == "Windows",
+        reason="This test is skipped on Windows",
     )
     def test_1(self):
         print("*****************************")

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -63,8 +63,8 @@ or a conda environment.
         * `OSQP`_ >= 0.6.2
         * `CLARABEL`_ >= 0.6.0
         * `SCS`_ >= 3.0
-        * `NumPy`_ >= 1.20.0
-        * `SciPy`_ >= 1.6.0
+        * `NumPy`_ >= 1.21.6
+        * `SciPy`_ >= 1.11.0
 
         All required packages are installed automatically alongside CVXPY.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ testpaths = [
 [build-system]
 requires = [
     "numpy >= 2.0.0",
-    "scipy >= 1.1.0",
+    "scipy >= 1.13.0",
     # 68.1.0 Promoted pyproject.toml's [tool.setuptools] out of beta.
     "setuptools >= 68.1.0",
     "wheel",
@@ -53,8 +53,8 @@ dependencies = [
     "osqp >= 0.6.2",
     "clarabel >= 0.5.0",
     "scs >= 3.2.4.post1",
-    "numpy >= 1.20",
-    "scipy >= 1.1.0",
+    "numpy >= 1.21.6",
+    "scipy >= 1.11.0",
 ]
 requires-python = ">=3.9"
 urls = {Homepage = "https://github.com/cvxpy/cvxpy"}


### PR DESCRIPTION
## Description
Please include a short summary of the change.
This PR aims to fix some issues found with deprecated API on sparse_arrays compared to sparse_matrices (see #2689).
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.