### PR TITLE
Update highs solver website links

### DIFF
--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -288,4 +288,4 @@ To run the tests when CVXPY was not installed from source, use
 .. _CVXPY git repository: https://github.com/cvxpy/cvxpy
 .. _pip: https://pip.pypa.io/
 .. _GLPK: https://www.gnu.org/software/glpk/
-.. _HiGHS: https://www.maths.ed.ac.uk/hall/HiGHS/#guide
+.. _HiGHS: https://highs.dev/

--- a/doc/source/tutorial/solvers/index.rst
+++ b/doc/source/tutorial/solvers/index.rst
@@ -838,7 +838,7 @@ will be the same as the class variable ``SUPPORTED_CONSTRAINTS``.
 .. _SCIP: https://scip.zib.de/
 .. _XPRESS: https://www.fico.com/en/products/fico-xpress-optimization
 .. _SCIPY: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.linprog.html#scipy.optimize.linprog
-.. _HiGHS: https://www.maths.ed.ac.uk/hall/HiGHS/#guide
+.. _HiGHS: https://highs.dev/
 .. _CLARABEL: https://oxfordcontrol.github.io/ClarabelDocs/
 .. _PIQP: https://predict-epfl.github.io/piqp/
 .. _PROXQP: https://github.com/simple-robotics/proxsuite


### PR DESCRIPTION
## Description
This PR updates the highs solver link which is the old website hosted on the academic page of the project lead which now reads "The HiGHS website moved in 2022 to https://highs.dev/. Please update your link."

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [X] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
- [X] Does not apply.