### PR TITLE
Assigning to and reading from sparse leaves

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -168,7 +168,7 @@ class Leaf(expression.Expression):
         Parameters:
         indices: List or tuple of indices indicating the positions of non-zero elements.
         """
-        validator = sp.coo_array((np.empty(len(indices[0]), dtype=np.void), indices))
+        validator = sp.coo_array((np.empty(len(indices[0])), indices))
         validator.sum_duplicates()
         return validator.coords
 

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -174,7 +174,7 @@ class Leaf(expression.Expression):
             return []
         validator = sp.coo_array((np.empty(len(indices[0])), indices), shape=self._shape)
         validator.sum_duplicates()
-        return validator.coords
+        return get_coords(validator)
 
     def _get_attr_str(self) -> str:
         """Get a string representing the attributes."""

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -172,8 +172,13 @@ class Leaf(expression.Expression):
             if indices != []:
                 raise ValueError("Indices should have 0 dimensions.")
             return []
+        # Attempt to form a COO_array with the indices matrix provided;
+        # this will raise errors if invalid.
         validator = sp.coo_array((np.empty(len(indices[0])), indices), shape=self._shape)
+        # Apply an in-place transformation to the coordinates to reduce the
+        # validator to canonical form
         validator.sum_duplicates()
+        # Return the canonicalized coordinates
         return get_coords(validator)
 
     def _get_attr_str(self) -> str:

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -450,6 +450,8 @@ class Leaf(expression.Expression):
         else:
             warnings.warn('Reading from a sparse CVXPY expression via `.value` is discouraged.'
                           ' Use `.value_sparse` instead', RuntimeWarning, 1)
+            if self._value is None:
+                return None
             val = np.zeros(self.shape)
             val[self.sparse_idx] = self._value.data
             return val

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -515,11 +515,14 @@ class Leaf(expression.Expression):
                     "Invalid dimensions %s for %s value." %
                     (intf.shape(val), self.__class__.__name__)
                 )
-            if sparse_path and (np.array(get_coords(val)) != np.array(self.sparse_idx)).any():
-                raise ValueError(
-                    'Invalid sparsity pattern %s for %s value.' %
-                    (get_coords(val), self.__class__.__name__)
-                )
+            if sparse_path:
+                coords_val = set(coord for coord in zip(*get_coords(val)))
+                coords_sparse_idx = set(coord for coord in zip(*self.sparse_idx))
+                if coords_val != coords_sparse_idx:
+                    raise ValueError(
+                        'Invalid sparsity pattern %s for %s value.' %
+                        (get_coords(val), self.__class__.__name__)
+                    )
             projection = self.project(val, sparse_path)
             # ^ might be a numpy array, or sparse scipy matrix.
             delta = np.abs(val - projection)

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -168,7 +168,7 @@ class Leaf(expression.Expression):
         Parameters:
         indices: List or tuple of indices indicating the positions of non-zero elements.
         """
-        validator = sp.coo_array((np.empty(len(indices[0])), indices))
+        validator = sp.coo_array((np.empty(len(indices[0])), indices), shape=self._shape)
         validator.sum_duplicates()
         return validator.coords
 

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -479,7 +479,7 @@ class Leaf(expression.Expression):
                 raise ValueError(
                     'Invalid type for assigning value_sparse.'
                     'Try using `'
-                    'expr.value_sparse = scipy.sparse.coo_array((values, expr instead.')
+                    'expr.value_sparse = scipy.sparse.coo_array((values, expr)) instead.')
             raise ValueError(
                 'Invalid type for assigning value_sparse.'
                 f'Recieved: {type(val)} Expected scipy.sparse.coo_array.'

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -30,7 +30,8 @@ class TestAttributes:
         assert np.allclose(X.value, z)
 
     def test_sparsity_invalid_input(self):
-        with pytest.raises(ValueError, match="mismatching number of index arrays for shape; got 3, expected 2"):
+        with pytest.raises(ValueError, match="mismatching number of index"
+                           " arrays for shape; got 3, expected 2"):
             cp.Variable((3, 3), sparsity=[(0, 1), (0, 1), (0, 1)])
 
     def test_sparsity_incorrect_dim(self):

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -81,6 +81,11 @@ class TestAttributes:
         prob.solve()
         assert np.allclose(X.value, z)
         
+        sparsity_rotated = [(1, 2, 2, 0), (2, 2, 1, 0)]
+        A.value_sparse = sp.coo_array((-np.ones(4), sparsity_rotated))
+        prob.solve()
+        assert np.allclose(X.value, z)
+        
     def test_sparsity_incorrect_pattern(self):
         A = cp.Parameter((3, 3), sparsity=[(0, 2, 1, 2), (0, 1, 2, 2)])
         with pytest.raises(

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -98,6 +98,8 @@ class TestAttributes:
     def test_sparsity_read_value(self):
         sparsity = [(0, 2, 1, 2), (0, 1, 2, 2)]
         X = cp.Variable((3, 3), sparsity=sparsity)
+        assert X.value is None
+        
         prob = cp.Problem(cp.Minimize(cp.sum(X)), [X >= -1])
         prob.solve()
         with pytest.warns(

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -81,8 +81,9 @@ class TestAttributes:
         prob.solve()
         assert np.allclose(X.value, z)
         
-        sparsity_rotated = [(1, 2, 2, 0), (2, 2, 1, 0)]
-        A.value_sparse = sp.coo_array((-np.ones(4), sparsity_rotated))
+        z = np.zeros((3, 3))
+        z[A.sparse_idx] = [-1, -2, -3, -4]
+        A.value_sparse = sp.coo_array(([-1, -3, -2, -4], [(0, 1, 2, 2), (0, 2, 1, 2)]))
         prob.solve()
         assert np.allclose(X.value, z)
         


### PR DESCRIPTION
## Description
This PR fixes two bugs. First, when assigning a sparse value, any order of nonzero indices is accepted, as long as the set of nonzero indices is correct. Previously, the sparsity pattern was rejected as invalid when the order of nonzero indices was not identical to that used when the `Leaf` was constructed. Second, when reading a sparse value and it is `None`, `None` will be returned. Previously, there was an error when attempting to read `_value.data`.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.