### PR TITLE
Finish ecos removal

### DIFF
--- a/cvxpy/tests/test_constant_atoms.py
+++ b/cvxpy/tests/test_constant_atoms.py
@@ -30,7 +30,7 @@ from cvxpy.expressions.constants import Constant, Parameter
 from cvxpy.expressions.variable import Variable
 from cvxpy.problems.problem import Problem
 from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS
-from cvxpy.settings import CVXOPT, CLARABEL, MOSEK, OSQP, ROBUST_KKTSOLVER, SCS
+from cvxpy.settings import CLARABEL, CVXOPT, MOSEK, OSQP, ROBUST_KKTSOLVER, SCS
 
 ROBUST_CVXOPT = "robust_cvxopt"
 SOLVER_TO_TOL = {SCS: 1e-2,

--- a/cvxpy/tests/test_constant_atoms.py
+++ b/cvxpy/tests/test_constant_atoms.py
@@ -30,13 +30,13 @@ from cvxpy.expressions.constants import Constant, Parameter
 from cvxpy.expressions.variable import Variable
 from cvxpy.problems.problem import Problem
 from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS
-from cvxpy.settings import CVXOPT, ECOS, MOSEK, OSQP, ROBUST_KKTSOLVER, SCS
+from cvxpy.settings import CVXOPT, CLARABEL, MOSEK, OSQP, ROBUST_KKTSOLVER, SCS
 
 ROBUST_CVXOPT = "robust_cvxopt"
 SOLVER_TO_TOL = {SCS: 1e-2,
-                 ECOS: 1e-7,
+                 CLARABEL: 1e-7,
                  OSQP: 1e-1}
-SOLVERS_TO_TRY = [ECOS, SCS, OSQP]
+SOLVERS_TO_TRY = [CLARABEL, SCS, OSQP]
 # Test CVXOPT if installed.
 if CVXOPT in INSTALLED_SOLVERS:
     SOLVERS_TO_TRY += [CVXOPT, ROBUST_CVXOPT]

--- a/cvxpy/tests/test_derivative.py
+++ b/cvxpy/tests/test_derivative.py
@@ -8,9 +8,12 @@ from cvxpy.tests.base_test import BaseTest
 
 warnings.filterwarnings("ignore")
 
-SOLVE_METHODS = [s.SCS, s.ECOS]
+SOLVE_METHODS = [s.CLARABEL, s.SCS, ]
 EPS_NAME = {s.SCS: "eps",
-            s.ECOS: "abstol"}
+            s.CLARABEL: "tol_gap_abs"}
+
+MAX_ITERS_NAME = {s.SCS: "max_iters",
+            s.CLARABEL: "max_iter"}
 
 
 def perturbcheck(problem, gp: bool = False, solve_methods: list = SOLVE_METHODS,


### PR DESCRIPTION
## Description

Removes the last two tests that depend on ECOS! I had to make a diffcp release to get one set of tests passing, but that should be on PyPI soon and then we can pass tests.

One test isn't working numerically, I want to spend a little time understanding what's happening and then I'll probably ping Paul.

Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.