### PR TITLE
Convert to sparray from spmatrix (spmatrix inputs should still work)

### DIFF
--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -191,10 +191,10 @@ class MulExpression(BinaryOperator):
         # DX = [diag(Y11), diag(Y12), ...]
         #      [diag(Y21), diag(Y22), ...]
         #      [   ...        ...     ...]
-        DX = sp.dok_matrix((DX_rows, cols))
+        DX = sp.dok_array((DX_rows, cols))
         for k in range(self.args[0].shape[0]):
             DX[k::self.args[0].shape[0], k::self.args[0].shape[0]] = Y
-        DX = sp.csc_matrix(DX)
+        DX = sp.csc_array(DX)
         cols = 1 if len(self.args[1].shape) == 1 else self.args[1].shape[1]
         DY = sp.block_diag([X.T for k in range(cols)], 'csc')
 

--- a/cvxpy/atoms/affine/cumsum.py
+++ b/cvxpy/atoms/affine/cumsum.py
@@ -28,7 +28,7 @@ from cvxpy.expressions.expression import Expression
 from cvxpy.expressions.variable import Variable
 
 
-def get_diff_mat(dim: int, axis: int) -> sp.csc_matrix:
+def get_diff_mat(dim: int, axis: int) -> sp.csc_array:
     """Return a sparse matrix representation of first order difference operator.
 
     Parameters
@@ -40,11 +40,11 @@ def get_diff_mat(dim: int, axis: int) -> sp.csc_matrix:
 
     Returns
     -------
-    sp.csc_matrix
+    sp.csc_array
         A square matrix representing first order difference.
     """
-    mat = sp.diags([np.ones(dim), -np.ones(dim - 1)], [0, -1], 
-                   shape=(dim, dim), 
+    mat = sp.diags_array([np.ones(dim), -np.ones(dim - 1)], offsets=[0, -1],
+                   shape=(dim, dim),
                    format='csc')
     return mat if axis == 0 else mat.T
 
@@ -86,7 +86,7 @@ class cumsum(AffAtom, AxisAtom):
             A list of SciPy CSC sparse matrices or None.
         """
         dim = values[0].shape[self.axis]
-        mat = sp.tril(np.ones((dim, dim)))
+        mat = sp.csc_array(np.tril(np.ones((dim, dim))))
         var = Variable(self.args[0].shape)
         if self.axis == 0:
             grad = MulExpression(mat, var)._grad(values)[1]

--- a/cvxpy/atoms/affine/index.py
+++ b/cvxpy/atoms/affine/index.py
@@ -158,14 +158,14 @@ class special_index(AffAtom):
         return [self.key]
 
     @property
-    def grad(self) -> Optional[list[sp.csc_matrix]]:
+    def grad(self) -> Optional[list[sp.csc_array]]:
         """Gives the (sub/super)gradient of the expression w.r.t. each variable.
 
         Matrix expressions are vectorized, so the gradient is a matrix.
         None indicates variable values unknown or outside domain.
         """
         select_vec = np.reshape(self._select_mat, self._select_mat.size, order='F')
-        identity = sp.eye(self.args[0].size).tocsc()
+        identity = sp.eye_array(self.args[0].size, format='csc')
         lowered = reshape(
             identity[select_vec] @ vec(self.args[0], order='F'),
             self._shape,
@@ -193,7 +193,7 @@ class special_index(AffAtom):
         select_vec = np.reshape(select_mat, select_mat.size, order='F')
         # Select the chosen entries from expr.
         arg = arg_objs[0]
-        identity = sp.eye(self.args[0].size).tocsc()
+        identity = sp.eye_array(self.args[0].size, format='csc')
         vec_arg = lu.reshape(arg, (self.args[0].size,))
         mul_mat = identity[select_vec]
         mul_const = lu.create_const(mul_mat, mul_mat.shape, sparse=True)

--- a/cvxpy/atoms/affine/partial_trace.py
+++ b/cvxpy/atoms/affine/partial_trace.py
@@ -48,7 +48,7 @@ def _term(expr, j: int, dims: Tuple[int], axis: Optional[int] = 0):
             a = sp.kron(a, v.T)
             b = sp.kron(b, v)
         else:
-            eye_mat = sp.eye(dim)
+            eye_mat = sp.eye_array(dim)
             a = sp.kron(a, eye_mat)
             b = sp.kron(b, eye_mat)
     return a @ expr @ b

--- a/cvxpy/atoms/affine/partial_transpose.py
+++ b/cvxpy/atoms/affine/partial_transpose.py
@@ -51,7 +51,7 @@ def _term(expr, i: int, j: int, dims: Tuple[int], axis: Optional[int] = 0):
             v = sp.coo_matrix(([1], ([i], [j])), shape=(dim, dim))
             a = sp.kron(a, v)
         else:
-            eye_mat = sp.eye(dim)
+            eye_mat = sp.eye_array(dim)
             a = sp.kron(a, eye_mat)
     return a @ expr @ a
 

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -140,11 +140,11 @@ def vec_to_upper_tri(expr, strict: bool = False):
     P_rows = n * row_idx + col_idx
     P_cols = np.arange(ell)
     P_vals = np.ones(P_cols.size)
-    P = sp.csc_matrix((P_vals, (P_rows, P_cols)), shape=(n * n, ell))
+    P = sp.csc_array((P_vals, (P_rows, P_cols)), shape=(n * n, ell))
     return reshape(P @ expr, (n, n), order='F').T
 
 
-def upper_tri_to_full(n: int) -> sp.csc_matrix:
+def upper_tri_to_full(n: int) -> sp.csc_array:
     """
     Returns a coefficient matrix A that creates a symmetric matrix when
     multiplied with a variable vector v.
@@ -157,7 +157,7 @@ def upper_tri_to_full(n: int) -> sp.csc_matrix:
 
     Returns
     -------
-    sp.csc_matrix
+    sp.csc_array
         The coefficient matrix.
     """
     entries = n*(n+1)//2
@@ -173,4 +173,4 @@ def upper_tri_to_full(n: int) -> sp.csc_matrix:
     values = np.ones(col_idx.size, dtype=float)
 
     # Construct and return the sparse matrix
-    return sp.csc_matrix((values, (row_idx, col_idx)), shape=(n * n, entries))
+    return sp.csc_array((values, (row_idx, col_idx)), shape=(n * n, entries))

--- a/cvxpy/atoms/axis_atom.py
+++ b/cvxpy/atoms/axis_atom.py
@@ -72,7 +72,7 @@ class AxisAtom(Atom):
                     raise ValueError(f"axis {axis} is out of bounds for array of dimension {dim}")
         super(AxisAtom, self).validate_arguments()
 
-    def _axis_grad(self, values) -> Optional[List[sp.csc_matrix]]:
+    def _axis_grad(self, values) -> Optional[List[sp.csc_array]]:
         """
         Gives the (sub/super)gradient of the atom w.r.t. each argument.
 
@@ -89,11 +89,11 @@ class AxisAtom(Atom):
             value = np.reshape(values[0].T, (self.args[0].size, 1))
             D = self._column_grad(value)
             if D is not None:
-                D = sp.csc_matrix(D)
+                D = sp.csc_array(D)
         else:
             m, n = self.args[0].shape
             if self.axis == 0:  # function apply to each column
-                D = sp.csc_matrix((m*n, n), dtype=float)
+                D = sp.csc_array((m*n, n), dtype=float)
                 for i in range(n):
                     value = values[0][:, i]
                     d = self._column_grad(value).T
@@ -103,11 +103,11 @@ class AxisAtom(Atom):
                         d = np.array(d).flatten()
                     row = np.linspace(i*n, i*n+m-1, m)  # [i*n, i*n+1, ..., i*n+m-1]
                     col = np.ones((m))*i
-                    D = D + sp.csc_matrix((d, (row, col)),
+                    D = D + sp.csc_array((d, (row, col)),
                                           shape=(m*n, n))  # d must be 1-D
             else:  # function apply to each row
                 values = np.transpose(values[0])
-                D = sp.csc_matrix((m*n, m), dtype=float)
+                D = sp.csc_array((m*n, m), dtype=float)
                 for i in range(m):
                     value = values[:, i]
                     d = self._column_grad(value).T
@@ -115,7 +115,7 @@ class AxisAtom(Atom):
                         return [None]
                     row = np.linspace(i, i+(n-1)*m, n)  # [0+i, m+i, ..., m(n-1)+i]
                     col = np.ones((n))*i
-                    D = D + sp.csc_matrix((np.array(d)[0], (row, col)),
+                    D = D + sp.csc_array((np.array(d)[0], (row, col)),
                                           shape=(m*n, m))  # d must be 1-D
         return [D]
 

--- a/cvxpy/atoms/dotsort.py
+++ b/cvxpy/atoms/dotsort.py
@@ -80,7 +80,7 @@ class dotsort(Atom):
         indices = np.argsort(x)
         n = len(x)
         sorted_w = np.sort(w_padded)
-        return [sp.csc_matrix((sorted_w, (indices, np.zeros(n))), shape=(n, 1))]
+        return [sp.csc_array((sorted_w, (indices, np.zeros(n))), shape=(n, 1))]
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Returns the (row, col) shape of the expression.

--- a/cvxpy/atoms/elementwise/ceil.py
+++ b/cvxpy/atoms/elementwise/ceil.py
@@ -96,7 +96,7 @@ class ceil(Elementwise):
         Returns:
             A list of SciPy CSC sparse matrices or None.
         """
-        return sp.csc_matrix(self.args[0].shape)
+        return sp.csc_array(self.args[0].shape)
 
 
 class floor(Elementwise):
@@ -172,4 +172,4 @@ class floor(Elementwise):
         Returns:
             A list of SciPy CSC sparse matrices or None.
         """
-        return sp.csc_matrix(self.args[0].shape)
+        return sp.csc_array(self.args[0].shape)

--- a/cvxpy/atoms/elementwise/elementwise.py
+++ b/cvxpy/atoms/elementwise/elementwise.py
@@ -58,7 +58,7 @@ class Elementwise(Atom):
         """
         if not np.isscalar(value):
             value = value.ravel(order='F')
-        return sp.dia_matrix((np.atleast_1d(value), [0]), shape=(rows, cols)).tocsc()
+        return sp.dia_array((np.atleast_1d(value), [0]), shape=(rows, cols)).tocsc()
 
     @staticmethod
     def _promote(arg, shape: Tuple[int, ...]):

--- a/cvxpy/atoms/elementwise/kl_div.py
+++ b/cvxpy/atoms/elementwise/kl_div.py
@@ -17,7 +17,7 @@ limitations under the License.
 from typing import List, Optional, Tuple
 
 import numpy as np
-from scipy.sparse import csc_matrix
+from scipy.sparse import csc_array
 from scipy.special import kl_div as kl_div_scipy
 
 from cvxpy.atoms.elementwise.elementwise import Elementwise
@@ -65,7 +65,7 @@ class kl_div(Elementwise):
         """
         return False
 
-    def _grad(self, values) -> List[Optional[csc_matrix]]:
+    def _grad(self, values) -> List[Optional[csc_array]]:
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.
 
         Matrix expressions are vectorized, so the gradient is a matrix.

--- a/cvxpy/atoms/elementwise/log_normcdf.py
+++ b/cvxpy/atoms/elementwise/log_normcdf.py
@@ -33,7 +33,7 @@ def log_normcdf(x):
         SciPy's analog of ``log_normcdf`` is called `log_ndtr <https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.log_ndtr.html>`_.
         We opted not to use that name because its meaning would not be obvious to the casual user.
     """
-    A = scipy.sparse.diags(
+    A = scipy.sparse.diags_array(
         np.sqrt(
             [
                 0.02301291,

--- a/cvxpy/atoms/elementwise/power.py
+++ b/cvxpy/atoms/elementwise/power.py
@@ -367,7 +367,7 @@ class power(Elementwise):
 
         if p == 0:
             # All zeros.
-            return [sp.csc_matrix((rows, cols), dtype='float64')]
+            return [sp.csc_array((rows, cols), dtype='float64')]
         # Outside domain or on boundary.
         if not is_power2(p) and np.min(values[0]) <= 0:
             if p < 1:

--- a/cvxpy/atoms/elementwise/rel_entr.py
+++ b/cvxpy/atoms/elementwise/rel_entr.py
@@ -17,7 +17,7 @@ limitations under the License.
 from typing import List, Optional, Tuple
 
 import numpy as np
-from scipy.sparse import csc_matrix
+from scipy.sparse import csc_array
 from scipy.special import rel_entr as rel_entr_scipy
 
 from cvxpy.atoms.elementwise.elementwise import Elementwise
@@ -66,7 +66,7 @@ class rel_entr(Elementwise):
         else:
             return True
 
-    def _grad(self, values) -> List[Optional[csc_matrix]]:
+    def _grad(self, values) -> List[Optional[csc_array]]:
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.
 
         Matrix expressions are vectorized, so the gradient is a matrix.

--- a/cvxpy/atoms/geo_mean.py
+++ b/cvxpy/atoms/geo_mean.py
@@ -287,7 +287,7 @@ class geo_mean(Atom):
             return [None]
         else:
             D = w_arr/x.ravel(order='F')*self.numeric(values)
-            return [sp.csc_matrix(D).T]
+            return [sp.csc_array([D]).T]
 
     def name(self) -> str:
         return "%s(%s, (%s))" % (self.__class__.__name__,

--- a/cvxpy/atoms/lambda_max.py
+++ b/cvxpy/atoms/lambda_max.py
@@ -59,7 +59,7 @@ class lambda_max(Atom):
         d[-1] = 1
         d = np.diag(d)
         D = v.dot(d).dot(v.T)
-        return [sp.csc_matrix(D.ravel(order='F')).T]
+        return [sp.csc_array([D.ravel(order='F')]).T]
 
     def validate_arguments(self) -> None:
         """Verify that the argument A is square.

--- a/cvxpy/atoms/log_det.py
+++ b/cvxpy/atoms/log_det.py
@@ -99,7 +99,7 @@ class log_det(Atom):
         if np.min(eigen_val) > 0:
             # Grad: X^{-1}.T
             D = np.linalg.inv(X).T
-            return [sp.csc_matrix(D.ravel(order='F')).T]
+            return [sp.csc_array([D.ravel(order='F')]).T]
         # Outside domain.
         else:
             return [None]

--- a/cvxpy/atoms/matrix_frac.py
+++ b/cvxpy/atoms/matrix_frac.py
@@ -75,13 +75,13 @@ class MatrixFrac(Atom):
         else:
             DX = np.dot(P_inv+np.transpose(P_inv), X)
             DX = DX.T.ravel(order='F')
-            DX = sp.csc_matrix(DX).T
+            DX = sp.csc_array([DX]).T
 
             DP = np.dot(P_inv, X)
             DP = np.dot(DP, X.T)
             DP = np.dot(DP, P_inv)
             DP = -DP.T
-            DP = sp.csc_matrix(DP.T.ravel(order='F')).T
+            DP = sp.csc_array([DP.T.ravel(order='F')]).T
             return [DX, DP]
 
     def validate_arguments(self) -> None:

--- a/cvxpy/atoms/norm1.py
+++ b/cvxpy/atoms/norm1.py
@@ -103,7 +103,7 @@ class norm1(AxisAtom):
             A NumPy ndarray matrix or None.
         """
         rows = value.size
-        D_null = sp.csc_matrix((rows, 1), dtype='float64')
+        D_null = sp.csc_array((rows, 1), dtype='float64')
         value = value.reshape((rows, 1))
         D_null += (value > 0)
         D_null -= (value < 0)

--- a/cvxpy/atoms/norm_nuc.py
+++ b/cvxpy/atoms/norm_nuc.py
@@ -49,7 +49,7 @@ class normNuc(Atom):
         # Grad UV^T
         U, _, V = np.linalg.svd(values[0], full_matrices=False)
         D = U.dot(V)
-        return [sp.csc_matrix(D.ravel(order='F')).T]
+        return [sp.csc_array([D.ravel(order='F')]).T]
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Returns the (row, col) shape of the expression.

--- a/cvxpy/atoms/one_minus_pos.py
+++ b/cvxpy/atoms/one_minus_pos.py
@@ -58,7 +58,7 @@ class one_minus_pos(Atom):
 
     def _grad(self, values):
         del values
-        return sp.csc_matrix(-1.0 * self._ones)
+        return sp.csc_array(-1.0 * self._ones)
 
     def name(self) -> str:
         return "%s(%s)" % (self.__class__.__name__, self.args[0])

--- a/cvxpy/atoms/pnorm.py
+++ b/cvxpy/atoms/pnorm.py
@@ -249,7 +249,7 @@ class Pnorm(AxisAtom):
         # Outside domain.
         if self.p < 1 and np.any(value <= 0):
             return None
-        D_null = sp.csc_matrix((rows, 1), dtype='float64')
+        D_null = sp.csc_array((rows, 1), dtype='float64')
         denominator = np.linalg.norm(value, float(self.p))
         denominator = np.power(denominator, self.p - 1)
         # Subgrad is 0 when denom is 0 (or undefined).

--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -118,7 +118,7 @@ class QuadForm(Atom):
         x = np.array(values[0])
         P = np.array(values[1])
         D = (P + np.conj(P.T)) @ x
-        return [sp.csc_matrix(D.ravel(order="F")).T]
+        return [sp.csc_array([D.ravel(order="F")]).T]
 
     def shape_from_args(self) -> Tuple[int, ...]:
         return tuple()

--- a/cvxpy/atoms/quad_over_lin.py
+++ b/cvxpy/atoms/quad_over_lin.py
@@ -71,10 +71,10 @@ class quad_over_lin(Atom):
             else:
                 Dy = -np.square(X).sum()/np.square(y)
 
-            Dy = sp.csc_matrix(Dy)
+            Dy = sp.csc_array([[Dy]])
             DX = 2.0*X/y
             DX = np.reshape(DX, (self.args[0].size, 1))
-            DX = scipy.sparse.csc_matrix(DX)
+            DX = scipy.sparse.csc_array(DX)
             return [DX, Dy]
 
     def shape_from_args(self) -> Tuple[int, ...]:

--- a/cvxpy/atoms/sigma_max.py
+++ b/cvxpy/atoms/sigma_max.py
@@ -52,7 +52,7 @@ class sigma_max(Atom):
         ds = np.zeros(len(s))
         ds[0] = 1
         D = U.dot(np.diag(ds)).dot(V)
-        return [sp.csc_matrix(D.ravel(order='F')).T]
+        return [sp.csc_array([D.ravel(order='F')]).T]
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Returns the (row, col) shape of the expression.

--- a/cvxpy/atoms/sum_largest.py
+++ b/cvxpy/atoms/sum_largest.py
@@ -65,7 +65,7 @@ class sum_largest(Atom):
         indices = np.argpartition(-value, kth=k)[:k]
         D = np.zeros((self.args[0].shape[0]*self.args[0].shape[1], 1))
         D[indices] = 1
-        return [sp.csc_matrix(D)]
+        return [sp.csc_array(D)]
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Returns the (row, col) shape of the expression.

--- a/cvxpy/atoms/suppfunc.py
+++ b/cvxpy/atoms/suppfunc.py
@@ -132,7 +132,7 @@ class SuppFuncAtom(Atom):
             # this means the support function is not finite at this input.
             return [None]
         else:
-            gradmat = sp.csc_matrix(gradval.ravel(order='F')).T
+            gradmat = sp.csc_array([gradval.ravel(order='F')]).T
             return [gradmat]
 
     def __lt__(self, other):

--- a/cvxpy/atoms/tr_inv.py
+++ b/cvxpy/atoms/tr_inv.py
@@ -102,7 +102,7 @@ class tr_inv(Atom):
             # Grad: -X^{-2}.T
             D = np.linalg.inv(X).T
             D = - D @ D
-            return [sp.csc_matrix(D.ravel(order='F')).T]
+            return [sp.csc_array(D.ravel(order='F')).T]
         # Outside domain.
         else:
             return [None]

--- a/cvxpy/constraints/utilities.py
+++ b/cvxpy/constraints/utilities.py
@@ -45,7 +45,7 @@ def format_axis(t, X, axis):
     terms = []
     # Make t_mat
     mat_shape = (cone_size, 1)
-    t_mat = sp.csc_matrix(([1.0], ([0], [0])), mat_shape)
+    t_mat = sp.csc_array(([1.0], ([0], [0])), mat_shape)
     t_mat = lu.create_const(t_mat, mat_shape, sparse=True)
     t_vec = t
     if not t.shape:
@@ -63,7 +63,7 @@ def format_axis(t, X, axis):
     val_arr = (cone_size - 1)*[1.0]
     row_arr = range(1, cone_size)
     col_arr = range(cone_size-1)
-    X_mat = sp.csc_matrix((val_arr, (row_arr, col_arr)), mat_shape)
+    X_mat = sp.csc_array((val_arr, (row_arr, col_arr)), mat_shape)
     X_mat = lu.create_const(X_mat, mat_shape, sparse=True)
     mul_shape = (cone_size, X.shape[1])
     terms += [lu.mul_expr(X_mat, X, mul_shape)]
@@ -120,5 +120,5 @@ def get_spacing_matrix(shape: Tuple[int, ...], spacing, offset):
         val_arr.append(1.0)
         row_arr.append(spacing*var_row + offset)
         col_arr.append(var_row)
-    mat = sp.csc_matrix((val_arr, (row_arr, col_arr)), shape)
+    mat = sp.csc_array((val_arr, (row_arr, col_arr)), shape)
     return lu.create_const(mat, shape, sparse=True)

--- a/cvxpy/cvxcore/python/cppbackend.py
+++ b/cvxpy/cvxcore/python/cppbackend.py
@@ -38,7 +38,7 @@ def build_matrix(
     var_length: int,
     constr_length: int,
     linOps: List[lo.LinOp],
-) -> sp.csc_matrix:
+) -> sp.csc_array:
     lin_vec = cvxcore.ConstLinOpVector()
 
     id_to_col_C = cvxcore.IntIntMap()
@@ -99,7 +99,7 @@ def build_matrix(
         np.int64(constr_length) * np.int64(var_length + 1),
         param_size_plus_one,
     )
-    A = sp.csc_matrix((V, (I, J)), shape=output_shape)
+    A = sp.csc_array((V, (I, J)), shape=output_shape)
     return A
 
 

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -401,7 +401,7 @@ class Leaf(expression.Expression):
                 val = val.diagonal()
             else:
                 val = np.diag(val)
-            return sp.diags([val], [0])
+            return sp.diags_array([val], offsets=[0])
         elif self.attributes['hermitian']:
             return (val + np.conj(val).T)/2.
         elif any([self.attributes[key] for

--- a/cvxpy/expressions/variable.py
+++ b/cvxpy/expressions/variable.py
@@ -58,13 +58,13 @@ class Variable(Leaf):
         return False
 
     @property
-    def grad(self) -> Optional[dict[Variable, sp.csc_matrix]]:
+    def grad(self) -> Optional[dict[Variable, sp.csc_array]]:
         """Gives the (sub/super)gradient of the expression w.r.t. each variable.
 
         Matrix expressions are vectorized, so the gradient is a matrix.
         """
         # TODO(akshayka): Do not assume shape is 2D.
-        return {self: sp.eye(self.size).tocsc()}
+        return {self: sp.eye_array(self.size, format='csc')}
 
     def variables(self) -> list[Variable]:
         """Returns itself as a variable."""

--- a/cvxpy/interface/matrix_utilities.py
+++ b/cvxpy/interface/matrix_utilities.py
@@ -24,13 +24,14 @@ from cvxpy.interface import numpy_interface as np_intf
 # A mapping of class to interface.
 INTERFACES = {np.ndarray: np_intf.NDArrayInterface(),
               np.matrix: np_intf.MatrixInterface(),
-              sp.csc_matrix: np_intf.SparseMatrixInterface(),
+              sp.csc_matrix: np_intf.SparseArrayInterface(),
+              sp.csc_array: np_intf.SparseArrayInterface(),
               }
 # Default Numpy interface.
 DEFAULT_NP_INTF = INTERFACES[np.ndarray]
 # Default dense and sparse matrix interfaces.
 DEFAULT_INTF = INTERFACES[np.ndarray]
-DEFAULT_SPARSE_INTF = INTERFACES[sp.csc_matrix]
+DEFAULT_SPARSE_INTF = INTERFACES[sp.csc_array]
 
 
 # Returns the interface for interacting with the target matrix class.
@@ -49,7 +50,7 @@ def get_cvxopt_sparse_intf():
     """Dynamic import of CVXOPT sparse interface.
     """
     import cvxpy.interface.cvxopt_interface.sparse_matrix_interface as smi
-    return smi.SparseMatrixInterface()
+    return smi.SparseArrayInterface()
 
 # Tools for handling CVXOPT matrices.
 
@@ -132,7 +133,7 @@ def shape(constant):
         return INTERFACES[constant.__class__].shape(constant)
     # Direct all sparse matrices to CSC interface.
     elif is_sparse(constant):
-        return INTERFACES[sp.csc_matrix].shape(constant)
+        return INTERFACES[sp.csc_array].shape(constant)
     else:
         raise TypeError("%s is not a valid type for a Constant value." % type(constant))
 
@@ -191,7 +192,7 @@ def scalar_value(constant):
         return INTERFACES[constant.__class__].scalar_value(constant)
     # Direct all sparse matrices to CSC interface.
     elif is_sparse(constant):
-        return INTERFACES[sp.csc_matrix].scalar_value(constant.tocsc())
+        return INTERFACES[sp.csc_array].scalar_value(constant.tocsc())
     else:
         raise TypeError("%s is not a valid type for a Constant value." % type(constant))
 
@@ -264,7 +265,7 @@ def index(constant, key):
         return INTERFACES[constant.__class__].index(constant, key)
     # Use CSC interface for all sparse matrices.
     elif is_sparse(constant):
-        interface = INTERFACES[sp.csc_matrix]
+        interface = INTERFACES[sp.csc_array]
         constant = interface.const_to_matrix(constant)
         return interface.index(constant, key)
 

--- a/cvxpy/interface/numpy_interface/__init__.py
+++ b/cvxpy/interface/numpy_interface/__init__.py
@@ -16,5 +16,4 @@ limitations under the License.
 
 from cvxpy.interface.numpy_interface.matrix_interface import MatrixInterface
 from cvxpy.interface.numpy_interface.ndarray_interface import NDArrayInterface
-from cvxpy.interface.numpy_interface.sparse_matrix_interface import (
-    SparseMatrixInterface,)
+from cvxpy.interface.numpy_interface.sparse_matrix_interface import SparseArrayInterface

--- a/cvxpy/interface/numpy_interface/sparse_matrix_interface.py
+++ b/cvxpy/interface/numpy_interface/sparse_matrix_interface.py
@@ -20,11 +20,11 @@ import scipy.sparse as sp
 from cvxpy.interface.numpy_interface.ndarray_interface import NDArrayInterface
 
 
-class SparseMatrixInterface(NDArrayInterface):
+class SparseArrayInterface(NDArrayInterface):
     """
     An interface to convert constant values to the scipy sparse CSC class.
     """
-    TARGET_MATRIX = sp.csc_matrix
+    TARGET_MATRIX = sp.csc_array
 
     @NDArrayInterface.scalar_const
     def const_to_matrix(self, value, convert_scalars: bool = False):
@@ -39,18 +39,18 @@ class SparseMatrixInterface(NDArrayInterface):
         """
         # Convert cvxopt sparse to coo matrix.
         if isinstance(value, list):
-            return sp.csc_matrix(value, dtype=np.double).T
+            return sp.csc_array(np.atleast_2d(value), dtype=np.double).T
         if value.dtype in [np.double, complex]:
             dtype = value.dtype
         else:
             # Cast bool, int, etc to double
             dtype = np.double
-        return sp.csc_matrix(value, dtype=dtype)
+        return sp.csc_array(value, dtype=dtype)
 
     def identity(self, size):
         """Return an identity matrix.
         """
-        return sp.eye(size, size, format="csc")
+        return sp.eye_array(size, size, format="csc")
 
     def size(self, matrix):
         """Return the dimensions of the matrix.
@@ -65,13 +65,13 @@ class SparseMatrixInterface(NDArrayInterface):
     def zeros(self, rows, cols):
         """Return a matrix with all 0's.
         """
-        return sp.csc_matrix((rows, cols), dtype='float64')
+        return sp.csc_array((rows, cols), dtype='float64')
 
     def reshape(self, matrix, size):
         """Change the shape of the matrix.
         """
         matrix = matrix.todense()
-        matrix = super(SparseMatrixInterface, self).reshape(matrix, size)
+        matrix = super(SparseArrayInterface, self).reshape(matrix, size)
         return self.const_to_matrix(matrix, convert_scalars=True)
 
     def block_add(self, matrix, block, vert_offset, horiz_offset, rows, cols,

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -103,21 +103,21 @@ class TensorRepresentation:
             shape,
         )
 
-    def flatten_tensor(self, num_param_slices: int) -> sp.csc_matrix:
+    def flatten_tensor(self, num_param_slices: int) -> sp.csc_array:
         """
         Flatten into 2D scipy csc-matrix in column-major order and transpose.
         """
         rows = (self.col.astype(np.int64) * np.int64(self.shape[0]) + self.row.astype(np.int64))
         cols = self.parameter_offset.astype(np.int64)
         shape = (np.prod(self.shape, dtype=np.int64), num_param_slices)
-        return sp.csc_matrix((self.data, (rows, cols)), shape=shape)
+        return sp.csc_array((self.data, (rows, cols)), shape=shape)
 
-    def get_param_slice(self, param_offset: int) -> sp.csc_matrix:
+    def get_param_slice(self, param_offset: int) -> sp.csc_array:
         """
         Returns a single slice of the tensor for a given parameter offset.
         """
         mask = self.parameter_offset == param_offset
-        return sp.csc_matrix((self.data[mask], (self.row[mask], self.col[mask])), self.shape)
+        return sp.csc_array((self.data[mask], (self.row[mask], self.col[mask])), self.shape)
 
 
 class CanonBackend(ABC):
@@ -164,11 +164,11 @@ class CanonBackend(ABC):
         return backends[backend_name](*args, **kwargs)
 
     @abstractmethod
-    def build_matrix(self, lin_ops: list[LinOp]) -> sp.csc_matrix:
+    def build_matrix(self, lin_ops: list[LinOp]) -> sp.csc_array:
         """
         Main function called from canonInterface.
         Given a list of LinOp trees, each representing a constraint (or the objective), get the
-        [A b] Tensor for each, stack them and return the result reshaped as a 2D sp.csc_matrix
+        [A b] Tensor for each, stack them and return the result reshaped as a 2D sp.csc_array
         of shape (total_rows * (var_length + 1)), param_size_plus_one)
 
         Parameters
@@ -177,7 +177,7 @@ class CanonBackend(ABC):
 
         Returns
         -------
-        2D sp.csc_matrix representing the constraints (or the objective).
+        2D sp.csc_array representing the constraints (or the objective).
         """
         pass  # noqa
 
@@ -193,7 +193,7 @@ class PythonCanonBackend(CanonBackend):
     - A new constant of size n has shape (1, n, 1)
     """
 
-    def build_matrix(self, lin_ops: list[LinOp]) -> sp.csc_matrix:
+    def build_matrix(self, lin_ops: list[LinOp]) -> sp.csc_array:
         self.id_to_col[-1] = self.var_length
 
         constraint_res = []
@@ -675,7 +675,7 @@ class RustCanonBackend(CanonBackend):
     https://github.com/phschiele/cvxpy/pull/31
     """
 
-    def build_matrix(self, lin_ops: list[LinOp]) -> sp.csc_matrix:
+    def build_matrix(self, lin_ops: list[LinOp]) -> sp.csc_array:
         import cvxpy_rust
         self.id_to_col[-1] = self.var_length
         (data, (row, col), shape) = cvxpy_rust.build_matrix(lin_ops,
@@ -685,7 +685,7 @@ class RustCanonBackend(CanonBackend):
                                                             self.param_to_col,
                                                             self.var_length)
         self.id_to_col.pop(-1)
-        return sp.csc_matrix((data, (row, col)), shape)
+        return sp.csc_array((data, (row, col)), shape)
 
 
 class NumPyCanonBackend(PythonCanonBackend):
@@ -1070,18 +1070,18 @@ class NumPyCanonBackend(PythonCanonBackend):
 
 class SciPyCanonBackend(PythonCanonBackend):
     @staticmethod
-    def get_constant_data_from_const(lin_op: LinOp) -> sp.csr_matrix:
+    def get_constant_data_from_const(lin_op: LinOp) -> sp.csr_array:
         """
         Extract the constant data from a LinOp node of type "*_const".
         """
-        constant = sp.csr_matrix(lin_op.data)
+        constant = sp.csr_array(lin_op.data)
         assert constant.shape == lin_op.shape
         return constant
 
     @staticmethod
-    def reshape_constant_data(constant_data: dict[int, sp.csc_matrix],
+    def reshape_constant_data(constant_data: dict[int, sp.csc_array],
                               lin_op_shape: tuple[int, int]) \
-            -> dict[int, sp.csc_matrix]:
+            -> dict[int, sp.csc_array]:
         """
         Reshape constant data from column format to the required shape for operations that
         do not require column format. This function unpacks the constant data dict and reshapes
@@ -1091,8 +1091,8 @@ class SciPyCanonBackend(PythonCanonBackend):
                 for k, v in constant_data.items()}
 
     @staticmethod
-    def _reshape_single_constant_tensor(v: sp.csc_matrix, lin_op_shape: tuple[int, int]) \
-            -> sp.csc_matrix:
+    def _reshape_single_constant_tensor(v: sp.csc_array, lin_op_shape: tuple[int, int]) \
+            -> sp.csc_array:
         """
         Given v, which is a matrix of shape (p * lin_op_shape[0] * lin_op_shape[1], 1),
         reshape v into a matrix of shape (p * lin_op_shape[0], lin_op_shape[1]).
@@ -1109,7 +1109,7 @@ class SciPyCanonBackend(PythonCanonBackend):
         new_rows = slices * lin_op_shape[0] + new_rows
 
         new_stacked_shape = (p * lin_op_shape[0], lin_op_shape[1])
-        return sp.csc_matrix((data, (new_rows, new_cols)), shape=new_stacked_shape)
+        return sp.csc_array((data, (new_rows, new_cols)), shape=new_stacked_shape)
 
     def get_empty_view(self) -> SciPyTensorView:
         """
@@ -1142,7 +1142,7 @@ class SciPyCanonBackend(PythonCanonBackend):
         if is_param_free_lhs:
             reps = view.rows // lhs.shape[-1]
             if reps > 1:
-                stacked_lhs = (sp.kron(sp.eye(reps, format="csr"), lhs))
+                stacked_lhs = (sp.kron(sp.eye_array(reps, format="csr"), lhs))
             else:
                 stacked_lhs = lhs
 
@@ -1150,7 +1150,7 @@ class SciPyCanonBackend(PythonCanonBackend):
                 if p == 1:
                     return (stacked_lhs @ x).tocsr()
                 else:
-                    return ((sp.kron(sp.eye(p, format="csc"), stacked_lhs)) @ x).tocsc()
+                    return ((sp.kron(sp.eye_array(p, format="csc"), stacked_lhs)) @ x).tocsc()
         else:
             reps = view.rows // next(iter(lhs.values())).shape[-1]
             if reps > 1:
@@ -1164,8 +1164,8 @@ class SciPyCanonBackend(PythonCanonBackend):
             func = parametrized_mul
         return view.accumulate_over_variables(func, is_param_free_function=is_param_free_lhs)
 
-    def _stacked_kron_r(self, lhs: dict[int, list[sp.csc_matrix]], reps: int) \
-            -> sp.csc_matrix:
+    def _stacked_kron_r(self, lhs: dict[int, list[sp.csc_array]], reps: int) \
+            -> sp.csc_array:
         """
         Given a stacked lhs
         [[A_0],
@@ -1192,7 +1192,7 @@ class SciPyCanonBackend(PythonCanonBackend):
                 np.tile(np.arange(reps) * old_shape[1], len(cols))
             new_data = np.repeat(data, reps)
             new_shape = (v.shape[0] * reps, v.shape[1] * reps)
-            res[param_id] = sp.csc_matrix(
+            res[param_id] = sp.csc_array(
                 (new_data, (new_rows, new_cols)), shape=new_shape)
         return res
 
@@ -1245,17 +1245,17 @@ class SciPyCanonBackend(PythonCanonBackend):
             axis, _ = _lin.data
             if p == 1:
                 if axis is None:
-                    return sp.csr_matrix(x.sum(axis=0))
+                    return sp.csr_array(x.sum(axis=0).reshape(1, x.shape[1]))
                 else:
                     A = sum_coeff_matrix(shape=shape, axis=axis)
                     return A @ x
             else:
                 m = x.shape[0] // p
                 if axis is None:
-                    return (sp.kron(sp.eye(p, format="csc"), np.ones(m)) @ x).tocsc()
+                    return (sp.kron(sp.eye_array(p, format="csc"), np.ones((1, m))) @ x).tocsc()
                 else:
                     A = sum_coeff_matrix(shape=shape, axis=axis)
-                    return (sp.kron(sp.eye(p, format="csc"), A) @ x).tocsc()
+                    return (sp.kron(sp.eye_array(p, format="csc"), A) @ x).tocsc()
 
         view.apply_all(func)
         return view
@@ -1289,7 +1289,7 @@ class SciPyCanonBackend(PythonCanonBackend):
         row_idx = np.ravel_multi_index(out_idx, dims=out_dims, order='F')
         return row_idx.flatten(order='F')
 
-    def _get_sum_coeff_matrix(self, shape: tuple, axis: tuple) -> sp.csr_matrix:
+    def _get_sum_coeff_matrix(self, shape: tuple, axis: tuple) -> sp.csr_array:
         """
         Internal function that computes the sum coefficient matrix for a given shape and axis.
         """
@@ -1298,7 +1298,7 @@ class SciPyCanonBackend(PythonCanonBackend):
         d = np.prod([shape[i] for i in axis], dtype=int)
         row_idx = self._get_sum_row_indices(shape, axis)
         col_idx = np.arange(n)
-        A = sp.csr_matrix((np.ones(n), (row_idx, col_idx)), shape=(n//d, n))
+        A = sp.csr_array((np.ones(n), (row_idx, col_idx)), shape=(n//d, n))
         return A
 
     def div(self, lin: LinOp, view: SciPyTensorView) -> SciPyTensorView:
@@ -1349,7 +1349,7 @@ class SciPyCanonBackend(PythonCanonBackend):
             else:
                 new_rows = x_row * (rows + 1) - k
             new_rows = (new_rows + x_slice * total_rows).astype(int)
-            return sp.csc_matrix((x.data, (new_rows, x.col)), shape)
+            return sp.csc_array((x.data, (new_rows, x.col)), shape)
 
         view.apply_all(func)
         return view
@@ -1366,7 +1366,7 @@ class SciPyCanonBackend(PythonCanonBackend):
             slices = coo_repr.row // m
             new_rows = (coo_repr.row + (slices + 1) * offset)
             new_rows = new_rows + slices * (total_rows - m - offset).astype(int)
-            return sp.csc_matrix((coo_repr.data, (new_rows, coo_repr.col)),
+            return sp.csc_array((coo_repr.data, (new_rows, coo_repr.col)),
                                  shape=(int(total_rows * p), tensor.shape[1]))
 
         return stack_func
@@ -1391,7 +1391,7 @@ class SciPyCanonBackend(PythonCanonBackend):
                 lhs = lhs.T
             reps = view.rows // lhs.shape[0]
             if reps > 1:
-                stacked_lhs = sp.kron(lhs.T, sp.eye(reps, format="csr"))
+                stacked_lhs = sp.kron(lhs.T, sp.eye_array(reps, format="csr"))
             else:
                 stacked_lhs = lhs.T
 
@@ -1399,7 +1399,7 @@ class SciPyCanonBackend(PythonCanonBackend):
                 if p == 1:
                     return (stacked_lhs @ x).tocsr()
                 else:
-                    return ((sp.kron(sp.eye(p, format="csc"), stacked_lhs)) @ x).tocsc()
+                    return ((sp.kron(sp.eye_array(p, format="csc"), stacked_lhs)) @ x).tocsc()
         else:
             k, v = next(iter(lhs.items()))
             lhs_rows = v.shape[0] // self.param_to_size[k]
@@ -1426,7 +1426,7 @@ class SciPyCanonBackend(PythonCanonBackend):
             func = parametrized_mul
         return view.accumulate_over_variables(func, is_param_free_function=is_param_free_lhs)
 
-    def _transpose_stacked(self, v: sp.csc_matrix, param_id: int) -> sp.csc_matrix:
+    def _transpose_stacked(self, v: sp.csc_array, param_id: int) -> sp.csc_array:
         """
         Given v, which is a stacked matrix of shape (p * n, m), transpose each slice of v,
         returning a stacked matrix of shape (p * m, n).
@@ -1448,10 +1448,10 @@ class SciPyCanonBackend(PythonCanonBackend):
         new_rows = cols + slices * new_shape[0]
         new_cols = rows
 
-        return sp.csc_matrix((data, (new_rows, new_cols)), shape=new_stacked_shape)
+        return sp.csc_array((data, (new_rows, new_cols)), shape=new_stacked_shape)
 
-    def _stacked_kron_l(self, lhs: dict[int, list[sp.csc_matrix]], reps: int) \
-            -> sp.csc_matrix:
+    def _stacked_kron_l(self, lhs: dict[int, list[sp.csc_array]], reps: int) \
+            -> sp.csc_array:
         """
         Given a stacked lhs with the following entries:
         [[a11, a12],
@@ -1474,7 +1474,7 @@ class SciPyCanonBackend(PythonCanonBackend):
             new_cols = np.repeat(cols * reps, reps) + np.tile(np.arange(reps), len(cols))
             new_data = np.repeat(data, reps)
             new_shape = (v.shape[0] * reps, v.shape[1] * reps)
-            res[param_id] = sp.csc_matrix(
+            res[param_id] = sp.csc_array(
                 (new_data, (new_rows, new_cols)), shape=new_shape)
         return res
 
@@ -1490,13 +1490,13 @@ class SciPyCanonBackend(PythonCanonBackend):
 
         data = np.ones(len(indices))
         idx = (np.zeros(len(indices)), indices.astype(int))
-        lhs = sp.csr_matrix((data, idx), shape=(1, np.prod(shape)))
+        lhs = sp.csr_array((data, idx), shape=(1, np.prod(shape)))
 
-        def func(x, p) -> sp.csc_matrix:
+        def func(x, p) -> sp.csc_array:
             if p == 1:
                 return (lhs @ x).tocsr()
             else:
-                return (sp.kron(sp.eye(p, format="csc"), lhs) @ x).tocsc()
+                return (sp.kron(sp.eye_array(p, format="csc"), lhs) @ x).tocsc()
 
         return view.accumulate_over_variables(func, is_param_free_function=True)
 
@@ -1527,7 +1527,7 @@ class SciPyCanonBackend(PythonCanonBackend):
         col_idx = (np.tile(lhs.col, cols) + np.repeat(np.arange(cols), nonzeros)).astype(int)
         data = np.tile(lhs.data, cols)
 
-        lhs = sp.csr_matrix((data, (row_idx, col_idx)), shape=(rows, cols))
+        lhs = sp.csr_array((data, (row_idx, col_idx)), shape=(rows, cols))
 
         def func(x, p):
             assert p == 1, \
@@ -1593,7 +1593,7 @@ class SciPyCanonBackend(PythonCanonBackend):
         return view.accumulate_over_variables(func, is_param_free_function=is_param_free_rhs)
 
     def get_variable_tensor(self, shape: tuple[int, ...], variable_id: int) -> \
-            dict[int, dict[int, sp.csc_matrix]]:
+            dict[int, dict[int, sp.csc_array]]:
         """
         Returns tensor of a variable node, i.e., eye(n) across axes 0 and 1, where n is
         the size of the variable.
@@ -1601,23 +1601,23 @@ class SciPyCanonBackend(PythonCanonBackend):
         """
         assert variable_id != Constant.ID
         n = int(np.prod(shape))
-        return {variable_id: {Constant.ID.value: sp.eye(n, format="csc")}}
+        return {variable_id: {Constant.ID.value: sp.eye_array(n, format="csc")}}
 
     def get_data_tensor(self, data: np.ndarray | sp.spmatrix) -> \
-            dict[int, dict[int, sp.csr_matrix]]:
+            dict[int, dict[int, sp.csr_array]]:
         """
         Returns tensor of constant node as a column vector.
         This function reshapes the data and converts it to csc format.
         """
         if isinstance(data, np.ndarray):
             # Slightly faster compared to reshaping after casting
-            tensor = sp.csr_matrix(data.reshape((-1, 1), order="F"))
+            tensor = sp.csr_array(data.reshape((-1, 1), order="F"))
         else:
             tensor = sp.coo_matrix(data).reshape((-1, 1), order="F").tocsr()
         return {Constant.ID.value: {Constant.ID.value: tensor}}
 
     def get_param_tensor(self, shape: tuple[int, ...], parameter_id: int) -> \
-            dict[int, dict[int, sp.csc_matrix]]:
+            dict[int, dict[int, sp.csc_array]]:
         """
         Returns tensor of a parameter node, i.e., eye(n) across axes 0 and 2, where n is
         the size of the parameter.
@@ -1628,7 +1628,7 @@ class SciPyCanonBackend(PythonCanonBackend):
         shape = (int(np.prod(shape) * param_size), 1)
         arg = np.ones(param_size), (np.arange(param_size) + np.arange(param_size) * param_size,
                                     np.zeros(param_size))
-        param_vec = sp.csc_matrix(arg, shape)
+        param_vec = sp.csc_array(arg, shape)
         return {Constant.ID.value: {parameter_id: param_vec}}
 
 
@@ -2009,4 +2009,4 @@ class SciPyTensorView(DictTensorView):
         The tensor representation of the stacked slices backend is one big
         sparse matrix instead of smaller sparse matrices in a list.
         """
-        return sp.spmatrix
+        return (sp.sparray, sp.spmatrix)

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -1074,7 +1074,8 @@ class SciPyCanonBackend(PythonCanonBackend):
         """
         Extract the constant data from a LinOp node of type "*_const".
         """
-        constant = sp.csr_array(lin_op.data)
+        data = [[lin_op.data]] if np.isscalar(lin_op.data) else lin_op.data
+        constant = sp.csr_array(data)
         assert constant.shape == lin_op.shape
         return constant
 

--- a/cvxpy/reductions/cone2cone/affine2direct.py
+++ b/cvxpy/reductions/cone2cone/affine2direct.py
@@ -366,10 +366,10 @@ class Slacks:
         if A_slk:
             # We need to introduce slack variables.
             A_slk = sp.sparse.vstack(tuple(A_slk))
-            eye = sp.sparse.eye(total_slack)
+            eye = sp.sparse.eye_array(total_slack)
             if A_aff:
                 A_aff = sp.sparse.vstack(tuple(A_aff), format='csr')
-                G = sp.sparse.bmat([[A_slk, eye], [A_aff, None]])
+                G = sp.sparse.block_array([[A_slk, eye], [A_aff, None]])
                 h = np.concatenate(b_slk + b_aff)  # concatenate lists, then turn to vector
             else:
                 G = sp.sparse.hstack((A_slk, eye))

--- a/cvxpy/reductions/cone2cone/soc2psd.py
+++ b/cvxpy/reductions/cone2cone/soc2psd.py
@@ -73,16 +73,16 @@ class SOC2PSD(Reduction):
                 however, this one makes writing `invert` routine simple.
                 """
 
-                A = scalar_term * sparse.eye(1)
+                A = scalar_term * sparse.eye_array(1)
                 B = cp.reshape(X,[-1,1], order='F').T
-                C = scalar_term * sparse.eye(vector_term_len)
+                C = scalar_term * sparse.eye_array(vector_term_len)
 
                 """
                 Another technique for reference
 
-                A = scalar_term * sparse.eye(vector_term_len)
+                A = scalar_term * sparse.eye_array(vector_term_len)
                 B = cp.reshape(X,[-1,1], order='F')
-                C = scalar_term * sparse.eye(1)
+                C = scalar_term * sparse.eye_array(1)
                 """
 
                 """
@@ -106,9 +106,9 @@ class SOC2PSD(Reduction):
                     scalar_term = t[subidx]
                     vector_term_len = X.shape[0]
 
-                    A = scalar_term * sparse.eye(1)
+                    A = scalar_term * sparse.eye_array(1)
                     B = X[:,subidx:subidx+1].T
-                    C = scalar_term * sparse.eye(vector_term_len)
+                    C = scalar_term * sparse.eye_array(vector_term_len)
 
                     M = cp.bmat([
                         [A, B],

--- a/cvxpy/reductions/cvx_attr2constr.py
+++ b/cvxpy/reductions/cvx_attr2constr.py
@@ -75,7 +75,7 @@ def attributes_present(variables, attr_map) -> list[str]:
 
 def recover_value_for_variable(variable, lowered_value, project: bool = True):
     if variable.attributes['diag']:
-        return sp.diags(lowered_value.flatten(order='F'))
+        return sp.diags_array(lowered_value.flatten(order='F'))
     elif attributes_present([variable], SYMMETRIC_ATTRIBUTES):
         n = variable.shape[0]
         value = np.zeros(variable.shape)
@@ -160,7 +160,7 @@ class CvxAttr2Constr(Reduction):
                     id2new_var[var.id] = sparse_var
                     row_idx = np.ravel_multi_index(var.sparse_idx, var.shape, order='F')
                     col_idx = np.arange(n)
-                    coeff_matrix = Constant(sp.csc_matrix((np.ones(n), (row_idx, col_idx)),
+                    coeff_matrix = Constant(sp.csc_array((np.ones(n), (row_idx, col_idx)),
                                                     shape=(np.prod(var.shape, dtype=int), n)),
                                                     name="sparse_coeff")
                     obj = reshape(coeff_matrix @ sparse_var, var.shape, order='F')

--- a/cvxpy/reductions/dcp2cone/canonicalizers/sigma_max_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/sigma_max_canon.py
@@ -28,8 +28,8 @@ def sigma_max_canon(expr, args):
     if not np.prod(shape) == 1:
         raise RuntimeError('Invalid shape of expr in sigma_max canonicalization.')
     t = Variable(shape)
-    tI_n = t * sp.eye(n)
-    tI_m = t * sp.eye(m)
+    tI_n = t * sp.eye_array(n)
+    tI_m = t * sp.eye_array(m)
     X = bmat([[tI_n, A],
               [A.T, tI_m]])
     constraints = [PSD(X)]

--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -237,7 +237,7 @@ class ParamConeProg(ParamProb):
 
         del_param_vec = delc @ self.c[:-1]
         flatdelA = delA.reshape((np.prod(delA.shape), 1), order='F')
-        delAb = sp.vstack([flatdelA, sp.csc_matrix(delb[:, None])])
+        delAb = sp.vstack([flatdelA, sp.csc_array(delb[:, None])])
 
         one_gig_of_doubles = 125000000
         if delAb.shape[0] < one_gig_of_doubles:

--- a/cvxpy/reductions/qp2quad_form/canonicalizers/power_canon.py
+++ b/cvxpy/reductions/qp2quad_form/canonicalizers/power_canon.py
@@ -33,9 +33,9 @@ def power_canon(expr, args):
         return affine_expr, []
     elif p == 2:
         if isinstance(affine_expr, Variable):
-            return SymbolicQuadForm(affine_expr, sp.eye(affine_expr.size), expr), []
+            return SymbolicQuadForm(affine_expr, sp.eye_array(affine_expr.size), expr), []
         else:
             t = Variable(affine_expr.shape)
-            return SymbolicQuadForm(t, sp.eye(t.size), expr), [affine_expr == t]
+            return SymbolicQuadForm(t, sp.eye_array(t.size), expr), [affine_expr == t]
     raise ValueError("non-constant quadratic forms can't be raised to a power "
                      "greater than 2.")

--- a/cvxpy/reductions/qp2quad_form/canonicalizers/quad_over_lin_canon.py
+++ b/cvxpy/reductions/qp2quad_form/canonicalizers/quad_over_lin_canon.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from scipy.sparse import eye
+from scipy.sparse import eye_array
 
 from cvxpy.atoms.quad_form import SymbolicQuadForm
 from cvxpy.expressions.variable import Variable
@@ -25,11 +25,11 @@ def quad_over_lin_canon(expr, args):
     y = args[1]
     # Simplify if y has no parameters.
     if len(y.parameters()) == 0:
-        quad_mat = eye(affine_expr.size)/y.value
+        quad_mat = eye_array(affine_expr.size) / y.value
     else:
         # TODO this codepath produces an intermediate dense matrix.
         # but it should be sparse the whole time.
-        quad_mat = eye(affine_expr.size)/y
+        quad_mat = eye_array(affine_expr.size) / y
 
     if isinstance(affine_expr, Variable):
         return SymbolicQuadForm(affine_expr, quad_mat, expr), []

--- a/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
@@ -192,14 +192,14 @@ class CLARABEL(ConicSolver):
         val_arr = val_arr[np.nonzero(val_arr)]
 
         shape = (entries, rows*cols)
-        scaled_upper_tri = sp.csc_matrix((val_arr, (row_arr, col_arr)), shape)
+        scaled_upper_tri = sp.csc_array((val_arr, (row_arr, col_arr)), shape)
 
         idx = np.arange(rows * cols)
         val_symm = 0.5 * np.ones(2 * rows * cols)
         K = idx.reshape((rows, cols))
         row_symm = np.append(idx, np.ravel(K, order='F'))
         col_symm = np.append(idx, np.ravel(K.T, order='F'))
-        symm_matrix = sp.csc_matrix((val_symm, (row_symm, col_symm)))
+        symm_matrix = sp.csc_array((val_symm, (row_symm, col_symm)))
 
         return scaled_upper_tri @ symm_matrix
 
@@ -306,7 +306,7 @@ class CLARABEL(ConicSolver):
             P = data[s.P]
         else:
             nvars = q.size
-            P = sp.csc_matrix((nvars, nvars))
+            P = sp.csc_array((nvars, nvars))
 
         cones = dims_to_solver_cones(data[ConicSolver.DIMS])
 

--- a/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
+++ b/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
@@ -156,14 +156,14 @@ class ConicSolver(Solver):
         row_arr = np.arange(0, num_blocks * streak_plus_spacing).reshape(
             num_blocks, streak_plus_spacing)[:, :streak].flatten() + offset
         col_arr = np.arange(num_values)
-        return sp.csc_matrix((val_arr, (row_arr, col_arr)), shape)
+        return sp.csc_array((val_arr, (row_arr, col_arr)), shape)
 
     @staticmethod
     def psd_format_mat(constr):
         """Return a matrix to multiply by PSD constraint coefficients.
         """
         # Default is identity.
-        return sp.eye(constr.size, format='csc')
+        return sp.eye_array(constr.size, format='csc')
 
     @classmethod
     def format_constraints(cls, problem, exp_cone_order):

--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -121,14 +121,14 @@ class COPT(ConicSolver):
         val_arr = val_arr[np.nonzero(val_arr)]
 
         shape = (entries, rows*cols)
-        scaled_lower_tri = sp.csc_matrix((val_arr, (row_arr, col_arr)), shape)
+        scaled_lower_tri = sp.csc_array((val_arr, (row_arr, col_arr)), shape)
 
         idx = np.arange(rows * cols)
         val_symm = 0.5 * np.ones(2 * rows * cols)
         K = idx.reshape((rows, cols))
         row_symm = np.append(idx, np.ravel(K, order='F'))
         col_symm = np.append(idx, np.ravel(K.T, order='F'))
-        symm_matrix = sp.csc_matrix((val_symm, (row_symm, col_symm)))
+        symm_matrix = sp.csc_array((val_symm, (row_symm, col_symm)))
 
         return scaled_lower_tri @ symm_matrix
 
@@ -250,7 +250,8 @@ class COPT(ConicSolver):
             b = data[s.B]
 
             # Solve the dualized problem
-            rowmap = model.loadConeMatrix(-b, A.transpose().tocsc(), -c, dims)
+            # TODO switch to `A.transpose().tocsc()` when COPT supports sparray
+            rowmap = model.loadConeMatrix(-b, sp.csc_matrix(A.transpose()), -c, dims)
             model.objsense = copt.COPT.MAXIMIZE
         else:
             # Build problem data
@@ -285,7 +286,7 @@ class COPT(ConicSolver):
                 nlinrow = dims[s.EQ_DIM] + dims[s.LEQ_DIM]
                 nlincol = A.shape[1]
 
-                diag = sp.diags(np.ones(nconedim), offsets=-nlinrow,
+                diag = sp.diags_array(np.ones(nconedim), offsets=-nlinrow,
                                 shape=(A.shape[0], nconedim))
                 A = sp.hstack([A, diag], format='csc')
 
@@ -314,8 +315,8 @@ class COPT(ConicSolver):
                     nlinrow += sum(dims[s.SOC_DIM])
                 nlincol = A.shape[1]
 
-                diag = sp.diags(np.ones(nexpconedim), offsets=-nlinrow,
-                                shape=(A.shape[0], nexpconedim))
+                diag = sp.diags_array(np.ones(nexpconedim), offsets=-nlinrow,
+                                      shape=(A.shape[0], nexpconedim))
                 A = sp.hstack([A, diag], format='csc')
 
                 c = np.append(c, np.zeros(nexpconedim))
@@ -327,7 +328,8 @@ class COPT(ConicSolver):
                     vtype = np.append(vtype, [copt.COPT.CONTINUOUS] * nexpconedim)
 
             # Load matrix data
-            model.loadMatrix(c, A, lhs, rhs, lb, ub, vtype)
+            # TODO remove `sp.csc_matrix` when COPT starts supporting sparray
+            model.loadMatrix(c, sp.csc_matrix(A), lhs, rhs, lb, ub, vtype)
 
             # Load cone data
             if dims[s.SOC_DIM]:

--- a/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
@@ -18,7 +18,7 @@ from collections import namedtuple
 from operator import attrgetter
 
 import numpy as np
-from scipy.sparse import dok_matrix
+from scipy.sparse import dok_array
 
 import cvxpy.settings as s
 from cvxpy.constraints import SOC
@@ -289,8 +289,8 @@ class CPLEX(ConicSolver):
 
         c = data[s.C]
         b = data[s.B]
-        A = dok_matrix(data[s.A])
-        # Save the dok_matrix.
+        A = dok_array(data[s.A])
+        # Save the dok_array.
         data[s.A] = A
         dims = dims_to_solver_dict(data[s.DIMS])
 
@@ -410,8 +410,9 @@ class CPLEX(ConicSolver):
         constr, lin_expr, rhs = [], [], []
         csr = mat.tocsr()
         for i in rows:
-            ind = [variables[x] for x in csr[i].indices]
-            val = [x for x in csr[i].data]
+            row = csr[[i], :]
+            ind = [variables[x] for x in row.indices]
+            val = [x for x in row.data]
             lin_expr.append([ind, val])
             rhs.append(vec[i])
         # For better performance, we add the constraints in a batch.

--- a/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cplex_conif.py
@@ -455,8 +455,9 @@ class CPLEX(ConicSolver):
         lin_expr_list, soc_vars, lin_rhs = [], [], []
         csr = mat.tocsr()
         for i in rows:
-            ind = [variables[x] for x in csr[i].indices]
-            val = [x for x in csr[i].data]
+            row = csr[[i], :]
+            ind = [variables[x] for x in row.indices]
+            val = [x for x in row.data]
             # Ignore empty constraints.
             if ind:
                 lin_expr_list.append((ind, val))

--- a/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
@@ -18,7 +18,7 @@ import logging
 from typing import Any, Dict, Tuple
 
 from numpy import array, ndarray
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 
 import cvxpy.settings as s
 from cvxpy import Zero
@@ -74,7 +74,7 @@ class GLOP(ConicSolver):
 
         # Min c'x + d such that Ax + b = s, s \in cones.
         c, d, A, b = problem.apply_parameters()
-        A = csr_matrix(A)
+        A = csr_array(A)
         data["num_constraints"], data["num_vars"] = A.shape
 
         # TODO: Switch to a vectorized model-building interface when one is

--- a/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/gurobi_conif.py
@@ -152,7 +152,7 @@ class GUROBI(ConicSolver):
 
         c = data[s.C]
         b = data[s.B]
-        A = sp.csr_matrix(data[s.A])
+        A = sp.csr_array(data[s.A])
         dims = dims_to_solver_dict(data[s.DIMS])
 
         n = c.shape[0]

--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -189,14 +189,14 @@ class MOSEK(ConicSolver):
         val_arr = val_arr[np.nonzero(val_arr)]
 
         shape = (entries, rows*cols)
-        scaled_lower_tri = sp.sparse.csc_matrix((val_arr, (row_arr, col_arr)), shape)
+        scaled_lower_tri = sp.sparse.csc_array((val_arr, (row_arr, col_arr)), shape)
 
         idx = np.arange(rows * cols)
         val_symm = 0.5 * np.ones(2 * rows * cols)
         K = idx.reshape((rows, cols))
         row_symm = np.append(idx, np.ravel(K, order='F'))
         col_symm = np.append(idx, np.ravel(K.T, order='F'))
-        symm_matrix = sp.sparse.csc_matrix((val_symm, (row_symm, col_symm)))
+        symm_matrix = sp.sparse.csc_array((val_symm, (row_symm, col_symm)))
 
         return scaled_lower_tri @ symm_matrix
 

--- a/cvxpy/reductions/solvers/conic_solvers/nag_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/nag_conif.py
@@ -137,7 +137,7 @@ class NAG(ConicSolver):
         if Gs:
             data[s.G] = sp.sparse.vstack(tuple(Gs))
         else:
-            data[s.G] = sp.sparse.csc_matrix((0, 0))
+            data[s.G] = sp.sparse.csc_array((0, 0))
         if hs:
             data[s.H] = np.hstack(tuple(hs))
         else:
@@ -209,7 +209,7 @@ class NAG(ConicSolver):
         # Define quadratic objective if it exists
         if s.P in data:
             P = data[s.P]
-            Put = sp.sparse.triu(P, format='csc')
+            Put = sp.sparse.csc_array(sp.sparse.triu(P, format='csc'))
             Prows, Pcols, Pvals = sp.sparse.find(Put)
             Prows = Prows + 1
             Pcols = Pcols + 1

--- a/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
@@ -18,7 +18,7 @@ import logging
 from typing import Any, Dict, Tuple
 
 import numpy as np
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 
 import cvxpy.settings as s
 from cvxpy import Zero
@@ -74,7 +74,7 @@ class PDLP(ConicSolver):
 
         # Min c'x + d such that Ax + b = s, s \in cones.
         c, d, A, b = problem.apply_parameters()
-        A = csr_matrix(A)
+        A = csr_array(A)
         data["num_constraints"], data["num_vars"] = A.shape
 
         model = pdlp.QuadraticProgram()

--- a/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
@@ -18,7 +18,7 @@ import logging
 from typing import Any, Dict, Generic, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
-from scipy.sparse import dok_matrix
+from scipy.sparse import dok_array
 
 import cvxpy.settings as s
 from cvxpy import Zero
@@ -187,8 +187,8 @@ class SCIP(ConicSolver):
         """Define data parts from the data reference."""
         c = data[s.C]
         b = data[s.B]
-        A = dok_matrix(data[s.A])
-        # Save the dok_matrix.
+        A = dok_array(data[s.A])
+        # Save the dok_array.
         data[s.A] = A
         dims = dims_to_solver_dict(data[s.DIMS])
         return A, b, c, dims
@@ -213,7 +213,7 @@ class SCIP(ConicSolver):
             self,
             model: ScipModel,
             variables: List,
-            A: dok_matrix,
+            A: dok_array,
             b: np.ndarray,
             dims: Dict[str, Union[int, List]],
     ) -> List:
@@ -380,7 +380,7 @@ class SCIP(ConicSolver):
         variables: List,
         rows: Iterator,
         ctype: str,
-        A: dok_matrix,
+        A: dok_array,
         b: np.ndarray,
     ) -> List:
         """Adds EQ/LEQ constraints to the model using the data from mat and vec.
@@ -418,7 +418,7 @@ class SCIP(ConicSolver):
         model: ScipModel,
         variables: List,
         rows: Iterator,
-        A: dok_matrix,
+        A: dok_array,
         b: np.ndarray,
     ) -> Tuple:
         """Adds SOC constraint to the model using the data from mat and vec.

--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -192,6 +192,9 @@ class SCIPY(ConicSolver):
             G = data[s.G]
             if G is not None:
                 ineq = scipy.optimize.LinearConstraint(G, ub=data[s.H])
+                # ensure that index arrays are int32
+                ineq.A.indptr = ineq.A.indptr.astype(np.int32)
+                ineq.A.indices = ineq.A.indices.astype(np.int32)
                 constraints.append(ineq)
             A = data[s.A]
             if A is not None:
@@ -200,7 +203,7 @@ class SCIPY(ConicSolver):
             lb = [t[0] if t[0] is not None else -np.inf for t in bounds]
             ub = [t[1] if t[1] is not None else np.inf for t in bounds]
             bounds = scipy.optimize.Bounds(lb, ub)
-            solution = opt.milp(data[s.C], 
+            solution = opt.milp(data[s.C],
                                 constraints=constraints,
                                 options=solver_opts['scipy_options'],
                                 integrality=integrality,

--- a/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
@@ -192,14 +192,14 @@ class SCS(ConicSolver):
         val_arr = val_arr[np.nonzero(val_arr)]
 
         shape = (entries, rows*cols)
-        scaled_lower_tri = sp.csc_matrix((val_arr, (row_arr, col_arr)), shape)
+        scaled_lower_tri = sp.csc_array((val_arr, (row_arr, col_arr)), shape)
 
         idx = np.arange(rows * cols)
         val_symm = 0.5 * np.ones(2 * rows * cols)
         K = idx.reshape((rows, cols))
         row_symm = np.append(idx, np.ravel(K, order='F'))
         col_symm = np.append(idx, np.ravel(K.T, order='F'))
-        symm_matrix = sp.csc_matrix((val_symm, (row_symm, col_symm)))
+        symm_matrix = sp.csc_array((val_symm, (row_symm, col_symm)))
 
         return scaled_lower_tri @ symm_matrix
 

--- a/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
@@ -144,11 +144,13 @@ class COPT(QpSolver):
                 vtype[data[s.INT_IDX]] = copt.COPT.INTEGER
 
         # Load matrix data
-        model.loadMatrix(q, Amat, lhs, rhs, lb, ub, vtype)
+        # TODO remove `sp.csc_matrix` when COPT starts supporting sparray
+        model.loadMatrix(q, sp.csc_matrix(Amat), lhs, rhs, lb, ub, vtype)
 
         # Load Q data
         if P.count_nonzero():
-            P = P.tocoo()
+            # TODO switch to `P = P.tocoo()` when COPT supports sparray
+            P = sp.coo_matrix(P)
             model.loadQ(0.5*P)
 
         # Set parameters

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -77,7 +77,7 @@ class OSQP(QpSolver):
             factorizing = False
             if P.data.shape != old_data[s.P].data.shape or any(
                     P.data != old_data[s.P].data):
-                P_triu = sp.triu(P).tocsc()
+                P_triu = sp.csc_array(sp.triu(P, format='csc'))
                 new_args['Px'] = P_triu.data
                 factorizing = True
             if A.data.shape != old_data['Ax'].data.shape or any(

--- a/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
+++ b/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
@@ -87,20 +87,20 @@ class QpSolver(Solver):
             A = AF[:len_eq, :]
             b = -bg[:len_eq]
         else:
-            A, b = sp.csr_matrix((0, n)), -np.array([])
+            A, b = sp.csr_array((0, n)), -np.array([])
 
         if len_leq > 0:
             F = -AF[len_eq:, :]
             g = bg[len_eq:]
         else:
-            F, g = sp.csr_matrix((0, n)), -np.array([])
+            F, g = sp.csr_array((0, n)), -np.array([])
 
         # Create dictionary with problem data
-        data[s.P] = sp.csc_matrix(P)
+        data[s.P] = sp.csc_array(P)
         data[s.Q] = q
-        data[s.A] = sp.csc_matrix(A)
+        data[s.A] = sp.csc_array(A)
         data[s.B] = b
-        data[s.F] = sp.csc_matrix(F)
+        data[s.F] = sp.csc_array(F)
         data[s.G] = g
         data[s.BOOL_IDX] = [t[0] for t in problem.x.boolean_idx]
         data[s.INT_IDX] = [t[0] for t in problem.x.integer_idx]

--- a/cvxpy/reductions/utilities.py
+++ b/cvxpy/reductions/utilities.py
@@ -55,7 +55,7 @@ def special_index_canon(expr, args):
     select_vec = np.reshape(select_mat, select_mat.size, order='F')
     # Select the chosen entries from expr.
     arg = args[0]
-    identity = sp.eye(arg.size).tocsc()
+    identity = sp.eye_array(arg.size, format='csc')
     lowered = reshape(identity[select_vec] @ vec(arg, order='F'), final_shape, order='F')
     return lowered, []
 

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -498,10 +498,10 @@ class TestAtoms(BaseTest):
             cp.sum(Variable(2), axis=1).shape
         self.assertEqual(str(cm.exception), "axis 1 is out of bounds for array of dimension 1")
 
-        A = sp.eye(3)
+        A = sp.eye_array(3)
         self.assertEqual(cp.sum(A).value, 3)
 
-        A = sp.eye(3)
+        A = sp.eye_array(3)
         self.assertItemsAlmostEqual(cp.sum(A, axis=0).value, [1, 1, 1])
 
     def test_multiply(self) -> None:

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -135,7 +135,7 @@ class TestAttributes:
         prob = cp.Problem(cp.Minimize(cp.sum(X)), [X >= -1, X <= 1])
         prob.solve()
         z = -np.eye(3)
-        assert type(X.value) is sp.dia_matrix
+        assert sp.issparse(X.value) and X.value.format == "dia"
         assert np.allclose(X.value.toarray(), z)
 
     def test_variable_bounds(self):

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -496,7 +496,7 @@ class TestComplex(BaseTest):
         row = np.array([0, 1])
         col = np.array([1, 0])
         data = np.array([1j, -1j])
-        A = sp.csr_matrix((data, (row, col)), shape=(2, 2))
+        A = sp.csr_array((data, (row, col)), shape=(2, 2))
 
         # Feasibility with sparse matrix
         rho = cp.Variable((2, 2), complex=True)

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -208,7 +208,7 @@ class TestSlacks(BaseTest):
         cone_prog = ConicSolver.format_constraints(cone_prog, exp_cone_order=[0, 1, 2])
         data, inv_data = a2d.Slacks.apply(cone_prog, affine)
         G, h, f, K_dir, K_aff = data[s.A], data[s.B], data[s.C], data['K_dir'], data['K_aff']
-        G = sp.sparse.csc_matrix(G)
+        G = sp.sparse.csc_array(G)
         y = cp.Variable(shape=(G.shape[1],))
         objective = cp.Minimize(f @ y)
         aff_con = TestSlacks.set_affine_constraints(G, h, y, K_aff)

--- a/cvxpy/tests/test_dgp.py
+++ b/cvxpy/tests/test_dgp.py
@@ -247,5 +247,5 @@ class TestDgp(BaseTest):
         self.assertFalse((x**1).is_nonpos())
 
     def test_sparse_constant_not_allowed(self) -> None:
-        sparse_matrix = cvxpy.Constant(sp.csc_matrix(np.array([1.0, 2.0])))
+        sparse_matrix = cvxpy.Constant(sp.csc_array(np.array([[1.0, 2.0]])))
         self.assertFalse(sparse_matrix.is_log_log_constant())

--- a/cvxpy/tests/test_examples.py
+++ b/cvxpy/tests/test_examples.py
@@ -355,9 +355,9 @@ class TestExamples(BaseTest):
         n = 100  # 10000
         m = 10  # 100
 
-        F = sp.rand(m, n, density=0.01)
+        F = sp.random_array((m, n), density=0.01)
         F.data = np.ones(len(F.data))
-        D = sp.eye(n).tocoo()
+        D = sp.eye_array(n, format='coo')
         D.data = np.random.randn(len(D.data))**2
         Z = np.random.randn(m, 1)
         Z = Z.dot(Z.T)

--- a/cvxpy/tests/test_expression_methods.py
+++ b/cvxpy/tests/test_expression_methods.py
@@ -308,10 +308,10 @@ class TestExpressionMethods(BaseTest):
         self.assertEqual(str(cm.exception),
                         "axis 4 is out of bounds for array of dimension 1")
 
-        A = sp.eye(3)
+        A = sp.eye_array(3)
         self.assertEqual(Constant(A).sum().value, 3)
 
-        A = sp.eye(3)
+        A = sp.eye_array(3)
         self.assertItemsAlmostEqual(Constant(A).sum(axis=0).value, [1, 1, 1])
     def test_trace(self) -> None:
         """Test the trace atom.

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -270,7 +270,7 @@ class TestExpressions(BaseTest):
         self.assertFalse(P.is_nsd())
 
         # Check with sparse inputs
-        P = Constant(sp.eye(10))
+        P = Constant(sp.eye_array(10))
         self.assertTrue(gershgorin_psd_check(P.value, s.EIGVAL_TOL))
         self.assertTrue(P.is_psd())
         self.assertTrue((-P).is_nsd())
@@ -307,17 +307,17 @@ class TestExpressions(BaseTest):
         self.assertFalse(C.is_skew_symmetric())
 
         # Test sparse constants
-        C = Constant(sp.csc_matrix(M1_false))
+        C = Constant(sp.csc_array(M1_false))
         self.assertFalse(C.is_skew_symmetric())
-        C = Constant(sp.csc_matrix(M2_true))
+        C = Constant(sp.csc_array(M2_true))
         self.assertTrue(C.is_skew_symmetric())
-        C = Constant(sp.csc_matrix(M4_true))
+        C = Constant(sp.csc_array(M4_true))
         self.assertTrue(C.is_skew_symmetric())
-        C = Constant(sp.csc_matrix(M5_false))
+        C = Constant(sp.csc_array(M5_false))
         self.assertFalse(C.is_skew_symmetric())
-        C = Constant(sp.csc_matrix(M6_false))
+        C = Constant(sp.csc_array(M6_false))
         self.assertFalse(C.is_skew_symmetric())
-        C = Constant(sp.csc_matrix(M7_false))
+        C = Constant(sp.csc_array(M7_false))
         self.assertFalse(C.is_skew_symmetric())
 
         # Test complex inputs: never recognized as skew-symmetric.
@@ -368,7 +368,7 @@ class TestExpressions(BaseTest):
 
         # Test valid diagonal parameter.
         p = Parameter((2, 2), diag=True)
-        p.value = sp.csc_matrix(np.eye(2))
+        p.value = sp.csc_array(np.eye(2))
         self.assertItemsAlmostEqual(p.value.todense(), np.eye(2), places=10)
 
     def test_psd_nsd_parameters(self) -> None:
@@ -1409,7 +1409,7 @@ class TestExpressions(BaseTest):
 
         # QuadForm with sparse matrices
         x = Variable(shape=(2,))
-        A = Constant(sp.eye(2))
+        A = Constant(sp.eye_array(2))
         expr = x.T.__matmul__(A).__matmul__(x)
         assert isinstance(expr, cp.QuadForm)
 

--- a/cvxpy/tests/test_interfaces.py
+++ b/cvxpy/tests/test_interfaces.py
@@ -74,7 +74,7 @@ class TestInterfaces(BaseTest):
     def test_scipy_sparse(self) -> None:
         """Test cvxopt sparse interface.
         """
-        interface = intf.get_matrix_interface(sp.csc_matrix)
+        interface = intf.get_matrix_interface(sp.csc_array)
         # const_to_matrix
         mat = interface.const_to_matrix([1, 2, 3])
         self.assertEqual(interface.shape(mat), (3, 1))
@@ -105,7 +105,7 @@ class TestInterfaces(BaseTest):
         mat = interface.index(mat, (slice(1, 4, 2), slice(0, 2, None)))
         self.assertFalse((mat - np.array([[2, 4], [4, 6]])).any())
         # scalar value
-        mat = sp.eye(1)
+        mat = sp.eye_array(1)
         self.assertEqual(intf.scalar_value(mat), 1.0)
         # Sign
         self.sign_for_intf(interface)
@@ -114,7 +114,7 @@ class TestInterfaces(BaseTest):
         row = np.array([0, 1])
         col = np.array([1, 0])
         data = np.array([1j, -1j])
-        A = sp.csr_matrix((data, (row, col)), shape=(2, 2))
+        A = sp.csr_array((data, (row, col)), shape=(2, 2))
         mat = interface.const_to_matrix(A)
         self.assertEqual(mat[0, 1], 1j)
         self.assertEqual(mat[1, 0], -1j)
@@ -123,7 +123,7 @@ class TestInterfaces(BaseTest):
         """Test conversion between every pair of interfaces.
         """
         interfaces = [intf.get_matrix_interface(np.ndarray),
-                      intf.get_matrix_interface(sp.csc_matrix)]
+                      intf.get_matrix_interface(sp.csc_array)]
         cmp_mat = [[1, 2, 3, 4], [3, 4, 5, 6], [-1, 0, 2, 4]]
         for i in range(len(interfaces)):
             for j in range(i+1, len(interfaces)):

--- a/cvxpy/tests/test_lin_ops.py
+++ b/cvxpy/tests/test_lin_ops.py
@@ -81,11 +81,11 @@ class test_lin_ops(BaseTest):
 
         # Sparse matrix constant.
         shape = (5, 5)
-        mat = create_const(sp.eye(5), shape, sparse=True)
+        mat = create_const(sp.eye_array(5), shape, sparse=True)
         self.assertEqual(mat.shape, shape)
         self.assertEqual(len(mat.args), 0)
         self.assertEqual(mat.type, SPARSE_CONST)
-        assert (mat.data.todense() == sp.eye(5).todense()).all()
+        assert (mat.data.todense() == np.eye(5)).all()
 
     def test_add_expr(self) -> None:
         """Test adding lin expr.

--- a/cvxpy/tests/test_linalg_utils.py
+++ b/cvxpy/tests/test_linalg_utils.py
@@ -43,7 +43,7 @@ class TestSparseCholesky(BaseTest):
     @pytest.mark.skipif(missing_extension, reason="requires sparse_cholesky")
     def test_diagonal(self):
         np.random.seed(0)
-        A = spar.csc_matrix(np.diag(np.random.rand(4)))
+        A = spar.csc_array(np.diag(np.random.rand(4)))
         _, L, p = lau.sparse_cholesky(A, 0.0)
         self.check_factor(L)
         self.check_gram(L[p, :], A)
@@ -54,7 +54,7 @@ class TestSparseCholesky(BaseTest):
         n = 5
         diag = np.random.rand(n) + 0.1
         offdiag = np.min(np.abs(diag)) * np.ones(n - 1) / 2
-        A = spar.diags([offdiag, diag, offdiag], [-1, 0, 1])
+        A = spar.diags_array([offdiag, diag, offdiag], offsets=[-1, 0, 1])
         _, L, p = lau.sparse_cholesky(A, 0.0)
         self.check_factor(L)
         self.check_gram(L[p, :], A)
@@ -63,7 +63,7 @@ class TestSparseCholesky(BaseTest):
     def test_generic(self):
         np.random.seed(0)
         B = np.random.randn(3, 3)
-        A = spar.csc_matrix(B @ B.T)
+        A = spar.csc_array(B @ B.T)
         _, L, p = lau.sparse_cholesky(A)
         self.check_factor(L)
         self.check_gram(L[p, :], A)
@@ -84,6 +84,6 @@ class TestSparseCholesky(BaseTest):
         diag = np.random.rand(n) + 0.1
         diag[n-1] = -1
         offdiag = np.min(np.abs(diag)) * np.ones(n - 1) / 2
-        A = spar.diags([offdiag, diag, offdiag], [-1, 0, 1])
+        A = spar.diags_array([offdiag, diag, offdiag], offsets=[-1, 0, 1])
         with self.assertRaises(ValueError, msg=lau.SparseCholeskyMessages.INDEFINITE):
             lau.sparse_cholesky(A, 0.0)

--- a/cvxpy/tests/test_matrices.py
+++ b/cvxpy/tests/test_matrices.py
@@ -108,8 +108,8 @@ class TestMatrices(unittest.TestCase):
         """Test scipy sparse matrices."""
         # Constants.
         A = numpy.arange(8).reshape((4, 2))
-        A = sp.csc_matrix(A)
-        A = sp.eye(2).tocsc()
+        A = sp.csc_array(A)
+        A = sp.eye_array(2, format='csc')
         key = (slice(0, 1, None), slice(None, None, None))
         Aidx = intf.index(A, (slice(0, 2, None), slice(None, None, None)))
         Aidx = intf.index(Aidx, key)
@@ -120,7 +120,7 @@ class TestMatrices(unittest.TestCase):
         # Linear ops.
         var = Variable((4, 2))
         A = numpy.arange(8).reshape((4, 2))
-        A = sp.csc_matrix(A)
+        A = sp.csc_array(A)
         B = sp.hstack([A, A])
         self.assertExpression(var + A, (4, 2))
         self.assertExpression(A + var, (4, 2))

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1314,7 +1314,7 @@ class TestProblem(BaseTest):
 
         # Test with a sparse matrix.
         import scipy.sparse as sp
-        interface = intf.get_matrix_interface(sp.csc_matrix)
+        interface = intf.get_matrix_interface(sp.csc_array)
         c = interface.const_to_matrix([1, 2])
         c = cp.Constant(c)
         expr = self.x[:, None]/(1/c)
@@ -1347,7 +1347,7 @@ class TestProblem(BaseTest):
 
         # Test with a sparse matrix.
         import scipy.sparse as sp
-        interface = intf.get_matrix_interface(sp.csc_matrix)
+        interface = intf.get_matrix_interface(sp.csc_array)
         c = interface.const_to_matrix([1, 2])
         expr = cp.multiply(c, self.x[:, None])
         obj = cp.Minimize(cp.norm_inf(expr))

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -316,7 +316,7 @@ class TestQp(BaseTest):
         n = 80
         np.random.seed(1)
         density = 0.4
-        A = sp.rand(m, n, density)
+        A = sp.random_array((m, n), density=density)
         b = np.random.randn(m)
 
         p = Problem(Minimize(sum_squares(A @ self.xs - b)), [self.xs == 0])
@@ -355,7 +355,7 @@ class TestQp(BaseTest):
         data = [0.89, 0.39, 0.96, 0.34, 0.68, 0.18, 0.63 ,0.42, 0.51, 0.66, 0.43, 0.77]
         indices = [0, 1, 2, 3, 4, 2, 3, 0, 1, 2, 3, 4]
         indptr = [0, 5, 7, 12]
-        A = sp.csc_matrix((data, indices, indptr), shape=(m,n))
+        A = sp.csc_array((data, indices, indptr), shape=(m,n))
         x_true = np.random.randn(n) / np.sqrt(n)
         ind95 = (np.random.rand(m) < 0.95).astype(float)
         b = A.dot(x_true) + np.multiply(0.5*np.random.randn(m), ind95) \

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -75,14 +75,14 @@ class TestNonOptimal(BaseTest):
     def test_sparse_quad_form(self) -> None:
         """Test quad form with a sparse matrix.
         """
-        Q = sp.eye(2)
+        Q = sp.eye_array(2)
         x = cp.Variable(2)
         cost = cp.quad_form(x, Q)
         prob = cp.Problem(cp.Minimize(cost), [x == [1, 2]])
         self.assertAlmostEqual(prob.solve(solver=cp.OSQP), 5)
 
         # Here are our QP factors
-        A = cp.Constant(sp.eye(4))
+        A = cp.Constant(sp.eye_array(4))
         c = np.ones(4).reshape((1, 4))
 
         # Here is our optimization variable

--- a/cvxpy/utilities/coeff_extractor.py
+++ b/cvxpy/utilities/coeff_extractor.py
@@ -105,7 +105,7 @@ class CoeffExtractor:
         # and obtains the Pi and qi for that entry i.
         # These are then combined into matrices [P1.flatten(), P2.flatten(), ...]
         # and [q1, q2, ...]
-        constant = param_coeffs[-1, :]
+        constant = param_coeffs[[-1], :]
         # TODO keep sparse.
         c = param_coeffs[:-1, :].toarray()
         num_params = param_coeffs.shape[1]
@@ -269,7 +269,7 @@ class CoeffExtractor:
             P_list: List[TensorRepresentation],
             P_height: int, 
             num_params: int,
-        ) -> sp.csc_matrix:
+        ) -> sp.csc_array:
         """Conceptually we build a block diagonal matrix
            out of all the Ps, then flatten the first two dimensions.
            eg P1
@@ -306,9 +306,9 @@ class CoeffExtractor:
     def merge_q_list(
         self,
         q_list: List[sp.spmatrix | np.ndarray],
-        constant: sp.csc_matrix,
+        constant: sp.csc_array,
         num_params: int,
-    ) -> sp.csr_matrix:
+    ) -> sp.csr_array:
         """Stack q with constant offset as last row.
 
         Args:
@@ -323,7 +323,7 @@ class CoeffExtractor:
         if num_params == 1:
             q = np.vstack(q_list)
             q = np.vstack([q, constant.toarray()])
-            return sp.csr_matrix(q)
+            return sp.csr_array(q)
         else:
             q = sp.vstack(q_list + [constant])
-            return sp.csr_matrix(q)
+            return sp.csr_array(q)

--- a/cvxpy/utilities/grad.py
+++ b/cvxpy/utilities/grad.py
@@ -38,7 +38,7 @@ def constant_grad(expr):
         if (rows, cols) == (1, 1):
             grad[var] = 0.0
         else:
-            grad[var] = sp.csc_matrix((rows, cols), dtype='float64')
+            grad[var] = sp.csc_array((rows, cols), dtype='float64')
     return grad
 
 

--- a/cvxpy/utilities/linalg.py
+++ b/cvxpy/utilities/linalg.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy.linalg as la
 import scipy.sparse as spar
 import scipy.sparse.linalg as sparla
-from scipy.sparse import csc_matrix
+from scipy.sparse import csc_array
 
 import cvxpy.settings as settings
 
@@ -36,8 +36,8 @@ def onb_for_orthogonal_complement(V):
 
 
 def is_diagonal(A):
-    if isinstance(A, spar.spmatrix):
-        off_diagonal_elements = A - spar.diags(A.diagonal())
+    if spar.issparse(A):
+        off_diagonal_elements = A - spar.diags_array(A.diagonal())
         off_diagonal_elements = off_diagonal_elements.toarray()
     elif isinstance(A, np.ndarray):
         off_diagonal_elements = A - np.diag(np.diag(A))
@@ -66,8 +66,8 @@ def is_psd_within_tol(A, tol):
 
     Parameters
     ----------
-    A : Union[np.ndarray, spar.spmatrix]
-        Symmetric (or Hermitian) NumPy ndarray or SciPy sparse matrix.
+    A : Union[np.ndarray, spar.sparray]
+        Symmetric (or Hermitian) NumPy ndarray or SciPy sparse array.
 
     tol : float
         Nonnegative. Something very small, like 1e-10.
@@ -77,7 +77,7 @@ def is_psd_within_tol(A, tol):
         return True
 
     if is_diagonal(A):
-        if isinstance(A, csc_matrix):
+        if isinstance(A, csc_array):
             return np.all(A.data >= -tol)
         else:
             min_diag_entry = np.min(np.diag(A))
@@ -149,8 +149,8 @@ def gershgorin_psd_check(A, tol):
 
     Parameters
     ----------
-    A : Union[np.ndarray, spar.spmatrix]
-        Symmetric (or Hermitian) NumPy ndarray or SciPy sparse matrix.
+    A : Union[np.ndarray, spar.sparray]
+        Symmetric (or Hermitian) NumPy ndarray or SciPy sparse array.
 
     tol : float
         Nonnegative. Something very small, like 1e-10.
@@ -160,11 +160,11 @@ def gershgorin_psd_check(A, tol):
     True if A is PSD according to the Gershgorin Circle Theorem.
     Otherwise, return False.
     """
-    if isinstance(A, spar.spmatrix):
+    if spar.issparse(A):
         diag = A.diagonal()
         if np.any(diag < -tol):
             return False
-        A_shift = A - spar.diags(diag)
+        A_shift = A - spar.diags_array(diag)
         A_shift = np.abs(A_shift)
         radii = np.array(A_shift.sum(axis=0)).ravel()
         return np.all(diag - radii >= -tol)
@@ -205,7 +205,7 @@ def sparse_cholesky(A, sym_tol=settings.CHOL_SYM_TOL, assume_posdef=False):
     """
     import cvxpy.utilities.cpp.sparsecholesky as spchol  # noqa: I001
 
-    if not isinstance(A, spar.spmatrix):
+    if not spar.issparse(A):
         raise ValueError(SparseCholeskyMessages.NOT_SPARSE)
     if np.iscomplexobj(A):
         raise ValueError(SparseCholeskyMessages.NOT_REAL)
@@ -253,5 +253,5 @@ def sparse_cholesky(A, sym_tol=settings.CHOL_SYM_TOL, assume_posdef=False):
     outrows = np.array(outrows)
     outcols = np.array(outcols)
     outpivs = np.array(outpivs)
-    L = spar.csr_matrix((outvals, (outrows, outcols)), shape=(n, n))
+    L = spar.csr_array((outvals, (outrows, outcols)), shape=(n, n))
     return 1.0, L, outpivs

--- a/doc/source/examples/applications/l1_trend_filter.rst
+++ b/doc/source/examples/applications/l1_trend_filter.rst
@@ -51,7 +51,7 @@ Formulate and solve problem
     
     # Form second difference matrix.
     e = np.ones((1, n))
-    D = scipy.sparse.diags([e, -2*e, e], offsets=range(3), shape=(n-2, n))
+    D = scipy.sparse.diags_array([e, -2*e, e], offsets=range(3), shape=(n-2, n))
     
     # Set regularization parameter.
     vlambda = 50

--- a/doc/source/examples/applications/sparse_covariance_est.rst
+++ b/doc/source/examples/applications/sparse_covariance_est.rst
@@ -55,7 +55,7 @@ Generate problem data
     
     # Create sparse, symmetric PSD matrix S
     A = np.random.randn(n, n)  # Unit normal gaussian distribution.
-    A[scipy.sparse.rand(n, n, 0.85).todense().nonzero()] = 0  # Sparsen the matrix.
+    A[scipy.sparse.random_array((n, n), density=0.85).todense().nonzero()] = 0  # Sparsen A
     Strue = A.dot(A.T) + 0.05 * np.eye(n)  # Force strict pos. def.
     
     # Create the covariance matrix associated with S.

--- a/examples/expr_trees/performance.py
+++ b/examples/expr_trees/performance.py
@@ -34,8 +34,8 @@ prob.solve(verbose=True)
 # # Point = namedtuple('Point', ['x', 'y', 'z'])
 # cProfile.run("prob.solve()")
 # cProfile.run("prob.solve()")
-#cProfile.run("sp.eye(n*n).tocsc()")
-#cProfile.run("[sp.eye(n*n).tolil()[0:1000,:] for i in range(n)] ")
+#cProfile.run("sp.eye_array(n*n).tocsc()")
+#cProfile.run("[sp.eye_array(n*n).tolil()[0:1000,:] for i in range(n)] ")
 # cProfile.run("[Point(i, i, i) for i in xrange(n*n)]")
 
 # from qcml import QCML

--- a/examples/expr_trees/portfolio_profiler.py
+++ b/examples/expr_trees/portfolio_profiler.py
@@ -27,9 +27,9 @@ m = 100
 pbar = (np.ones((n, 1)) * .03 +
         np.matrix(np.append(np.random.rand(n - 1, 1), 0)).T * .12)
 
-F = sp.rand(m, n, density=0.01)
+F = sp.random_array((m, n), density=0.01)
 F.data = np.ones(len(F.data))
-D = sp.eye(n).tocoo()
+D = sp.eye_array(n, format='coo')
 D.data = np.random.randn(len(D.data))**2
 # num_points=100 # number of points in each vector
 # num_vects=m-1

--- a/examples/fig6_9.py
+++ b/examples/fig6_9.py
@@ -51,7 +51,7 @@ corrupt = cvxopt.matrix(corrupt)
 
 e = np.ones(n).T
 ee = np.column_stack((-e,e)).T
-D = sparse.diags(ee, offsets=range(-1,1), shape=(n, n))
+D = sparse.diags_array(ee, offsets=range(-1,1), shape=(n, n))
 D = D.todense()
 D = cvxopt.matrix(D)
 

--- a/examples/notebooks/WWW/l1_trend_filter.ipynb
+++ b/examples/notebooks/WWW/l1_trend_filter.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "# Form second difference matrix.\n",
     "e = np.ones((1, n))\n",
-    "D = scipy.sparse.diags([e, -2*e, e], offsets=range(3), shape=(n-2, n))\n",
+    "D = scipy.sparse.diags_array([e, -2*e, e], offsets=range(3), shape=(n-2, n))\n",
     "\n",
     "# Set regularization parameter.\n",
     "vlambda = 50\n",

--- a/examples/notebooks/WWW/sparse_covariance_est.ipynb
+++ b/examples/notebooks/WWW/sparse_covariance_est.ipynb
@@ -55,7 +55,7 @@
     "\n",
     "# Create sparse, symmetric PSD matrix S\n",
     "A = np.random.randn(n, n)  # Unit normal gaussian distribution.\n",
-    "A[scipy.sparse.rand(n, n, 0.85).todense().nonzero()] = 0  # Sparsen the matrix.\n",
+    "A[scipy.sparse.random_array((n, n), density=0.85).todense().nonzero()] = 0  # Sparsen A\n",
     "Strue = A.dot(A.T) + 0.05 * np.eye(n)  # Force strict pos. def.\n",
     "\n",
     "# Create the covariance matrix associated with S.\n",

--- a/examples/notebooks/building_models_with_fast_compile_times.ipynb
+++ b/examples/notebooks/building_models_with_fast_compile_times.ipynb
@@ -66,7 +66,7 @@
     "\n",
     "def gen_A_b_c(m, n):\n",
     "    # Generate data for a linear program which is guaranteed to be feasible.\n",
-    "    A = scipy.sparse.rand(m, n, density=0.1).toarray()\n",
+    "    A = scipy.sparse.random_array((m, n), density=0.1).toarray()\n",
     "    x0 = np.random.rand(n, 1)\n",
     "    b = np.dot(A, x0)\n",
     "    c = np.random.randn(n, 1)\n",


### PR DESCRIPTION
This PR works through "pass 2" of the [scipy.sparse migration guide from sparray to spmatrix](https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html). It is a large diff with lots of changes, but each is hopefully easy to understand as one of the following:

- change from `sp.eye()` to `sp.eye_array()`, `sp.diags()` to `sp.diags_array()`, `sp.random()` to `sp.random_array()`, `sp.bmat()` to `sp.block_array()`.
- change from `*_matrix` to `*_array` for sparse constructors.
- convert the index arrays of the `csc_array` to int32 instead of int64 so it can run with pyamg and scipy.sparse/linalg. 
- wrap `tril(np.ones(dim,dim))` inside `csc_array` to ensure it creates as sparray
- change `tensor_type` to return `(spmatrix, sparray)` so any `isinstance` checks allow either type.
- change type checking on sparse to use idioms like `sp.issparse(A)` and `A.format == "dia"`.
- change indexing from `A[:, -1]` to `A[:, [-1]]` which gives 2D output for both spmatrix and sparray.
- adjust shape manipulations usually something like `[sp.csc_array([D.ravel(order='F')]).T]` [an extra square bracket is added around the ravel to ensure the csc_array is 2D before transposing].  Some other places it looks like `np.atleast2d(...)`.

The handling of SpasreArrayInterface could be treated differently if you like. For example, we could keep the name SparseMatrixInterface, and still point both classes to that.  But this is what I did: 
- rename SparseMatrixInterface to SparseArrayInterface and add entires for both `csc_matrix` and `csc_array` to INTERFACES dict that both point to the same interface.

By far the most changes are just `csc_array` to `csc_matrix`.

-----------------------
The way I have done this, it allows inputs to be spmatrix, but created outputs are always sparray.  More effort would be needed to do something like: any function that currently returns an spmatrix would get a keyword arg to indicate which to return.  While that approach might allow people who use the returned sparse obj to continue their use of `*` for matrix multiply instead of `@`, I hope they are willing to either update their code to use `@` and to replace `**p` with `sp.linalg.matrix_power(A, p)`, OR  they could wrap the return sparse objects in `csc_matrix()` when needed.  But ultimately that is your choice based on your culture and your users reactions.

Let me know if there is anything I can to do simplify review of this monster. :}