### PR TITLE
docs: add links to interactive marimo examples

### DIFF
--- a/doc/source/examples/index.rst
+++ b/doc/source/examples/index.rst
@@ -13,31 +13,50 @@ These examples show many different ways to use CVXPY.
 
 There are also application-specific sections.
 
+* The :ref:`basic-applications` section shows real-world applications of
+  common optimization problems.
 * The :ref:`machine-learning` section is a tutorial on convex optimization in
   machine learning.
 * The :ref:`advanced-python` and :ref:`applications` sections contains
   more complex examples for experts in convex optimization.
-  
+
+Most of these examples are implemented as `Jupyter notebooks
+<https://github.com/jupyter/notebook>`_, while some are implemented as
+interactive `marimo notebooks <https://github.com/marimo-team/marimo>`_.
+
+
 .. _basic:
 
 Basic examples
 --------------
 
-- :doc:`Least squares <basic/least_squares>` `[.ipynb] <https://colab.research.google.com/github/cvxpy/cvxpy/blob/master/examples/notebooks/WWW/least_squares.ipynb>`_
+*For geometric interpretations of linear and quadratic programs, see the marimo links.*
 
-- :doc:`Linear program <basic/linear_program>` `[.ipynb] <https://colab.research.google.com/github/cvxpy/cvxpy/blob/master/examples/notebooks/WWW/linear_program.ipynb>`_
+- :doc:`Least squares <basic/least_squares>` `[.ipynb] <https://colab.research.google.com/github/cvxpy/cvxpy/blob/master/examples/notebooks/WWW/least_squares.ipynb>`_ `[marimo] <https://marimo.app/gh/marimo-team/learn/main?entrypoint=optimization%2F01_least_squares.py>`_
 
-- :doc:`Quadratic program <basic/quadratic_program>` `[.ipynb] <https://colab.research.google.com/github/cvxpy/cvxpy/blob/master/examples/notebooks/WWW/quadratic_program.ipynb>`_
+- :doc:`Linear program <basic/linear_program>` `[.ipynb] <https://colab.research.google.com/github/cvxpy/cvxpy/blob/master/examples/notebooks/WWW/linear_program.ipynb>`_ `[marimo] <https://marimo.app/gh/marimo-team/learn/main?entrypoint=optimization%2F02_linear_program.py>`_
 
-- :doc:`Second-order cone program <basic/socp>` `[.ipynb] <https://colab.research.google.com/github/cvxpy/cvxpy/blob/master/examples/notebooks/WWW/socp.ipynb>`_
+- :doc:`Quadratic program <basic/quadratic_program>` `[.ipynb] <https://colab.research.google.com/github/cvxpy/cvxpy/blob/master/examples/notebooks/WWW/quadratic_program.ipynb>`_ `[marimo] <https://marimo.app/gh/marimo-team/learn/main?entrypoint=optimization%2F04_quadratic_program.py>`_
 
-- :doc:`Semidefinite program <basic/sdp>` `[.ipynb] <https://colab.research.google.com/github/cvxpy/cvxpy/blob/master/examples/notebooks/WWW/sdp.ipynb>`_
+- :doc:`Semidefinite program <basic/sdp>` `[.ipynb] <https://colab.research.google.com/github/cvxpy/cvxpy/blob/master/examples/notebooks/WWW/sdp.ipynb>`_ `[marimo] <https://marimo.app/gh/marimo-team/learn/main?entrypoint=optimization%2F07_sdp.py>`_
+
+- `Disciplined convex programming <https://marimo.app/gh/marimo-team/learn/main?entrypoint=optimization%2F06_convex_optimization.py>`_
 
 - :doc:`Mixed-integer quadratic program <basic/mixed_integer_quadratic_program>` `[.ipynb] <https://colab.research.google.com/github/cvxpy/cvxpy/blob/master/examples/notebooks/WWW/mixed_integer_quadratic_program.ipynb>`_
 
-- `Control <https://colab.research.google.com/github/cvxgrp/cvx_short_course/blob/master/book/docs/intro/notebooks/control.ipynb>`_
 
-- `Portfolio optimization <https://colab.research.google.com/github/cvxgrp/cvx_short_course/blob/master/book/docs/applications/notebooks/portfolio_optimization.ipynb>`_
+.. _basic-applications:
+
+Basic applications
+------------------
+
+- `Minimum-fuel optimal control <https://marimo.app/gh/marimo-team/learn/main?entrypoint=optimization%2F03_minimum_fuel_optimal_control.py>`_
+
+- `Markowitz portfolio optimization <https://marimo.app/gh/marimo-team/learn/main?entrypoint=optimization%2F05_portfolio_optimization.py>`_
+
+- `More control <https://colab.research.google.com/github/cvxgrp/cvx_short_course/blob/master/book/docs/intro/notebooks/control.ipynb>`_
+
+- `Beyond Markowitz portoflio optimization <https://colab.research.google.com/github/cvxgrp/cvx_short_course/blob/master/book/docs/applications/notebooks/portfolio_optimization.ipynb>`_
 
 - `Worst-case risk analysis <https://colab.research.google.com/github/cvxgrp/cvx_short_course/blob/master/book/docs/applications/notebooks/worst_case_analysis.ipynb>`_
 
@@ -119,6 +138,8 @@ Finance
 Advanced
 --------
 
+- :doc:`Second-order cone program <basic/socp>` `[.ipynb] <https://colab.research.google.com/github/cvxpy/cvxpy/blob/master/examples/notebooks/WWW/socp.ipynb>`_
+
 - :doc:`Object-oriented convex optimization <applications/OOCO>` `[.ipynb] <https://colab.research.google.com/github/cvxpy/cvxpy/blob/master/examples/notebooks/WWW/OOCO.ipynb>`_
 
 - :doc:`Consensus optimization <applications/consensus_opt>` `[.ipynb] <https://colab.research.google.com/github/cvxpy/cvxpy/blob/master/examples/notebooks/WWW/consensus_opt.ipynb>`_
@@ -127,7 +148,7 @@ Advanced
 
 .. _applications:
 
-Advanced Applications
+Advanced applications
 ---------------------
 
 - :doc:`Allocating interdiction effort to catch a smuggler <applications/interdiction>` `[.ipynb] <https://colab.research.google.com/github/cvxpy/cvxpy/blob/master/examples/notebooks/WWW/interdiction.ipynb>`_


### PR DESCRIPTION
## Description

This change adds links to interactive marimo examples for:

1. least squares
2. linear programs
3. quadratic programs
4. generic convex optimization (which points the reader to the DCP docs)
5. SDPs
6. minimum fuel optimal control
7. markowitz portfolio optimization

Examples 2, 3, 6, and 7 have interesting interactive components and visualizations that hopefully help the reader better understand the topic at hand.

Additionally, this change splits up "basic examples" into "basic examples" and "basic applications", to make the simpler application notebooks more discoverable. The SOCP example was moved into Advanced; it manually uses an `SOC` constraint, which feels very not basic to me.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)

This is purely a docs change, so these are vacuously true.

- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.