### PR TITLE
Added workflow to install and test optional solvers

### DIFF
--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -37,9 +37,9 @@ jobs:
         run: |
           source continuous_integration/install_optional_solvers.sh
           pip install . pytest hypothesis
-      - name: Print installed solvers
-        run : |
-          python -c "import cvxpy; print(cvxpy.installed_solvers())" 
+      # - name: Print installed solvers
+      #   run : |
+      #     python -c "import cvxpy; print(cvxpy.installed_solvers())" 
       - name: Run test_conic_solvers
         run : |
           pytest -rs cvxpy/tests/test_conic_solvers.py

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -9,7 +9,11 @@ on:
           - '*'
 jobs:
   test_optional_solvers:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-22.04, macos-13, windows-2022 ]
     steps:
       - uses: actions/checkout@v4
       - name: Set Additional Envs

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -1,0 +1,36 @@
+name: test_optional_solvers
+
+on:
+    pull_request:
+    push:
+        branches:
+            - master
+        tags:
+          - '*'
+jobs:
+  test_optional_solvers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set Additional Envs
+        run: |
+          echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
+          echo $MOSEK_CI_BASE64 | base64 -d > mosek.lic
+          echo "MOSEKLM_LICENSE_FILE=$( [[ $RUNNER_OS == 'macOS' ]] && echo $(pwd)/mosek.lic || echo $(realpath mosek.lic) )" >> $GITHUB_ENV
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: 3.12
+          channels: conda-forge,anaconda
+      - uses: actions/checkout@v4
+      - name: Install cvxpy dependencies and all optional solvers
+        run: |
+          source continuous_integration/install_optional_solvers.sh
+          pip install . pytest hypothesis
+      - name: Print installed solvers
+        run : |
+          python -c "import cvxpy; print(cvxpy.installed_solvers())" 
+      - name: Run test_conic_solvers
+        run : |
+          pytest -rs cvxpy/tests/test_conic_solvers.py
+

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -27,6 +27,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.12
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: 3.12
+          channels: conda-forge,anaconda
       - uses: actions/checkout@v4
       - name: Install cvxpy dependencies and all optional solvers
         run: |

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set Additional Envs
+        shell: bash
         run: |
           echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
           echo $MOSEK_CI_BASE64 | base64 -d > mosek.lic

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   test_optional_solvers:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       fail-fast: false
       matrix:
@@ -17,11 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set Additional Envs
-        shell: bash
         run: |
           echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
           echo $MOSEK_CI_BASE64 | base64 -d > mosek.lic
           echo "MOSEKLM_LICENSE_FILE=$( [[ $RUNNER_OS == 'macOS' ]] && echo $(pwd)/mosek.lic || echo $(realpath mosek.lic) )" >> $GITHUB_ENV
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
@@ -29,7 +34,6 @@ jobs:
           channels: conda-forge,anaconda
       - uses: actions/checkout@v4
       - name: Install cvxpy dependencies and all optional solvers
-        shell: bash
         run: |
           source continuous_integration/install_optional_solvers.sh
           pip install . pytest hypothesis
@@ -39,8 +43,3 @@ jobs:
       - name: Run test_conic_solvers
         run : |
           pytest -rs cvxpy/tests/test_conic_solvers.py
-
-    env:
-      RUNNER_OS: ${{ matrix.os }}
-      PYTHON_VERSION: 3.12
-      

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -29,6 +29,7 @@ jobs:
           channels: conda-forge,anaconda
       - uses: actions/checkout@v4
       - name: Install cvxpy dependencies and all optional solvers
+        shell: bash
         run: |
           source continuous_integration/install_optional_solvers.sh
           pip install . pytest hypothesis

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -39,3 +39,7 @@ jobs:
         run : |
           pytest -rs cvxpy/tests/test_conic_solvers.py
 
+    env:
+      RUNNER_OS: ${{ matrix.os }}
+      PYTHON_VERSION: 3.12
+      

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -37,9 +37,9 @@ jobs:
         run: |
           source continuous_integration/install_optional_solvers.sh
           pip install . pytest hypothesis
-      # - name: Print installed solvers
-      #   run : |
-      #     python -c "import cvxpy; print(cvxpy.installed_solvers())" 
+      - name: Print installed solvers
+        run : |
+          python -c "import cvxpy; print(cvxpy.installed_solvers())" 
       - name: Run test_conic_solvers
         run : |
           pytest -rs cvxpy/tests/test_conic_solvers.py

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -27,11 +27,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.12
-      - uses: conda-incubator/setup-miniconda@v3
-        with:
-          auto-update-conda: true
-          python-version: 3.12
-          channels: conda-forge,anaconda
       - uses: actions/checkout@v4
       - name: Install cvxpy dependencies and all optional solvers
         run: |
@@ -43,3 +38,7 @@ jobs:
       - name: Run test_conic_solvers
         run : |
           pytest -rs cvxpy/tests/test_conic_solvers.py
+
+    env:
+      RUNNER_OS: ${{ matrix.os }}
+      PYTHON_VERSION: 3.12

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -11,52 +11,14 @@ conda config --set remote_backoff_factor 2
 conda config --set remote_read_timeout_secs 120.0
 conda install mkl pip pytest pytest-cov hypothesis openblas "setuptools>65.5.1"
 
-if [[ "$PYTHON_VERSION" != "3.13" ]]; then
-  conda install ecos scs proxsuite daqp
-  python -m pip install coptpy==7.1.7 gurobipy piqp clarabel osqp highspy
-else
-  # only install the essential solvers for Python 3.13.
-  conda install scs
-  python -m pip install clarabel osqp
-fi
+conda install scs
+python -m pip install clarabel osqp
 
 # Install newest stable versions for Python 3.13.
 if [[ "$PYTHON_VERSION" == "3.13" ]]; then
   conda install scipy numpy
 else
   conda install scipy=1.13.0 numpy=1.26.4
-fi
-
-if [[ "$PYTHON_VERSION" == "3.11" ]]; then
-  python -m pip install cplex "ortools>=9.7,<9.12"
-fi
-
-if [[ "$RUNNER_OS" == "Windows" ]] && [[ "$PYTHON_VERSION" != "3.13" ]]; then
-  # SDPA with OpenBLAS backend does not pass LP5 on Windows
-  python -m pip install sdpa-multiprecision
-fi
-
-if [[ "$RUNNER_OS" != "Windows" ]] && [[ "$PYTHON_VERSION" != "3.13" ]]; then
-  conda install cvxopt
-fi
-
-if [[ "$PYTHON_VERSION" == "3.12" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then
-  # cylp has no wheels for Windows
-  python -m pip install cylp pyscipopt==5.2.1
-fi
-
-if [[ "$PYTHON_VERSION" == "3.10" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then
-  # SDPA didn't pass LP5 on Ubuntu for Python 3.9 and 3.12
-  python -m pip install sdpa-python
-fi
-
-if [[ "$PYTHON_VERSION" == "3.11" ]] && [[ "$RUNNER_OS" != "macOS" ]]; then
-  python -m pip install xpress==9.4.3
-fi
-
-# Only install Mosek if license is available (secret is not copied to forks)
-if [[ -n "$MOSEK_CI_BASE64" ]] && [[ "$PYTHON_VERSION" != "3.13" ]]; then
-    python -m pip install mosek
 fi
 
 if [[ "$USE_OPENMP" == "True" ]]; then

--- a/continuous_integration/install_optional_solvers.sh
+++ b/continuous_integration/install_optional_solvers.sh
@@ -16,7 +16,7 @@ else
   python -m pip install clarabel osqp
 fi
 
-if [[ "$PYTHON_VERSION" == "3.11" ]]; then
+if [[ "$PYTHON_VERSION" == "3.12" ]]; then
   python -m pip install cplex "ortools>=9.7,<9.12"
 fi
 
@@ -39,12 +39,12 @@ if [[ "$PYTHON_VERSION" == "3.12" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then
   python -m pip install cylp pyscipopt==5.2.1
 fi
 
-if [[ "$PYTHON_VERSION" == "3.10" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then
+if [[ "$PYTHON_VERSION" == "3.12" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then
   # SDPA didn't pass LP5 on Ubuntu for Python 3.9 and 3.12
   python -m pip install sdpa-python
 fi
 
-if [[ "$PYTHON_VERSION" == "3.11" ]] && [[ "$RUNNER_OS" != "macOS" ]]; then
+if [[ "$PYTHON_VERSION" == "3.12" ]] && [[ "$RUNNER_OS" != "macOS" ]]; then
   python -m pip install xpress==9.4.3
 fi
 

--- a/continuous_integration/install_optional_solvers.sh
+++ b/continuous_integration/install_optional_solvers.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+conda config --set remote_connect_timeout_secs 30.0
+conda config --set remote_max_retries 10
+conda config --set remote_backoff_factor 2
+conda config --set remote_read_timeout_secs 120.0
+
+if [[ "$PYTHON_VERSION" != "3.13" ]]; then
+  pip install ecos scs proxsuite daqp
+  python -m pip install coptpy==7.1.7 gurobipy piqp clarabel osqp highspy
+else
+  # only install the essential solvers for Python 3.13.
+  pip install scs
+  python -m pip install clarabel osqp
+fi
+
+if [[ "$PYTHON_VERSION" == "3.11" ]]; then
+  python -m pip install cplex "ortools>=9.7,<9.12"
+fi
+
+if [[ "$RUNNER_OS" != "Windows" ]]; then
+  # qoco has no wheels for Windows
+  python -m pip install qoco
+fi
+
+if [[ "$RUNNER_OS" == "Windows" ]] && [[ "$PYTHON_VERSION" != "3.13" ]]; then
+  # SDPA with OpenBLAS backend does not pass LP5 on Windows
+  python -m pip install sdpa-multiprecision
+fi
+
+if [[ "$RUNNER_OS" != "Windows" ]] && [[ "$PYTHON_VERSION" != "3.13" ]]; then
+  python -m pip install cvxopt
+fi
+
+if [[ "$PYTHON_VERSION" == "3.12" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then
+  # cylp has no wheels for Windows
+  python -m pip install cylp pyscipopt==5.2.1
+fi
+
+if [[ "$PYTHON_VERSION" == "3.10" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then
+  # SDPA didn't pass LP5 on Ubuntu for Python 3.9 and 3.12
+  python -m pip install sdpa-python
+fi
+
+if [[ "$PYTHON_VERSION" == "3.11" ]] && [[ "$RUNNER_OS" != "macOS" ]]; then
+  python -m pip install xpress==9.4.3
+fi
+
+# Only install Mosek if license is available (secret is not copied to forks)
+if [[ -n "$MOSEK_CI_BASE64" ]] && [[ "$PYTHON_VERSION" != "3.13" ]]; then
+    python -m pip install mosek
+fi

--- a/continuous_integration/install_optional_solvers.sh
+++ b/continuous_integration/install_optional_solvers.sh
@@ -9,11 +9,17 @@ conda config --set remote_read_timeout_secs 120.0
 
 if [[ "$PYTHON_VERSION" != "3.13" ]]; then
   pip install ecos scs proxsuite daqp
-  python -m pip install coptpy==7.1.7 gurobipy piqp clarabel osqp highspy
+  python -m pip install gurobipy piqp clarabel osqp highspy
 else
   # only install the essential solvers for Python 3.13.
   pip install scs
   python -m pip install clarabel osqp
+fi
+
+if [[ "$PYTHON_VERSION" != "3.13" ]] && [[ "$RUNNER_OS" != "macOS" ]]; then
+  # coptpy does not have wheels for macos-13, only macos-10, 
+  # but the runners are on macos-13, so do not install coptpy for macos.
+  python -m pip install coptpy==7.1.7
 fi
 
 if [[ "$PYTHON_VERSION" == "3.12" ]]; then

--- a/continuous_integration/install_optional_solvers.sh
+++ b/continuous_integration/install_optional_solvers.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+conda config --set remote_connect_timeout_secs 30.0
+conda config --set remote_max_retries 10
+conda config --set remote_backoff_factor 2
+conda config --set remote_read_timeout_secs 120.0
+conda install pip
+
 if [[ "$PYTHON_VERSION" != "3.13" ]]; then
   python -m pip install ecos scs proxsuite daqp gurobipy piqp clarabel osqp highspy
 else

--- a/continuous_integration/install_optional_solvers.sh
+++ b/continuous_integration/install_optional_solvers.sh
@@ -3,22 +3,21 @@
 set -e
 
 if [[ "$PYTHON_VERSION" != "3.13" ]]; then
-  pip install ecos scs proxsuite daqp
-  python -m pip install gurobipy piqp clarabel osqp highspy
+  python -m pip install ecos scs proxsuite daqp gurobipy piqp clarabel osqp highspy
 else
   # only install the essential solvers for Python 3.13.
-  pip install scs
-  python -m pip install clarabel osqp
+  python -m pip install scs clarabel osqp
 fi
 
 if [[ "$PYTHON_VERSION" != "3.13" ]] && [[ "$RUNNER_OS" != "macOS" ]]; then
   # coptpy does not have wheels for macos-13, only macos-10, 
   # but the runners are on macos-13, so do not install coptpy for macos.
-  python -m pip install coptpy==7.1.7
+  # cplex does not have macos wheels
+  python -m pip install coptpy==7.1.7 cplex
 fi
 
 if [[ "$PYTHON_VERSION" == "3.12" ]]; then
-  python -m pip install cplex "ortools>=9.7,<9.12"
+  python -m pip install "ortools>=9.7,<9.12"
 fi
 
 if [[ "$RUNNER_OS" != "Windows" ]]; then

--- a/continuous_integration/install_optional_solvers.sh
+++ b/continuous_integration/install_optional_solvers.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-conda config --set remote_connect_timeout_secs 30.0
-conda config --set remote_max_retries 10
-conda config --set remote_backoff_factor 2
-conda config --set remote_read_timeout_secs 120.0
-conda install pip
 if [[ "$PYTHON_VERSION" != "3.13" ]]; then
   pip install ecos scs proxsuite daqp
   python -m pip install gurobipy piqp clarabel osqp highspy

--- a/continuous_integration/install_optional_solvers.sh
+++ b/continuous_integration/install_optional_solvers.sh
@@ -15,20 +15,8 @@ else
   python -m pip install scs clarabel osqp
 fi
 
-if [[ "$PYTHON_VERSION" != "3.13" ]] && [[ "$RUNNER_OS" != "macOS" ]]; then
-  # coptpy does not have wheels for macos-13, only macos-10, 
-  # but the runners are on macos-13, so do not install coptpy for macos.
-  # cplex does not have macos wheels
-  python -m pip install coptpy==7.1.7 cplex
-fi
-
 if [[ "$PYTHON_VERSION" == "3.12" ]]; then
   python -m pip install "ortools>=9.7,<9.12"
-fi
-
-if [[ "$RUNNER_OS" != "Windows" ]]; then
-  # qoco has no wheels for Windows
-  python -m pip install qoco
 fi
 
 if [[ "$RUNNER_OS" == "Windows" ]] && [[ "$PYTHON_VERSION" != "3.13" ]]; then
@@ -42,16 +30,16 @@ fi
 
 if [[ "$PYTHON_VERSION" == "3.12" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then
   # cylp has no wheels for Windows
-  python -m pip install cylp pyscipopt==5.2.1
+  python -m pip install cylp qoco
 fi
 
-if [[ "$PYTHON_VERSION" == "3.12" ]] && [[ "$RUNNER_OS" != "Windows" ]]; then
+if [[ "$PYTHON_VERSION" == "3.12" ]] && [[ "$RUNNER_OS" != "Ubuntu" ]]; then
   # SDPA didn't pass LP5 on Ubuntu for Python 3.9 and 3.12
   python -m pip install sdpa-python
 fi
 
 if [[ "$PYTHON_VERSION" == "3.12" ]] && [[ "$RUNNER_OS" != "macOS" ]]; then
-  python -m pip install xpress==9.4.3
+  python -m pip install xpress==9.4.3 coptpy==7.1.7 cplex
 fi
 
 # Only install Mosek if license is available (secret is not copied to forks)

--- a/continuous_integration/install_optional_solvers.sh
+++ b/continuous_integration/install_optional_solvers.sh
@@ -6,7 +6,7 @@ conda config --set remote_connect_timeout_secs 30.0
 conda config --set remote_max_retries 10
 conda config --set remote_backoff_factor 2
 conda config --set remote_read_timeout_secs 120.0
-
+conda install pip
 if [[ "$PYTHON_VERSION" != "3.13" ]]; then
   pip install ecos scs proxsuite daqp
   python -m pip install gurobipy piqp clarabel osqp highspy


### PR DESCRIPTION
## Description
This PR creates a new file in `continuous_integration/` called `install_optional_solvers.sh`, which moves the installation of optional solvers from  `install_dependencies.sh` so that the failure of optional solver unit tests does not affect the cvxpy build. A new workflow is also created titled `test_optional_solvers.yml` which calls `install_optional_solvers.sh` and runs unit tests for the optional solvers.

## Type of change
- [x] CI

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.