### PR TITLE
Swap order of `passOptions` and `passModel` in HiGHS interface

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
@@ -211,8 +211,8 @@ class HIGHS(ConicSolver):
             setattr(options, key, value)
 
         solver = hp.Highs()
-        solver.passModel(model)
         solver.passOptions(options)
+        solver.passModel(model)
 
         # initialize and solve problem
         try:

--- a/cvxpy/reductions/solvers/qp_solvers/highs_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/highs_qpif.py
@@ -184,8 +184,8 @@ class HIGHS(QpSolver):
             setattr(options, key, value)
 
         solver = hp.Highs()
-        solver.passModel(model)
         solver.passOptions(options)
+        solver.passModel(model)
 
         if warm_start and solver_cache is not None and self.name() in solver_cache:
             old_solver, old_data, old_result = solver_cache[self.name()]


### PR DESCRIPTION
## Description
Currently, when using the CVXPY interface to `highspy`, the message `Running HiGHS 1.9.0 (git hash: fa40bdf): Copyright (c) 2024 HiGHS under MIT licence terms` is logged to standard output even if `output_flag` is set to `False`. Here's a minimum working example:
```python
import cvxpy as cp

x = cp.Variable(nonneg=True)
problem = cp.Problem(cp.Minimize(x))
problem.solve(solver="HIGHS", output_flag=False)
```
This pull request swaps the order of `passOptions` and `passModel` to ensure that options are set prior to model instantiation, when the logging seems to be triggered.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.