### PR TITLE
Fix failing optional solvers

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/ecos_bb_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/ecos_bb_conif.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from scipy import sparse
 
 import cvxpy.interface as intf
 import cvxpy.settings as s
@@ -117,8 +118,16 @@ class ECOS_BB(ECOS):
             del solver_opts['mi_verbose']
         else:
             mi_verbose = verbose
-        solution = ecos.solve(data[s.C], data[s.G], data[s.H],
-                              cones, data[s.A], data[s.B],
+
+        # Convert csc_array to csc_matrix
+        G = data[s.G]
+        A = data[s.A]
+        if G is not None:
+            G = sparse.csc_matrix((G.data, G.indices, G.indptr), shape=G.shape)
+        if A is not None:
+            A = sparse.csc_matrix((A.data, A.indices, A.indptr), shape=A.shape)
+        solution = ecos.solve(data[s.C], G, data[s.H],
+                              cones, A, data[s.B],
                               verbose=verbose,
                               mi_verbose=mi_verbose,
                               bool_vars_idx=data[s.BOOL_IDX],

--- a/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import numpy as np
+from scipy import sparse
 
 import cvxpy.interface as intf
 import cvxpy.settings as s
@@ -134,8 +135,17 @@ class ECOS(ConicSolver):
                 "ECOS cannot handle sparse data with nnz == 0; "
                 "this is a bug in ECOS, and it indicates that your problem "
                 "might have redundant constraints.")
-        solution = ecos.solve(data[s.C], data[s.G], data[s.H],
-                              cones, data[s.A], data[s.B],
+
+        # Convert csc_array to csc_matrix
+        G = data[s.G]
+        A = data[s.A]
+        if G is not None:
+            G = sparse.csc_matrix((G.data, G.indices, G.indptr), shape=G.shape)
+        if A is not None:
+            A = sparse.csc_matrix((A.data, A.indices, A.indptr), shape=A.shape)
+
+        solution = ecos.solve(data[s.C], G, data[s.H],
+                              cones, A, data[s.B],
                               verbose=verbose,
                               **solver_opts)
         return solution

--- a/cvxpy/reductions/solvers/conic_solvers/qoco_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/qoco_conif.py
@@ -15,13 +15,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 """
+from numpy import int32
+
 import cvxpy.settings as s
 from cvxpy.constraints import SOC
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
-from numpy import int32
-from scipy.sparse import safely_cast_index_arrays
 
 # QOCO standard form.
 # minimize   (1/2)x'Px + c'x
@@ -153,11 +153,14 @@ class QOCO(ConicSolver):
 
         # Cast row indices and column pointer arrays to int32.
         if P is not None:
-            P.indices, P.indptr = safely_cast_index_arrays(P, int32)
+            P.indices = P.indices.astype(int32)
+            P.indptr = P.indptr.astype(int32)
         if A is not None:
-            A.indices, A.indptr = safely_cast_index_arrays(A, int32)
+            A.indices = A.indices.astype(int32)
+            A.indptr = A.indptr.astype(int32)
         if G is not None:
-            G.indices, G.indptr = safely_cast_index_arrays(G, int32)
+            G.indices = G.indices.astype(int32)
+            G.indptr = G.indptr.astype(int32)
 
         solver = qoco.QOCO()
         solver.setup(n, m, p, P, c, A, b, G, h, num_nno, nsoc, q, verbose=verbose, **solver_opts)

--- a/cvxpy/reductions/solvers/conic_solvers/qoco_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/qoco_conif.py
@@ -20,6 +20,8 @@ from cvxpy.constraints import SOC
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+from numpy import int32
+from scipy.sparse import safely_cast_index_arrays
 
 # QOCO standard form.
 # minimize   (1/2)x'Px + c'x
@@ -148,6 +150,14 @@ class QOCO(ConicSolver):
 
         G = data[s.A][p::, :] if m > 0 else None
         h = data[s.B][p::] if m > 0 else None
+
+        # Cast row indices and column pointer arrays to int32.
+        if P is not None:
+            P.indices, P.indptr = safely_cast_index_arrays(P, int32)
+        if A is not None:
+            A.indices, A.indptr = safely_cast_index_arrays(A, int32)
+        if G is not None:
+            G.indices, G.indptr = safely_cast_index_arrays(G, int32)
 
         solver = qoco.QOCO()
         solver.setup(n, m, p, P, c, A, b, G, h, num_nno, nsoc, q, verbose=verbose, **solver_opts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "clarabel >= 0.5.0",
     "scs >= 3.2.4.post1",
     "numpy >= 1.21.6",
-    "scipy >= 1.15.0",
+    "scipy >= 1.11.0",
 ]
 requires-python = ">=3.9"
 urls = {Homepage = "https://github.com/cvxpy/cvxpy"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "clarabel >= 0.5.0",
     "scs >= 3.2.4.post1",
     "numpy >= 1.21.6",
-    "scipy >= 1.11.0",
+    "scipy >= 1.15.0",
 ]
 requires-python = ">=3.9"
 urls = {Homepage = "https://github.com/cvxpy/cvxpy"}


### PR DESCRIPTION
## Description
After the sparse_array PR #2710 merged, qoco and ecos/ecos_bb unit tests started failing.

QOCO unit tests failed, since the python wrapper expects the row index and column pointer arrays to be int32, but with sparse_arrays they are int64. This PR uses the `safely_cast_index_arrays` function to cast these indices. Unfortunately, this function first appears in scipy v1.15.0, but cvxpy requires only scipy  >=1.11.0.

The ecos failures are due to the expectation that matrices passed to the ecos python wrapper are of type csc_matrix rather than csc_array. There are two potential solutions: open a PR in [ecos-python](https://github.com/embotech/ecos-python) to expect csc_array, but this might be an invasive change and break existing projects csc_matrix is passed into ecos-python. The second potential solution is to convert the csc_array into a csc_matrix before passing problem data to `ecos_conif.py`. I would love to get some feedback on which solution is preferred.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.