### PR TITLE
Remove Redundant Variables in quad_form

### DIFF
--- a/cvxpy/reductions/qp2quad_form/canonicalizers/quad_over_lin_canon.py
+++ b/cvxpy/reductions/qp2quad_form/canonicalizers/quad_over_lin_canon.py
@@ -31,8 +31,4 @@ def quad_over_lin_canon(expr, args):
         # but it should be sparse the whole time.
         quad_mat = eye_array(affine_expr.size) / y
 
-    if isinstance(affine_expr, Variable):
-        return SymbolicQuadForm(affine_expr, quad_mat, expr), []
-    else:
-        t = Variable(affine_expr.shape)
-        return SymbolicQuadForm(t, quad_mat, expr), [affine_expr == t]
+    return SymbolicQuadForm(t, quad_mat, expr), [affine_expr == t]


### PR DESCRIPTION
## Description
In quad_form, sometimes redundant variables and additional consensus constraints are created (see issue linked below). This PR is an attempt to remove this.  

Issue link:
https://github.com/cvxpy/cvxpy/issues/2600

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.