### PR TITLE
Adds new broadcast_to atom for nd broadcasting

### DIFF
--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -17,6 +17,7 @@ limitations under the License.
 from cvxpy.atoms.affine.binary_operators import (matmul, multiply,
                                                  vdot, scalar_product, outer,)
 from cvxpy.atoms.affine.bmat import bmat
+from cvxpy.atoms.affine.broadcast_to import broadcast_to
 from cvxpy.atoms.affine.conj import conj
 from cvxpy.atoms.affine.conv import conv, convolve
 from cvxpy.atoms.affine.cumsum import cumsum

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -232,21 +232,18 @@ class MulExpression(BinaryOperator):
 
 
 class multiply(MulExpression):
-    """ Multiplies two expressions elementwise.
-    """
+    """Multiplies two expressions elementwise."""
 
     def __init__(self, lh_expr, rh_expr) -> None:
         lh_expr, rh_expr = self.broadcast(lh_expr, rh_expr)
         super(multiply, self).__init__(lh_expr, rh_expr)
 
     def is_atom_log_log_convex(self) -> bool:
-        """Is the atom log-log convex?
-        """
+        """Is the atom log-log convex?"""
         return True
 
     def is_atom_log_log_concave(self) -> bool:
-        """Is the atom log-log concave?
-        """
+        """Is the atom log-log concave?"""
         return True
 
     def is_atom_quasiconvex(self) -> bool:
@@ -262,8 +259,7 @@ class multiply(MulExpression):
             arg.is_nonpos() for arg in self.args)
 
     def numeric(self, values):
-        """Multiplies the values elementwise.
-        """
+        """Multiplies the values elementwise."""
         if sp.issparse(values[0]):
             return values[0].multiply(values[1])
         elif sp.issparse(values[1]):
@@ -271,10 +267,13 @@ class multiply(MulExpression):
         else:
             return np.multiply(values[0], values[1])
 
+    def validate_arguments(self):
+        """Validate that the arguments are broadcastable."""
+        np.broadcast_shapes(self.args[0].shape, self.args[1].shape)
+
     def shape_from_args(self) -> Tuple[int, ...]:
-        """The sum of the argument dimensions - 1.
-        """
-        return u.shape.sum_shapes([arg.shape for arg in self.args])
+        """Call np.broadcast on multiply arguments."""
+        return np.broadcast_shapes(self.args[0].shape, self.args[1].shape)
 
     def is_psd(self) -> bool:
         """Is the expression a positive semidefinite matrix?

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -269,11 +269,10 @@ class multiply(MulExpression):
 
     def validate_arguments(self):
         """Validate that the arguments are broadcastable."""
-        if not self.args[0].is_scalar() and not self.args[1].is_scalar():
-            output_shape = np.broadcast_shapes(self.args[0].shape, self.args[1].shape)
-            if self.args[0].shape != output_shape and self.args[1].shape != output_shape:
-                raise ValueError("Cannot multiply expressions with dimensions %s and %s" %
-                                (self.args[0].shape, self.args[1].shape))
+        np.broadcast(
+            np.empty(self.args[0].shape, dtype=np.dtype([])),
+            np.empty(self.args[1].shape, dtype=np.dtype([]))
+        )
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Call np.broadcast on multiply arguments."""

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -269,10 +269,11 @@ class multiply(MulExpression):
 
     def validate_arguments(self):
         """Validate that the arguments are broadcastable."""
-        output_shape = np.broadcast_shapes(self.args[0].shape, self.args[1].shape)
-        if self.args[0].shape != output_shape or self.args[1].shape != output_shape:
-            raise ValueError("Cannot multiply expressions with dimensions %s and %s" %
-                             (self.args[0].shape, self.args[1].shape))
+        if not self.args[0].is_scalar() and not self.args[1].is_scalar():
+            output_shape = np.broadcast_shapes(self.args[0].shape, self.args[1].shape)
+            if self.args[0].shape != output_shape and self.args[1].shape != output_shape:
+                raise ValueError("Cannot multiply expressions with dimensions %s and %s" %
+                                (self.args[0].shape, self.args[1].shape))
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Call np.broadcast on multiply arguments."""

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -269,7 +269,10 @@ class multiply(MulExpression):
 
     def validate_arguments(self):
         """Validate that the arguments are broadcastable."""
-        np.broadcast_shapes(self.args[0].shape, self.args[1].shape)
+        output_shape = np.broadcast_shapes(self.args[0].shape, self.args[1].shape)
+        if self.args[0].shape != output_shape or self.args[1].shape != output_shape:
+            raise ValueError("Cannot multiply expressions with dimensions %s and %s" %
+                             (self.args[0].shape, self.args[1].shape))
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Call np.broadcast on multiply arguments."""

--- a/cvxpy/atoms/affine/broadcast_to.py
+++ b/cvxpy/atoms/affine/broadcast_to.py
@@ -1,0 +1,89 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+import cvxpy.lin_ops.lin_op as lo
+import cvxpy.lin_ops.lin_utils as lu
+from cvxpy.atoms.affine.affine_atom import AffAtom
+from cvxpy.constraints.constraint import Constraint
+
+
+class Broadcast(AffAtom):
+    """Broadcast the expression given a shape input"""
+
+    def __init__(self, *args) -> None:
+        if isinstance(args[-1], int) or args[-1] is None:
+            # Assume the last positional argument is axis
+            axis = args[-1]
+            args = args[:-1]
+            self.axis = axis
+        else:
+            self.axis = None
+        super().__init__(*args)
+
+    def is_atom_log_log_convex(self) -> bool:
+        return True
+
+    def is_atom_log_log_concave(self) -> bool:
+        return True
+
+    # Returns the concatenation of the values along the specified axis.
+    def numeric(self, values):
+        return np.concatenate(values, axis=self.axis)
+
+    def get_data(self) -> List[Optional[int]]:
+        return [self.axis]
+
+    def validate_arguments(self) -> None:
+        # Validates that the input shapes in `self.args` are suitable for
+        # concatenation along a specified axis using numpy API with empty arrays
+        np.concatenate(
+            [np.empty(arg.shape, dtype=np.dtype([])) for arg in self.args],
+            axis=self.axis,
+        )
+
+    def shape_from_args(self) -> Tuple[int, ...]:
+        return np.concatenate(
+            [np.empty(arg.shape, dtype=np.dtype([])) for arg in self.args],
+            axis=self.axis,
+        ).shape
+
+    def graph_implementation(
+        self,
+        arg_objs,
+        shape: Tuple[int, ...],
+        data=None,
+    ) -> Tuple[lo.LinOp, List[Constraint]]:
+        """Concatenate the expressions along an existing axis.
+
+        Parameters
+        ----------
+        arg_objs : list
+            LinOp for each argument.
+        shape : tuple
+            The shape of the resulting expression.
+        data :
+            Additional data required by the atom. In this case data wraps axis
+
+        Returns
+        -------
+        tuple
+            (LinOp for the objective, list of constraints)
+        """
+        return (lu.broadcast_to(arg_objs, shape, data[0]), [])

--- a/cvxpy/atoms/affine/broadcast_to.py
+++ b/cvxpy/atoms/affine/broadcast_to.py
@@ -32,6 +32,9 @@ class broadcast_to(AffAtom):
         self._shape = expr.shape
         super(broadcast_to, self).__init__(expr)
 
+    def _supports_cpp(self) -> bool:
+        return False
+
     def is_atom_log_log_convex(self) -> bool:
         return True
 

--- a/cvxpy/atoms/affine/broadcast_to.py
+++ b/cvxpy/atoms/affine/broadcast_to.py
@@ -24,12 +24,13 @@ from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.constraints.constraint import Constraint
 
 
-class Broadcast(AffAtom):
+class broadcast_to(AffAtom):
     """Broadcast the expression given a shape input"""
 
     def __init__(self, expr, shape) -> None:
         self.broadcast_shape = shape
-        super(Broadcast, self).__init__(expr)
+        self._shape = expr.shape
+        super(broadcast_to, self).__init__(expr)
 
     def is_atom_log_log_convex(self) -> bool:
         return True
@@ -74,4 +75,4 @@ class Broadcast(AffAtom):
         tuple
             (LinOp for the objective, list of constraints)
         """
-        return (lu.broadcast_to(arg_objs, shape, data[0]), [])
+        return (lu.broadcast_to(arg_objs, shape), [])

--- a/cvxpy/atoms/affine/promote.py
+++ b/cvxpy/atoms/affine/promote.py
@@ -50,7 +50,7 @@ def promote(expr: Expression, shape: Tuple[int, ...]):
 
 
 class Promote(AffAtom):
-    """ Promote a scalar expression to a vector/matrix.
+    """Promote a scalar expression to a vector/matrix.
 
     Attributes
     ----------

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -605,7 +605,7 @@ class Expression(u.Canonical):
             if rh_expr.shape[1] == 1 and rh_expr.shape[1] < dims[1]:
                 rh_expr = rh_expr @ np.ones((1, dims[1]))
         # Broadcasting.
-        else:
+        elif lh_expr.ndim >= 3 or rh_expr.ndim >= 3 or lh_expr.ndim != rh_expr.ndim:
             output_shape = np.broadcast_shapes(lh_expr.shape, rh_expr.shape)
             if lh_expr.shape != output_shape:
                 lh_expr = cp.broadcast_to(lh_expr, output_shape)

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -605,7 +605,7 @@ class Expression(u.Canonical):
             if rh_expr.shape[1] == 1 and rh_expr.shape[1] < dims[1]:
                 rh_expr = rh_expr @ np.ones((1, dims[1]))
         # Broadcasting.
-        elif lh_expr.ndim >= 3 or rh_expr.ndim >= 3 or lh_expr.ndim != rh_expr.ndim:
+        else:
             output_shape = np.broadcast_shapes(lh_expr.shape, rh_expr.shape)
             if lh_expr.shape != output_shape:
                 lh_expr = cp.broadcast_to(lh_expr, output_shape)

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -588,15 +588,8 @@ class Expression(u.Canonical):
             lh_expr = cp.promote(lh_expr, rh_expr.shape)
         elif rh_expr.is_scalar() and not lh_expr.is_scalar():
             rh_expr = cp.promote(rh_expr, lh_expr.shape)
-        # Broadcasting.
-        if lh_expr.ndim >= 2 or rh_expr.ndim >= 2:
-            output_shape = np.broadcast_shapes(lh_expr.shape, rh_expr.shape)
-            if lh_expr.shape != output_shape:
-                lh_expr = cp.broadcast_to(lh_expr, output_shape)
-            if rh_expr.shape != output_shape:
-                rh_expr = cp.broadcast_to(rh_expr, output_shape)
-        """
-        if lh_expr.ndim >= 2 and rh_expr.ndim >= 2:
+        # TODO: cleanup once CPP backend is removed
+        if lh_expr.ndim == 2 and rh_expr.ndim == 2:
             dims = [max(lh_expr.shape[i], rh_expr.shape[i]) for i in range(2)]
             # Broadcast along dim 0.
             if lh_expr.shape[0] == 1 and lh_expr.shape[0] < dims[0]:
@@ -608,7 +601,13 @@ class Expression(u.Canonical):
                 lh_expr = lh_expr @ np.ones((1, dims[1]))
             if rh_expr.shape[1] == 1 and rh_expr.shape[1] < dims[1]:
                 rh_expr = rh_expr @ np.ones((1, dims[1]))
-        """
+        # Broadcasting.
+        if lh_expr.ndim >= 3 or rh_expr.ndim >= 3:
+            output_shape = np.broadcast_shapes(lh_expr.shape, rh_expr.shape)
+            if lh_expr.shape != output_shape:
+                lh_expr = cp.broadcast_to(lh_expr, output_shape)
+            if rh_expr.shape != output_shape:
+                rh_expr = cp.broadcast_to(rh_expr, output_shape)
         return lh_expr, rh_expr
 
     @_cast_other

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -17,7 +17,7 @@ limitations under the License.
 import abc
 import warnings
 from functools import wraps
-from typing import List, Literal, Optional, Tuple, Union
+from typing import List, Literal, Optional, Tuple
 
 import numpy as np
 
@@ -110,7 +110,7 @@ __BINARY_EXPRESSION_UFUNCS__ = {
 }
 
 
-ExpressionLike = Union["Expression", np._typing.ArrayLike]
+ExpressionLike = "Expression" | np.typing.ArrayLike
 
 
 class Expression(u.Canonical):

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -607,7 +607,6 @@ class Expression(u.Canonical):
         # Broadcasting.
         elif lh_expr.ndim >= 3 or rh_expr.ndim >= 3 or lh_expr.ndim != rh_expr.ndim:
             output_shape = np.broadcast_shapes(lh_expr.shape, rh_expr.shape)
-            # breakpoint()
             if lh_expr.shape != output_shape:
                 lh_expr = cp.broadcast_to(lh_expr, output_shape)
             if rh_expr.shape != output_shape:

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -588,6 +588,9 @@ class Expression(u.Canonical):
             lh_expr = cp.promote(lh_expr, rh_expr.shape)
         elif rh_expr.is_scalar() and not lh_expr.is_scalar():
             rh_expr = cp.promote(rh_expr, lh_expr.shape)
+        # TODO: remove special case once CPP backend is removed
+        elif lh_expr.is_scalar() and rh_expr.is_scalar():
+            return lh_expr, rh_expr
         # TODO: cleanup once CPP backend is removed
         if lh_expr.ndim == 2 and rh_expr.ndim == 2:
             dims = [max(lh_expr.shape[i], rh_expr.shape[i]) for i in range(2)]
@@ -602,8 +605,9 @@ class Expression(u.Canonical):
             if rh_expr.shape[1] == 1 and rh_expr.shape[1] < dims[1]:
                 rh_expr = rh_expr @ np.ones((1, dims[1]))
         # Broadcasting.
-        else:
+        elif lh_expr.ndim >= 3 or rh_expr.ndim >= 3 or lh_expr.ndim != rh_expr.ndim:
             output_shape = np.broadcast_shapes(lh_expr.shape, rh_expr.shape)
+            # breakpoint()
             if lh_expr.shape != output_shape:
                 lh_expr = cp.broadcast_to(lh_expr, output_shape)
             if rh_expr.shape != output_shape:

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -110,7 +110,7 @@ __BINARY_EXPRESSION_UFUNCS__ = {
 }
 
 
-ExpressionLike = "Expression" | np.typing.ArrayLike
+ExpressionLike = "Expression | np.typing.ArrayLike"
 
 
 class Expression(u.Canonical):

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -602,7 +602,7 @@ class Expression(u.Canonical):
             if rh_expr.shape[1] == 1 and rh_expr.shape[1] < dims[1]:
                 rh_expr = rh_expr @ np.ones((1, dims[1]))
         # Broadcasting.
-        else:
+        if lh_expr.ndim >= 3 or rh_expr.ndim >= 3:
             output_shape = np.broadcast_shapes(lh_expr.shape, rh_expr.shape)
             if lh_expr.shape != output_shape:
                 lh_expr = cp.broadcast_to(lh_expr, output_shape)

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -602,7 +602,7 @@ class Expression(u.Canonical):
             if rh_expr.shape[1] == 1 and rh_expr.shape[1] < dims[1]:
                 rh_expr = rh_expr @ np.ones((1, dims[1]))
         # Broadcasting.
-        elif lh_expr.ndim >= 3 or rh_expr.ndim >= 3:
+        else:
             output_shape = np.broadcast_shapes(lh_expr.shape, rh_expr.shape)
             if lh_expr.shape != output_shape:
                 lh_expr = cp.broadcast_to(lh_expr, output_shape)

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -602,7 +602,7 @@ class Expression(u.Canonical):
             if rh_expr.shape[1] == 1 and rh_expr.shape[1] < dims[1]:
                 rh_expr = rh_expr @ np.ones((1, dims[1]))
         # Broadcasting.
-        if lh_expr.ndim >= 3 or rh_expr.ndim >= 3:
+        else:
             output_shape = np.broadcast_shapes(lh_expr.shape, rh_expr.shape)
             if lh_expr.shape != output_shape:
                 lh_expr = cp.broadcast_to(lh_expr, output_shape)

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -602,7 +602,7 @@ class Expression(u.Canonical):
             if rh_expr.shape[1] == 1 and rh_expr.shape[1] < dims[1]:
                 rh_expr = rh_expr @ np.ones((1, dims[1]))
         # Broadcasting.
-        else:
+        elif lh_expr.ndim >= 3 or rh_expr.ndim >= 3:
             output_shape = np.broadcast_shapes(lh_expr.shape, rh_expr.shape)
             if lh_expr.shape != output_shape:
                 lh_expr = cp.broadcast_to(lh_expr, output_shape)

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -777,7 +777,18 @@ class NumPyCanonBackend(PythonCanonBackend):
 
     @staticmethod
     def broadcast_to(lin: LinOp, view: NumPyTensorView) -> NumPyTensorView:
-        pass
+        """
+        Broadcast view by repeating along axis 1 (rows).
+        """
+        num_entries = int(np.prod(lin.shape))
+        current_dim = int(np.prod(lin.args[0].shape))
+        times = num_entries // current_dim
+
+        def func(x):
+            return np.tile(x, (1, times, 1))
+
+        view.apply_all(func)
+        return view
     
     def mul_elem(self, lin: LinOp, view: NumPyTensorView) -> NumPyTensorView:
         """
@@ -1221,7 +1232,12 @@ class SciPyCanonBackend(PythonCanonBackend):
 
     @staticmethod
     def broadcast_to(lin: LinOp, view: SciPyTensorView) -> SciPyTensorView:
-        pass
+        num_entries = int(np.prod(lin.shape))
+        current_dim = int(np.prod(lin.args[0].shape))
+        times = num_entries // current_dim
+        rows = np.repeat(np.arange(current_dim), times)
+        view.select_rows(rows)
+        return view
     
     def mul_elem(self, lin: LinOp, view: SciPyTensorView) -> SciPyTensorView:
         """

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -1220,7 +1220,7 @@ class SciPyCanonBackend(PythonCanonBackend):
         return view
 
     @staticmethod
-    def broadcast_to(lin, view):
+    def broadcast_to(lin: LinOp, view: SciPyTensorView) -> SciPyTensorView:
         pass
     
     def mul_elem(self, lin: LinOp, view: SciPyTensorView) -> SciPyTensorView:

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -332,6 +332,7 @@ class PythonCanonBackend(CanonBackend):
             "sum": self.sum_op,
             "mul": self.mul,
             "promote": self.promote,
+            "broadcast_to": self.broadcast_to,
             "neg": self.neg,
             "mul_elem": self.mul_elem,
             "sum_entries": self.sum_entries,
@@ -384,6 +385,14 @@ class PythonCanonBackend(CanonBackend):
         Promote view by repeating along axis 0 (rows)
         """
         pass  # noqa
+    
+    @staticmethod
+    @abstractmethod
+    def broadcast_to(lin: LinOp, view: TensorView) -> TensorView:
+        """
+        Broadcast view to a new shape.
+        """
+        pass # noqa
 
     @staticmethod
     def neg(_lin: LinOp, view: TensorView) -> TensorView:
@@ -766,6 +775,10 @@ class NumPyCanonBackend(PythonCanonBackend):
         view.apply_all(func)
         return view
 
+    @staticmethod
+    def broadcast_to(lin: LinOp, view: NumPyTensorView) -> NumPyTensorView:
+        pass
+    
     def mul_elem(self, lin: LinOp, view: NumPyTensorView) -> NumPyTensorView:
         """
         Given (A, b) in view and constant data d, return (A*d, b*d).
@@ -1206,6 +1219,10 @@ class SciPyCanonBackend(PythonCanonBackend):
         view.select_rows(rows)
         return view
 
+    @staticmethod
+    def broadcast_to(lin, view):
+        pass
+    
     def mul_elem(self, lin: LinOp, view: SciPyTensorView) -> SciPyTensorView:
         """
         Given (A, b) in view and constant data d, return (A*d, b*d).

--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -778,7 +778,7 @@ class NumPyCanonBackend(PythonCanonBackend):
     @staticmethod
     def broadcast_to(lin: LinOp, view: NumPyTensorView) -> NumPyTensorView:
         """
-        Broadcast view by repeating along axis 1 (rows).
+        Broadcast view by calling np.broadcast_to on the rows and indexing the view.
         """
         broadcast_shape = lin.shape
         original_shape = lin.args[0].shape
@@ -1230,7 +1230,7 @@ class SciPyCanonBackend(PythonCanonBackend):
     @staticmethod
     def broadcast_to(lin: LinOp, view: SciPyTensorView) -> SciPyTensorView:
         """
-        Broadcast view by repeating/tiling along axis 0 (rows).
+        Broadcast view by calling np.broadcast_to on the rows and indexing the view.
         """
         broadcast_shape = lin.shape
         original_shape = lin.args[0].shape

--- a/cvxpy/lin_ops/lin_op.py
+++ b/cvxpy/lin_ops/lin_op.py
@@ -40,6 +40,9 @@ VARIABLE = "variable"
 # Promoting a scalar expression.
 # Data: None
 PROMOTE = "promote"
+# Broadcasting an expression.
+# Data: Shape to broadcast to.
+BROADCAST_TO = "broadcast_to"
 # Multiplying an expression by a constant.
 # Data: LinOp evaluating to the left hand multiple.
 MUL = "mul"

--- a/cvxpy/lin_ops/lin_utils.py
+++ b/cvxpy/lin_ops/lin_utils.py
@@ -368,6 +368,12 @@ def promote(operator, shape: Tuple[int, ...]):
     return lo.LinOp(lo.PROMOTE, shape, [operator], None)
 
 
+def broadcast_to(operators, shape: Tuple[int, ...]):
+    """Broadcasts operators to a common shape.
+    """
+    return lo.LinOp(lo.BROADCAST_TO, shape, operators, [])
+
+
 def sum_entries(operator, shape: Tuple[int, ...], axis=None, keepdims=None):
     """Sum the entries of an operator.
 

--- a/cvxpy/problems/objective.py
+++ b/cvxpy/problems/objective.py
@@ -40,6 +40,8 @@ class Objective(u.Canonical):
 
     def __init__(self, expr) -> None:
         self.args = [Expression.cast_to_const(expr)]
+        # Needed for Canonical._aggregate_metrics.
+        self.ndim = 0
         # Validate that the objective resolves to a scalar.
         if not self.args[0].is_scalar():
             raise ValueError("The '%s' objective must resolve to a scalar."

--- a/cvxpy/reductions/complex2real/canonicalizers/__init__.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/__init__.py
@@ -22,7 +22,7 @@ from cvxpy.atoms import (MatrixFrac, Pnorm, QuadForm, abs, bmat, conj, conv,
 from cvxpy.atoms.affine.add_expr import AddExpression
 from cvxpy.atoms.affine.binary_operators import (DivExpression, MulExpression,
                                                  multiply,)
-from cvxpy.atoms.affine.broadcast_to import Broadcast
+from cvxpy.atoms.affine.broadcast_to import broadcast_to
 from cvxpy.atoms.affine.diag import diag_mat, diag_vec
 from cvxpy.atoms.affine.hstack import Hstack
 from cvxpy.atoms.affine.index import index, special_index
@@ -71,7 +71,7 @@ CANON_METHODS = {
     index: separable_canon,
     special_index: separable_canon,
     Promote: separable_canon,
-    Broadcast: separable_canon,
+    broadcast_to: separable_canon,
     reshape: separable_canon,
     Sum: separable_canon,
     trace: trace_canon,

--- a/cvxpy/reductions/complex2real/canonicalizers/__init__.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/__init__.py
@@ -22,6 +22,7 @@ from cvxpy.atoms import (MatrixFrac, Pnorm, QuadForm, abs, bmat, conj, conv,
 from cvxpy.atoms.affine.add_expr import AddExpression
 from cvxpy.atoms.affine.binary_operators import (DivExpression, MulExpression,
                                                  multiply,)
+from cvxpy.atoms.affine.broadcast_to import Broadcast
 from cvxpy.atoms.affine.diag import diag_mat, diag_vec
 from cvxpy.atoms.affine.hstack import Hstack
 from cvxpy.atoms.affine.index import index, special_index
@@ -70,6 +71,7 @@ CANON_METHODS = {
     index: separable_canon,
     special_index: separable_canon,
     Promote: separable_canon,
+    Broadcast: separable_canon,
     reshape: separable_canon,
     Sum: separable_canon,
     trace: trace_canon,

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1065,6 +1065,7 @@ class TestAtoms(BaseTest):
         # Check that the CVaR constraint is satisfied
         cvar_value = cp.cvar(A @ x.value, beta).value
         self.assertTrue(cvar_value <= kappa)
+
     def test_index(self) -> None:
         """Test the copy function for index.
         """

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1750,7 +1750,6 @@ class TestND_Expressions():
     @pytest.mark.parametrize("shapes", [((3),(253, 253, 3)),
                                         ((7, 1, 5),(8, 7, 6, 5)),
                                         ((1),(5, 4)),
-                                        ((4),(5, 4)),
                                         ((15, 1, 5), (15, 3, 5)),
                                         ((3, 5), (15, 3, 5)),
                                         ((3, 1), (15, 3, 5))])
@@ -1761,3 +1760,12 @@ class TestND_Expressions():
         prob = cp.Problem(cp.Minimize(cp.sum(expr)), [x == 1])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, y)
+
+    def test_nd_multiply_broadcast_error(self) -> None:
+        error_str = "inconsistent shapes"
+        with pytest.raises(Exception, match=error_str):
+            x = cp.Variable(4)
+            y = np.arange(20).reshape(5, 4)
+            expr = cp.multiply(x, y)
+            prob = cp.Problem(cp.Minimize(cp.sum(expr)), [x == 1])
+            prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1718,7 +1718,7 @@ class TestND_Expressions():
                                         ((4),(5, 4)),
                                         ((15, 1, 5), (15, 3, 5)),
                                         ((3, 5), (15, 3, 5)),
-                                        ((3, 1), (15, 3, 5)),])
+                                        ((3, 1), (15, 3, 5))])
     def test_nd_broadcast(self, shapes) -> None:
         x = cp.Variable(shapes[0])
         y = cp.broadcast_to(x, shape=shapes[1])
@@ -1746,3 +1746,18 @@ class TestND_Expressions():
             obj = cp.sum(cp.max(cp.multiply(a, x) + b, axis=0))
             prob = cp.Problem(cp.Minimize(obj), [])
             prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+
+    @pytest.mark.parametrize("shapes", [((3),(253, 253, 3)),
+                                        ((7, 1, 5),(8, 7, 6, 5)),
+                                        ((1),(5, 4)),
+                                        ((4),(5, 4)),
+                                        ((15, 1, 5), (15, 3, 5)),
+                                        ((3, 5), (15, 3, 5)),
+                                        ((3, 1), (15, 3, 5))])
+    def test_nd_multiply_broadcast(self, shapes) -> None:
+        x = cp.Variable(shapes[0])
+        y = np.arange(np.prod(shapes[1])).reshape(shapes[1])
+        expr = cp.multiply(x, y)
+        prob = cp.Problem(cp.Minimize(cp.sum(expr)), [x == 1])
+        prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+        assert np.allclose(expr.value, y)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1719,9 +1719,16 @@ class TestND_Expressions():
         assert np.allclose(expr.value, y)
 
     def test_nd_broadcast(self) -> None:
-        # test broadcast dim 1
         x = cp.Variable(2)
-        y = cp.broadcast_to(x, shape=(2, 2))
-        assert y.shape == (2, 2)
+        y = cp.broadcast_to(x, shape=(2, 2, 2))
+        assert y.shape == (2, 2, 2)
         prob = cp.Problem(cp.Minimize(cp.sum(y)), [y == 1])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+        assert np.allclose(y.value, 1)
+
+    def test_nd_broadcast_error(self) -> None:
+        error_str = "operands could not be broadcast together"
+        with pytest.raises(Exception, match=error_str):
+            x = cp.Variable(3)
+            y = cp.broadcast_to(x, shape=(2, 2, 2))
+            assert y.shape == (2, 2, 2)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -859,12 +859,6 @@ class TestExpressions(BaseTest):
         A = np.ones((3, 3)) / c
         self.assertItemsAlmostEqual(A, expr.value)
 
-        with self.assertRaises(Exception) as cm:
-            (x/c[:, 0])
-        print(cm.exception)
-        self.assertRegex(str(cm.exception),
-                         "Incompatible shapes for division.*")
-
     # Test the NegExpression class.
     def test_neg_expression(self) -> None:
         # Vectors

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -816,7 +816,7 @@ class TestExpressions(BaseTest):
             (self.x/[2, 2, 3])
         print(cm.exception)
         self.assertRegex(str(cm.exception),
-                         "Incompatible shapes for division.*")
+                         "shape mismatch")
 
         c = Constant([3.0, 4.0, 12.0])
         self.assertItemsAlmostEqual(
@@ -1734,9 +1734,9 @@ class TestND_Expressions():
     @pytest.mark.parametrize("shapes", [((5),(3, 1)),
                                         ((15, 1),(8)),
                                         ((3), (2, 1))])
-    def test_segfault_multiply(self, shapes) -> None:
+    def test_no_segfault_multiply(self, shapes) -> None:
         """
-        This test ensures that an inconsistent shape error is raised when
+        This test ensures that no error is raised when
         multiplying two broadcastable array shapes <= 2.
         Previously this would cause a segfault in the CPP backend.
         """

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -23,7 +23,6 @@ from hypothesis import assume, given
 from hypothesis.extra.numpy import (
     arrays,
     basic_indices,
-    broadcastable_shapes,
     integer_array_indices,
 )
 
@@ -1719,11 +1718,14 @@ class TestND_Expressions():
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, y)
 
-    @given(shapes=broadcastable_shapes(shape=(2, 1, 1)))
-    def test_nd_multiply_broadcast(self, shapes) -> None:
-        var = cp.Variable((2, 1, 1))
-        for shape in shapes:
-            data = np.random.randn(shape)
-            var = cp.multiply(var, data)
-        prob = cp.Problem(cp.Minimize(cp.sum(var)), [])
-        prob.solve()
+    def test_nd_broadcast(self) -> None:
+        # test broadcast dim 1
+        x = cp.Variable(2)
+        y = cp.Constant(np.ones((2,2)))
+
+        # test broadcast dim 0
+        x = cp.Variable(shape=(2,1))
+        y = cp.Constant(np.ones((2,2)))
+
+        expr = x+y
+        print(expr.shape)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1721,11 +1721,7 @@ class TestND_Expressions():
     def test_nd_broadcast(self) -> None:
         # test broadcast dim 1
         x = cp.Variable(2)
-        y = cp.Constant(np.ones((2,2)))
-
-        # test broadcast dim 0
-        x = cp.Variable(shape=(2,1))
-        y = cp.Constant(np.ones((2,2)))
-
-        expr = x+y
-        print(expr.shape)
+        y = cp.broadcast_to(x, shape=(2, 2))
+        assert y.shape == (2, 2)
+        prob = cp.Problem(cp.Minimize(cp.sum(y)), [y == 1])
+        prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1736,3 +1736,13 @@ class TestND_Expressions():
             x = cp.Variable(shapes[0])
             y = cp.broadcast_to(x, shape=shapes[1])
             assert y.shape == shapes[1]
+
+    def test_no_segfault_multiply(self) -> None:
+        error_str = "Cannot multiply expressions with dimensions"
+        with pytest.raises(Exception, match=error_str):
+            x = cp.Variable(5)
+            a = np.array([1,2,3]).reshape(-1, 1)
+            b = np.array([1,2,3]).reshape(-1, 1)        
+            obj = cp.sum(cp.max(cp.multiply(a, x) + b, axis=0))
+            prob = cp.Problem(cp.Minimize(obj), [])
+            prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -23,6 +23,7 @@ from hypothesis import assume, given
 from hypothesis.extra.numpy import (
     arrays,
     basic_indices,
+    broadcastable_shapes,
     integer_array_indices,
 )
 
@@ -1774,5 +1775,15 @@ class TestND_Expressions():
         expr = x + y
         target = np.arange(np.prod(shapes[0])).reshape(shapes[0])
         prob = cp.Problem(cp.Minimize(cp.sum(expr)), [expr == target + y])
+        prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+        assert np.allclose(x.value, target)
+
+    @given(shape=broadcastable_shapes((8, 14, 8, 28), max_dims=4))
+    def test_nd_broadcast_generated(self, shape) -> None:
+        x = cp.Variable((8, 14, 8, 28))
+        y = np.arange(np.prod((shape))).reshape((shape))
+        expr = x - y
+        target = np.arange(np.prod((8,14,8,28))).reshape(8,14,8,28)
+        prob = cp.Problem(cp.Minimize(cp.sum(expr)), [expr == target - y])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(x.value, target)

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1718,17 +1718,27 @@ class TestND_Expressions():
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, y)
 
-    def test_nd_broadcast(self) -> None:
-        x = cp.Variable(2)
-        y = cp.broadcast_to(x, shape=(2, 2, 2))
-        assert y.shape == (2, 2, 2)
+    @pytest.mark.parametrize("shapes", [((3),(253, 253, 3)),
+                                        ((7, 1, 5),(8, 7, 6, 5)),
+                                        ((1),(5, 4)),
+                                        ((4),(5, 4)),
+                                        ((15, 1, 5), (15, 3, 5)),
+                                        ((3, 5), (15, 3, 5)),
+                                        ((3, 1), (15, 3, 5)),])
+    def test_nd_broadcast(self, shapes) -> None:
+        x = cp.Variable(shapes[0])
+        y = cp.broadcast_to(x, shape=shapes[1])
+        assert y.shape == shapes[1]
         prob = cp.Problem(cp.Minimize(cp.sum(y)), [y == 1])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(y.value, 1)
 
-    def test_nd_broadcast_error(self) -> None:
+    @pytest.mark.parametrize("shapes", [((3), (2, 2, 2)),
+                                        ((3), (4)),
+                                        ((2, 1),(8, 4, 3))])
+    def test_nd_broadcast_error(self, shapes) -> None:
         error_str = "operands could not be broadcast together"
         with pytest.raises(Exception, match=error_str):
-            x = cp.Variable(3)
-            y = cp.broadcast_to(x, shape=(2, 2, 2))
-            assert y.shape == (2, 2, 2)
+            x = cp.Variable(shapes[0])
+            y = cp.broadcast_to(x, shape=shapes[1])
+            assert y.shape == shapes[1]

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1735,20 +1735,19 @@ class TestND_Expressions():
                                         ((15, 1),(8)),
                                         ((3), (2, 1))])
     def test_segfault_multiply(self, shapes) -> None:
-        # TODO this test should pass once CPP backend is removed
         """
         This test ensures that an inconsistent shape error is raised when
         multiplying two broadcastable array shapes <= 2.
         Previously this would cause a segfault in the CPP backend.
         """
-        error_str = "inconsistent shapes"
-        with pytest.raises(Exception, match=error_str):
-            x = cp.Variable(shapes[0])
-            a = np.arange(np.prod(shapes[1])).reshape(shapes[1])
-            b = np.arange(np.prod(shapes[1])).reshape(shapes[1])
-            obj = cp.sum(cp.max(cp.multiply(a, x) + b, axis=0))
-            prob = cp.Problem(cp.Minimize(obj), [])
-            prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
+        x = cp.Variable(shapes[0])
+        target = np.arange(np.prod(shapes[0])).reshape(shapes[0])
+        a = np.arange(np.prod(shapes[1])).reshape(shapes[1])
+        b = np.arange(np.prod(shapes[1])).reshape(shapes[1])
+        obj = cp.sum(cp.max(cp.multiply(a, x) + b, axis=0))
+        prob = cp.Problem(cp.Minimize(obj), [x == target])
+        prob.solve()
+        assert np.allclose(x.value, target)
 
     @pytest.mark.parametrize("shapes", [((3),(252, 253, 3)),
                                         ((7, 1, 5),(8, 7, 6, 5)),

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -816,7 +816,7 @@ class TestExpressions(BaseTest):
             (self.x/[2, 2, 3])
         print(cm.exception)
         self.assertRegex(str(cm.exception),
-                         "shape mismatch")
+                         "Incompatible shapes for division")
 
         c = Constant([3.0, 4.0, 12.0])
         self.assertItemsAlmostEqual(

--- a/cvxpy/tests/test_python_backends.py
+++ b/cvxpy/tests/test_python_backends.py
@@ -2257,7 +2257,7 @@ class TestND_Backends:
         # Note: view is edited in-place:
         assert out_view.get_tensor_representation(0, 1) == view.get_tensor_representation(0, 1)
 
-    def test_broadcast_to_cols(self, backend):
+    def test_nd_broadcast_to(self, backend):
         """
         define x = Variable((2,1,2)) with
         [[x11, x12], 

--- a/cvxpy/utilities/canonical.py
+++ b/cvxpy/utilities/canonical.py
@@ -172,7 +172,7 @@ class Canonical(metaclass=abc.ABCMeta):
 
         for arg in self.args:
             max_ndim = max(max_ndim, arg._max_ndim())
-            cpp_support = cpp_support and arg._supports_cpp()
+            cpp_support = cpp_support and arg._all_support_cpp()
 
         metrics = {
             "max_ndim": max_ndim,


### PR DESCRIPTION
## Description
Please include a short summary of the change.
This PR introduces the broadcast_to atom in hopes of fixing issues with broadcasting in higher dimensions. 
The broadcast_to atom is used internally inside of the expression class in its ``broadcast`` method.
This method is called in many places, including binary ops, basic ops and others.

The implementation of the atom follows other similar shape manipulation atoms such as vstack and concatenate. The idea is to form a set of indices which are reshaped to the expression's shape, then using numpy's API we are able to mimic the behavior of ``np.broadcast_to`` on cvxpy's tensor views in the backend. 

### CPP backend compatibility
In the #2728 discussion, I brought up some issues with the difference in behavior for the backends. Those issues were resolved as follows: 
- only call ``cp.broadcast_to`` when one of the operands has dim > 2, which ensures that the SCIPY backend is used.
- full broadcasting is supported in those cases, even the edge cases mentioned in the discussion above.
- in hopes of keeping the CPP backend behavior the same, both the SCIPY and CPP backends don't do full broadcasting when both operands are <= 2. However, this only omits some edge cases, as most practical scenarios are covered by existing code. 

### Improved error messages
Recent changes to the codebase (notably adding the cp.concatenate atom) showed that we are able to instantiate empty numpy arrays (using ``dtype=np.empty([])``) and then perform analogous operations on those arrays to get the error handling from numpy for free. This technique has been reused here to improve on the existing multiply atom error handling. 

Issue link (if applicable): #2739 

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.