### PR TITLE
Force int32 dtype for mosek reduction -- see https://docs.mosek.com/l…

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -333,21 +333,21 @@ class MOSEK(ConicSolver):
         n, m = A.shape
         task.appendvars(m)
         o = np.zeros(m)
-        task.putvarboundlist(np.arange(m, dtype=int), [mosek.boundkey.fr] * m, o, o)
+        task.putvarboundlist(np.arange(m, dtype=np.int32), [mosek.boundkey.fr] * m, o, o)
         task.appendcons(n)
         # objective
-        task.putclist(np.arange(c.size, dtype=int), c)
+        task.putclist(np.arange(c.size, dtype=np.int32), c)
         task.putobjsense(mosek.objsense.maximize)
         # equality constraints
         rows, cols, vals = sp.sparse.find(A)
         task.putaijlist(rows.tolist(), cols.tolist(), vals.tolist())
-        task.putconboundlist(np.arange(n, dtype=int), [mosek.boundkey.fx] * n, b, b)
+        task.putconboundlist(np.arange(n, dtype=np.int32), [mosek.boundkey.fx] * n, b, b)
         # conic constraints
         idx = K[a2d.FREE]
         num_pos = K[a2d.NONNEG]
         if num_pos > 0:
             o = np.zeros(num_pos)
-            task.putvarboundlist(np.arange(idx, idx + num_pos, dtype=int),
+            task.putvarboundlist(np.arange(idx, idx + num_pos, dtype=np.int32),
                                  [mosek.boundkey.lo] * num_pos, o, o)
             idx += num_pos
         num_soc = len(K[a2d.SOC])
@@ -408,17 +408,17 @@ class MOSEK(ConicSolver):
         m, n = A.shape
         task.appendvars(n)
         o = np.zeros(n)
-        task.putvarboundlist(np.arange(n, dtype=int), [mosek.boundkey.fr] * n, o, o)
+        task.putvarboundlist(np.arange(n, dtype=np.int32), [mosek.boundkey.fr] * n, o, o)
         task.appendcons(m)
         # objective
-        task.putclist(np.arange(n, dtype=int), c)
+        task.putclist(np.arange(n, dtype=np.int32), c)
         task.putobjsense(mosek.objsense.minimize)
         # elementwise constraints
         rows, cols, vals = sp.sparse.find(A)
         task.putaijlist(rows, cols, vals)
         eq_keys = [mosek.boundkey.fx] * K_aff[a2d.ZERO]
         ineq_keys = [mosek.boundkey.up] * K_aff[a2d.NONNEG]
-        task.putconboundlist(np.arange(m, dtype=int), eq_keys + ineq_keys, b, b)
+        task.putconboundlist(np.arange(m, dtype=np.int32), eq_keys + ineq_keys, b, b)
         # conic constraints
         idx = K_dir[a2d.FREE]
         num_soc = len(K_dir[a2d.SOC])


### PR DESCRIPTION
…atest/pythonapi/changes.html#important-changes-compared-to-version-10.

## Description
In Mosek 11, passing int64 index args forces a slow copy. This fixes it. 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.