### PR TITLE
Fix cvxpy with osqp v1.0.0

### DIFF
--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -62,6 +62,11 @@ class OSQP(QpSolver):
         lA = np.concatenate([data[s.B], -np.inf*np.ones(data[s.G].shape)])
         data['l'] = lA
 
+        if P is not None:
+            P = sp.csc_matrix((P.data, P.indices, P.indptr), shape=P.shape)
+        if A is not None:
+            A = sp.csc_matrix((A.data, A.indices, A.indptr), shape=A.shape)
+
         # Overwrite defaults eps_abs=eps_rel=1e-3, max_iter=4000
         solver_opts['eps_abs'] = solver_opts.get('eps_abs', 1e-5)
         solver_opts['eps_rel'] = solver_opts.get('eps_rel', 1e-5)


### PR DESCRIPTION
## Description
CVXPY does not currently work with OSQP v1.0.0b1 and v1.0.0.b3 due to changes in the PR: https://github.com/cvxpy/cvxpy/pull/2710.

The failure method is similar to that observed by QOCO and ECOS due to the same PR (`TypeError: Cannot cast array data from dtype('int64') to dtype('int32') according to the rule 'safe'`), however QOCO and ECOS were fixed with the PR: https://github.com/cvxpy/cvxpy/pull/2720.

This current PR makes the changes that will allow OSQP v1.0.0b1 and v1.0.0.b3 to work with CVXPY v1.7.0.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.