### PR TITLE
correct indexing in _axis_grad

### DIFF
--- a/cvxpy/atoms/axis_atom.py
+++ b/cvxpy/atoms/axis_atom.py
@@ -101,7 +101,7 @@ class AxisAtom(Atom):
                         return [None]
                     else:
                         d = np.array(d).flatten()
-                    row = np.linspace(i*n, i*n+m-1, m)  # [i*n, i*n+1, ..., i*n+m-1]
+                    row = np.linspace(i*m, i*m+m-1, m)  # [i*m, i*m+1, ..., i*m+m-1]
                     col = np.ones((m))*i
                     D = D + sp.csc_array((d, (row, col)),
                                           shape=(m*n, n))  # d must be 1-D

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -36,6 +36,7 @@ class TestGrad(BaseTest):
         self.A = Variable((2, 2), name='A')
         self.B = Variable((2, 2), name='B')
         self.C = Variable((3, 2), name='C')
+        self.D = Variable((1, 2), name='D')
 
     def test_affine_prod(self) -> None:
         """Test gradient for affine_prod
@@ -105,6 +106,14 @@ class TestGrad(BaseTest):
         self.A.value = np.array([[0, 0], [10, 0]])
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(),
                                     np.array([[0, 0], [0, 1], [0, 0], [0, 0]]))
+        
+        expr = cp.norm(self.D, 2, axis=0)
+        self.D.value = np.array([[0, 10]])
+        self.assertItemsAlmostEqual(expr.grad[self.D].toarray(), np.array([[0, 0], [0, 1]]))
+        
+        expr = cp.norm(self.D, 2, axis=1)
+        self.D.value = np.array([[0, 10]])
+        self.assertItemsAlmostEqual(expr.grad[self.D].toarray(), np.array([[0], [1]]))
 
         expr = cp.pnorm(self.A, 0.5)
         self.A.value = np.array([[3, -4], [4, 3]])


### PR DESCRIPTION
## Description
This PR fixes an indexing bug in the `_axis_grad` method of the `AxisAtom` class.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.