### PR TITLE
fix clarabel crash on parametric update in v1.6.1

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
@@ -308,6 +308,8 @@ class CLARABEL(ConicSolver):
             nvars = q.size
             P = sp.csc_array((nvars, nvars))
 
+        P = sp.triu(P).tocsc()
+
         cones = dims_to_solver_cones(data[ConicSolver.DIMS])
 
         def new_solver():

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -448,9 +448,11 @@ class TestClarabel(BaseTest):
             b.value = np.random.rand(2)
             q.value = np.random.randn(2)
 
-        prob = cp.Problem(cp.Minimize(P[0]*cp.square(x[0]) + cp.sum_squares(x) + q.T @ x),
-                          [A[0] * x[0] + A[1] * x[1] == b[0],
-                           A[2] * x[0] + A[3] * x[1] <= b[1]])
+        prob = cp.Problem(
+                cp.Minimize(P[0]*cp.square(x[0]) + cp.quad_form(x, np.ones([2, 2])) + q.T @ x),
+                [A[0] * x[0] + A[1] * x[1] == b[0],
+                 A[2] * x[0] + A[3] * x[1] <= b[1]]
+            )
 
         update_parameters(P, A, b, q)
         result1 = prob.solve(solver=cp.CLARABEL, warm_start=False)


### PR DESCRIPTION
## Description
Fixes a crash condition when making parametric updates using clarabel v0.10.0 and cvxpy v1.6.1.

The issue arises when updating data for a problem with a non-diagonal quadratic cost, since the internal update function in clarabel wants updated `P` data to be in upper triangular form.   This crash does *not* happen during solver initialization because in that case clarabel accepts non-triangular `P` and enforces the triangularity condition internally when copying the problem data.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.