### PR TITLE
Draft: fix #2503 , turn `cvxpy` into meta-package that depends on `cvxpy-base`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,6 @@ jobs:
       matrix:
         os: [ ubuntu-22.04, macos-13, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13" ]
-        build-cvxpy-base: [ true, false ]  # whether to build cvxpy-base (true) or regular cvxpy (false)
         include:
           # This is intended to just add the single_action_config parameter to one existing combination;
           # see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
@@ -100,8 +99,8 @@ jobs:
       PIP_INSTALL: "${{ matrix.python-version == '3.11' }}"
       PYPI_SERVER: ${{ secrets.PYPI_SERVER }}
       PYPI_USER: ${{ secrets.PYPI_USER }}
-      PYPI_PASSWORD: ${{ matrix.build-cvxpy-base && secrets.PYPI_BASE_PASSWORD || secrets.PYPI_PASSWORD }}
-      CVXPY_BASE_SUFFIX: ${{ matrix.build-cvxpy-base && 'base-' || '' }}
+      PYPI_BASE_PASSWORD: ${{ secrets.PYPI_BASE_PASSWORD }}
+      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v4
@@ -114,27 +113,6 @@ jobs:
         run: |
           echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
           echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
-
-      - name: Adapt pyproject.toml
-        if: ${{matrix.build-cvxpy-base}}
-        shell: bash
-        run: |
-          # Mac has a different syntax for sed -i, this works across oses
-          sed -i.bak -e 's/name = "cvxpy"/name = "cvxpy-base"/g' pyproject.toml
-          sed -i.bak '/clarabel >= /d' pyproject.toml
-          sed -i.bak '/osqp >= /d' pyproject.toml
-          sed -i.bak '/ecos >= /d' pyproject.toml
-          sed -i.bak '/scs >= /d' pyproject.toml
-          sed -i.bak -e 's/name="cvxpy",/name="cvxpy-base",/g' setup.py
-          rm -rf pyproject.toml.bak setup.py.bak
-
-      - name: Verify that we can build by pip-install on each OS.
-        if: ${{matrix.build-cvxpy-base && env.PIP_INSTALL == 'True'}}
-        run: |
-          pip install . pytest cplex
-          pytest cvxpy/tests/test_conic_solvers.py -k 'TestCPLEX'
-          # ensure a fresh state for cibuildwheel
-          rm -r build
 
       - name: Set up QEMU  # For aarch64, see https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation
         if: runner.os == 'Linux'
@@ -157,22 +135,41 @@ jobs:
           pip install build
           python -m build --sdist -o wheelhouse
 
+      - name: Build metapackage source
+        if: ${{github.event_name == 'push' && env.SINGLE_ACTION_CONFIG == 'True'}}
+        run: |
+          cd ./meta-package
+          pip install build
+          python -m build --sdist -o wheelhouse
+
+
       - name: Check wheels
         if: ${{github.event_name == 'push' && env.USE_OPENMP != 'True'}}
         shell: bash
         run: |
           python -m pip install --upgrade twine
           twine check wheelhouse/*
+          cd ./meta-package
+          twine check wheelhouse/*
 
       - name: Release to pypi
         if: ${{env.DEPLOY == 'True' && env.USE_OPENMP != 'True'}}
         shell: bash
         run: |
+          twine upload --skip-existing --repository-url $PYPI_SERVER wheelhouse/* -u $PYPI_USER -p $PYPI_BASE_PASSWORD
+          cd ./meta-package
           twine upload --skip-existing --repository-url $PYPI_SERVER wheelhouse/* -u $PYPI_USER -p $PYPI_PASSWORD
 
       - name: Upload artifacts to github
         if: ${{github.event_name == 'push' && env.USE_OPENMP != 'True'}}
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ env.CVXPY_BASE_SUFFIX }}${{ matrix.os }}-${{ matrix.python-version }}
+          name: wheels-base-${{ matrix.os }}-${{ matrix.python-version }}
           path: ./wheelhouse
+
+      - name: Upload metapackage artifacts to github
+        if: ${{github.event_name == 'push' && env.USE_OPENMP != 'True'}}
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.python-version }}
+          path: ./meta-package/wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,6 @@ jobs:
         if: ${{github.event_name == 'push' && env.SINGLE_ACTION_CONFIG == 'True'}}
         run: |
           cd ./meta-package
-          pip install build
           python -m build --sdist -o wheelhouse
 
 

--- a/.github/workflows/test_backends.yml
+++ b/.github/workflows/test_backends.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Install cvxpy dependencies
         run: |
           pip install .
+          pip install meta-package
           pip install pytest hypothesis
       - name: Run tests for each non-default backend
         run : |

--- a/.github/workflows/test_backends.yml
+++ b/.github/workflows/test_backends.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install cvxpy dependencies
         run: |
           pip install .
-          pip install meta-package
+          pip install "./meta-package"
           pip install pytest hypothesis
       - name: Run tests for each non-default backend
         run : |

--- a/.github/workflows/test_metapackage.yml
+++ b/.github/workflows/test_metapackage.yml
@@ -8,7 +8,7 @@ on:
         tags:
           - '*'
 jobs:
-  test_optional_solvers:
+  test_metapackage:
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/test_metapackage.yml
+++ b/.github/workflows/test_metapackage.yml
@@ -1,0 +1,48 @@
+name: test_metapackage
+
+on:
+    pull_request:
+    push:
+        branches:
+            - master
+        tags:
+          - '*'
+jobs:
+  test_optional_solvers:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-22.04, macos-13, windows-2022 ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set Additional Envs
+        run: |
+          echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
+          echo $MOSEK_CI_BASE64 | base64 -d > mosek.lic
+          echo "MOSEKLM_LICENSE_FILE=$( [[ $RUNNER_OS == 'macOS' ]] && echo $(pwd)/mosek.lic || echo $(realpath mosek.lic) )" >> $GITHUB_ENV
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: 3.12
+          channels: conda-forge,anaconda
+      - uses: actions/checkout@v4
+      - name: Install cvxpy dependencies and all optional solvers
+        run: |
+          pip install "./meta-package"
+      - name: Print installed solvers
+        run : |
+          python -c "import cvxpy; print(cvxpy.installed_solvers())" 
+          python -c "import clarabel" 
+          python -c "import scs" 
+          python -c "import osqp" 
+
+    env:
+      RUNNER_OS: ${{ matrix.os }}
+      PYTHON_VERSION: 3.12

--- a/.github/workflows/test_metapackage.yml
+++ b/.github/workflows/test_metapackage.yml
@@ -39,6 +39,7 @@ jobs:
           pip install .
       - name: Print installed solvers
         run : |
+          cd meta-package
           python -c "import cvxpy; print(cvxpy.installed_solvers())" 
           python -c "import clarabel" 
           python -c "import scs" 

--- a/.github/workflows/test_metapackage.yml
+++ b/.github/workflows/test_metapackage.yml
@@ -35,7 +35,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install cvxpy dependencies and all optional solvers
         run: |
-          pip install "./meta-package"
+          cd meta-package
+          pip install .
       - name: Print installed solvers
         run : |
           python -c "import cvxpy; print(cvxpy.installed_solvers())" 

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -37,7 +37,6 @@ jobs:
         run: |
           source continuous_integration/install_optional_solvers.sh
           pip install . pytest hypothesis
-          pip install "./meta-package"
       - name: Print installed solvers
         run : |
           python -c "import cvxpy; print(cvxpy.installed_solvers())" 

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           source continuous_integration/install_optional_solvers.sh
           pip install . pytest hypothesis
+          pip install "./meta-package"
       - name: Print installed solvers
         run : |
           python -c "import cvxpy; print(cvxpy.installed_solvers())" 

--- a/meta-package/README.md
+++ b/meta-package/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/meta-package/pyproject.toml
+++ b/meta-package/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cvxpy"
+description = "A domain-specific language for modeling convex optimization problems in Python, meta-package including solvers."
+dependencies = [
+    "osqp >= 0.6.2",
+    "clarabel >= 0.5.0",
+    "scs >= 3.2.4.post1",
+    "cvxpy-base" # TODO: use dynamic dependencies
+]
+requires-python = ">=3.9"
+urls = {Homepage = "https://github.com/cvxpy/cvxpy"}
+license = {text = "Apache License, Version 2.0"}
+authors = [{name = "Steven Diamond", email = "stevend2@stanford.edu"},
+           {name = "", email = "akshayka@cs.stanford.edu"},
+           {name = "Eric Chu", email = "echu508@stanford.edu"},
+           {name = "Stephen Boyd", email = "boyd@stanford.edu"}]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+# Solver names as in cvxpy.settings = pip-installable distribution providing it
+CBC = ["cylp>=0.91.5"]
+CLARABEL = []
+CVXOPT = ["cvxopt"]
+DIFFCP = ["diffcp"]
+ECOS = ["ecos"]
+ECOS_BB = ["ecos"]
+GLOP = ["ortools>=9.7,<9.12"]
+GLPK = ["cvxopt"]
+GLPK_MI = ["cvxopt"]
+GUROBI = ["gurobipy"]
+HIGHS = ["highspy"]
+MOSEK = ["Mosek"]
+OSQP = []
+PDLP = ["ortools>=9.7,<9.12"]
+PIQP = ["piqp"]
+PROXQP = ["proxsuite"]
+QOCO = ["qoco"]
+SCIP = ["PySCIPOpt"]
+SCIPY = ["scipy"]
+SCS = []
+XPRESS = ["xpress"]
+DAQP = ["daqp"]
+
+[project.readme]
+file = "README.md" # symlinked from root, not allowed relative paths
+content-type = "text/markdown"

--- a/meta-package/pyproject.toml
+++ b/meta-package/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "cvxpy"
 description = "A domain-specific language for modeling convex optimization problems in Python, meta-package including solvers."
@@ -19,6 +15,13 @@ authors = [{name = "Steven Diamond", email = "stevend2@stanford.edu"},
            {name = "Eric Chu", email = "echu508@stanford.edu"},
            {name = "Stephen Boyd", email = "boyd@stanford.edu"}]
 dynamic = ["version"]
+
+[build-system]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+root = ".."
 
 [project.optional-dependencies]
 # Solver names as in cvxpy.settings = pip-installable distribution providing it

--- a/meta-package/pyproject.toml
+++ b/meta-package/pyproject.toml
@@ -44,6 +44,7 @@ SCIPY = ["scipy"]
 SCS = []
 XPRESS = ["xpress"]
 DAQP = ["daqp"]
+MPAX = ["mpax", "jax"]
 
 [project.readme]
 file = "README.md" # symlinked from root, not allowed relative paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,12 +47,9 @@ build-backend = "setup.build_meta"  # just re-exports setuptools.build_meta defi
 backend-path = ["."]
 
 [project]
-name = "cvxpy"
-description = "A domain-specific language for modeling convex optimization problems in Python."
+name = "cvxpy-base"
+description = "A domain-specific language for modeling convex optimization problems in Python, base package without solvers."
 dependencies = [
-    "osqp >= 0.6.2",
-    "clarabel >= 0.5.0",
-    "scs >= 3.2.4.post1",
     "numpy >= 1.21.6",
     "scipy >= 1.11.0",
 ]
@@ -66,29 +63,6 @@ authors = [{name = "Steven Diamond", email = "stevend2@stanford.edu"},
 dynamic = ["version"]
 
 [project.optional-dependencies]
-# Solver names as in cvxpy.settings = pip-installable distribution providing it
-CBC = ["cylp>=0.91.5"]
-CLARABEL = []
-CVXOPT = ["cvxopt"]
-DIFFCP = ["diffcp"]
-ECOS = ["ecos"]
-ECOS_BB = ["ecos"]
-GLOP = ["ortools>=9.7,<9.12"]
-GLPK = ["cvxopt"]
-GLPK_MI = ["cvxopt"]
-GUROBI = ["gurobipy"]
-HIGHS = ["highspy"]
-MOSEK = ["Mosek"]
-OSQP = []
-PDLP = ["ortools>=9.7,<9.12"]
-PIQP = ["piqp"]
-PROXQP = ["proxsuite"]
-QOCO = ["qoco"]
-SCIP = ["PySCIPOpt"]
-SCIPY = ["scipy"]
-SCS = []
-XPRESS = ["xpress"]
-DAQP = ["daqp"]
 testing = ["pytest", "hypothesis"]
 doc = ["sphinx",
        "sphinxcontrib.jquery",


### PR DESCRIPTION
## Description
See discussion in #2503, improve compatibility between `cvxpy` and `cvxpy-base` dependents.

## Type of change
- [ X] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.