### PR TITLE
Improve string representation of bounded variables

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -185,8 +185,21 @@ class Leaf(expression.Expression):
         """Get a string representing the attributes."""
         attr_str = ""
         for attr, val in self.attributes.items():
-            if attr != 'real' and val:
-                attr_str += ", %s=%s" % (attr, val)
+            if val is not False and val is not None:
+                if isinstance(val, bool):
+                    attr_str += ", %s=%s" % (attr, val)
+                elif attr == 'bounds' and val is not None:
+                    lower = np.array2string(val[0],
+                                    edgeitems=s.PRINT_EDGEITEMS,
+                                    threshold=s.PRINT_THRESHOLD,
+                                    formatter={'float': lambda x: f'{x:.2f}'})
+                    upper = np.array2string(val[1],
+                                    edgeitems=s.PRINT_EDGEITEMS,
+                                    threshold=s.PRINT_THRESHOLD,
+                                    formatter={'float': lambda x: f'{x:.2f}'})
+                    attr_str += ", %s=(%s, %s)" % (attr, lower, upper)
+                elif attr in ('sparsity', 'boolean', 'integer') and isinstance(val, Iterable):
+                    attr_str += ", %s=%s" % (attr, val)
         return attr_str
 
     def copy(self, args=None, id_objects=None):
@@ -491,8 +504,6 @@ class Leaf(expression.Expression):
                 f' Instantiate with scipy.sparse.coo_array((value_array, coordinates))'
                 )
         self.save_value(self._validate_value(val, True), True)
-
-
 
     def project_and_assign(self, val) -> None:
         """Project and assign a value to the variable.

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -204,3 +204,28 @@ class TestAttributes:
             ValueError, match="np.inf is not feasible as a lower bound."
         ):
             x = cp.Variable((2, 2), name="x", bounds=bounds)
+
+    def test_variable_repr(self):
+        # test boolean attributes
+        x = cp.Variable((10, 10), name="x", nonneg=True)
+        assert x.__repr__() == "Variable((10, 10), x, nonneg=True)"
+
+        # test bounds representation
+        y = cp.Variable((10, 10), name="y", bounds=[0, 10])
+        assert y.__repr__() == (
+            "Variable((10, 10), y, bounds=([[0 0 ... 0 0]\n"
+            " [0 0 ... 0 0]\n"
+            " ...\n"
+            " [0 0 ... 0 0]\n"
+            " [0 0 ... 0 0]], [[10 10 ... 10 10]\n"
+            " [10 10 ... 10 10]\n"
+            " ...\n"
+            " [10 10 ... 10 10]\n"
+            " [10 10 ... 10 10]]))"
+        )
+
+        # test sparse, mixed-integer/boolean representation
+        z = cp.Variable((10, 10), name="z", sparsity=[(0, 1), (0, 2)])
+        assert z.__repr__() == (
+            "Variable((10, 10), z, sparsity=[(0, 1), (0, 2)])"
+        )


### PR DESCRIPTION
## Description
Please include a short summary of the change.
Variable with bounds currently print the entire arrays which is not ideal.
This PR aims to improve the string representation of this case by using the ``np.array2string`` method to shorten the bounded variable repr.
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.