### PR TITLE
Bug: fix issue with infeasible sparse problems

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -449,7 +449,9 @@ class Leaf(expression.Expression):
 
     # Getter and setter for parameter value.
     def save_value(self, val, sparse_path=False) -> None:
-        if self.sparse_idx is not None and not sparse_path:
+        if val is None:
+            self._value = None
+        elif self.sparse_idx is not None and not sparse_path:
             self._value = sp.coo_array((val[self.sparse_idx], self.sparse_idx), shape=self.shape)
         elif self.sparse_idx is not None and sparse_path:
             self._value = val.data

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -130,6 +130,17 @@ class TestAttributes:
         X_value_sparse = X.value_sparse
         assert np.allclose(X_value_sparse.toarray(), z)
 
+    def test_infeasible_sparse(self):
+        # Create a sparse variable 
+        x = cp.Variable(100, sparsity=(np.array([1, 15, 45, 67, 89]),))
+        objective = cp.Minimize(cp.sum_squares(x))
+
+        # Create infeasible constraints
+        constraints = [x[1] >= 10, x[1] <= 1]
+        problem = cp.Problem(objective, constraints)
+        problem.solve()
+        assert problem.status == "infeasible"
+
     def test_diag_value_sparse(self):
         X = cp.Variable((3, 3), diag=True)
         prob = cp.Problem(cp.Minimize(cp.sum(X)), [X >= -1, X <= 1])


### PR DESCRIPTION
## Description
Please include a short summary of the change.
This part adds a special path for None values in the ``save_value`` method. This way it avoids an error while trying to index a NoneType. 
Issue link (if applicable): #2759 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.