### PR TITLE
Fix equality only constraints error in QOCO

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/qoco_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/qoco_conif.py
@@ -175,8 +175,8 @@ class QOCO(ConicSolver):
         n = len(data[s.C])
 
         P = data[s.P] if s.P in data.keys() else None
-        A = data[s.A]
-        G = data[s.G]
+        A = data[s.A] if p > 0 else None
+        G = data[s.G] if m > 0 else None
 
         # Cast row indices and column pointer arrays to int32.
         if P is not None:


### PR DESCRIPTION
## Description
Prior to this PR, the following problem would throw a setup error within QOCO.
```
import cvxpy as cp
import numpy as np

x = cp.Variable(2)
objective = cp.Minimize(cp.quad_form(x, np.eye(2)))
constraints = [x[0]+x[1] == 4]
prob = cp.Problem(objective, constraints)
prob.solve(solver='QOCO', verbose=True)
```

If a problem data matrix is not present for a given problem, it should be passed to qoco's setup function as `None`. 

For example, in the problem above, the conic constraint matrix `G` should be passed to qoco's setup function as None, but in the problem, `data[s.G]` is not None, it is some CSC matrix with 0 rows.

This PR fixes this issue, by setting `A` and `G` to  `data[s.A]` and  `data[s.G]` respectively if their respective constraints are present (i.e. `p>0` and `m>0`).

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.