### PR TITLE
fix change in problem status for newest osqp version

### DIFF
--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -138,8 +138,13 @@ class TestAttributes:
         # Create infeasible constraints
         constraints = [x[1] >= 10, x[1] <= 1]
         problem = cp.Problem(objective, constraints)
-        problem.solve()
+        problem.solve(solver=cp.CLARABEL)
         assert problem.status == "infeasible"
+
+        # Solve with OSQP > 1.0.0 gives infeasible innacurate
+        problem = cp.Problem(objective, constraints)
+        problem.solve(cp.OSQP)
+        assert problem.status == "infeasible_inaccurate"
 
     def test_diag_value_sparse(self):
         X = cp.Variable((3, 3), diag=True)


### PR DESCRIPTION
## Description
Please include a short summary of the change.
OSQP v1.0.0 was recently [released](https://github.com/osqp/osqp/releases/tag/v1.0.0). And one test started failing because the problem status changed. This PR aims to fix this issue to ensure the CI passes once again.
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.