### PR TITLE
fixes for PR 2769

### DIFF
--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -138,13 +138,8 @@ class TestAttributes:
         # Create infeasible constraints
         constraints = [x[1] >= 10, x[1] <= 1]
         problem = cp.Problem(objective, constraints)
-        problem.solve(solver=cp.CLARABEL)
+        problem.solve()
         assert problem.status == "infeasible"
-
-        # Solve with OSQP > 1.0.0 gives infeasible innacurate
-        problem = cp.Problem(objective, constraints)
-        problem.solve(cp.OSQP)
-        assert problem.status == "infeasible_inaccurate"
 
     def test_diag_value_sparse(self):
         X = cp.Variable((3, 3), diag=True)


### PR DESCRIPTION
@bstellato - here are some tweaks to maintain osqp correctness going forward. Not ideal (we should probably be pulling these from `osqp` instead of hard-coding), but that's another discussion, and hard-coding values for now is better than having incorrect ones.

Also reverted the change `cvxpy` made in its tests.