### PR TITLE
Improvements to argument validation for atoms (ND errors/warnings)

### DIFF
--- a/cvxpy/atoms/affine/add_expr.py
+++ b/cvxpy/atoms/affine/add_expr.py
@@ -47,6 +47,7 @@ class AddExpression(AffAtom):
             return expr.args
         else:
             return [expr]
+
     def name(self) -> str:
         result = str(self.args[0])
         for i in range(1, len(self.args)):

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -117,11 +117,6 @@ class MulExpression(BinaryOperator):
         """Validate that the arguments can be multiplied together."""
         if self.args[0].ndim > 2 or self.args[1].ndim > 2:
             raise ValueError("Multiplication with N-d arrays is not yet supported")
-        else:
-            # asserts that shapes can be multiplied
-            lhs = np.empty(self.args[0].shape, dtype=np.dtype([]))
-            rhs = np.empty(self.args[1].shape, dtype=np.dtype([]))
-            lhs @ rhs
     
     def shape_from_args(self) -> Tuple[int, ...]:
         """Returns the (row, col) shape of the expression.

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -479,10 +479,10 @@ def outer(x, y):
     """
     x = Expression.cast_to_const(x)
     if x.ndim > 1:
-        raise ValueError("x must be a vector.")
+        raise ValueError("x must be a 1-d array.")
     y = Expression.cast_to_const(y)
     if y.ndim > 1:
-        raise ValueError("y must be a vector.")
+        raise ValueError("y must be a 1-d array.")
     
     x = reshape(x, (x.size, 1), order='F')
     y = reshape(y, (1, y.size), order='F')

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -113,6 +113,16 @@ class MulExpression(BinaryOperator):
         else:
             return values[0] @ values[1]
 
+    def validate_arguments(self):
+        """Validate that the arguments can be multiplied together."""
+        if self.args[0].ndim > 2 or self.args[1].ndim > 2:
+            raise ValueError("Multiplication with N-d arrays is not yet supported")
+        else:
+            # asserts that shapes can be multiplied
+            lhs = np.empty(self.args[0].shape, dtype=np.dtype([]))
+            rhs = np.empty(self.args[1].shape, dtype=np.dtype([]))
+            lhs @ rhs
+    
     def shape_from_args(self) -> Tuple[int, ...]:
         """Returns the (row, col) shape of the expression.
         """

--- a/cvxpy/atoms/affine/conj.py
+++ b/cvxpy/atoms/affine/conj.py
@@ -24,13 +24,13 @@ from cvxpy.constraints.constraint import Constraint
 
 
 class conj(AffAtom):
-    """Complex conjugate.
+    """Elementwise complex conjugate.
     """
     def __init__(self, expr) -> None:
         super(conj, self).__init__(expr)
 
     def numeric(self, values):
-        """Convert the vector constant into a diagonal matrix.
+        """Elementwise Complex conjugate of an array
         """
         return np.conj(values[0])
 

--- a/cvxpy/atoms/affine/conv.py
+++ b/cvxpy/atoms/affine/conv.py
@@ -66,7 +66,7 @@ class conv(AffAtom):
         """Checks that both arguments are vectors, and the first is constant.
         """
         if not self.args[0].is_vector() or not self.args[1].is_vector():
-            raise ValueError("The arguments to conv must resolve to vectors.")
+            raise ValueError("The arguments to conv must resolve to a 1-d array")
         if not self.args[0].is_constant():
             raise ValueError("The first argument to conv must be constant.")
 

--- a/cvxpy/atoms/affine/cumsum.py
+++ b/cvxpy/atoms/affine/cumsum.py
@@ -70,6 +70,13 @@ class cumsum(AffAtom, AxisAtom):
         """
         return np.cumsum(values[0], axis=self.axis)
 
+    def validate_arguments(self):
+        if self.args[0].ndim > 2:
+            raise UserWarning(
+                "cumsum is only implemented for 1D or 2D arrays and might not "
+                "work as expected for higher dimensions."
+            )
+    
     def shape_from_args(self) -> Tuple[int, ...]:
         """The same as the input."""
         return self.args[0].shape

--- a/cvxpy/atoms/affine/diag.py
+++ b/cvxpy/atoms/affine/diag.py
@@ -51,7 +51,7 @@ def diag(expr, k: int = 0) -> Union["diag_mat", "diag_vec"]:
         assert abs(k) < expr.shape[0], "Offset out of bounds."
         return diag_mat(expr, k)
     else:
-        raise ValueError("Argument to diag must be a vector or square matrix.")
+        raise ValueError("Argument to diag must be a 1 or 2-d array.")
 
 
 class diag_vec(AffAtom):
@@ -65,11 +65,11 @@ class diag_vec(AffAtom):
         return [self.k]
     
     def validate_arguments(self) -> None:
-        """Checks that the argument is a square matrix.
+        """Checks that the argument is a vector.
         """
         if not self.args[0].ndim == 1:
             raise ValueError(
-                "Argument to diag_vec must be a vector."
+                "Argument to diag_vec must be a 1-d array"
             )
         
     def is_atom_log_log_convex(self) -> bool:
@@ -151,7 +151,7 @@ class diag_mat(AffAtom):
         """
         if not self.args[0].ndim == 2:
             raise ValueError(
-                "Argument to diag_mat must be a matrix."
+                "Argument to diag_mat must be a 2-d array."
             )
 
     def is_atom_log_log_convex(self) -> bool:

--- a/cvxpy/atoms/affine/diag.py
+++ b/cvxpy/atoms/affine/diag.py
@@ -51,7 +51,7 @@ def diag(expr, k: int = 0) -> Union["diag_mat", "diag_vec"]:
         assert abs(k) < expr.shape[0], "Offset out of bounds."
         return diag_mat(expr, k)
     else:
-        raise ValueError("Argument to diag must be a 1 or 2-d array.")
+        raise ValueError("Argument to diag must be a 1-d array or 2-d square array.")
 
 
 class diag_vec(AffAtom):

--- a/cvxpy/atoms/affine/diag.py
+++ b/cvxpy/atoms/affine/diag.py
@@ -55,8 +55,7 @@ def diag(expr, k: int = 0) -> Union["diag_mat", "diag_vec"]:
 
 
 class diag_vec(AffAtom):
-    """Converts a vector into a diagonal matrix.
-    """
+    """Converts a vector into a diagonal matrix."""
 
     def __init__(self, expr, k: int = 0) -> None:
         self.k = k
@@ -64,7 +63,15 @@ class diag_vec(AffAtom):
 
     def get_data(self) -> list[int]:
         return [self.k]
-
+    
+    def validate_arguments(self) -> None:
+        """Checks that the argument is a square matrix.
+        """
+        if not self.args[0].ndim == 1:
+            raise ValueError(
+                "Argument to diag_vec must be a vector."
+            )
+        
     def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """
@@ -135,9 +142,17 @@ class diag_mat(AffAtom):
     def __init__(self, expr, k: int = 0) -> None:
         self.k = k
         super(diag_mat, self).__init__(expr)
-
+    
     def get_data(self) -> list[int]:
         return [self.k]
+
+    def validate_arguments(self) -> None:
+        """Checks that the argument is a square matrix.
+        """
+        if not self.args[0].ndim == 2:
+            raise ValueError(
+                "Argument to diag_mat must be a matrix."
+            )
 
     def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
@@ -150,22 +165,18 @@ class diag_mat(AffAtom):
         return True
 
     @AffAtom.numpy_numeric
-    def numeric(self, values):
-        """Extract the diagonal from a square matrix constant.
-        """
-        # The return type in numpy versions < 1.10 was ndarray.
+    def numeric(self, values) -> np.ndarray:
+        """Extract the diagonal from a square matrix constant."""
         return np.diag(values[0], k=self.k)
 
     def shape_from_args(self) -> Tuple[int]:
-        """A column vector.
-        """
+        """A column vector."""
         rows, _ = self.args[0].shape
         rows -= abs(self.k)
         return (rows,)
 
     def is_nonneg(self) -> bool:
-        """Is the expression nonnegative?
-        """
+        """Is the expression nonnegative?"""
         return (self.args[0].is_nonneg() or self.args[0].is_psd()) and self.k == 0
 
     def graph_implementation(

--- a/cvxpy/atoms/affine/imag.py
+++ b/cvxpy/atoms/affine/imag.py
@@ -27,7 +27,7 @@ class imag(AffAtom):
         super(imag, self).__init__(expr)
 
     def numeric(self, values):
-        """Convert the vector constant into a diagonal matrix.
+        """Imaginary part of an expression
         """
         return np.imag(values[0])
 

--- a/cvxpy/atoms/affine/kron.py
+++ b/cvxpy/atoms/affine/kron.py
@@ -45,7 +45,7 @@ class kron(AffAtom):
         if not (self.args[0].is_constant() or self.args[1].is_constant()):
             raise ValueError("At least one argument to kron must be constant.")
         elif self.args[0].ndim != 2 or self.args[1].ndim != 2:
-            raise ValueError("kron requires matrix arguments.")
+            raise ValueError("kron requires both arguments to be 2-d.")
 
     def shape_from_args(self) -> Tuple[int, int]:
         rows = self.args[0].shape[0]*self.args[1].shape[0]

--- a/cvxpy/atoms/affine/partial_trace.py
+++ b/cvxpy/atoms/affine/partial_trace.py
@@ -78,7 +78,7 @@ def partial_trace(expr, dims: Tuple[int], axis: Optional[int] = 0):
     """
     expr = Atom.cast_to_const(expr)
     if expr.ndim < 2 or expr.shape[0] != expr.shape[1]:
-        raise ValueError("partial_trace only supports 2-d arrays.")
+        raise ValueError("partial_trace only supports 2-d square arrays.")
     if axis < 0 or axis >= len(dims):
         raise ValueError(
             f"Invalid axis argument, should be between 0 and {len(dims)}, got {axis}."

--- a/cvxpy/atoms/affine/partial_trace.py
+++ b/cvxpy/atoms/affine/partial_trace.py
@@ -78,7 +78,7 @@ def partial_trace(expr, dims: Tuple[int], axis: Optional[int] = 0):
     """
     expr = Atom.cast_to_const(expr)
     if expr.ndim < 2 or expr.shape[0] != expr.shape[1]:
-        raise ValueError("Only supports square matrices.")
+        raise ValueError("partial_trace only supports 2-d arrays.")
     if axis < 0 or axis >= len(dims):
         raise ValueError(
             f"Invalid axis argument, should be between 0 and {len(dims)}, got {axis}."

--- a/cvxpy/atoms/affine/partial_transpose.py
+++ b/cvxpy/atoms/affine/partial_transpose.py
@@ -79,7 +79,7 @@ def partial_transpose(expr, dims: Tuple[int, ...], axis: Optional[int] = 0):
     """
     expr = Atom.cast_to_const(expr)
     if expr.ndim < 2 or expr.shape[0] != expr.shape[1]:
-        raise ValueError("Only supports square matrices.")
+        raise ValueError("partial_transpose only supports 2-d arrays.")
     if axis < 0 or axis >= len(dims):
         raise ValueError(
             f"Invalid axis argument, should be between 0 and {len(dims)}, got {axis}."

--- a/cvxpy/atoms/affine/partial_transpose.py
+++ b/cvxpy/atoms/affine/partial_transpose.py
@@ -79,7 +79,7 @@ def partial_transpose(expr, dims: Tuple[int, ...], axis: Optional[int] = 0):
     """
     expr = Atom.cast_to_const(expr)
     if expr.ndim < 2 or expr.shape[0] != expr.shape[1]:
-        raise ValueError("partial_transpose only supports 2-d arrays.")
+        raise ValueError("partial_transpose only supports 2-d square arrays.")
     if axis < 0 or axis >= len(dims):
         raise ValueError(
             f"Invalid axis argument, should be between 0 and {len(dims)}, got {axis}."

--- a/cvxpy/atoms/affine/promote.py
+++ b/cvxpy/atoms/affine/promote.py
@@ -43,7 +43,7 @@ def promote(expr: Expression, shape: Tuple[int, ...]):
     expr = Expression.cast_to_const(expr)
     if expr.shape != shape:
         if not expr.is_scalar():
-            raise ValueError('Only scalars may be promoted.')
+            raise ValueError('Only 0-d arrays may be promoted.')
         return Promote(expr, shape)
     else:
         return expr

--- a/cvxpy/atoms/affine/promote.py
+++ b/cvxpy/atoms/affine/promote.py
@@ -43,7 +43,7 @@ def promote(expr: Expression, shape: Tuple[int, ...]):
     expr = Expression.cast_to_const(expr)
     if expr.shape != shape:
         if not expr.is_scalar():
-            raise ValueError('Only 0-d arrays may be promoted.')
+            raise ValueError('Only 0-d arrays (i.e., scalars) may be promoted.')
         return Promote(expr, shape)
     else:
         return expr

--- a/cvxpy/atoms/affine/real.py
+++ b/cvxpy/atoms/affine/real.py
@@ -28,8 +28,8 @@ class real(AffAtom):
 
     def numeric(self, values):
         """
+        Return the real part of a complex array.
         """
-        # Convert values to 1D.
         return np.real(values[0])
 
     def shape_from_args(self) -> Tuple[int, ...]:

--- a/cvxpy/atoms/affine/real.py
+++ b/cvxpy/atoms/affine/real.py
@@ -27,7 +27,7 @@ class real(AffAtom):
         super(real, self).__init__(expr)
 
     def numeric(self, values):
-        """Convert the vector constant into a diagonal matrix.
+        """
         """
         # Convert values to 1D.
         return np.real(values[0])

--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -42,9 +42,9 @@ class reshape(AffAtom):
     Parameters
     ----------
     expr : Expression
-       The expression to promote.
+       The expression to reshape
     shape : tuple or int
-        The shape to promote to.
+        The shape to reshape to
     order : F(ortran) or C
     """
 
@@ -115,7 +115,7 @@ class reshape(AffAtom):
             )
 
     def shape_from_args(self) -> Tuple[int, ...]:
-        """Returns the shape from the rows, cols arguments.
+        """Returns the shape argument.
         """
         return self._shape
 

--- a/cvxpy/atoms/affine/trace.py
+++ b/cvxpy/atoms/affine/trace.py
@@ -55,7 +55,7 @@ class trace(AffAtom):
         """
         shape = self.args[0].shape
         if self.args[0].ndim != 2 or shape[0] != shape[1]:
-            raise ValueError("Argument to trace must be a 2-d array.")
+            raise ValueError("Argument to trace must be a 2-d square array.")
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Always scalar.

--- a/cvxpy/atoms/affine/trace.py
+++ b/cvxpy/atoms/affine/trace.py
@@ -55,7 +55,7 @@ class trace(AffAtom):
         """
         shape = self.args[0].shape
         if self.args[0].ndim != 2 or shape[0] != shape[1]:
-            raise ValueError("Argument to trace must be a square matrix.")
+            raise ValueError("Argument to trace must be a 2-d array.")
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Always scalar.

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -65,7 +65,7 @@ class upper_tri(AffAtom):
         """
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
             raise ValueError(
-                "Argument to upper_tri must be a 2-d array."
+                "Argument to upper_tri must be a 2-d square array."
             )
 
     def shape_from_args(self) -> Tuple[int, int]:

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -65,7 +65,7 @@ class upper_tri(AffAtom):
         """
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
             raise ValueError(
-                "Argument to upper_tri must be a square matrix."
+                "Argument to upper_tri must be a 2-d array."
             )
 
     def shape_from_args(self) -> Tuple[int, int]:

--- a/cvxpy/atoms/affine/vec.py
+++ b/cvxpy/atoms/affine/vec.py
@@ -22,7 +22,7 @@ from cvxpy.expressions.expression import DEFAULT_ORDER_DEPRECATION_MSG, Expressi
 
 
 def vec(X, order: Literal["F", "C", None] = None):
-    """Flattens the matrix X into a vector.
+    """Flattens the matrix X into a 1-d array.
 
     Parameters
     ----------

--- a/cvxpy/atoms/affine/vstack.py
+++ b/cvxpy/atoms/affine/vstack.py
@@ -30,7 +30,7 @@ def vstack(arg_list) -> "Vstack":
 
 
 class Vstack(AffAtom):
-    """ Vertical concatenation """
+    """Vertical concatenation"""
     def is_atom_log_log_convex(self) -> bool:
         """Is the atom log-log convex?
         """

--- a/cvxpy/atoms/condition_number.py
+++ b/cvxpy/atoms/condition_number.py
@@ -57,7 +57,7 @@ class condition_number(Atom):
         raise NotImplementedError
 
     def validate_arguments(self) -> None:
-        """Verify that the argument A is square.
+        """Verify that the argument A is a square matrix.
         """
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
             raise ValueError(

--- a/cvxpy/atoms/condition_number.py
+++ b/cvxpy/atoms/condition_number.py
@@ -61,7 +61,7 @@ class condition_number(Atom):
         """
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
             raise ValueError(
-                f"The argument {self.args[0].name()} to condition_number must be a square matrix."
+                f"The argument {self.args[0].name()} to condition_number must be a 2-d array."
             )
 
     def shape_from_args(self) -> Tuple[int, ...]:

--- a/cvxpy/atoms/condition_number.py
+++ b/cvxpy/atoms/condition_number.py
@@ -61,7 +61,7 @@ class condition_number(Atom):
         """
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
             raise ValueError(
-                f"The argument {self.args[0].name()} to condition_number must be a 2-d array."
+                f"The argument {self.args[0].name()} to condition_number must be a 2-d square array"
             )
 
     def shape_from_args(self) -> Tuple[int, ...]:

--- a/cvxpy/atoms/cvar.py
+++ b/cvxpy/atoms/cvar.py
@@ -50,7 +50,7 @@ def cvar(x, beta):
         raise ValueError(f"The probability level beta must be in the range [0, 1), got {beta}")
 
     if len(x.shape) != 1:
-        raise ValueError(f"Input must be a vector (1D array), got shape {x.shape}")
+        raise ValueError(f"cvar input must be a 1d array, got shape {x.shape}")
     
     k = (1 - beta) * x.shape[0]
     w = np.append(np.ones(int(k)), k - int(k))

--- a/cvxpy/atoms/errormsg.py
+++ b/cvxpy/atoms/errormsg.py
@@ -1,5 +1,5 @@
 SECOND_ARG_SHOULD_NOT_BE_EXPRESSION_ERROR_MESSAGE = """
 The second argument has type cvxpy.Expression. However, that is not allowed.
 Most likely, you want to call this atom by using cvxpy.hstack to combine the
-two arguemnts into a vector.
+two arguments into a vector.
 """

--- a/cvxpy/atoms/gen_lambda_max.py
+++ b/cvxpy/atoms/gen_lambda_max.py
@@ -22,7 +22,7 @@ from cvxpy.constraints.constraint import Constraint
 
 
 class gen_lambda_max(Atom):
-    """ Maximum generalized eigenvalue; :math:`\\lambda_{\\max}(A, B)`.
+    """Maximum generalized eigenvalue; :math:`\\lambda_{\\max}(A, B)`.
     """
 
     def __init__(self, A, B) -> None:

--- a/cvxpy/atoms/lambda_max.py
+++ b/cvxpy/atoms/lambda_max.py
@@ -62,7 +62,7 @@ class lambda_max(Atom):
         return [sp.csc_array([D.ravel(order='F')]).T]
 
     def validate_arguments(self) -> None:
-        """Verify that the argument A is square.
+        """Verify that the argument A is a square matrix.
         """
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
             raise ValueError("The argument '%s' to lambda_max must resolve to a square matrix."

--- a/cvxpy/atoms/log_det.py
+++ b/cvxpy/atoms/log_det.py
@@ -51,7 +51,7 @@ class log_det(Atom):
     def validate_arguments(self) -> None:
         X = self.args[0]
         if not len(X.shape) == 2 or X.shape[0] != X.shape[1]:
-            raise TypeError("The argument to log_det must be a square matrix.")
+            raise TypeError("The argument to log_det must be a 2-d square array.")
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Returns the (row, col) shape of the expression.

--- a/cvxpy/atoms/log_det.py
+++ b/cvxpy/atoms/log_det.py
@@ -50,7 +50,7 @@ class log_det(Atom):
     # Any argument shape is valid.
     def validate_arguments(self) -> None:
         X = self.args[0]
-        if len(X.shape) == 1 or X.shape[0] != X.shape[1]:
+        if not len(X.shape) == 2 or X.shape[0] != X.shape[1]:
             raise TypeError("The argument to log_det must be a square matrix.")
 
     def shape_from_args(self) -> Tuple[int, ...]:

--- a/cvxpy/atoms/pf_eigenvalue.py
+++ b/cvxpy/atoms/pf_eigenvalue.py
@@ -47,7 +47,7 @@ class pf_eigenvalue(Atom):
         """Verify that the argument is a square matrix."""
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
             raise ValueError(
-                f"The argument {self.args[0].name()} to pf_eigenvalue must be a square matrix."
+                f"The argument {self.args[0].name()} to pf_eigenvalue must be a 2-d square array."
             )
     
     def name(self) -> str:

--- a/cvxpy/atoms/pf_eigenvalue.py
+++ b/cvxpy/atoms/pf_eigenvalue.py
@@ -38,14 +38,18 @@ class pf_eigenvalue(Atom):
     """
     def __init__(self, X) -> None:
         super(pf_eigenvalue, self).__init__(X)
-        if len(X.shape) != 2 or X.shape[0] != X.shape[1]:
-            raise ValueError("Argument to `spectral radius` must be a "
-                             "square matrix, received ", X)
         self.args[0] = X
 
     def numeric(self, values):
         return np.max(np.abs(np.linalg.eig(values[0])[0]))
 
+    def validate_arguments(self):
+        """Verify that the argument is a square matrix."""
+        if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
+            raise ValueError(
+                f"The argument {self.args[0].name()} to pf_eigenvalue must be a square matrix."
+            )
+    
     def name(self) -> str:
         return "%s(%s)" % (self.__class__.__name__, self.args[0])
 

--- a/cvxpy/atoms/pnorm.py
+++ b/cvxpy/atoms/pnorm.py
@@ -141,7 +141,6 @@ class Pnorm(AxisAtom):
     def numeric(self, values):
         """Returns the p-norm of x.
         """
-
         if self.axis is None:
             values = np.array(values[0]).flatten()
         else:

--- a/cvxpy/atoms/prod.py
+++ b/cvxpy/atoms/prod.py
@@ -102,7 +102,7 @@ class Prod(AxisAtom):
                 if self.keepdims:
                     result = np.expand_dims(result, self.axis)
             else:
-                raise UserWarning("cp.prod only supports axis=0 or axis=1 for sparse matrices.")
+                raise UserWarning("cp.prod does not support axis > 1 for sparse matrices.")
         else:
             result = np.prod(values[0], axis=self.axis, keepdims=self.keepdims)
         return result

--- a/cvxpy/atoms/prod.py
+++ b/cvxpy/atoms/prod.py
@@ -91,8 +91,7 @@ class Prod(AxisAtom):
                 else:
                     data = np.zeros(1, dtype=sp_mat.dtype)
                 result = np.prod(data)
-            else:
-                assert self.axis in [0, 1]
+            elif self.axis in [0, 1]:
                 # The following snippet is taken from stackoverflow.
                 # https://stackoverflow.com/questions/44320865/
                 # can replace private _getnnz for scipy 1.15+ with count_nonzero
@@ -102,6 +101,8 @@ class Prod(AxisAtom):
                 result[mask] = np.prod(data.toarray(), axis=self.axis)
                 if self.keepdims:
                     result = np.expand_dims(result, self.axis)
+            else:
+                raise UserWarning("cp.prod only supports axis=0 or axis=1 for sparse matrices.")
         else:
             result = np.prod(values[0], axis=self.axis, keepdims=self.keepdims)
         return result

--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -51,7 +51,7 @@ class QuadForm(Atom):
         super(QuadForm, self).validate_arguments()
         n = self.args[1].shape[0]
         if self.args[1].shape[1] != n or self.args[0].shape not in [(n, 1), (n,)]:
-            raise ValueError("Invalid dimensions for arguments.")
+            raise ValueError("Invalid dimensions for arguments to quad_form.")
         if not self.args[1].is_hermitian():
             raise ValueError("Quadratic form matrices must be symmetric/Hermitian.")
 
@@ -241,7 +241,7 @@ def quad_form(x, P, assume_PSD: bool = False):
     x, P = map(Expression.cast_to_const, (x, P))
     # Check dimensions.
     if not P.ndim == 2 or P.shape[0] != P.shape[1] or max(x.shape, (1,))[0] != P.shape[0]:
-        raise Exception("Invalid dimensions for arguments.")
+        raise Exception("Invalid dimensions for arguments to quad_form.")
     if x.is_constant():
         return x.T.conjugate() @ P @ x
     elif P.is_constant():

--- a/cvxpy/atoms/quad_over_lin.py
+++ b/cvxpy/atoms/quad_over_lin.py
@@ -27,8 +27,7 @@ from cvxpy.expressions.constants.parameter import is_param_free
 
 
 class quad_over_lin(Atom):
-    """ :math:`(sum_{ij}X^2_{ij})/y`
-
+    """:math:`(sum_{ij}X^2_{ij})/y`
     """
     _allow_complex = True
 

--- a/cvxpy/atoms/quantum_rel_entr.py
+++ b/cvxpy/atoms/quantum_rel_entr.py
@@ -61,8 +61,10 @@ class quantum_rel_entr(Atom):
 
     def validate_arguments(self) -> None:
         if not (self.args[0].is_hermitian() and self.args[1].is_hermitian()):
-            raise ValueError('Arguments must be Hermitian')
-
+            raise ValueError(
+                "The arguments to quantum_rel_entr must both be hermitian."
+            )
+        
     def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """

--- a/cvxpy/atoms/sigma_max.py
+++ b/cvxpy/atoms/sigma_max.py
@@ -34,7 +34,7 @@ class sigma_max(Atom):
         """Verify that the argument is a matrix."""
         if not self.args[0].ndim == 2:
             raise ValueError(
-                f"The argument {self.args[0].name()} to sigma_max must be a matrix."
+                f"The argument {self.args[0].name()} to sigma_max must be a 2-d array."
             )
     
     @Atom.numpy_numeric

--- a/cvxpy/atoms/sigma_max.py
+++ b/cvxpy/atoms/sigma_max.py
@@ -30,6 +30,13 @@ class sigma_max(Atom):
     def __init__(self, A) -> None:
         super(sigma_max, self).__init__(A)
 
+    def validate_arguments(self):
+        """Verify that the argument is a matrix."""
+        if not self.args[0].ndim == 2:
+            raise ValueError(
+                f"The argument {self.args[0].name()} to sigma_max must be a matrix."
+            )
+    
     @Atom.numpy_numeric
     def numeric(self, values):
         """Returns the largest singular value of A.

--- a/cvxpy/atoms/stats.py
+++ b/cvxpy/atoms/stats.py
@@ -30,7 +30,7 @@ def mean(x, axis=None, keepdims=False):
     elif axis in (0, 1):
         return cvxpy_sum(x, axis, keepdims) / x.shape[axis]
     else:
-        raise ValueError("Invalid axis value.")
+        raise UserWarning("cp.mean doesn't yet support axis values other than 0 or 1.")
 
 
 def std(x, axis=None, keepdims=False, ddof=0):
@@ -45,7 +45,7 @@ def std(x, axis=None, keepdims=False, ddof=0):
         return norm(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims) \
                 / np.sqrt(x.shape[axis] - ddof)
     else:
-        raise ValueError("Invalid axis value.")
+        raise ValueError("cp.std doesn't yet support axis values other than 0 or 1.")
 
 def var(x, axis=None, keepdims=False, ddof=0):
     """
@@ -65,4 +65,4 @@ def var(x, axis=None, keepdims=False, ddof=0):
         # return sum_squares(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims) \
         #         / (x.shape[axis] - ddof)
     else:
-        raise ValueError("Invalid axis value.")
+        raise ValueError("cp.var doesn't yet support axis values other than 0 or 1.")

--- a/cvxpy/atoms/total_variation.py
+++ b/cvxpy/atoms/total_variation.py
@@ -60,4 +60,4 @@ def tv(value, *args):
         stacked = vstack([reshape(diff, (1, length), order='F') for diff in diffs])
         return sum(norm(stacked, p=2, axis=0))
     else:
-        raise ValueError("tv cannot have inputs with more than 2 dimensions.")
+        raise ValueError("tv cannot have input arrays with more than 2 dimensions.")

--- a/cvxpy/atoms/total_variation.py
+++ b/cvxpy/atoms/total_variation.py
@@ -46,7 +46,7 @@ def tv(value, *args):
     elif value.ndim == 1:
         return norm(value[1:] - value[0:value.shape[0]-1], 1)
     # L2 norm for matrices.
-    else:
+    elif value.ndim == 2:
         rows, cols = value.shape
         args = map(Expression.cast_to_const, args)
         values = [value] + list(args)
@@ -59,3 +59,5 @@ def tv(value, *args):
         length = diffs[0].shape[0]*diffs[1].shape[1]
         stacked = vstack([reshape(diff, (1, length), order='F') for diff in diffs])
         return sum(norm(stacked, p=2, axis=0))
+    else:
+        raise ValueError("tv cannot have inputs with more than 2 dimensions.")

--- a/cvxpy/atoms/tr_inv.py
+++ b/cvxpy/atoms/tr_inv.py
@@ -53,7 +53,7 @@ class tr_inv(Atom):
         """Verify that the argument is a square matrix."""
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
             raise ValueError(
-                f"The argument {self.args[0].name()} to tr_inv must be a 2-d array."
+                f"The argument {self.args[0].name()} to tr_inv must be a 2-d square array."
             )
 
     def shape_from_args(self) -> Tuple[int, ...]:

--- a/cvxpy/atoms/tr_inv.py
+++ b/cvxpy/atoms/tr_inv.py
@@ -49,11 +49,12 @@ class tr_inv(Atom):
             return np.inf
         return np.sum(eigVal**-1)
 
-    # The shape of argument must be square.
     def validate_arguments(self) -> None:
-        X = self.args[0]
-        if len(X.shape) == 1 or X.shape[0] != X.shape[1]:
-            raise TypeError("The argument to tr_inv must be a square matrix.")
+        """Verify that the argument is a square matrix."""
+        if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
+            raise ValueError(
+                f"The argument {self.args[0].name()} to tr_inv must be a square matrix."
+            )
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Returns the (row, col) shape of the expression.

--- a/cvxpy/atoms/tr_inv.py
+++ b/cvxpy/atoms/tr_inv.py
@@ -53,7 +53,7 @@ class tr_inv(Atom):
         """Verify that the argument is a square matrix."""
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
             raise ValueError(
-                f"The argument {self.args[0].name()} to tr_inv must be a square matrix."
+                f"The argument {self.args[0].name()} to tr_inv must be a 2-d array."
             )
 
     def shape_from_args(self) -> Tuple[int, ...]:
@@ -119,7 +119,7 @@ class tr_inv(Atom):
                            self.args[0].value.T.conj(),
                            rtol=s.ATOM_EVAL_TOL,
                            atol=s.ATOM_EVAL_TOL):
-            raise ValueError("Input matrix was not Hermitian/symmetric.")
+            raise ValueError("Input array to tr_inv was not Hermitian/symmetric.")
         if any([p.value is None for p in self.parameters()]):
             return None
         return self._value_impl()

--- a/cvxpy/atoms/von_neumann_entr.py
+++ b/cvxpy/atoms/von_neumann_entr.py
@@ -63,13 +63,12 @@ class von_neumann_entr(Atom):
         return val
 
     def validate_arguments(self) -> None:
-        """Verify that the argument A is PSD.
-        """
-        N = self.args[0]
-        if N.size > 1:
-            if N.ndim != 2 or N.shape[0] != N.shape[1]:
-                raise ValueError('Argument must be a square matrix.')
-
+        """Verify that the argument is a square matrix."""
+        if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
+            raise ValueError(
+                f"The argument {self.args[0].name()} to von_neumann_entr must be a square matrix."
+            )
+        
     def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """

--- a/cvxpy/atoms/von_neumann_entr.py
+++ b/cvxpy/atoms/von_neumann_entr.py
@@ -66,7 +66,7 @@ class von_neumann_entr(Atom):
         """Verify that the argument is a square matrix."""
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
             raise ValueError(
-                f"The argument {self.args[0].name()} to von_neumann_entr must be a 2-d array."
+                f"The argument {self.args[0].name()} to von_neumann_entr must be a 2-d square array"
             )
         
     def sign_from_args(self) -> Tuple[bool, bool]:

--- a/cvxpy/atoms/von_neumann_entr.py
+++ b/cvxpy/atoms/von_neumann_entr.py
@@ -66,7 +66,7 @@ class von_neumann_entr(Atom):
         """Verify that the argument is a square matrix."""
         if not self.args[0].ndim == 2 or self.args[0].shape[0] != self.args[0].shape[1]:
             raise ValueError(
-                f"The argument {self.args[0].name()} to von_neumann_entr must be a square matrix."
+                f"The argument {self.args[0].name()} to von_neumann_entr must be a 2-d array."
             )
         
     def sign_from_args(self) -> Tuple[bool, bool]:

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -775,7 +775,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.trace(self.C)
         self.assertEqual(str(cm.exception),
-                         "Argument to trace must be a square matrix.")
+                         "Argument to trace must be a 2-d array.")
 
     def test_trace_sign_psd(self) -> None:
         """Test sign of trace for psd/nsd inputs.
@@ -803,7 +803,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.upper_tri(self.C)
         self.assertEqual(str(cm.exception),
-                         "Argument to upper_tri must be a square matrix.")
+                         "Argument to upper_tri must be a 2-d array.")
 
     def test_vec_to_upper_tri(self) -> None:
         x = Variable(shape=(3,))
@@ -1712,7 +1712,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(ValueError) as cm:
             cp.partial_trace(X, dims=[2, 3], axis=0)
         self.assertEqual(str(cm.exception),
-                         "Only supports square matrices.")
+                         "partial_trace only supports 2-d arrays.")
 
         X = cp.Variable((6, 6))
         with self.assertRaises(ValueError) as cm:
@@ -1771,7 +1771,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(ValueError) as cm:
             cp.partial_transpose(X, dims=[2, 3], axis=0)
         self.assertEqual(str(cm.exception),
-                         "Only supports square matrices.")
+                         "partial_transpose only supports 2-d arrays.")
 
         X = cp.Variable((6, 6))
         with self.assertRaises(ValueError) as cm:

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -736,7 +736,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.diag(self.C)
         self.assertEqual(str(cm.exception),
-                         "Argument to diag must be a 1 or 2-d array.")
+                         "Argument to diag must be a 1-d array or 2-d square array.")
 
         # Test that diag is PSD
         w = np.array([1.0, 2.0])
@@ -775,7 +775,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.trace(self.C)
         self.assertEqual(str(cm.exception),
-                         "Argument to trace must be a 2-d array.")
+                         "Argument to trace must be a 2-d square array.")
 
     def test_trace_sign_psd(self) -> None:
         """Test sign of trace for psd/nsd inputs.
@@ -803,7 +803,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.upper_tri(self.C)
         self.assertEqual(str(cm.exception),
-                         "Argument to upper_tri must be a 2-d array.")
+                         "Argument to upper_tri must be a 2-d square array.")
 
     def test_vec_to_upper_tri(self) -> None:
         x = Variable(shape=(3,))
@@ -1712,7 +1712,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(ValueError) as cm:
             cp.partial_trace(X, dims=[2, 3], axis=0)
         self.assertEqual(str(cm.exception),
-                         "partial_trace only supports 2-d arrays.")
+                         "partial_trace only supports 2-d square arrays.")
 
         X = cp.Variable((6, 6))
         with self.assertRaises(ValueError) as cm:
@@ -1771,7 +1771,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(ValueError) as cm:
             cp.partial_transpose(X, dims=[2, 3], axis=0)
         self.assertEqual(str(cm.exception),
-                         "partial_transpose only supports 2-d arrays.")
+                         "partial_transpose only supports 2-d square arrays.")
 
         X = cp.Variable((6, 6))
         with self.assertRaises(ValueError) as cm:

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1118,7 +1118,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.conv([[0, 1], [0, 1]], self.x)
         self.assertEqual(str(cm.exception),
-                         "The arguments to conv must resolve to a 1-d array.")
+                         "The arguments to conv must resolve to a 1-d array")
 
         # Test with parameter input.
         # https://github.com/cvxpy/cvxpy/issues/2218

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -736,7 +736,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.diag(self.C)
         self.assertEqual(str(cm.exception),
-                         "Argument to diag must be a vector or square matrix.")
+                         "Argument to diag must be a 1 or 2-d array.")
 
         # Test that diag is PSD
         w = np.array([1.0, 2.0])
@@ -1118,7 +1118,7 @@ class TestAtoms(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.conv([[0, 1], [0, 1]], self.x)
         self.assertEqual(str(cm.exception),
-                         "The arguments to conv must resolve to vectors.")
+                         "The arguments to conv must resolve to a 1-d array.")
 
         # Test with parameter input.
         # https://github.com/cvxpy/cvxpy/issues/2218
@@ -1630,9 +1630,9 @@ class TestAtoms(BaseTest):
         # Test with matrices
         A = np.arange(4).reshape((2, 2))
 
-        with pytest.raises(ValueError, match="x must be a vector"):
+        with pytest.raises(ValueError, match="x must be a 1-d array"):
             cp.outer(A, d)
-        with pytest.raises(ValueError, match="y must be a vector"):
+        with pytest.raises(ValueError, match="y must be a 1-d array"):
             cp.outer(d, A)
 
         # allow 2D inputs once row-major flattening is the default

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -695,11 +695,9 @@ class TestDqcp(base_test.BaseTest):
         problem.solve(SOLVER, qcp=True)
         self.assertAlmostEqual(problem.value, 0, places=3)
 
-        # TODO: Make this test pass. Need to add a special case for scalar sums.
-        with self.assertRaises(Exception) as cm:
-            problem = cp.Problem(cp.Minimize(cp.cumsum(1/x)))
-            problem.solve(SOLVER, qcp=True)
-        self.assertEqual(str(cm.exception), "axis 0 is out of bounds for array of dimension 0")
+        problem = cp.Problem(cp.Minimize(cp.cumsum(1/x)))
+        problem.solve(SOLVER, qcp=True)
+        self.assertAlmostEqual(problem.value, 0, places=3)
 
     def test_parameter_bug(self) -> None:
         """Test bug with parameters arising from interaction of

--- a/cvxpy/tests/test_expression_methods.py
+++ b/cvxpy/tests/test_expression_methods.py
@@ -313,6 +313,7 @@ class TestExpressionMethods(BaseTest):
 
         A = sp.eye_array(3)
         self.assertItemsAlmostEqual(Constant(A).sum(axis=0).value, [1, 1, 1])
+
     def test_trace(self) -> None:
         """Test the trace atom.
         """
@@ -324,7 +325,7 @@ class TestExpressionMethods(BaseTest):
         with self.assertRaises(Exception) as cm:
             self.C.trace()
         self.assertEqual(str(cm.exception),
-                         "Argument to trace must be a 2-d array.")
+                         "Argument to trace must be a 2-d square array.")
 
     def test_trace_sign_psd(self) -> None:
         """Test sign of trace for psd/nsd inputs.

--- a/cvxpy/tests/test_expression_methods.py
+++ b/cvxpy/tests/test_expression_methods.py
@@ -324,7 +324,7 @@ class TestExpressionMethods(BaseTest):
         with self.assertRaises(Exception) as cm:
             self.C.trace()
         self.assertEqual(str(cm.exception),
-                         "Argument to trace must be a square matrix.")
+                         "Argument to trace must be a 2-d array.")
 
     def test_trace_sign_psd(self) -> None:
         """Test sign of trace for psd/nsd inputs.

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1774,3 +1774,18 @@ class TestND_Expressions():
         prob = cp.Problem(cp.Minimize(cp.sum(expr)), [expr == target - y])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(x.value, target)
+
+    #TODO make tests pass, support nd matmul
+    def test_nd_matmul_exception(self) -> None:
+        error_str = "Multiplication with N-d arrays is not yet supported"
+        with pytest.raises(ValueError, match=error_str):
+            x = cp.Variable((5,20,3))
+            y = cp.Variable((3,10))
+            x @ y
+    
+    #TODO make tests pass, support cumsum with multiple axes
+    def test_nd_cumsum_warning(self) -> None:
+        warning_str = "cumsum is only implemented for 1D or 2D arrays and might not"
+        with pytest.raises(UserWarning, match=warning_str):
+            x = cp.Variable((5,20,3))
+            cp.cumsum(x, axis=1)

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -862,7 +862,7 @@ class TestProblem(BaseTest):
 
         with self.assertRaises(Exception) as cm:
             Problem(cp.Minimize(cp.quad_form(1, self.A))).solve(solver=cp.SCS, eps=1e-6)
-        self.assertEqual(str(cm.exception), "Invalid dimensions for arguments.")
+        self.assertEqual(str(cm.exception), "Invalid dimensions for arguments to quad_form.")
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")


### PR DESCRIPTION
## Description
Please include a short summary of the change.
This PR revisits the ``validate_arguments`` method for almost all atoms. This leads to improvements in the error messages of existing validation functions as well as adding additional warnings for atoms that don't have full ND support yet. 
Issue link (if applicable):

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.