### PR TITLE
Fix bug with quad_over_lin and use_quad_obj = True

### DIFF
--- a/cvxpy/reductions/dcp2cone/dcp2cone.py
+++ b/cvxpy/reductions/dcp2cone/dcp2cone.py
@@ -17,6 +17,7 @@ limitations under the License.
 from typing import Tuple
 
 from cvxpy import problems
+from cvxpy.atoms.quad_over_lin import quad_over_lin
 from cvxpy.expressions import cvxtypes
 from cvxpy.expressions.expression import Expression
 from cvxpy.problems.objective import Minimize
@@ -121,6 +122,8 @@ class Dcp2Cone(Canonicalization):
         if self.quad_obj and affine_above and type(expr) in self.quad_canon_methods:
             # Special case for power.
             if type(expr) == cvxtypes.power() and not expr._quadratic_power():
+                return self.cone_canon_methods[type(expr)](expr, args)
+            elif type(expr) == quad_over_lin and not expr.is_quadratic():
                 return self.cone_canon_methods[type(expr)](expr, args)
             else:
                 return self.quad_canon_methods[type(expr)](expr, args)

--- a/cvxpy/tests/test_quadratic.py
+++ b/cvxpy/tests/test_quadratic.py
@@ -201,3 +201,14 @@ class TestExpressions(BaseTest):
         assert cp.matrix_frac(y**3, P).has_quadratic_term()
         P = cp.Parameter((2, 2), PSD=True)
         assert cp.matrix_frac(y**3, P).has_quadratic_term()
+
+    def test_composite_quad_over_lin(self) -> None:
+        """Test sum_squares(x) + quad_over_lin(x, y)"""
+        # https://github.com/cvxpy/cvxpy/issues/2773 
+        x = cp.Variable()
+        y = cp.Variable()
+        obj = cp.Minimize(cp.square(y) + cp.quad_over_lin(x, y))
+        prob = cp.Problem(obj, [y == 1])
+        prob.solve(solver=cp.CLARABEL, use_quad_obj=True)
+        assert np.isclose(y.value, 1)
+        assert np.isclose(x.value, 0)


### PR DESCRIPTION
## Description
Fixes a bug where non-quadratic quad_over_lin was interpreted as quadratic when using a conic solver that supports use_quad_obj = True.
Issue link (if applicable): #2773 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.