### PR TITLE
change OSQP error type when passing non-psd A matrix

### DIFF
--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -125,7 +125,7 @@ class OSQP(QpSolver):
             solver = osqp.OSQP()
             try:
                 solver.setup(P, q, A, lA, uA, verbose=verbose, **solver_opts)
-            except ValueError as e:
+            except Exception as e:
                 raise SolverError(e)
 
         results = solver.solve()

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -20,6 +20,7 @@ import numpy as np
 import pytest
 import scipy.sparse as sp
 from numpy.testing import assert_allclose, assert_equal
+from osqp.interface import OSQPException
 
 import cvxpy as cp
 from cvxpy.settings import EIGVAL_TOL
@@ -214,6 +215,5 @@ class TestNonOptimal(BaseTest):
 
         prob = cp.Problem(cp.Minimize(expr))
         # Transform to a SolverError.
-        with pytest.raises(cp.SolverError,
-                           match=r"(Workspace allocation error!)|(Setup Error \(Error Code 4\))"):
+        with pytest.raises(OSQPException):
             prob.solve(solver=cp.OSQP)

--- a/cvxpy/tests/test_quad_form.py
+++ b/cvxpy/tests/test_quad_form.py
@@ -20,7 +20,6 @@ import numpy as np
 import pytest
 import scipy.sparse as sp
 from numpy.testing import assert_allclose, assert_equal
-from osqp.interface import OSQPException
 
 import cvxpy as cp
 from cvxpy.settings import EIGVAL_TOL
@@ -215,5 +214,5 @@ class TestNonOptimal(BaseTest):
 
         prob = cp.Problem(cp.Minimize(expr))
         # Transform to a SolverError.
-        with pytest.raises(OSQPException):
+        with pytest.raises(cp.SolverError):
             prob.solve(solver=cp.OSQP)


### PR DESCRIPTION
## Description
Please include a short summary of the change.
Not sure if this is the correct fix.
I think there were some changes to the OSQP interface which causes one of the test to fail.
The test in question uses the wrapper ``assume_PSD=True`` on a clearly non-PSD matrix, which causes the OSQP solver to fail. However, it seems like the error being raised is different with the new OSQP. 
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.