### PR TITLE
Make solver name more flexible

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -732,7 +732,7 @@ class Problem(u.Canonical):
 
         start = time.time()
         # Convert solver argument to upper case.
-        if solver is not None:
+        if isinstance(solver, str):
             solver = solver.upper()
         # Cache includes ignore_dpp and solver_opts['use_quad_obj']
         # because they alter compilation.
@@ -853,9 +853,10 @@ class Problem(u.Canonical):
                       'conic_solvers': []}
         if isinstance(solver, Solver):
             return self._add_custom_solver_candidates(solver)
-        if solver is not None:
-            # Convert solver to upper case.
+        # Convert solver to upper case.
+        if isinstance(solver, str):
             solver = solver.upper()
+        if solver is not None:
             if solver not in slv_def.INSTALLED_SOLVERS:
                 raise error.SolverError("The solver %s is not installed." % solver)
             if solver in slv_def.CONIC_SOLVERS:

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -731,6 +731,9 @@ class Problem(u.Canonical):
             raise DPPError("Cannot set enforce_dpp = True and ignore_dpp = True.")
 
         start = time.time()
+        # Convert solver argument to upper case.
+        if solver is not None:
+            solver = solver.upper()
         # Cache includes ignore_dpp and solver_opts['use_quad_obj']
         # because they alter compilation.
         if solver_opts is None:
@@ -851,6 +854,8 @@ class Problem(u.Canonical):
         if isinstance(solver, Solver):
             return self._add_custom_solver_candidates(solver)
         if solver is not None:
+            # Convert solver to upper case.
+            solver = solver.upper()
             if solver not in slv_def.INSTALLED_SOLVERS:
                 raise error.SolverError("The solver %s is not installed." % solver)
             if solver in slv_def.CONIC_SOLVERS:

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -472,6 +472,10 @@ class TestClarabel(BaseTest):
     def test_clarabel_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver=cp.CLARABEL)
 
+    def test_clarabel_nonstandard_name(self) -> None:
+        # Test that solver name with non-standard capitalization works.
+        StandardTestLPs.test_lp_0(solver="Clarabel")
+
     def test_clarabel_lp_1(self) -> None:
         StandardTestLPs.test_lp_1(solver='CLARABEL')
 
@@ -2151,6 +2155,11 @@ class TestHIGHS:
     )
     def test_highs_solving(self, problem) -> None:
         problem(solver=cp.HIGHS)
+
+    def test_highs_nonstandard_name(self) -> None:
+        """Test HiGHS solver with non-capitalized solver name."""
+        # https://github.com/cvxpy/cvxpy/issues/2751
+        StandardTestLPs.test_lp_0(solver="HiGHS")
 
     @pytest.mark.parametrize(
         "problem",

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1411,8 +1411,9 @@ class TestProblem(BaseTest):
         # valid input, return solution
         solvers_with_str=[(s.OSQP, {'max_iter':1}), s.CLARABEL]
         solvers_empty_dict=[(s.OSQP, {'max_iter':1}), (s.CLARABEL, {})]
+        solvers_wrong_case=[("osqp", {'max_iter':1}), "Clarabel"]
 
-        for solvers in [solvers_with_str, solvers_empty_dict]:
+        for solvers in [solvers_with_str, solvers_empty_dict, solvers_wrong_case]:
             self.assertIsNotNone(Problem(cp.Minimize(
                 cp.sum_squares(cp.matmul(A, cp.Variable(40)) - b))).solve(
                 solver_path=solvers))

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -256,6 +256,13 @@ class TestProblem(BaseTest):
             # offsets were correctly parsed until we update the CVXOPT
             # interface.
 
+        # Test with uncapitalized solver name.
+        data, _, _ = Problem(cp.Minimize(cp.norm(self.x) + 3)).get_problem_data("Clarabel")
+        dims = data[ConicSolver.DIMS]
+        self.assertEqual(dims.soc, [3])
+        self.assertEqual(data["c"].shape, (3,))
+        self.assertEqual(data["A"].shape, (3, 3))
+
     def test_unpack_results(self) -> None:
         """Test unpack results method.
         """


### PR DESCRIPTION
## Description
Enables solver name to be non-upper case (e.g., HiGHS instead of HIGHS).
Issue link (if applicable): https://github.com/cvxpy/cvxpy/issues/2751

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.