### PR TITLE
Add warm_start option to HIGHS MIP and LP solver

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
@@ -141,7 +141,7 @@ class HIGHS(ConicSolver):
         ----------
         data : dict
             Data used by the solver.
-        warm_start : Bool
+        warm_start : bool
             Whether to warm_start HiGHS.
         verbose : bool
             Should the solver print output?

--- a/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
@@ -141,8 +141,8 @@ class HIGHS(ConicSolver):
         ----------
         data : dict
             Data used by the solver.
-        warm_start : bool
-            Not used.
+        warm_start : Bool
+            Whether to warm_start HiGHS.
         verbose : bool
             Should the solver print output?
         solver_opts : dict
@@ -223,6 +223,12 @@ class HIGHS(ConicSolver):
         solver = hp.Highs()
         solver.passOptions(options)
         solver.passModel(model)
+
+        if warm_start and solver_cache is not None and self.name() in solver_cache:
+            old_solver, old_data, old_result = solver_cache[self.name()]
+            old_status = self.STATUS_MAP.get(old_result["model_status"], s.SOLVER_ERROR)
+            if old_status in s.SOLUTION_PRESENT:
+                solver.setSolution(old_result["solution"])
 
         # initialize and solve problem
         try:

--- a/cvxpy/reductions/solvers/qp_solvers/highs_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/highs_qpif.py
@@ -125,8 +125,8 @@ class HIGHS(QpSolver):
         ----------
         data : dict
             Data used by the solver.
-        warm_start : bool
-            Not used.
+        warm_start : Bool
+            Whether to warm_start HiGHS.
         verbose : bool
             Should the solver print output?
         solver_opts : dict

--- a/cvxpy/reductions/solvers/qp_solvers/highs_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/highs_qpif.py
@@ -125,7 +125,7 @@ class HIGHS(QpSolver):
         ----------
         data : dict
             Data used by the solver.
-        warm_start : Bool
+        warm_start : bool
             Whether to warm_start HiGHS.
         verbose : bool
             Should the solver print output?
@@ -200,7 +200,6 @@ class HIGHS(QpSolver):
         if warm_start and solver_cache is not None and self.name() in solver_cache:
             old_solver, old_data, old_result = solver_cache[self.name()]
             old_status = self.STATUS_MAP.get(old_result["model_status"], s.SOLVER_ERROR)
-
             if old_status in s.SOLUTION_PRESENT:
                 solver.setSolution(old_result["solution"])
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import math
+import re
 import unittest
 
 import numpy as np
@@ -2155,6 +2156,27 @@ class TestHIGHS:
     )
     def test_highs_solving(self, problem) -> None:
         problem(solver=cp.HIGHS)
+
+    @pytest.mark.parametrize(
+        ["problem", "confirmation_string"],
+        [
+            (StandardTestLPs.test_lp_2, "Solving LP .* with basis"),
+            (StandardTestLPs.test_mi_lp_2, "MIP start solution is feasible"),
+        ],
+    )
+    def test_highs_warm_start(self, problem, confirmation_string, capfd) -> None:
+        """Test that HiGHS actually gets warm started for each problem type.
+
+        Args:
+            problem: LP or MIP.
+            confirmation_string: Regex that confirms that HiGHS was warm started.
+            capfd: Captures stdout to search for confirmation_string.
+        """
+        p = problem(cp.HIGHS, verbose=True)
+        p.prob.solve(cp.HIGHS, warm_start=True, verbose=True)
+        captured = capfd.readouterr()
+        assert re.search(confirmation_string, captured.out) is not None
+
 
     def test_highs_nonstandard_name(self) -> None:
         """Test HiGHS solver with non-capitalized solver name."""


### PR DESCRIPTION
## Description
Adds the ability to warm-start HiGHS for MIPs and LPs, solved via `cvxpy/reductions/solvers/conic_solvers/highs_conif.py`. 

This change essentially copies exactly the existing design for warm-starting HiGHS's QP solver (`cvxpy/reductions/solvers/qp_solvers/highs_qpif.py`). On that note, also updates the description there, which was out of date.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
Not all solvers present on my machine, but HIGHS is.
```
================ 1200 passed, 356 skipped, 1412 warnings in 25.19s ================
```
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
Skipped—didn't seem worth it.