### PR TITLE
PIQP interface API changes and warm-start support

### DIFF
--- a/cvxpy/reductions/solvers/qp_solvers/piqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/piqp_qpif.py
@@ -77,7 +77,7 @@ class PIQP(QpSolver):
         del solver_opts['backend']
 
         if backend not in ['dense', 'sparse']:
-            raise ValueError("Wrong input, backend most be either dense or sparse")
+            raise ValueError("Wrong input, backend must be either dense or sparse")
 
         def update_solver_settings(solver):
             for opt in solver_opts.keys():

--- a/cvxpy/reductions/solvers/qp_solvers/piqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/piqp_qpif.py
@@ -67,7 +67,8 @@ class PIQP(QpSolver):
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts,
                        solver_cache=None):
         import piqp
-        old_interface = float(piqp.__version__.split('.')[0]) == 0 and float(piqp.__version__.split('.')[1]) <= 5
+        old_interface = float(piqp.__version__.split('.')[0]) == 0 \
+                        and float(piqp.__version__.split('.')[1]) <= 5
 
         solver_opts = solver_opts.copy()
 
@@ -101,17 +102,20 @@ class PIQP(QpSolver):
 
             if backend == 'sparse' and data[s.P].data.shape != old_data[s.P].data.shape:
                     structure_changed = True
-            elif data[s.P].data.shape != old_data[s.P].data.shape or any(data[s.P].data != old_data[s.P].data):
+            elif data[s.P].data.shape != old_data[s.P].data.shape or any(
+                    data[s.P].data != old_data[s.P].data):
                 new_args['P'] = data[s.P] if backend == 'sparse' else data[s.P].toarray()
 
             if backend == 'sparse' and data[s.A].data.shape != old_data[s.A].data.shape:
                     structure_changed = True
-            elif data[s.A].data.shape != old_data[s.A].data.shape or any(data[s.A].data != old_data[s.A].data):
+            elif data[s.A].data.shape != old_data[s.A].data.shape or any(
+                    data[s.A].data != old_data[s.A].data):
                 new_args['A'] = data[s.A] if backend == 'sparse' else data[s.A].toarray()
 
             if backend == 'sparse' and data[s.F].data.shape != old_data[s.F].data.shape:
                     structure_changed = True
-            elif data[s.F].data.shape != old_data[s.F].data.shape or any(data[s.F].data != old_data[s.F].data):
+            elif data[s.F].data.shape != old_data[s.F].data.shape or any(
+                    data[s.F].data != old_data[s.F].data):
                 new_args['G'] = data[s.F] if backend == 'sparse' else data[s.F].toarray()
 
             if backend == 'dense' and not isinstance(solver, piqp.DenseSolver):

--- a/cvxpy/reductions/solvers/qp_solvers/piqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/piqp_qpif.py
@@ -57,7 +57,7 @@ class PIQP(QpSolver):
             }
 
             dual_vars = {PIQP.DUAL_VAR_ID: np.concatenate(
-                (solution.y, solution.z))}
+                (solution.y, solution.z if hasattr(solution, 'z') else solution.z_u))}
             attr[s.NUM_ITERS] = solution.info.iter
             sol = Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
@@ -67,56 +67,96 @@ class PIQP(QpSolver):
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts,
                        solver_cache=None):
         import piqp
+        old_interface = float(piqp.__version__.split('.')[0]) == 0 and float(piqp.__version__.split('.')[1]) <= 5
 
         solver_opts = solver_opts.copy()
 
         solver_opts['backend'] = solver_opts.get('backend', 'sparse')
         backend = solver_opts['backend']
+        del solver_opts['backend']
 
-        if backend == "dense":
-            # Convert sparse to dense matrices
-            P = data[s.P].toarray()
-            A = data[s.A].toarray()
-            F = data[s.F].toarray()
-        elif backend == "sparse":
-            P = data[s.P]
-            A = data[s.A]
-            F = data[s.F]
-        else:
+        if backend not in ['dense', 'sparse']:
             raise ValueError("Wrong input, backend most be either dense or sparse")
 
-        q = data[s.Q]
-        b = data[s.B]
-        g = data[s.G]
+        def update_solver_settings(solver):
+            for opt in solver_opts.keys():
+                try:
+                    solver.settings.__setattr__(opt, solver_opts[opt])
+                except TypeError as e:
+                    raise TypeError(f"PIQP: Incorrect type for setting '{opt}'.") from e
+                except AttributeError as e:
+                    raise TypeError(f"PIQP: Unrecognized solver setting '{opt}'.") from e
+            solver.settings.verbose = verbose
 
-        if backend == "dense":
-            solver = piqp.DenseSolver()
-        elif backend == "sparse":
-            solver = piqp.SparseSolver()
+        structure_changed = True
+        if warm_start and solver_cache is not None and self.name() in solver_cache:
+            structure_changed = False
 
-        del solver_opts['backend']
-        for opt in solver_opts.keys():
-            try:
-                solver.settings.__setattr__(opt, solver_opts[opt])
-            except TypeError as e:
-                raise TypeError(f"PIQP: Incorrect type for setting '{opt}'.") from e
-            except AttributeError as e:
-                raise TypeError(f"PIQP: unrecognized solver setting '{opt}'.") from e
-        solver.settings.verbose = verbose
+            solver, old_data, _ = solver_cache[self.name()]
+            new_args = {}
 
-        solver.setup(P=P,
-                     c=q,
-                     A=A,
-                     b=b,
-                     G=F,
-                     h=g)
+            for key, param in [(s.Q, 'c'), (s.B, 'b'), (s.G, 'h' if old_interface else 'h_u')]:
+                if any(data[key] != old_data[key]):
+                    new_args[param] = data[key]
+
+            if backend == 'sparse' and data[s.P].data.shape != old_data[s.P].data.shape:
+                    structure_changed = True
+            elif data[s.P].data.shape != old_data[s.P].data.shape or any(data[s.P].data != old_data[s.P].data):
+                new_args['P'] = data[s.P] if backend == 'sparse' else data[s.P].toarray()
+
+            if backend == 'sparse' and data[s.A].data.shape != old_data[s.A].data.shape:
+                    structure_changed = True
+            elif data[s.A].data.shape != old_data[s.A].data.shape or any(data[s.A].data != old_data[s.A].data):
+                new_args['A'] = data[s.A] if backend == 'sparse' else data[s.A].toarray()
+
+            if backend == 'sparse' and data[s.F].data.shape != old_data[s.F].data.shape:
+                    structure_changed = True
+            elif data[s.F].data.shape != old_data[s.F].data.shape or any(data[s.F].data != old_data[s.F].data):
+                new_args['G'] = data[s.F] if backend == 'sparse' else data[s.F].toarray()
+
+            if backend == 'dense' and not isinstance(solver, piqp.DenseSolver):
+                structure_changed = True
+            if backend == 'sparse' and not isinstance(solver, piqp.SparseSolver):
+                structure_changed = True
+
+            update_solver_settings(solver)
+
+            if not structure_changed and new_args:
+                solver.update(**new_args)
+
+        if structure_changed:
+            if backend == 'dense':
+                solver = piqp.DenseSolver()
+            else:
+                solver = piqp.SparseSolver()
+
+            update_solver_settings(solver)
+
+            if backend == 'dense':
+                # Convert sparse to dense matrices
+                P = data[s.P].toarray()
+                A = data[s.A].toarray()
+                F = data[s.F].toarray()
+            else:
+                P = data[s.P]
+                A = data[s.A]
+                F = data[s.F]
+
+            q = data[s.Q]
+            b = data[s.B]
+            g = data[s.G]
+
+            if old_interface:
+                solver.setup(P=P, c=q, A=A, b=b, G=F, h=g)
+            else:
+                solver.setup(P=P, c=q, A=A, b=b, G=F, h_u=g)
 
         solver.solve()
 
         result = solver.result
 
         if solver_cache is not None:
-            solver_cache[self.name()] = result
+            solver_cache[self.name()] = (solver, data, result)
 
         return result
 

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -505,6 +505,29 @@ class TestQp(BaseTest):
             result2 = prob.solve(solver=cp.HIGHS, warm_start=False)
             self.assertAlmostEqual(result, result2)
 
+    def test_piqp_warmstart(self) -> None:
+        """Test warm start.
+        """
+        if cp.PIQP in INSTALLED_SOLVERS:
+            m = 200
+            n = 100
+            np.random.seed(1)
+            A = np.random.randn(m, n)
+            b = Parameter(m)
+
+            # Construct the problem.
+            x = Variable(n)
+            prob = Problem(Minimize(sum_squares(A @ x - b)))
+
+            b.value = np.random.randn(m)
+            result = prob.solve(solver=cp.PIQP, warm_start=False)
+            result2 = prob.solve(solver=cp.PIQP, warm_start=True)
+            self.assertAlmostEqual(result, result2)
+            b.value = np.random.randn(m)
+            result = prob.solve(solver=cp.PIQP, warm_start=True)
+            result2 = prob.solve(solver=cp.PIQP, warm_start=False)
+            self.assertAlmostEqual(result, result2)
+
     def test_parametric(self) -> None:
         """Test solve parametric problem vs full problem"""
         x = Variable()


### PR DESCRIPTION
## Description

In the next version of PIQP, the API is going to change due to the addition of general double-sided inequality constraints: [https://github.com/PREDICT-EPFL/piqp/pull/22](https://github.com/PREDICT-EPFL/piqp/pull/22)

To not break CVXPY for users using PIQP as a backend, this PR implements version depended logic to retain backwards compability. The the new version of PIQP will be publish after a new release of CVXPY.

Additionaly, the PR implements support for warm starting, i.e., reusing the problem strucutre and data if it doesn't change.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.