### PR TITLE
settings.py: send logging messages to stderr

### DIFF
--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -19,7 +19,7 @@ import sys
 LOGGER = logging.getLogger("__cvxpy__")
 LOGGER.propagate = False
 LOGGER.setLevel(logging.INFO)
-_stream_handler = logging.StreamHandler(sys.stdout)
+_stream_handler = logging.StreamHandler(sys.stderr)
 _stream_handler.setLevel(logging.INFO)
 _formatter = logging.Formatter(
     fmt="(CVXPY) %(asctime)s: %(message)s", datefmt="%b %d %I:%M:%S %p"


### PR DESCRIPTION
## Description
As is the UNIX convention. See eg https://stackoverflow.com/questions/4919093/should-i-log-messages-to-stderr-or-stdout. Sending messages to stdout breaks scripts that wish to use cvxpy but also have requirements on their own stdout specification. For example, if `myscript` is required to output valid JSON then one cannot use cvxpy in `myscript`.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.