### PR TITLE
support negative axes in sum (and other axis_atoms)

### DIFF
--- a/cvxpy/atoms/axis_atom.py
+++ b/cvxpy/atoms/axis_atom.py
@@ -44,6 +44,8 @@ class AxisAtom(Atom):
         elif isinstance(self.axis, int):
             # Normalize negative axis
             axis = self.axis if self.axis >= 0 else self.axis + ndim
+            if axis < 0:
+                ValueError(f"axis {self.axis} is out of bounds for array of dimension {ndim}")
             if self.keepdims:
                 shape[axis] = 1
             else:
@@ -51,6 +53,9 @@ class AxisAtom(Atom):
         else:
             # Normalize each axis in the list
             axes = [axis if axis >= 0 else axis + ndim for axis in self.axis]
+            if any(axis < 0 for axis in axes):
+                ValueError(f"axis {[axis for axis in self.axis if axis < -ndim][0]}"
+                           f" is out of bounds for array of dimension {ndim}")
             if self.keepdims:
                 for axis in axes:
                     shape[axis] = 1

--- a/cvxpy/atoms/axis_atom.py
+++ b/cvxpy/atoms/axis_atom.py
@@ -35,21 +35,27 @@ class AxisAtom(Atom):
     def shape_from_args(self) -> Tuple[int, ...]:
         """
         Returns the shape of the atom after applying a function along an axis.
+        Handles negative axis inputs by normalizing them to positive indices.
         """
         shape = list(self.args[0].shape)
+        ndim = len(shape)
         if self.axis is None:
             return (1,) * len(shape) if self.keepdims else ()
         elif isinstance(self.axis, int):
+            # Normalize negative axis
+            axis = self.axis if self.axis >= 0 else self.axis + ndim
             if self.keepdims:
-                shape[self.axis] = 1
+                shape[axis] = 1
             else:
-                shape = shape[:self.axis] + shape[self.axis+1:]
+                shape = shape[:axis] + shape[axis+1:]
         else:
+            # Normalize each axis in the list
+            axes = [axis if axis >= 0 else axis + ndim for axis in self.axis]
             if self.keepdims:
-                for axis in self.axis:
+                for axis in axes:
                     shape[axis] = 1
             else:
-                shape[:] = [shape[i] for i in range(len(shape)) if i not in self.axis]
+                shape[:] = [shape[i] for i in range(len(shape)) if i not in axes]
         return tuple(shape)
 
     def get_data(self):

--- a/cvxpy/tests/test_shape.py
+++ b/cvxpy/tests/test_shape.py
@@ -13,12 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
 import numpy as np
 import pytest
 from hypothesis import given
 from hypothesis.extra.numpy import mutually_broadcastable_shapes
 
+import cvxpy as cp
 from cvxpy.atoms.affine.reshape import reshape
 from cvxpy.expressions.variable import Variable
 from cvxpy.utilities import shape
@@ -61,3 +61,8 @@ class TestShape():
         assert (a + c).shape == (n, n)
         d = reshape(b, (n, n), order='F')
         assert (a + d).shape == (n, n)
+
+    def test_negative_axis(self) -> None:
+        a = cp.Parameter(shape=(7, 3, 9, 5))
+        b = cp.sum(a, axis=-1)
+        assert b.shape == (7, 3, 9)

--- a/cvxpy/tests/test_shape.py
+++ b/cvxpy/tests/test_shape.py
@@ -66,3 +66,29 @@ class TestShape():
         a = cp.Parameter(shape=(7, 3, 9, 5))
         b = cp.sum(a, axis=-1)
         assert b.shape == (7, 3, 9)
+        b = cp.sum(a, axis=-2)
+        assert b.shape == (7, 3, 5)
+        b = cp.sum(a, axis=-3)
+        assert b.shape == (7, 9, 5)
+
+        b = cp.sum(a, axis=-1, keepdims=True)
+        assert b.shape == (7, 3, 9, 1)
+        b = cp.sum(a, axis=-2, keepdims=True)
+        assert b.shape == (7, 3, 1, 5)
+        b = cp.sum(a, axis=-3, keepdims=True)
+        assert b.shape == (7, 1, 9, 5)
+        with pytest.raises(ValueError):
+            cp.sum(a, axis=-5)
+        with pytest.raises(ValueError):
+            cp.sum(a, axis=-10)
+        with pytest.raises(ValueError):
+            cp.sum(a, axis=-5, keepdims=True)
+        with pytest.raises(ValueError):
+            cp.sum(a, axis=-10, keepdims=True)
+
+        b = cp.sum(a, axis=(-2, -1, 0), keepdims=True)
+        assert b.shape == (1, 3, 1, 1)
+        b = cp.sum(a, axis=(-2, -1, 0))
+        assert b.shape == (3,)
+        with pytest.raises(ValueError):
+            cp.sum(a, axis=(-5, 3))


### PR DESCRIPTION
## Description
Please include a short summary of the change.
MrMonday on discord pointed out a bug with the ``shape_from_args`` method for the axis_atom.
I think there was already some logic for this before, but it might have been removed accidentally when we added the n-d sum and made changes to the axis_atom class. 
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.