### PR TITLE
Set variable value after bound sanitization

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -155,10 +155,10 @@ class Leaf(expression.Expression):
                 "A CVXPY Variable cannot have more than one of the following attributes: "
                 f"{dim_reducing_attr}"
             )
-        if value is not None:
-            self.value = value
         self.args = []
         self.bounds = self._ensure_valid_bounds(bounds)
+        if value is not None:
+            self.value = value
 
     def _validate_indices(self, indices: list[tuple[int]] | tuple[np.ndarray]) -> tuple[np.ndarray]:
         """

--- a/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
@@ -247,7 +247,7 @@ class HIGHS(ConicSolver):
             solver_cache[self.name()] = (solver, data, results)
 
         return results
-    
+
     def cite(self, data):
         """Returns bibtex citation for the solver.
 

--- a/cvxpy/tests/solver_test_helpers.py
+++ b/cvxpy/tests/solver_test_helpers.py
@@ -119,7 +119,7 @@ class SolverTestHelper:
             else:
                 raise ValueError('Unknown constraint type %s.' % type(con))
             self.tester.assertAlmostEqual(comp, 0, places)
-            
+
     def check_stationary_lagrangian(self, places) -> None:
         L = self.prob.objective.expr
         objective = self.prob.objective
@@ -225,7 +225,7 @@ class SolverTestHelper:
                 msg += f"\n\t\t\t{opt_var.name} : {norm}"
             msg += '\n'
             self.tester.fail(msg)
-        pass 
+        pass
 
     def verify_objective(self, places) -> None:
         actual = self.prob.value
@@ -647,7 +647,7 @@ def sdp_pcp_1() -> SolverTestHelper:
         (y, np.array([[0.01],
                       [0.01]])),
         (X, np.array([[0.52024779, 0.20103426],
-                      [0.20103426, 0.0776837 ]])),        
+                      [0.20103426, 0.0776837 ]])),
     ]
     con_pairs = [
         (cp.sum(x) == 1, -0.1503204799112807),
@@ -1164,9 +1164,9 @@ class StandardTestLPs:
 
     @staticmethod
     def test_lp_bound_attr(
-            solver, 
-            places: int = 4, 
-            duals: bool = True, 
+            solver,
+            places: int = 4,
+            duals: bool = True,
             **kwargs
         ) -> SolverTestHelper:
         sth = lp_bound_attr()
@@ -1311,7 +1311,7 @@ class StandardTestSOCPs:
         sth.verify_objective(places)
         sth.verify_primal_values(places)
         return sth
-    
+
     @staticmethod
     def test_socp_bounds_attr(solver, places: int = 4, **kwargs) -> SolverTestHelper:
         sth = socp_bounds_attr()
@@ -1398,7 +1398,7 @@ class StandardTestMixedCPs:
             sth.check_dual_domains(places)
         return sth
 
-    
+
 class StandardTestPCPs:
 
     @staticmethod

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -410,7 +410,7 @@ class TestSCS(BaseTest):
 
     def test_scs_sdp_pcp_1(self):
         StandardTestMixedCPs.test_sdp_pcp_1(solver='SCS')
-        
+
     def test_scs_pcp_1(self) -> None:
         StandardTestPCPs.test_pcp_1(solver='SCS')
 
@@ -532,7 +532,7 @@ class TestClarabel(BaseTest):
         StandardTestSDPs.test_sdp_1min(solver='CLARABEL')
 
     def test_clarabel_sdp_2(self) -> None:
-        # produces a different optimizer than 
+        # produces a different optimizer than
         # the one expected by the standard test
         places = 3
         sth = sths.sdp_2()
@@ -721,7 +721,6 @@ class TestMosek(unittest.TestCase):
     def test_mosek_sdp_power(self) -> None:
         """Test the problem in issue #2128"""
         StandardTestMixedCPs.test_sdp_pcp_1(solver='MOSEK')
-        
 
     def test_power_portfolio(self) -> None:
         """Test the portfolio problem in issue #2042"""
@@ -1737,7 +1736,7 @@ class TestGUROBI(BaseTest):
         StandardTestSOCPs.test_socp_3ax0(solver='GUROBI')
         # axis 1
         StandardTestSOCPs.test_socp_3ax1(solver='GUROBI')
-    
+
     def test_gurobi_socp_bound_attr(self) -> None:
         sth = StandardTestSOCPs.test_socp_bounds_attr(solver='GUROBI')
         # check that the bounds do reach the solver and don't just generate constraints
@@ -1987,7 +1986,7 @@ class TestNAG(BaseTest):
 
     def test_nag_quad_obj(self) -> None:
         """Test NAG canonicalization with a quadratic objective.
-        """    
+        """
         x = cp.Variable(2)
         expr = cp.sum_squares(x)
         constr = [x >= 1]
@@ -2206,7 +2205,7 @@ class TestHIGHS:
             "time_limit": 0.123,  # double option
             "random_seed": 1234,  # int option
             # no need to optimize for real
-            "mip_rel_gap": 1.0,  
+            "mip_rel_gap": 1.0,
             "primal_feasibility_tolerance": 1e-3,
             "dual_feasibility_tolerance": 1e-3,
         }

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -93,6 +93,13 @@ class TestProblem(BaseTest):
         ref = [self.a, self.x, self.b, self.A]
         self.assertCountEqual(vars_, ref)
 
+
+    def test_variables_with_value(self):
+        Variable(name="without_bounds", value=0.0)
+        Variable(name="with_none_bounds", value=0.0, bounds=None)
+        Variable(name="with_none_none_bounds", value=0.0, bounds=[None, None])
+
+
     def test_var_dict(self) -> None:
         p = Problem(cp.Minimize(self.a), [self.a <= self.x, self.b <= self.A + 2])
         assert p.var_dict == {"a": self.a, "x": self.x, "b": self.b, "A": self.A}

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -612,21 +612,21 @@ class TestProblem(BaseTest):
         combo1 = prob1 + 2 * prob2
         combo1_ref = Problem(cp.Minimize(self.a + 4 * self.b),
                              [self.a >= self.b, self.a >= 1, self.b >= 2])
-        self.assertAlmostEqual(combo1.solve(solver=cp.CLARABEL), 
+        self.assertAlmostEqual(combo1.solve(solver=cp.CLARABEL),
                                combo1_ref.solve(solver=cp.CLARABEL))
 
         # division and subtraction
         combo2 = prob1 - prob3/2
         combo2_ref = Problem(cp.Minimize(self.a + pow(self.b + self.a, 2)/2),
                              [self.b >= 3, self.a >= self.b])
-        self.assertAlmostEqual(combo2.solve(solver=cp.CLARABEL), 
+        self.assertAlmostEqual(combo2.solve(solver=cp.CLARABEL),
                                combo2_ref.solve(solver=cp.CLARABEL))
 
         # multiplication with 0 (prob2's constraints should still hold)
         combo3 = prob1 + 0 * prob2 - 3 * prob3
         combo3_ref = Problem(cp.Minimize(self.a + 3 * pow(self.b + self.a, 2)),
                              [self.a >= self.b, self.a >= 1, self.b >= 3])
-        self.assertAlmostEqual(combo3.solve(solver=cp.CLARABEL), 
+        self.assertAlmostEqual(combo3.solve(solver=cp.CLARABEL),
                                combo3_ref.solve(solver=cp.CLARABEL))
 
     # Test scalar LP problems.
@@ -1122,7 +1122,7 @@ class TestProblem(BaseTest):
             problem.solve(solver=cp.SCS, eps=1e-5)
         self.assertTrue("Problem does not follow DCP rules."
                         in str(cm.exception))
-        
+
         # Test parametrized vstack
         p = Parameter((2, 1), value=np.array([[3], [3]]))
         q = Parameter((2, 1), value=np.array([[-8], [-8]]))
@@ -1437,16 +1437,16 @@ class TestProblem(BaseTest):
     def test_solve_solver_path(self) -> None:
         """
         Tests the solve_solver_path method under various conditions:
-        
+
         1. Verifies that a SolverError is raised when all solvers fail.
         2. Validates that a solution is returned when any of the solvers succeeds.
         3. Ensures that a ValueError is raised when the inner inputs of the solvers are invalid.
-        
+
         """
 
         A = numpy.random.randn(40, 40)
         b = cp.matmul(A, numpy.random.randn(40))
-        
+
         # valid input, return solution
         solvers_with_str=[(s.OSQP, {'max_iter':1}), s.CLARABEL]
         solvers_empty_dict=[(s.OSQP, {'max_iter':1}), (s.CLARABEL, {})]
@@ -1459,12 +1459,12 @@ class TestProblem(BaseTest):
 
         # valid input, raise SolverError
         solvers = [(s.OSQP, {'max_iter':1})]
-        
+
         with self.assertRaises(SolverError):
             Problem(cp.Minimize(
                 cp.sum_squares(cp.matmul(A, cp.Variable(40)) - b))).solve(
                 solver_path=solvers)
-                
+
         # invalid input, raise ValueError
         solvers_invalid_inner_input = [{'str':{}}, 'str', [], [1], [()], [(1)], [(1,{})],
                                         [(s.OSQP,[])], [(s.OSQP,)]]
@@ -2258,7 +2258,7 @@ class TestProblem(BaseTest):
                 prob.solve()
                 assert isinstance(w[0].message, FutureWarning)
                 assert str(w[0].message) == ECOS_DEPRECATION_MSG
-            
+
             # No warning if CLARABEL solver specified.
             with warnings.catch_warnings(record=True) as w:
                 prob.solve(solver=cp.CLARABEL)


### PR DESCRIPTION
## Description
If the `value` of a variable is set during object creation but if the `bounds` set to be `[None,None]` then the value setter raises an `AttributeError: 'Variable' object has no attribute 'bounds'` because the bounds are not "sanitized" yet. 

This PR swaps the order of value assignment and the bound cleanup operation in `Leaf.__init__` and adds a tiny non-regression test.

(While at it I also fixed some of the obvious white-space issues.)

Issue link (if applicable): N/A

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [X] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [N/A] Add our license to new files.
- [X] Check that your code adheres to our coding style. 
- [X] Write unittests.
- [X] Run the unittests and check that they’re passing.
- [N/A] Run the benchmarks to make sure your change doesn’t introduce a regression.