### PR TITLE
attempt to speedup indice sorting in canon backend

### DIFF
--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -157,13 +157,15 @@ def nonzero_csc_array(A):
     # A.nonzero() returns (rows, cols) sorted in C-style order,
     # but (when A is a csc matrix) A.data is stored in Fortran-order, hence
     # the sorting below
-    A_rows, A_cols = A.nonzero()
-    ind = np.argsort(A_cols, kind='mergesort')
-    A_rows = A_rows[ind]
-    A_cols = A_cols[ind]
+
+    A.sort_indices()  # Ensure indices are sorted within each column
+
+    rows = A.indices.copy()
+    counts = A.indptr[1:] - A.indptr[:-1]
+    cols = np.repeat(np.arange(A.shape[1]), counts)
 
     A.data[zero_indices] = 0
-    return A_rows, A_cols
+    return rows, cols
 
 
 def A_mapping_nonzero_rows(problem_data_tensor, var_length):


### PR DESCRIPTION
## Description
Please include a short summary of the change.
While profiling (almost a year ago) with parth, we noticed that a long time was spent sorting indices for a CSC matrix (seems like the goal of the function is to get the (row,cols) tuple used in COO format. 
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.