### PR TITLE
Fix typos across docs and comments

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -547,7 +547,7 @@ class Leaf(expression.Expression):
             # ^ might be a numpy array, scipy matrix, or sparse scipy matrix.
             if intf.is_sparse(delta):
                 # ^ based on current implementation of project(...),
-                #   is is not possible for this Leaf to be PSD/NSD *and*
+                #   it is not possible for this Leaf to be PSD/NSD *and*
                 #   a sparse matrix.
                 close_enough = np.allclose(delta.data, 0,
                                            atol=SPARSE_PROJECTION_TOL)

--- a/cvxpy/tests/test_python_backends.py
+++ b/cvxpy/tests/test_python_backends.py
@@ -1316,7 +1316,7 @@ class TestBackends:
          [0, c],
          [0, d]].
 
-        Thus, we need to to return [0, 1, 4, 5, 2, 3, 6, 7].
+        Thus, we need to return [0, 1, 4, 5, 2, 3, 6, 7].
         """
 
         indices = backend._get_kron_row_indices((2, 1), (2, 2))

--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -346,7 +346,7 @@ for any cone supported by a target solver, but the current elementary convex con
 
 We address the vectorization options for the semidefinite cones later.
 For now it's useful to say that the ``Awesome(ConicSolver)`` class will access an
-explicit representation for problem :math:`(P)` in in ``apply``, with a code snippet like
+explicit representation for problem :math:`(P)` in ``apply``, with a code snippet like
 
 .. code::
 
@@ -358,7 +358,7 @@ explicit representation for problem :math:`(P)` in in ``apply``, with a code sni
     cone_dims = problem.cone_dims
     c, d, A, b = problem.apply_parameters()
 
-The variable ``constr_map`` is is a dict of lists of CVXPY Constraint objects.
+The variable ``constr_map`` is a dict of lists of CVXPY Constraint objects.
 The dict is keyed by the references to CVXPY's Zero, NonNeg, SOC, PSD, ExpCone,
 and PowCone3D classes. You will need to interact with these constraint classes during
 dual variable recovery.

--- a/doc/source/examples/dqcp/hypersonic_shape_design.rst
+++ b/doc/source/examples/dqcp/hypersonic_shape_design.rst
@@ -21,7 +21,7 @@ coefficients, respectively, that are obtained by integrating the
 projection of the pressure coefficient in directions parallel to, and
 perpendicular to, the body.
 
-It turns out that the the drag-to-lift ratio is a quasilinear function,
+It turns out that the drag-to-lift ratio is a quasilinear function,
 as we'll now show. We will assume the pressure coefficient is given by
 the Newtonian sine-squared law for whetted areas of the body,
 

--- a/doc/source/examples/machine_learning/lasso_regression.rst
+++ b/doc/source/examples/machine_learning/lasso_regression.rst
@@ -79,7 +79,7 @@ Fitting the model
 ~~~~~~~~~~~~~~~~~
 
 All we need to do to fit the model is create a CVXPY problem where the
-objective is to minimize the the objective function defined above. We
+objective is to minimize the objective function defined above. We
 make :math:`\lambda` a CVXPY parameter, so that we can use a single
 CVXPY problem to obtain estimates for many values of :math:`\lambda`.
 

--- a/doc/source/examples/machine_learning/ridge_regression.rst
+++ b/doc/source/examples/machine_learning/ridge_regression.rst
@@ -87,7 +87,7 @@ Fitting the model
 ~~~~~~~~~~~~~~~~~
 
 All we need to do to fit the model is create a CVXPY problem where the
-objective is to minimize the the objective function defined above. We
+objective is to minimize the objective function defined above. We
 make :math:`\lambda` a CVXPY parameter, so that we can use a single
 CVXPY problem to obtain estimates for many values of :math:`\lambda`.
 

--- a/doc/source/tutorial/dpp/index.rst
+++ b/doc/source/tutorial/dpp/index.rst
@@ -348,7 +348,7 @@ the gradient is therefore just 2. So, as expected, the above code prints
 Next, we use the ``derivative`` method to see how a small change in ``p``
 would affect the solution ``x``. We will perturb ``p`` by ``1e-5``, by
 setting ``p.delta = 1e-5``, and calling the ``derivative`` method will populate
-the ``delta`` attribute of ``x`` with the the change in ``x`` predicted by
+the ``delta`` attribute of ``x`` with the change in ``x`` predicted by
 a first-order approximation (which is ``dx/dp * p.delta``).
 
 .. code:: python3

--- a/examples/machine_learning/lasso_regression.ipynb
+++ b/examples/machine_learning/lasso_regression.ipynb
@@ -97,7 +97,7 @@
    "source": [
     "### Fitting the model\n",
     "\n",
-    "All we need to do to fit the model is create a CVXPY problem where the objective is to minimize the the objective function defined above. We make $\\lambda$ a CVXPY parameter, so that we can use a single CVXPY problem to obtain estimates for many values of $\\lambda$."
+    "All we need to do to fit the model is create a CVXPY problem where the objective is to minimize the objective function defined above. We make $\\lambda$ a CVXPY parameter, so that we can use a single CVXPY problem to obtain estimates for many values of $\\lambda$."
    ]
   },
   {

--- a/examples/machine_learning/ridge_regression.ipynb
+++ b/examples/machine_learning/ridge_regression.ipynb
@@ -99,7 +99,7 @@
    "source": [
     "### Fitting the model\n",
     "\n",
-    "All we need to do to fit the model is create a CVXPY problem where the objective is to minimize the the objective function defined above. We make $\\lambda$ a CVXPY parameter, so that we can use a single CVXPY problem to obtain estimates for many values of $\\lambda$."
+    "All we need to do to fit the model is create a CVXPY problem where the objective is to minimize the objective function defined above. We make $\\lambda$ a CVXPY parameter, so that we can use a single CVXPY problem to obtain estimates for many values of $\\lambda$."
    ]
   },
   {

--- a/examples/notebooks/dqcp/hypersonic_shape_design.ipynb
+++ b/examples/notebooks/dqcp/hypersonic_shape_design.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "where $\\mathrm{c_d}$ and $\\mathrm{c_l}$ are drag and lift coefficients, respectively, that are obtained by integrating the projection of the pressure coefficient in directions parallel to, and perpendicular to, the body.\n",
     "\n",
-    "It turns out that the the drag-to-lift ratio is a quasilinear function, as we'll now show. We will assume the pressure coefficient is given by the Newtonian sine-squared law for whetted areas of the body,\n",
+    "It turns out that the drag-to-lift ratio is a quasilinear function, as we'll now show. We will assume the pressure coefficient is given by the Newtonian sine-squared law for whetted areas of the body,\n",
     "\n",
     "$$\n",
     "\\mathrm{c_p} = 2(\\hat{v}\\cdot\\hat{n})^2\n",


### PR DESCRIPTION
## Summary
- fix repeated words in docs
- fix a typo in backend test
- fix a typo in Leaf comment
- update example notebooks to match doc fixes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_684380e8c9f48331938d34fb06840d0f