### PR TITLE
Replace custom axis handling with numpy.array_utils.normalize_axis_*

### DIFF
--- a/cvxpy/atoms/affine/partial_trace.py
+++ b/cvxpy/atoms/affine/partial_trace.py
@@ -17,6 +17,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 import scipy.sparse as sp
+from numpy.lib.array_utils import normalize_axis_index
 
 from cvxpy.atoms.atom import Atom
 
@@ -79,10 +80,7 @@ def partial_trace(expr, dims: Tuple[int], axis: Optional[int] = 0):
     expr = Atom.cast_to_const(expr)
     if expr.ndim < 2 or expr.shape[0] != expr.shape[1]:
         raise ValueError("partial_trace only supports 2-d square arrays.")
-    if axis < 0 or axis >= len(dims):
-        raise ValueError(
-            f"Invalid axis argument, should be between 0 and {len(dims)}, got {axis}."
-        )
     if expr.shape[0] != np.prod(dims):
         raise ValueError("Dimension of system doesn't correspond to dimension of subsystems.")
+    axis = normalize_axis_index(axis, len(dims))
     return sum([_term(expr, j, dims, axis) for j in range(dims[axis])])

--- a/cvxpy/atoms/affine/partial_transpose.py
+++ b/cvxpy/atoms/affine/partial_transpose.py
@@ -20,6 +20,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 import scipy.sparse as sp
+from numpy.lib.array_utils import normalize_axis_index
 
 from cvxpy.atoms.atom import Atom
 
@@ -80,12 +81,9 @@ def partial_transpose(expr, dims: Tuple[int, ...], axis: Optional[int] = 0):
     expr = Atom.cast_to_const(expr)
     if expr.ndim < 2 or expr.shape[0] != expr.shape[1]:
         raise ValueError("partial_transpose only supports 2-d square arrays.")
-    if axis < 0 or axis >= len(dims):
-        raise ValueError(
-            f"Invalid axis argument, should be between 0 and {len(dims)}, got {axis}."
-        )
     if expr.shape[0] != np.prod(dims):
         raise ValueError("Dimension of system doesn't correspond to dimension of subsystems.")
+    axis = normalize_axis_index(axis, len(dims))
     return sum([
         _term(expr, i, j, dims, axis) for i in range(dims[axis]) for j in range(dims[axis])
     ])

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1716,12 +1716,6 @@ class TestAtoms(BaseTest):
 
         X = cp.Variable((6, 6))
         with self.assertRaises(ValueError) as cm:
-            cp.partial_trace(X, dims=[2, 3], axis=-1)
-        self.assertEqual(str(cm.exception),
-                         "Invalid axis argument, should be between 0 and 2, got -1.")
-
-        X = cp.Variable((6, 6))
-        with self.assertRaises(ValueError) as cm:
             cp.partial_trace(X, dims=[2, 4], axis=0)
         self.assertEqual(str(cm.exception),
                          "Dimension of system doesn't correspond to dimension of subsystems.")
@@ -1775,15 +1769,7 @@ class TestAtoms(BaseTest):
 
         X = cp.Variable((6, 6))
         with self.assertRaises(ValueError) as cm:
-            cp.partial_transpose(X, dims=[2, 3], axis=-1)
-        self.assertEqual(str(cm.exception),
-                         "Invalid axis argument, should be between 0 and 2, got -1.")
-
-        X = cp.Variable((6, 6))
-        with self.assertRaises(ValueError) as cm:
             cp.partial_transpose(X, dims=[2, 4], axis=0)
-        self.assertEqual(str(cm.exception),
-                         "Dimension of system doesn't correspond to dimension of subsystems.")
 
     def test_log_sum_exp(self) -> None:
         """Test log_sum_exp sign.

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1770,6 +1770,8 @@ class TestAtoms(BaseTest):
         X = cp.Variable((6, 6))
         with self.assertRaises(ValueError) as cm:
             cp.partial_transpose(X, dims=[2, 4], axis=0)
+        self.assertEqual(str(cm.exception),
+                         "Dimension of system doesn't correspond to dimension of subsystems.")
 
     def test_log_sum_exp(self) -> None:
         """Test log_sum_exp sign.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "osqp >= 0.6.2",
     "clarabel >= 0.5.0",
     "scs >= 3.2.4.post1",
-    "numpy >= 1.22.4",
+    "numpy >= 1.26.0",
     "scipy >= 1.13.0",
 ]
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "osqp >= 0.6.2",
     "clarabel >= 0.5.0",
     "scs >= 3.2.4.post1",
-    "numpy >= 1.26.0",
+    "numpy >= 2.0.0",
     "scipy >= 1.13.0",
 ]
 requires-python = ">=3.9"


### PR DESCRIPTION
Addresses issue #2816 

- Replaced manual axis checks with:
  - `normalize_axis_index` in `partial_trace.py` and `partial_transpose.py`
  - `normalize_axis_index` and `normalize_axis_tuple` in `axis_atom.py`
- Removed redundant `ValueError` checks for out-of-bounds axes
- Removed tests that manually validated axis bounds (since NumPy now handles this)

## Description
Please include a short summary of the change.
Issue link (if applicable):
Please see above. 

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [] Run the benchmarks to make sure your change doesn’t introduce a regression.

FYI I did not see the benchmark test. 