### PR TITLE
Only warns about `.value` for sparse leafs when it causes significant fillin

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -145,7 +145,7 @@ class Leaf(expression.Expression):
             self.integer_idx = integer
         if sparsity:
             self.sparse_idx = self._validate_indices(sparsity)
-            self._sparse_high_fill_in = (len(self.sparse_idx) / np.prod(self.shape) <= 0.25)
+            self._sparse_high_fill_in = (len(self.sparse_idx[0]) / np.prod(self.shape) <= 0.25)
         else:
             self.sparse_idx = None
         # count number of attributes

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -476,7 +476,7 @@ class Leaf(expression.Expression):
 
     @value.setter
     def value(self, val) -> None:
-        if self.sparse_idx is not None and self._high_sparse_fill_in:
+        if self.sparse_idx is not None and self._sparse_high_fill_in:
             warnings.warn('Writing to a sparse CVXPY expression via `.value` is discouraged.'
                           ' Use `.value_sparse` instead', RuntimeWarning, 1)
         self.save_value(self._validate_value(val))

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -145,6 +145,7 @@ class Leaf(expression.Expression):
             self.integer_idx = integer
         if sparsity:
             self.sparse_idx = self._validate_indices(sparsity)
+            self._sparse_high_fill_in = (len(self.sparse_idx) / np.prod(self.shape) <= 0.25)
         else:
             self.sparse_idx = None
         # count number of attributes
@@ -475,7 +476,7 @@ class Leaf(expression.Expression):
 
     @value.setter
     def value(self, val) -> None:
-        if self.sparse_idx is not None:
+        if self.sparse_idx is not None and self._high_sparse_fill_in:
             warnings.warn('Writing to a sparse CVXPY expression via `.value` is discouraged.'
                           ' Use `.value_sparse` instead', RuntimeWarning, 1)
         self.save_value(self._validate_value(val))

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -65,11 +65,11 @@ class TestAttributes:
         assert prob.get_problem_data(cp.CLARABEL)[0]['A'].shape[1] == 9
         
     def test_sparsity_assign_value(self):
-        X = cp.Variable((3, 3))
+        X = cp.Variable((10, 10))
         sparsity = [(0, 2, 1, 2), (0, 1, 2, 2)]
-        A = cp.Parameter((3, 3), sparsity=sparsity)
+        A = cp.Parameter((10, 10), sparsity=sparsity)
         prob = cp.Problem(cp.Minimize(cp.sum(X)), [X >= A])
-        A_value = np.zeros((3, 3))
+        A_value = np.zeros((10, 10))
         A_value[sparsity[0], sparsity[1]] = -1
         with pytest.warns(
             RuntimeWarning,
@@ -79,7 +79,7 @@ class TestAttributes:
             A.value = A_value
         
         prob.solve()
-        z = np.zeros((3, 3))
+        z = np.zeros((10, 10))
         z[A.sparse_idx] = -1
         assert np.allclose(X.value, z)
         
@@ -99,7 +99,7 @@ class TestAttributes:
         assert np.allclose(z.toarray(), z1.toarray())
         assert np.allclose(X.value, z1.toarray())
         assert np.allclose(X.value, z.toarray())
-        
+
     def test_sparsity_incorrect_pattern(self):
         A = cp.Parameter((3, 3), sparsity=[(0, 2, 1, 2), (0, 1, 2, 2)])
         with pytest.raises(

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -83,7 +83,7 @@ class TestAttributes:
         z[A.sparse_idx] = -1
         assert np.allclose(X.value, z)
         
-        A.value_sparse = sp.coo_array((-np.ones(4), sparsity))
+        A.value_sparse = sp.coo_array((-np.ones(4), sparsity), (10, 10))
         prob.solve()
         assert np.allclose(X.value, z)
         

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -87,8 +87,8 @@ class TestAttributes:
         prob.solve()
         assert np.allclose(X.value, z)
         
-        z = sp.coo_array(([-1, -3, -2, -4], [(0, 1, 2, 2), (0, 2, 1, 2)]))
-        z1 = sp.coo_array(([-1, -4, -2, -3], [(0, 2, 2, 1), (0, 2, 1, 2)]))
+        z = sp.coo_array(([-1, -3, -2, -4], [(0, 1, 2, 2), (0, 2, 1, 2)]), shape=(10, 10))
+        z1 = sp.coo_array(([-1, -4, -2, -3], [(0, 2, 2, 1), (0, 2, 1, 2)]), shape=(10, 10))
         A.value_sparse = z
         prob.solve()
         assert np.allclose(z.toarray(), z1.toarray())


### PR DESCRIPTION
## Description

This makes us only warn about `.value` for sparse leafs when it causes significant fill-in. I'm not sure about my exact metric for fill-in, right now I'm doing 3 x as many 0s as my cut off. I'm open to making it an absolute number of zeros being added or some mix of the two. (more than 100 0s added and 2x as much perhaps?)

@rileyjmurray this feels like something you'd care about.

Issue link (if applicable): https://github.com/cvxpy/cvxpy/discussions/2782

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.