### PR TITLE
Fix docstring in Constraint.violation: remove mention of squaring

### DIFF
--- a/cvxpy/constraints/constraint.py
+++ b/cvxpy/constraints/constraint.py
@@ -149,7 +149,7 @@ class Constraint(u.Canonical):
 
         .. math::
 
-            ||\\Pi(v) - v||_2^2
+            ||\\Pi(v) - v||_2
 
         where :math:`v` is the value of the constrained expression and
         :math:`\\Pi` is the projection operator onto the constraint's domain .


### PR DESCRIPTION
## Description
This PR fixes a docstring typo in `cvxpy/constraints/constraint.py`.
The description incorrectly stated that the residual is squared, but in fact it is not.

For example, the `violation` methods in other constraint classes such as [`SecondOrderCone`](https://github.com/cvxpy/cvxpy/blob/master/cvxpy/constraints/second_order.py#L105) and [`NonPos`](https://github.com/cvxpy/cvxpy/blob/master/cvxpy/constraints/nonpos.py#L95) compute the norm via `np.linalg.norm(x, ord=2)` without squaring the result.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [X] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [X] Add our license to new files.
- [X] Check that your code adheres to our coding style.
- [X] Write unittests.
- [X] Run the unittests and check that they’re passing.
- [X] Run the benchmarks to make sure your change doesn’t introduce a regression.