### PR TITLE
update scipy version in dependencies (prep 1.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ CVXPY has the following dependencies:
 - Clarabel >= 0.5.0
 - OSQP >= 0.6.2
 - SCS >= 3.2.4.post1
-- NumPy >= 1.21.6
-- SciPy >= 1.11.0
+- NumPy >= 1.22.4
+- SciPy >= 1.13.0
 
 For detailed instructions, see the [installation
 guide](https://www.cvxpy.org/install/index.html).

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -63,8 +63,8 @@ or a conda environment.
         * `OSQP`_ >= 0.6.2
         * `CLARABEL`_ >= 0.6.0
         * `SCS`_ >= 3.0
-        * `NumPy`_ >= 1.21.6
-        * `SciPy`_ >= 1.11.0
+        * `NumPy`_ >= 1.22.4
+        * `SciPy`_ >= 1.13.0
 
         All required packages are installed automatically alongside CVXPY.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,8 @@ dependencies = [
     "osqp >= 0.6.2",
     "clarabel >= 0.5.0",
     "scs >= 3.2.4.post1",
-    "numpy >= 1.21.6",
-    "scipy >= 1.11.0",
+    "numpy >= 1.22.4",
+    "scipy >= 1.13.0",
 ]
 requires-python = ">=3.9"
 urls = {Homepage = "https://github.com/cvxpy/cvxpy"}


### PR DESCRIPTION
## Description
Please include a short summary of the change.
This PR updates the scipy and numpy versions to 1.13.0 and 1.22.4, respectively for CVXPY's dependencies. 
This change was already in place for the [build](https://github.com/cvxpy/cvxpy/blob/master/pyproject.toml#L34) but we forgot to update the [dependencies](https://github.com/cvxpy/cvxpy/blob/master/pyproject.toml#L52) as well. 
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.