### PR TITLE
BUG: raise ValueError for invalid axis argument to norm

### DIFF
--- a/cvxpy/atoms/norm.py
+++ b/cvxpy/atoms/norm.py
@@ -67,6 +67,8 @@ def norm(x, p: Union[int, str] = 2, axis=None, keepdims: bool = False):
         else:
             raise RuntimeError('Unsupported matrix norm.')
     else:
+        if not isinstance(axis, int):
+            raise ValueError(f'Axis must be an integer, not {type(axis)}.')
         if p == 1 or x.is_scalar():
             return norm1(x, axis=axis, keepdims=keepdims)
         elif str(p).lower() == "inf":

--- a/cvxpy/atoms/norm.py
+++ b/cvxpy/atoms/norm.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -28,7 +28,7 @@ from cvxpy.atoms.sigma_max import sigma_max
 from cvxpy.expressions.expression import Expression
 
 
-def norm(x, p: Union[int, str] = 2, axis=None, keepdims: bool = False):
+def norm(x, p: Union[int, str] = 2, axis: Optional[int] = None, keepdims: bool = False):
     """Wrapper on the different norm atoms.
 
     Parameters
@@ -52,6 +52,8 @@ def norm(x, p: Union[int, str] = 2, axis=None, keepdims: bool = False):
     x = Expression.cast_to_const(x)
     # matrix norms take precedence
     num_nontrivial_idxs = sum([d > 1 for d in x.shape])
+    if axis is not None and not isinstance(axis, int):
+        raise ValueError(f'Axis must be an integer, not {type(axis)}.')
     if axis is None and x.ndim == 2:
         if p == 1:  # matrix 1-norm
             return cvxpy.atoms.max(norm1(x, axis=0))
@@ -67,8 +69,6 @@ def norm(x, p: Union[int, str] = 2, axis=None, keepdims: bool = False):
         else:
             raise RuntimeError('Unsupported matrix norm.')
     else:
-        if not isinstance(axis, int):
-            raise ValueError(f'Axis must be an integer, not {type(axis)}.')
         if p == 1 or x.is_scalar():
             return norm1(x, axis=axis, keepdims=keepdims)
         elif str(p).lower() == "inf":

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -297,6 +297,11 @@ class TestAtoms(BaseTest):
         self.assertTrue(copy.args[0] is self.y)
         self.assertEqual(copy.get_data(), atom.get_data())
 
+    def test_norm_axis_input(self) -> None:
+        x = cp.Variable()
+        with pytest.raises(Exception, match="Axis must be an integer"):
+            cp.norm2(cp.Constant(1), x)
+
     def test_matrix_norms(self) -> None:
         """
         Matrix 1-norm, 2-norm (sigma_max), infinity-norm,


### PR DESCRIPTION
## Description
Please include a short summary of the change.
Straightforward from title.
However, I am thinking maybe the norm class is supposed to sub-class from AxisAtom? Then the validation could be done there? Not sure if its really important though. (edit: NVM, the norm file is just a factory class that creates pnorm atoms which do subclass from AxisAtom)

Issue link (if applicable): someone posted this on Ed for the 364a summer class. Thanks for pointing this @dance858!

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.