### PR TITLE
Remove cuopt_sh_client dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dynamic = ["version"]
 # Solver names as in cvxpy.settings = pip-installable distribution providing it
 CBC = ["cylp>=0.91.5"]
 CLARABEL = []
-CUOPT = ["cuopt-cu12>=25.5", "cuopt-sh-client>=25.5", "nvidia-cuda-runtime-cu12>=12.8,<13.0"]
+CUOPT = ["cuopt-cu12>=25.5", "nvidia-cuda-runtime-cu12>=12.8,<13.0"]
 CVXOPT = ["cvxopt"]
 DIFFCP = ["diffcp"]
 ECOS = ["ecos"]


### PR DESCRIPTION
## Description
Originally the cuopt integration during development had a cuopt service option which was removed. The dependency for the client was accidentally left in pyproject.toml.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [X] Bug fix
- [ ] Other (Documentation, CI, ...)