### PR TITLE
Fix status mapping issues

### DIFF
--- a/continuous_integration/install_optional_solvers.sh
+++ b/continuous_integration/install_optional_solvers.sh
@@ -38,7 +38,7 @@ if [[ "$RUNNER_OS" != "Ubuntu" ]]; then
 fi
 
 if [[ "$RUNNER_OS" != "macOS" ]]; then
-  python -m pip install xpress==9.5.0 coptpy==7.1.7 cplex
+  python -m pip install xpress coptpy==7.1.7 cplex
 fi
 
 # Only install Mosek if license is available (secret is not copied to forks)

--- a/continuous_integration/install_optional_solvers.sh
+++ b/continuous_integration/install_optional_solvers.sh
@@ -38,7 +38,7 @@ if [[ "$RUNNER_OS" != "Ubuntu" ]]; then
 fi
 
 if [[ "$RUNNER_OS" != "macOS" ]]; then
-  python -m pip install xpress==9.4.3 coptpy==7.1.7 cplex
+  python -m pip install xpress==9.5.0 coptpy==7.1.7 cplex
 fi
 
 # Only install Mosek if license is available (secret is not copied to forks)

--- a/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
@@ -404,31 +404,59 @@ def get_status_maps():
 
     import xpress as xp
 
-    # Map of Xpress' LP status to CVXPY status.
-    status_map_lp = {
+    if Version(xp.__version__) < Version('9.6.0'):
+        # Map of Xpress' LP status to CVXPY status.
+        status_map_lp = {
 
-        xp.lp_unstarted:       s.SOLVER_ERROR,
-        xp.lp_optimal:         s.OPTIMAL,
-        xp.lp_infeas:          s.INFEASIBLE,
-        xp.lp_cutoff:          s.OPTIMAL_INACCURATE,
-        xp.lp_unfinished:      s.OPTIMAL_INACCURATE,
-        xp.lp_unbounded:       s.UNBOUNDED,
-        xp.lp_cutoff_in_dual:  s.OPTIMAL_INACCURATE,
-        xp.lp_unsolved:        s.OPTIMAL_INACCURATE,
-        xp.lp_nonconvex:       s.SOLVER_ERROR
-    }
+            xp.lp_unstarted:       s.SOLVER_ERROR,
+            xp.lp_optimal:         s.OPTIMAL,
+            xp.lp_infeas:          s.INFEASIBLE,
+            xp.lp_cutoff:          s.OPTIMAL_INACCURATE,
+            xp.lp_unfinished:      s.OPTIMAL_INACCURATE,
+            xp.lp_unbounded:       s.UNBOUNDED,
+            xp.lp_cutoff_in_dual:  s.OPTIMAL_INACCURATE,
+            xp.lp_unsolved:        s.OPTIMAL_INACCURATE,
+            xp.lp_nonconvex:       s.SOLVER_ERROR
+        }
 
-    # Same map, for MIPs
-    status_map_mip = {
+        # Same map, for MIPs
+        status_map_mip = {
 
-        xp.mip_not_loaded:     s.SOLVER_ERROR,
-        xp.mip_lp_not_optimal: s.SOLVER_ERROR,
-        xp.mip_lp_optimal:     s.SOLVER_ERROR,
-        xp.mip_no_sol_found:   s.SOLVER_ERROR,
-        xp.mip_solution:       s.OPTIMAL_INACCURATE,
-        xp.mip_infeas:         s.INFEASIBLE,
-        xp.mip_optimal:        s.OPTIMAL,
-        xp.mip_unbounded:      s.UNBOUNDED
-    }
+            xp.mip_not_loaded:     s.SOLVER_ERROR,
+            xp.mip_lp_not_optimal: s.SOLVER_ERROR,
+            xp.mip_lp_optimal:     s.SOLVER_ERROR,
+            xp.mip_no_sol_found:   s.SOLVER_ERROR,
+            xp.mip_solution:       s.OPTIMAL_INACCURATE,
+            xp.mip_infeas:         s.INFEASIBLE,
+            xp.mip_optimal:        s.OPTIMAL,
+            xp.mip_unbounded:      s.UNBOUNDED
+        }
+    else:
+        status_map_lp = {
+
+            xp.enums.LPStatus.UNSTARTED:       s.SOLVER_ERROR,
+            xp.enums.LPStatus.OPTIMAL:         s.OPTIMAL,
+            xp.enums.LPStatus.INFEAS:          s.INFEASIBLE,
+            xp.enums.LPStatus.CUTOFF:          s.OPTIMAL_INACCURATE,
+            xp.enums.LPStatus.UNFINISHED:      s.OPTIMAL_INACCURATE,
+            xp.enums.LPStatus.UNBOUNDED:       s.UNBOUNDED,
+            xp.enums.LPStatus.CUTOFF_IN_DUAL:  s.OPTIMAL_INACCURATE,
+            xp.enums.LPStatus.UNSOLVED:        s.OPTIMAL_INACCURATE,
+            xp.enums.LPStatus.NONCONVEX:       s.SOLVER_ERROR
+        }
+
+        # Same map, for MIPs
+        status_map_mip = {
+
+            xp.enums.MIPStatus.NOT_LOADED:     s.SOLVER_ERROR,
+            xp.enums.MIPStatus.LP_NOT_OPTIMAL: s.SOLVER_ERROR,
+            xp.enums.MIPStatus.LP_OPTIMAL:     s.SOLVER_ERROR,
+            xp.enums.MIPStatus.NO_SOL_FOUND:   s.SOLVER_ERROR,
+            xp.enums.MIPStatus.SOLUTION:       s.OPTIMAL_INACCURATE,
+            xp.enums.MIPStatus.INFEAS:         s.INFEASIBLE,
+            xp.enums.MIPStatus.OPTIMAL:        s.OPTIMAL,
+            xp.enums.MIPStatus.UNBOUNDED:      s.UNBOUNDED
+        }
+
 
     return (status_map_lp, status_map_mip)

--- a/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
@@ -180,17 +180,17 @@ class XPRESS(ConicSolver):
 
         self.prob_.loadproblem(probname="CVX_xpress_conic",
                                # constraint types
-                               qrtypes=['E'] * nrowsEQ + ['L'] * nrowsLEQ,
+                               rowtype=['E'] * nrowsEQ + ['L'] * nrowsLEQ,
                                rhs=b,                               # rhs
-                               range=None,                          # range
-                               obj=c,                               # obj coeff
-                               mstart=mstart,                       # mstart
-                               mnel=None,                           # mnel (unused)
+                               rng=None,                            # range
+                               objcoef=c,                           # obj coeff
+                               start=mstart,                        # mstart
+                               collen=None,                         # mnel (unused)
                                # linear coefficients
-                               mrwind=A.indices[A.data != 0],       # row indices
-                               dmatval=A.data[A.data != 0],         # coefficients
-                               dlb=[-xp.infinity] * len(c),         # lower bound
-                               dub=[xp.infinity] * len(c),          # upper bound
+                               rowind=A.indices[A.data != 0],       # row indices
+                               rowcoef=A.data[A.data != 0],         # coefficients
+                               lb=[-xp.infinity] * len(c),          # lower bound
+                               ub=[xp.infinity] * len(c),           # upper bound
                                colnames=varnames,                   # column names
                                rownames=linRownames)                # row    names
 
@@ -297,13 +297,13 @@ class XPRESS(ConicSolver):
         results_dict = {
 
             'problem':   self.prob_,
-            'status':    self.prob_.getProbStatus(),
-            'obj_value': self.prob_.getObjVal(),
+            'status':    self.prob_.attributes.solstatus,
+            'obj_value': self.prob_.attributes.objval,
         }
 
         status_map_lp, status_map_mip = get_status_maps()
 
-        if 'mip_' in self.prob_.getProbStatusString():
+        if len(data[s.BOOL_IDX]) > 0 or len(data[s.INT_IDX]) > 0:
             status = status_map_mip[results_dict['status']]
         else:
             status = status_map_lp[results_dict['status']]
@@ -315,7 +315,7 @@ class XPRESS(ConicSolver):
         if status in s.SOLUTION_PRESENT:
             results_dict['x'] = self.prob_.getSolution()
             if not (data[s.BOOL_IDX] or data[s.INT_IDX]):
-                results_dict['y'] = - np.array(self.prob_.getDual())
+                results_dict['y'] = - np.array(self.prob_.getDuals())
 
         elif status == s.INFEASIBLE and 'save_iis' in solver_opts and solver_opts['save_iis'] != 0:
 
@@ -380,7 +380,7 @@ class XPRESS(ConicSolver):
         solution[s.XPRESS_IIS] = results_dict[s.XPRESS_IIS]
         solution[s.XPRESS_TROW] = results_dict[s.XPRESS_TROW]
 
-        solution['getObjVal'] = self.prob_.getObjVal()
+        solution['getObjVal'] = self.prob_.attributes.objval
 
         solution[s.SOLVE_TIME] = self.prob_.attributes.time
 

--- a/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
@@ -4,7 +4,7 @@ import cvxpy.interface as intf
 import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.conic_solvers.xpress_conif import (
-    get_status_maps,
+    get_status_map,
     makeMstart,
 )
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
@@ -55,14 +55,12 @@ class XPRESS(QpSolver):
             int(results['bariter']) \
             if not inverse_data[XPRESS.IS_MIP] \
             else 0
-        status_map_lp, status_map_mip = get_status_maps()
+        status_map = get_status_map()
 
         if results['status'] == 'solver_error':
             status = 'solver_error'
-        elif inverse_data[XPRESS.IS_MIP]:
-            status = status_map_mip[results['status']]
         else:
-            status = status_map_lp[results['status']]
+            status = status_map[results['status']]
 
         if status in s.SOLUTION_PRESENT:
             # Get objective value
@@ -235,14 +233,12 @@ class XPRESS(QpSolver):
             except xp.SolverError:
                 results_dict[s.PRIMAL] = np.zeros(self.prob_.attributes.cols)
 
-            status_map_lp, status_map_mip = get_status_maps()
+            status_map = get_status_map()
 
             if results_dict['status'] == 'solver_error':
                 status = 'solver_error'
-            elif len(data[s.BOOL_IDX]) > 0 or len(data[s.INT_IDX]) > 0:
-                status = status_map_mip[results_dict['status']]
             else:
-                status = status_map_lp[results_dict['status']]
+                status = status_map[results_dict['status']]
 
             results_dict['bariter'] = self.prob_.attributes.bariter
             results_dict['getProbStatusString'] = self.prob_.attributes.solvestatus

--- a/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
@@ -222,7 +222,7 @@ class XPRESS(QpSolver):
             self.prob_.solve()
 
             results_dict[s.SOLVE_TIME] = self.prob_.attributes.time
-        except xp.SolverError:  # Error in the solution
+        except xp.ModelError:  # Error in the solution
             results_dict["status"] = s.SOLVER_ERROR
         else:
             results_dict['status'] = self.prob_.attributes.solstatus
@@ -230,7 +230,7 @@ class XPRESS(QpSolver):
             results_dict['obj_value'] = self.prob_.attributes.objval
             try:
                 results_dict[s.PRIMAL] = np.array(self.prob_.getSolution())
-            except xp.SolverError:
+            except xp.ModelError:
                 results_dict[s.PRIMAL] = np.zeros(self.prob_.attributes.cols)
 
             status_map = get_status_map()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ QOCO = ["qoco"]
 SCIP = ["PySCIPOpt"]
 SCIPY = ["scipy"]
 SCS = []
-XPRESS = ["xpress"]
+XPRESS = ["xpress>=9.5"]
 DAQP = ["daqp"]
 testing = ["pytest", "hypothesis"]
 doc = ["sphinx",


### PR DESCRIPTION
## Description
Fix various deprecation warnings in Xpress. Currently fixed the status mapping warnings. Still getting the following warnings:

`/home/govind/Desktop/git/cvxpy/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py:231: DeprecationWarning: Deprecated in Xpress 9.5: use problem.attributes.solvestatus and problem.attributes.solstatus instead
  results_dict['status'] = self.prob_.getProbStatus()
/home/govind/Desktop/git/cvxpy/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py:232: DeprecationWarning: Deprecated in Xpress 9.5: use problem.attributes.solvestatus and problem.attributes.solstatus instead
  results_dict['getProbStatusString'] = self.prob_.getProbStatusString()
/home/govind/Desktop/git/cvxpy/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py:233: DeprecationWarning: Deprecated in Xpress 9.5: use problem.attributes.objval instead
  results_dict['obj_value'] = self.prob_.getObjVal()
/home/govind/Desktop/git/cvxpy/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py:249: DeprecationWarning: Deprecated in Xpress 9.5: use problem.attributes.solvestatus and problem.attributes.solstatus instead
  results_dict['getProbStatusString'] = self.prob_.getProbStatusString()
/home/govind/Desktop/git/cvxpy/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py:252: DeprecationWarning: Deprecated in Xpress 9.5: use problem.attributes.objval instead
  results_dict['getObjVal'] = self.prob_.getObjVal()
/home/govind/Desktop/git/cvxpy/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py:256: DeprecationWarning: Deprecated in Xpress 9.5: use problem.getDuals instead
  results_dict['getDual'] = self.prob_.getDual()
`
Would like some input on the cleanest way of fixing these. The obvious way is to do a version check before calling the getXXX() functions but that seems sloppy.

Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.