### PR TITLE
CI: update macOS runners to ``macos-14``

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macos-13, windows-2022 ]
+        os: [ ubuntu-22.04, macos-14, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13" ]
         include:
           # These are intended to just add their extra parameter to existing matrix combinations;
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macos-13, windows-2022 ]
+        os: [ ubuntu-22.04, macos-14, windows-2022 ]
         python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13" ]
         build-cvxpy-base: [ true, false ]  # whether to build cvxpy-base (true) or regular cvxpy (false)
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
             python-version: 3.12
             openmp: "True"
             single_action_config: false
-          - os: macos-13
+          - os: macos-14
             python-version: 3.12
             single_action_config: true
 

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macos-13, windows-2022 ]
+        os: [ ubuntu-22.04, macos-14, windows-2022 ]
     steps:
       - uses: actions/checkout@v4
       - name: Set Additional Envs

--- a/continuous_integration/install_dependencies.sh
+++ b/continuous_integration/install_dependencies.sh
@@ -9,10 +9,14 @@ conda config --set remote_connect_timeout_secs 30.0
 conda config --set remote_max_retries 10
 conda config --set remote_backoff_factor 2
 conda config --set remote_read_timeout_secs 120.0
-conda install mkl pip pytest pytest-cov hypothesis openblas "setuptools>65.5.1"
+conda install pip pytest pytest-cov hypothesis openblas "setuptools>65.5.1"
 
 conda install scs
 python -m pip install clarabel osqp
+
+if [[ "$RUNNER_OS" != "macOS" ]]; then
+  conda install mkl
+fi
 
 # Install newest stable versions for Python 3.13.
 if [[ "$PYTHON_VERSION" == "3.13" ]]; then


### PR DESCRIPTION
## Description
Please include a short summary of the change.
This [official github blog](https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down) states that the ``macos-13`` action runners are being deprecated on September 1st, 2025. However, they are the last runners that are on x86 intel machines, see this [discussion](https://github.com/astropy/astropy/issues/18456). 

Issue link (if applicable): 
Per discussion in #2872

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.