### PR TITLE
BUG: allow integer and boolean variable values

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -408,7 +408,7 @@ class Leaf(expression.Expression):
                 return new_val.reshape(val.shape) if val.ndim == 0 else new_val
         elif self.attributes['integer']:
             if hasattr(self, "integer_idx"):
-                new_val = np.atleast_1d(np.astype(val, np.int64, copy=True))
+                new_val = np.atleast_1d(np.astype(val, np.float64, copy=True))
                 new_val[self.integer_idx] = np.round(new_val[self.integer_idx])
                 return new_val.reshape(val.shape) if val.ndim == 0 else new_val
         elif self.attributes['diag']:

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -403,12 +403,12 @@ class Leaf(expression.Expression):
             return val.astype(complex)
         elif self.attributes['boolean']:
             if hasattr(self, "boolean_idx"):
-                new_val = np.atleast_1d(val).copy()
+                new_val = np.atleast_1d(np.astype(val, np.float64, copy=True))
                 new_val[self.boolean_idx] = np.round(np.clip(new_val[self.boolean_idx], 0., 1.))
                 return new_val.reshape(val.shape) if val.ndim == 0 else new_val
         elif self.attributes['integer']:
             if hasattr(self, "integer_idx"):
-                new_val = np.atleast_1d(val).copy()
+                new_val = np.atleast_1d(np.astype(val, np.int64, copy=True))
                 new_val[self.integer_idx] = np.round(new_val[self.integer_idx])
                 return new_val.reshape(val.shape) if val.ndim == 0 else new_val
         elif self.attributes['diag']:

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -403,12 +403,12 @@ class Leaf(expression.Expression):
             return val.astype(complex)
         elif self.attributes['boolean']:
             if hasattr(self, "boolean_idx"):
-                new_val = np.atleast_1d(np.astype(val, np.float64, copy=True))
+                new_val = np.atleast_1d(val.astype(np.float64, copy=True))
                 new_val[self.boolean_idx] = np.round(np.clip(new_val[self.boolean_idx], 0., 1.))
                 return new_val.reshape(val.shape) if val.ndim == 0 else new_val
         elif self.attributes['integer']:
             if hasattr(self, "integer_idx"):
-                new_val = np.atleast_1d(np.astype(val, np.float64, copy=True))
+                new_val = np.atleast_1d(val.astype(np.float64, copy=True))
                 new_val[self.integer_idx] = np.round(new_val[self.integer_idx])
                 return new_val.reshape(val.shape) if val.ndim == 0 else new_val
         elif self.attributes['diag']:

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -231,6 +231,18 @@ class TestAttributes:
         n = cp.Variable(integer=True)
         cp.Problem(cp.Maximize(x), [n == 1]).solve()
 
+    def test_boolean_var_value(self):
+        # ensure that boolean variables can be assigned values
+        # https://github.com/cvxpy/cvxpy/issues/2879
+        x = cp.Variable(2, boolean=True)
+        val = np.array([True, False])
+        x.value = val
+
+    def test_integer_var_value(self):
+        x = cp.Variable(2, integer=True)
+        val = np.array([1, 2], dtype=int)
+        x.value = val
+
 class TestMultipleAttributes:
 
     def test_multiple_attributes(self) -> None:


### PR DESCRIPTION
## Description
Please include a short summary of the change.
This PR re-enables setting variable values with boolean and integer arrays. 
The issue happened because the ``copy()`` method kept the datatype of the original array. 
So clipping a boolean array ``[True,False]`` would turn it into a numeric array ``[1,0]``, but setting it would turn the array back to ``[True, False]`` because of the dtype. 
This PR ensures that the dtype is being changed while copying the value array. 

Notes for future:
you are allowed to do the following: numeric - boolean, but cannot do boolean - boolean (which was the error being raised in the issue below). 
Issue link (if applicable): #2879 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.