### PR TITLE
Add `var_dict` to documentation

### DIFF
--- a/doc/source/api_reference/cvxpy.problems.rst
+++ b/doc/source/api_reference/cvxpy.problems.rst
@@ -70,7 +70,7 @@ Problem
     :members: value, status, objective, constraints, is_dcp, is_dgp, is_dqcp,
               is_qp, is_dpp, variables, parameters, constants,
               backward, derivative, atoms, size_metrics, solver_stats, compilation_time, solve,
-              register_solve, get_problem_data, unpack_results
+              register_solve, get_problem_data, unpack_results, var_dict
     :undoc-members:
     :member-order: groupwise
 


### PR DESCRIPTION


## Description
This will make `var_dict` visible in the automatically generated docs. This is a very convenient property for accessing variables by name.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.