### PR TITLE
Enable Support for Advanced HIGHS Options

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
@@ -226,15 +226,17 @@ class HIGHS(ConicSolver):
         lp.col_lower_ = col_lower
         lp.col_upper_ = col_upper
 
+        solver = hp.Highs()
+
         # setup options
         unpack_highs_options_inplace(solver_opts)
-        options = hp.HighsOptions()
-        options.log_to_console = verbose
+        solver.setOptionValue("log_to_console", verbose)
         for key, value in solver_opts.items():
-            setattr(options, key, value)
+            # note that calling setOptionValue directly on the solver
+            # allows one to pass advanced options that aren't available
+            # on the HighOptions class (e.g., presolve_rule_off)
+            solver.setOptionValue(key, value)
 
-        solver = hp.Highs()
-        solver.passOptions(options)
         solver.passModel(model)
 
         if warm_start and solver_cache is not None and self.name() in solver_cache:

--- a/cvxpy/reductions/solvers/qp_solvers/highs_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/highs_qpif.py
@@ -186,15 +186,17 @@ class HIGHS(QpSolver):
             hessian.index_ = P.indices
             hessian.value_ = P.data
 
+        solver = hp.Highs()
+
         # setup options
         unpack_highs_options_inplace(solver_opts)
-        options = hp.HighsOptions()
-        options.log_to_console = verbose
+        solver.setOptionValue("log_to_console", verbose)
         for key, value in solver_opts.items():
-            setattr(options, key, value)
+            # note that calling setOptionValue directly on the solver
+            # allows one to pass advanced options that aren't available
+            # on the HighOptions class (e.g., presolve_rule_off)
+            solver.setOptionValue(key, value)
 
-        solver = hp.Highs()
-        solver.passOptions(options)
         solver.passModel(model)
 
         if warm_start and solver_cache is not None and self.name() in solver_cache:


### PR DESCRIPTION
This pull requests enables support for advanced HIGHS solver options that are not accessible through the HighsOptions class. If we just call `solver.setOptionValue(key, value)`, we are able to set the same options on the HighsOptions class (e.g., threads) as well as additional options that are not included there (e.g., presolve_rule_off).

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.