### PR TITLE
Fix link in dcp tutorial

### DIFF
--- a/doc/source/tutorial/dcp/index.rst
+++ b/doc/source/tutorial/dcp/index.rst
@@ -7,8 +7,8 @@ Disciplined convex programming (DCP) is a system for constructing mathematical e
 
 This section of the tutorial explains the rules of DCP and how they are applied by CVXPY.
 
-Visit `dcp.stanford.edu <http://dcp.stanford.edu>`__ for a
-more interactive introduction to DCP.
+Visit `Disciplined Convex Programming <https://web.stanford.edu/~boyd/papers/disc_cvx_prog.html>`__ for a
+broader introduction to DCP.
 
 Expressions
 -----------


### PR DESCRIPTION
## Description

In the DCP tutorial, there is a link to a DCP website from stanford. That address now hosts the 'developmental community of practice'. Also interesting, but probably not what we wanted to see.

I looked into the Wayback Machine: https://web.archive.org/web/20210506191139/https://dcp.stanford.edu/

And I can't find that original source hosted anywhere anymore so I guess the change to https://web.stanford.edu/~boyd/papers/disc_cvx_prog.html I propose is the closest to it? Unless someone knows where the new DCP tutorial is hosted?

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.