### PR TITLE
Update inv_prod.py

### DIFF
--- a/cvxpy/atoms/inv_prod.py
+++ b/cvxpy/atoms/inv_prod.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 import numpy as np
 
-from cvxpy.atoms.elementwise.inv_pos import inv_pos
 from cvxpy.atoms.elementwise.power import power
 from cvxpy.atoms.geo_mean import geo_mean
 
@@ -37,4 +36,4 @@ def inv_prod(value):
 
         where :math:`n` is the length of :math:`x`.
     """
-    return power(inv_pos(geo_mean(value)), int(np.prod(value.shape)))
+    return power(geo_mean(value)), -int(np.prod(value.shape))


### PR DESCRIPTION
## Description
Eliminates the double call to power in inv_prod, so it is canonicalized as a single power(geo_mean) instead of power(power(geo_mean).


## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.