### PR TITLE
build python314 and free-threaded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-22.04, macos-14, windows-2022 ]
-        python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t" ]
         include:
           # These are intended to just add their extra parameter to existing matrix combinations;
           # see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
@@ -60,6 +60,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true # needed for 3.14
           channels: conda-forge,anaconda
 
       - name: Install
@@ -85,7 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-22.04, macos-14, windows-2022 ]
-        python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t" ]
         build-cvxpy-base: [ true, false ]  # whether to build cvxpy-base (true) or regular cvxpy (false)
         include:
           # This is intended to just add the single_action_config parameter to one existing combination;
@@ -109,6 +110,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true # needed for 3.14
 
       - name: Set Additional Envs
         shell: bash


### PR DESCRIPTION
## Description
Please include a short summary of the change.
There is a list of the 360 most popular python packages [here](https://hugovk.github.io/free-threaded-wheels/) and the status on their free-threaded python support. CVXPY is on the list, so I thought we should try to also build free-threaded python wheels. 
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.