### PR TITLE
Check if there are constraints before calling getDual()

### DIFF
--- a/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
@@ -73,9 +73,9 @@ class XPRESS(QpSolver):
                 intf.DEFAULT_INTF.const_to_matrix(np.array(x))
             }
 
-            # Only add duals if not a MIP.
+            # Only add duals if not a MIP and if duals exist (i.e. there are constraints present).
             dual_vars = None
-            if not inverse_data[XPRESS.IS_MIP]:
+            if 'getDual' in results.keys():
                 y = -np.array(results['getDual'])
                 dual_vars = {XPRESS.DUAL_VAR_ID: y}
 
@@ -248,7 +248,8 @@ class XPRESS(QpSolver):
                 results_dict['getSolution'] = self.prob_.getSolution()
 
                 if not (data[s.BOOL_IDX] or data[s.INT_IDX]):
-                    results_dict['getDual'] = self.prob_.getDuals()
+                    if self.prob_.attributes.rows > 0:
+                        results_dict['getDual'] = self.prob_.getDuals()
 
         del self.prob_
 


### PR DESCRIPTION
## Description
If Xpress is given a QP without constraints, it fails when calling the `getDuals()` method. This PR checks if constraints are present before calling for the duals.

>                   results_dict['getDual'] = self.prob_.getDuals()
                                              ^^^^^^^^^^^^^^^^^^^^^
E                   xpress.ModelError: Dual values are not available

Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.