### PR TITLE
If solver hits max iters it should return s.USER_LIMIT

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/ecos_conif.py
@@ -63,7 +63,7 @@ class ECOS(ConicSolver):
                   10: s.OPTIMAL_INACCURATE,
                   11: s.INFEASIBLE_INACCURATE,
                   12: s.UNBOUNDED_INACCURATE,
-                  -1: s.SOLVER_ERROR,
+                  -1: s.USER_LIMIT,
                   -2: s.SOLVER_ERROR,
                   -3: s.SOLVER_ERROR,
                   -4: s.SOLVER_ERROR,

--- a/cvxpy/reductions/solvers/qp_solvers/daqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/daqp_qpif.py
@@ -36,7 +36,7 @@ class DAQP(QpSolver):
                   -1: s.INFEASIBLE,
                   -3: s.UNBOUNDED,
                   # TODO to be tested
-                  -4: s.USER_LIMIT, # iter limit reached, should it be error?
+                  -4: s.USER_LIMIT, # iter limit reached
                   -5: s.SOLVER_ERROR, # non-convex problem, shouldn't happen
                   -6: s.INFEASIBLE} # provided active set (equality
                                     # constraints) infeasible

--- a/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/osqp_qpif.py
@@ -16,7 +16,7 @@ class OSQP(QpSolver):
     # Note: Status map has changed in versions >= 1
     STATUS_MAP_PRE_V1 = {1: s.OPTIMAL,
                   2: s.OPTIMAL_INACCURATE,
-                  -2: s.SOLVER_ERROR,           # Maxiter reached
+                  -2: s.USER_LIMIT,           # Maxiter reached
                   -3: s.INFEASIBLE,
                   3: s.INFEASIBLE_INACCURATE,
                   -4: s.UNBOUNDED,
@@ -30,7 +30,7 @@ class OSQP(QpSolver):
                   4: s.INFEASIBLE_INACCURATE,
                   5: s.UNBOUNDED,
                   6: s.UNBOUNDED_INACCURATE,
-                  7: s.SOLVER_ERROR,           # Maxiter reached
+                  7: s.USER_LIMIT,           # Maxiter reached
                   8: s.USER_LIMIT,
                   10: s.SOLVER_ERROR,          # Interrupted by user
                   11: s.SOLVER_ERROR}          # Unsolved

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1433,9 +1433,6 @@ class TestProblem(BaseTest):
     def test_solver_error_raised_on_failure(self) -> None:
         """Tests that a SolverError is raised when a solver fails.
         """
-        A = numpy.random.randn(40, 40)
-        b = cp.matmul(A, numpy.random.randn(40))
-
         with self.assertRaises(SolverError):
             Problem(cp.Minimize(cp.quad_form(cp.Variable(1) + 1, np.array([[-1]]), True))).solve(
                 solver=s.OSQP

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1437,9 +1437,9 @@ class TestProblem(BaseTest):
         b = cp.matmul(A, numpy.random.randn(40))
 
         with self.assertRaises(SolverError):
-            Problem(cp.Minimize(
-                cp.sum_squares(cp.matmul(A, cp.Variable(40)) - b))).solve(
-                solver=s.OSQP, max_iter=1)
+            Problem(cp.Minimize(cp.quad_form(cp.Variable(1) + 1, np.array([[-1]]), True))).solve(
+                solver=s.OSQP
+            )
 
     def test_solve_solver_path(self) -> None:
         """
@@ -1468,9 +1468,9 @@ class TestProblem(BaseTest):
         solvers = [(s.OSQP, {'max_iter':1})]
 
         with self.assertRaises(SolverError):
-            Problem(cp.Minimize(
-                cp.sum_squares(cp.matmul(A, cp.Variable(40)) - b))).solve(
-                solver_path=solvers)
+            Problem(cp.Minimize(cp.quad_form(cp.Variable(1) + 1, np.array([[-1]]), True))).solve(
+                solver_path=solvers
+            )
 
         # invalid input, raise ValueError
         solvers_invalid_inner_input = [{'str':{}}, 'str', [], [1], [()], [(1)], [(1,{})],


### PR DESCRIPTION
## Description
If solver hits max iters it should return `s.USER_LIMIT`.

Another question is if the user interrupts the solver with ctrl+C, should the solver return `s.SOLVER_ERROR` or `s.USER_LIMIT`. Some interfaces do one, others do the other. 

Issue link (if applicable):
https://github.com/cvxpy/cvxpy/issues/2533

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.