### PR TITLE
Grad bilinear

### DIFF
--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -201,7 +201,7 @@ class MulExpression(BinaryOperator):
             DX[k::self.args[0].shape[0], k::self.args[0].shape[0]] = Y
         DX = sp.csc_array(DX)
         cols = 1 if len(self.args[1].shape) == 1 else self.args[1].shape[1]
-        DY = sp.block_diag([X.T for k in range(cols)], 'csc')
+        DY = sp.block_diag([np.atleast_2d(X.T) for k in range(cols)], "csc")
 
         return [DX, DY]
 

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -193,6 +193,12 @@ class MulExpression(BinaryOperator):
         DX_rows = self.args[0].size
         cols = self.args[0].size
 
+        # dot product of two vectors with shape (n,)
+        if len(self.args[0].shape) == 1 and len(self.args[1].shape) == 1:
+            DX = sp.csc_array(Y.reshape(-1, 1))  # y as column vector
+            DY = sp.csc_array(X.reshape(-1, 1))  # x as column vector
+            return [DX, DY]
+
         # DX = [diag(Y11), diag(Y12), ...]
         #      [diag(Y21), diag(Y22), ...]
         #      [   ...        ...     ...]

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -901,3 +901,13 @@ class TestGrad(BaseTest):
         self.x.value = [1, 2]
         val = np.eye(2)
         self.assertItemsAlmostEqual(expr.grad[self.x].toarray(), val)
+
+    def test_bilinear(self) -> None:
+        """Test grad for bilinear expressions."""
+        q = cp.Variable(1, value=[1.0])
+        p = cp.Variable(1, value=[2.0])
+        expr = q @ p
+        grad_q = expr.grad[q]
+        grad_p = expr.grad[p]
+        self.assertAlmostEqual(grad_q, [2.0])
+        self.assertAlmostEqual(grad_p, [1.0])

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -904,10 +904,56 @@ class TestGrad(BaseTest):
 
     def test_bilinear(self) -> None:
         """Test grad for bilinear expressions."""
-        q = cp.Variable(1, value=[1.0])
-        p = cp.Variable(1, value=[2.0])
-        expr = q @ p
-        grad_q = expr.grad[q]
-        grad_p = expr.grad[p]
-        self.assertAlmostEqual(grad_q, [2.0])
-        self.assertAlmostEqual(grad_p, [1.0])
+        for n in [1, 2, 3]:
+            with self.subTest(n=n):
+                x_vals = np.arange(1, n + 1)
+                y_vals = -np.arange(1, n + 1)
+                x = cp.Variable(n, value=x_vals)
+                y = cp.Variable(n, value=y_vals)
+
+                # test bilinear expression x @ y
+                # which has partial derivatives grad_x = y, grad_y = x
+                expr = x @ y
+
+                grad_x = expr.grad[x]
+                grad_y = expr.grad[y]
+
+                assert x.value is not None
+                assert y.value is not None
+
+                if n == 1:
+                    assert grad_x.shape == ()
+                    assert grad_y.shape == ()
+                    self.assertAlmostEqual(grad_x, y.value)
+                    self.assertAlmostEqual(grad_y, x.value)
+                else:
+                    assert grad_x.shape == (n, 1)
+                    assert grad_y.shape == (n, 1)
+                    self.assertItemsAlmostEqual(grad_x.toarray(), y.value.reshape(-1, 1))
+                    self.assertItemsAlmostEqual(grad_y.toarray(), x.value.reshape(-1, 1))
+
+    def test_matrix_product(self) -> None:
+        """Test matrix-matrix product."""
+        x_vals = np.array([[1, -1], [2, -2]])
+        y_vals = np.array([[-1, 1], [-2, 2]])
+        x = cp.Variable((2, 2), value=x_vals)
+        y = cp.Variable((2, 2), value=y_vals)
+        expr = x @ y
+        grad_x = expr.grad[x]
+        grad_y = expr.grad[y]
+        assert x.value is not None
+        assert y.value is not None
+        
+        # expected gradients are 4x4 Jacobian matrices for 2x2 matrix variables
+        expected_grad_x = np.array([[-1.,  0.,  1.,  0.],
+                                   [ 0., -1.,  0.,  1.],
+                                   [-2.,  0.,  2.,  0.],
+                                   [ 0., -2.,  0.,  2.]])
+        expected_grad_y = np.array([[ 1.,  2.,  0.,  0.],
+                                   [-1., -2.,  0.,  0.],
+                                   [ 0.,  0.,  1.,  2.],
+                                   [ 0.,  0., -1., -2.]])
+        
+        self.assertItemsAlmostEqual(grad_x.toarray(), expected_grad_x)
+        self.assertItemsAlmostEqual(grad_y.toarray(), expected_grad_y)
+


### PR DESCRIPTION
## Description

This change makes it possible to compute gradients for bilinear expressions. This gradient can then be used to linearize expressions that contain products of variables, such as in DCCP problems. 

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.