### PR TITLE
Treat assignment of numpy arrays and lists similarly

### DIFF
--- a/cvxpy/interface/matrix_utilities.py
+++ b/cvxpy/interface/matrix_utilities.py
@@ -171,7 +171,7 @@ def from_1D_to_2D(constant):
 def convert(constant, sparse: bool = False, convert_scalars: bool = False):
     """Convert to appropriate type.
     """
-    if isinstance(constant, (list, np.matrix)):
+    if isinstance(constant, (list, np.ndarray, np.matrix)):
         return DEFAULT_INTF.const_to_matrix(constant,
                                             convert_scalars=convert_scalars)
     elif sparse:

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -237,11 +237,13 @@ class TestAttributes:
         x = cp.Variable(2, boolean=True)
         val = np.array([True, False])
         x.value = val
+        np.testing.assert_array_equal(x.value, val.astype(float), strict=True)
 
     def test_integer_var_value(self):
         x = cp.Variable(2, integer=True)
         val = np.array([1, 2], dtype=int)
         x.value = val
+        np.testing.assert_array_equal(x.value, val.astype(float), strict=True)
 
 class TestMultipleAttributes:
 

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -40,6 +40,33 @@ class TestConstraints(BaseTest):
         self.B = Variable((2, 2), name='B')
         self.C = Variable((3, 2), name='C')
 
+    def test_boolean_violation(self):
+        # https://github.com/cvxpy/cvxpy/issues/2900
+        z = cp.Variable(1, boolean=True)
+        for value in ([1], [1.0], [True], np.array([1]), np.array([1.0]), np.array([True])):
+            with self.subTest(value=value):
+                z.value = value
+
+                constraint = z >= 0.6
+                actual = constraint.violation()
+                expected = np.array([0.0])
+                np.testing.assert_array_equal(actual, expected, strict=True)
+
+                constraint = 1 - z <= 0.6
+                actual = constraint.violation()
+                expected = np.array([0.0])
+                np.testing.assert_array_equal(actual, expected, strict=True)
+
+                constraint = z <= 0.6
+                actual = constraint.violation()
+                expected = np.array([0.4])
+                np.testing.assert_array_equal(actual, expected, strict=True)
+
+                constraint = 1 - z >= 0.6
+                actual = constraint.violation()
+                expected = np.array([0.6])
+                np.testing.assert_array_equal(actual, expected, strict=True)
+
     def test_equality(self) -> None:
         """Test the Equality class.
         """

--- a/cvxpy/tests/test_matrix_utilities.py
+++ b/cvxpy/tests/test_matrix_utilities.py
@@ -1,0 +1,61 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+
+import numpy as np
+
+from cvxpy.interface import matrix_utilities
+from cvxpy.interface.numpy_interface.ndarray_interface import COMPLEX_TYPES
+
+
+class TestMatrixUtilities(unittest.TestCase):
+    def test_convert(self):
+        underlying_values = [0, 1]
+
+        # List of values
+        values = underlying_values
+        with self.subTest(array=values):
+            actual = matrix_utilities.convert(values)
+            expected = np.array(values, dtype=float)
+            np.testing.assert_array_equal(actual, expected, strict=True)
+
+        # List of list
+        values = [underlying_values]
+        with self.subTest(array=values):
+            actual = matrix_utilities.convert(values)
+            expected = np.array(values, dtype=float).T
+            np.testing.assert_array_equal(actual, expected, strict=True)
+
+        for dtype in [int, float, bool] + COMPLEX_TYPES:
+            expected_dtype = dtype if dtype in COMPLEX_TYPES else float
+
+            # 1D arrays
+            values = np.array(underlying_values, dtype=dtype)
+            with self.subTest(array=values, dtype=dtype):
+                actual = matrix_utilities.convert(values)
+                expected = values.astype(expected_dtype)
+                np.testing.assert_array_equal(actual, expected, strict=True)
+
+            # 2D arrays
+            for values in (
+                np.array([underlying_values], dtype=dtype),
+                np.matrix(underlying_values, dtype=dtype),
+            ):
+                with self.subTest(array=values, dtype=dtype):
+                    actual = matrix_utilities.convert(values)
+                    expected = np.array([underlying_values], dtype=expected_dtype)
+                    np.testing.assert_array_equal(actual, expected, strict=True)


### PR DESCRIPTION
 This fixes an issue where lists and numpy ndarrays were treated
 differently when assigned to a Leaf's value property.
 
 When assigning a list (or numpy matrix), the provided object is first
 converted to a numpy ndarray with float dtype.  However, when provided a
 numpy ndarray, the object was being assigned as provided.  As a result,
 lists of bools and ints were converted to numpy arrays of floats, while
 numpy arrays of bools and ints retained their original dtypes.  This
 would result in errors when attempting to perform certain arithmetic
 operations on these arrays.
 
 Now, we make lists and numpy ndarrays follow the same code path during
 the conversion process.

This also adds several tests to help verify various aspects of the
relevant code.  These tests would all fail in one way or another without
this fix.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.