### PR TITLE
Check KNITRO license before running tests

### DIFF
--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2772,8 +2772,22 @@ class TestCOSMO(BaseTest):
         self.assertAlmostEqual(result2, result, places=2)
         print(time > time2)
 
-        
-@unittest.skipUnless(cp.KNITRO in INSTALLED_SOLVERS, 'KNITRO is not installed.')
+def is_knitro_available():
+    """Check if KNITRO is installed and a license is available."""
+    if 'KNITRO' not in INSTALLED_SOLVERS:
+        return False
+    try:
+        import knitro  # type: ignore
+        # Try to create and delete a Knitro solver instance
+        kc = knitro.KN_new()
+        if kc is None:
+            return False
+        knitro.KN_free(kc)
+        return True
+    except Exception:
+        return False
+
+@unittest.skipUnless(is_knitro_available(), 'KNITRO is not installed or license is not available.')
 class TestKNITRO(BaseTest):
 
     def test_knitro_lp_0(self) -> None:

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2376,13 +2376,10 @@ class TestAllSolvers(BaseTest):
         prob = cp.Problem(cp.Minimize(cp.norm(self.x, 1) + 1.0), [self.x == 0])
         for solver in SOLVER_MAP_CONIC.keys():
             if solver in INSTALLED_SOLVERS:
-                if solver is cp.MOSEK:
-                    if is_mosek_available():
-                        prob.solve(solver=solver)
-                        assert prob.value == 1.0
-                        assert self.x.value == [0, 0]
-                    else:
-                        pass
+                if solver is cp.MOSEK and not is_mosek_available():
+                    pass
+                elif solver is cp.KNITRO and not is_knitro_available():
+                    pass
                 else:
                     prob.solve(solver=solver)
                     self.assertAlmostEqual(prob.value, 1.0)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2391,8 +2391,11 @@ class TestAllSolvers(BaseTest):
 
         for solver in SOLVER_MAP_QP.keys():
             if solver in INSTALLED_SOLVERS:
-                prob.solve(solver=solver)
-                self.assertItemsAlmostEqual(self.x.value, [0, 0])
+                if solver is cp.KNITRO and not is_knitro_available():
+                    pass
+                else:
+                    prob.solve(solver=solver)
+                    self.assertItemsAlmostEqual(self.x.value, [0, 0])
             else:
                 with self.assertRaises(Exception) as cm:
                     prob.solve(solver=solver)

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -72,6 +72,7 @@ class TestQp(BaseTest):
 
         # Check for all installed QP solvers
         self.solvers = [x for x in QP_SOLVERS if x in INSTALLED_SOLVERS]
+
         def is_mosek_available():
             """Check if MOSEK is installed and a license is available."""
             if 'MOSEK' not in INSTALLED_SOLVERS:
@@ -84,6 +85,22 @@ class TestQp(BaseTest):
                 return status == mosek.rescode.ok
             except Exception:
                 return False
+        
+        def is_knitro_available():
+            """Check if KNITRO is installed and a license is available."""
+            if 'KNITRO' not in INSTALLED_SOLVERS:
+                return False
+            try:
+                import knitro  # type: ignore
+                # Try to create and delete a Knitro solver instance
+                kc = knitro.KN_new()
+                if kc is None:
+                    return False
+                knitro.KN_free(kc)
+                return True
+            except Exception:
+                return False
+        
         def is_xpress_available():
             """Check if XPRESS is installed and a license is available."""
             if 'XPRESS' not in INSTALLED_SOLVERS:
@@ -98,8 +115,10 @@ class TestQp(BaseTest):
         # Remove XPRESS if license is not available
         if 'XPRESS' in self.solvers and not is_xpress_available():
             self.solvers.remove('XPRESS')
-        if is_mosek_available():
-            self.solvers.append('MOSEK')
+        if 'MOSEK' in self.solvers and not is_mosek_available():
+            self.solvers.remove('MOSEK')
+        if 'KNITRO' in self.solvers and not is_knitro_available():
+            self.solvers.remove('KNITRO')
 
     def solve_QP(self, problem, solver_name):
         return problem.solve(solver=solver_name, verbose=False)


### PR DESCRIPTION
## Description
Check KNITRO license before running tests. 
This should prevent failed tests for optional solvers in CI.
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.