### PR TITLE
Fix issue #2896: harmonic mean gradient computation dtype error

### DIFF
--- a/cvxpy/atoms/pnorm.py
+++ b/cvxpy/atoms/pnorm.py
@@ -249,15 +249,21 @@ class Pnorm(AxisAtom):
         if self.p < 1 and np.any(value <= 0):
             return None
         D_null = sp.csc_array((rows, 1), dtype='float64')
+        # Ensure vector semantics and consistent column-major vectorization.
+        value = np.asarray(value).ravel(order='F')
         denominator = np.linalg.norm(value, float(self.p))
-        denominator = np.power(denominator, self.p - 1)
+        exp = float(self.p - 1)  # cast to float to avoid dtype=object with Fraction exponents
+        denominator = np.power(denominator, exp)
         # Subgrad is 0 when denom is 0 (or undefined).
         if denominator == 0:
             if self.p > 1:
                 return D_null.todense()
             else:
                 return None
+        if self.p > 1:
+            # nominator = sign(value) * |value|^(p-1)
+            nominator = np.sign(value) * np.power(np.abs(value), exp)
         else:
-            nominator = np.power(value, self.p - 1)
-            frac = np.divide(nominator, denominator)
-            return np.reshape(frac, (frac.size, 1))
+            nominator = np.power(value, exp)
+        frac = np.divide(nominator, denominator)
+        return np.reshape(frac, (frac.size, 1))

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -92,6 +92,49 @@ class TestGrad(BaseTest):
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(),
                                     np.array([[0.6, 0], [0.8, 0], [0, -0.6], [0, 0.8]]))
 
+        # Helper: normalize gradient to a flat ndarray (works for sparse/dense)
+        def _flat(g):
+            g_arr = g.toarray() if hasattr(g, "toarray") else np.asarray(g)
+            return g_arr.ravel(order="F")
+
+        # Regression test for issue #2896 - harmonic_mean gradient dtype=object error
+        x = cp.Variable(2, name="x", value=[1.0, 1.0])
+        expr = cp.harmonic_mean(x)
+        grad = expr.grad[x]
+        self.assertIsNotNone(grad)
+        # Robust dtype check (float or complex, but not object)
+        self.assertIn(getattr(grad, "dtype", np.asarray(grad).dtype).kind, ("f", "c"))
+        # Check expected values: HM([1,1]) = 1, ∂HM/∂x_i = n*||x||_{-1}^2/x_i^2 = 0.5
+        self.assertTrue(np.allclose(_flat(grad), [0.5, 0.5]))
+
+        # Test gradient for negative p values (harmonic mean case p=-1)
+        expr = cp.pnorm(self.x, -1)
+        self.x.value = np.array([1.0, 2.0])
+        grad = expr.grad[self.x]
+        self.assertIsNotNone(grad)
+        self.assertIn(getattr(grad, "dtype", np.asarray(grad).dtype).kind, ("f", "c"))
+
+        # Test gradient sign correctness for p=3 with negative values
+        expr = cp.pnorm(self.x, 3)
+        self.x.value = np.array([-2.0, 3.0])
+        grad = expr.grad[self.x]
+        g = _flat(grad)
+        # Sign checks
+        self.assertLess(g[0], 0)
+        self.assertGreater(g[1], 0)
+        # Analytic check
+        den = (np.linalg.norm(self.x.value, ord=3.0))**(3-1)
+        expected = np.sign(self.x.value) * np.abs(self.x.value)**(3-1) / den
+        self.assertTrue(np.allclose(g, expected))
+
+        # Test p=-0.5 on column-shaped value (vector semantics)
+        y = cp.Variable((3, 1), pos=True)
+        y.value = np.array([[1.0], [2.0], [4.0]])
+        expr = cp.pnorm(y, -0.5)
+        grad = expr.grad[y]
+        self.assertIsNotNone(grad)
+        self.assertIn(getattr(grad, "dtype", np.asarray(grad).dtype).kind, ("f", "c"))
+
         expr = cp.pnorm(self.A, 2, axis=1)
         self.A.value = np.array([[3, -4], [4, 3]])
         self.assertItemsAlmostEqual(expr.grad[self.A].toarray(),


### PR DESCRIPTION
## Description
Fixes issue #2896.
The gradient computation for `cp.harmonic_mean` was failing with `ValueError: scipy.sparse does not support dtype object`.

The issue occurred when computing gradients with `p=-1` (used by harmonic_mean), where `self.p` is a `Fraction` object. Computing `np.power(value, self.p - 1)` with Fraction exponents creates object dtype arrays that scipy.sparse rejects.

### Changes made:
- Cast Fraction exponents to float in `_column_grad` to prevent dtype=object arrays
- Ensure consistent vector semantics with `ravel(order='F')` 
- Fix sign handling for `p>1` with negative values to prevent incorrect gradients

### Tests added:
- Regression test using exact reproduction from issue #2896
- Test for negative p values including harmonic mean case (p=-1)
- Test for gradient sign correctness with p>1 and negative values  
- Test for column-shaped variables to verify vector semantics
- Analytic gradient value checks for correctness


## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression. [didn't do: benchmarks are now a separate github workflow]