### PR TITLE
Support for cvxpy.convolve into complex2real, fix sparse convolutions in Scipy

### DIFF
--- a/cvxpy/lin_ops/canon_backend.py
+++ b/cvxpy/lin_ops/canon_backend.py
@@ -1556,9 +1556,10 @@ class SciPyCanonBackend(PythonCanonBackend):
 
         rows = lin.shape[0]
         cols = lin.args[0].shape[0] if len(lin.args[0].shape) > 0 else 1
-        nonzeros = lhs.shape[0]
 
         lhs = lhs.tocoo()
+        nonzeros = lhs.nnz
+
         row_idx = (np.tile(lhs.row, cols) + np.repeat(np.arange(cols), nonzeros)).astype(int)
         col_idx = (np.tile(lhs.col, cols) + np.repeat(np.arange(cols), nonzeros)).astype(int)
         data = np.tile(lhs.data, cols)

--- a/cvxpy/reductions/complex2real/canonicalizers/__init__.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/__init__.py
@@ -15,10 +15,10 @@ limitations under the License.
 """
 
 from cvxpy.atoms import (MatrixFrac, Pnorm, QuadForm, abs, bmat, conj, conv,
-                         cumsum, imag, kron, lambda_max, lambda_sum_largest,
-                         log_det, norm1, norm_inf, quad_over_lin, real,
-                         reshape, sigma_max, Trace, upper_tri,
-                         von_neumann_entr, quantum_rel_entr)
+                         convolve, cumsum, imag, kron, lambda_max,
+                         lambda_sum_largest, log_det, norm1, norm_inf,
+                         quad_over_lin, real, reshape, sigma_max, Trace,
+                         upper_tri, von_neumann_entr, quantum_rel_entr)
 from cvxpy.atoms.affine.add_expr import AddExpression
 from cvxpy.atoms.affine.binary_operators import (DivExpression, MulExpression,
                                                  multiply,)
@@ -82,6 +82,7 @@ CANON_METHODS = {
     Concatenate: separable_canon,
 
     conv: binary_canon,
+    convolve: binary_canon,
     DivExpression: binary_canon,
     kron: binary_canon,
     MulExpression: binary_canon,


### PR DESCRIPTION
Altough cvxpy.conv is supported, cvxpy.convolve is a different atom and thus requires to be explicitly specified in order to be supported.

Fixes #2946

Note: I am not familiar with the codebase, there may be some reason that cvxpy.convolve is not supported and is not supposed to be supported by the complex2real step.