### PR TITLE
Update Python version in devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Python 3",
-	"image": "mcr.microsoft.com/devcontainers/python:0-3.10",
+	"image": "mcr.microsoft.com/devcontainers/python:dev-3.12",
 	"onCreateCommand": "bash .devcontainer/startup.sh",
 	"customizations": {
 		"vscode": {


### PR DESCRIPTION
## Description
Previously, the devcontainer was using python 3.10, while the pytests require python 3.11. 

## Type of change
- Bug fix: Update the python image in the devcontainer to 3.12. 