### PR TITLE
excludes build for windows-2022 on py-314t

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,10 @@ jobs:
           - os: macos-14
             python-version: 3.12
             single_action_config: true
+        # exluding this build because it is failing and blocks wheels
+        exclude:
+          - os: windows-2022
+          - python-version: 3.14t
 
     env:
       RUNNER_OS: ${{ matrix.os }}
@@ -93,6 +97,10 @@ jobs:
           - os: ubuntu-22.04
             python-version: 3.12
             single_action_config: true
+        # exluding this version because it is failing
+        exclude:
+          - os: windows-2022
+            python-version: 3.14t
 
     env:
       RUNNER_OS: ${{ matrix.os }}


### PR DESCRIPTION
## Description
Please include a short summary of the change.
#2899 enables free-threaded builds. However, one case is failing and blocks the subsequent CI task of building wheels (which is quite important). This PR aims to allow wheels to still build and skips the specific build that is currently failing.
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.