### PR TITLE
adds proper error message for specifying tuple bounds

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -641,7 +641,7 @@ class Leaf(expression.Expression):
         if not isinstance(value, Iterable) or len(value) != 2:
             raise ValueError("Bounds should be a list of two items.")
 
-        if isinstance(value, tuple):
+        if isinstance(value, tuple) and len(value) == 2:
             raise ValueError("Bounds should be a list, not a tuple.")
 
         # Check that bounds contains two scalars or two arrays with matching shapes.

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -641,6 +641,9 @@ class Leaf(expression.Expression):
         if not isinstance(value, Iterable) or len(value) != 2:
             raise ValueError("Bounds should be a list of two items.")
 
+        if isinstance(value, tuple):
+            raise ValueError("Bounds should be a list, not a tuple.")
+
         # Check that bounds contains two scalars or two arrays with matching shapes.
         for val in value:
             valid_array = isinstance(val, np.ndarray) and val.shape == self.shape

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -182,6 +182,10 @@ class TestAttributes:
         with pytest.raises(ValueError, match="Bounds should be a list of two items."):
             x = cp.Variable((2, 2), name="x", bounds=bounds)
 
+        bounds = (0, 10)  # Tuple instead of list
+        with pytest.raises(ValueError, match="Bounds should be a list, not a tuple."):
+            x = cp.Variable((2, 2), name="x", bounds=bounds)
+
         # Invalid bounds: Arrays with non-matching shape
         bounds = [np.zeros((3, 3)), np.ones((3, 3))]
         with pytest.raises(


### PR DESCRIPTION
## Description
Please include a short summary of the change.
This PR raises an error when the user specifies a tuple for variable bounds. One other option could be to convert it to a list before processing it further, but maybe we should stick to this for now. 
Issue link (if applicable): #2981 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.