### PR TITLE
Exploration of batch support

### DIFF
--- a/cvxpy/__init__.py
+++ b/cvxpy/__init__.py
@@ -33,6 +33,7 @@ from cvxpy.constraints import (
     FiniteSet as FiniteSet,
 )
 from cvxpy.error import (
+    BatchedValueError as BatchedValueError,
     DCPError as DCPError,
     DGPError as DGPError,
     DPPError as DPPError,

--- a/cvxpy/atoms/affine/cumsum.py
+++ b/cvxpy/atoms/affine/cumsum.py
@@ -68,7 +68,8 @@ class cumsum(AffAtom, AxisAtom):
         """
         Returns the cumulative sum of elements of an expression over an axis.
         """
-        return np.cumsum(values[0], axis=self.axis)
+        effective_axis = self._get_effective_axis(values[0])
+        return np.cumsum(values[0], axis=effective_axis)
 
     def validate_arguments(self):
         if self.args[0].ndim > 2:

--- a/cvxpy/atoms/affine/index.py
+++ b/cvxpy/atoms/affine/index.py
@@ -87,7 +87,15 @@ class index(AffAtom):
 
     def numeric(self, values):
         """Returns the index/slice into the given value."""
-        return values[0][self._orig_key]
+        val = values[0]
+        # Handle batched values: prepend slice(None) for each batch dimension
+        batch_ndim = np.ndim(val) - len(self.args[0].shape)
+        if batch_ndim > 0:
+            # Prepend : for each batch dimension to preserve them
+            batch_slices = (slice(None),) * batch_ndim
+            key = self._orig_key if isinstance(self._orig_key, tuple) else (self._orig_key,)
+            return val[batch_slices + key]
+        return val[self._orig_key]
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Returns the shape of the index expression."""
@@ -160,7 +168,14 @@ class special_index(AffAtom):
     def numeric(self, values):
         """Returns the index/slice into the given value.
         """
-        return values[0][self.key]
+        val = values[0]
+        # Handle batched values: prepend slice(None) for each batch dimension
+        batch_ndim = np.ndim(val) - len(self.args[0].shape)
+        if batch_ndim > 0:
+            batch_slices = (slice(None),) * batch_ndim
+            key = self.key if isinstance(self.key, tuple) else (self.key,)
+            return val[batch_slices + key]
+        return val[self.key]
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Returns the shape of the index expression."""

--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -102,7 +102,13 @@ class reshape(AffAtom):
     def numeric(self, values):
         """Reshape the value.
         """
-        return np.reshape(values[0], self.shape, order=self.order)
+        val = values[0]
+        # Handle batched values: preserve batch dimensions
+        batch_ndim = np.ndim(val) - len(self.args[0].shape)
+        if batch_ndim > 0:
+            batch_shape = val.shape[:batch_ndim]
+            return np.reshape(val, batch_shape + self.shape, order=self.order)
+        return np.reshape(val, self.shape, order=self.order)
 
     def validate_arguments(self) -> None:
         """Checks that the new shape has the same number of entries as the old.

--- a/cvxpy/atoms/affine/sum.py
+++ b/cvxpy/atoms/affine/sum.py
@@ -96,7 +96,8 @@ class Sum(AxisAtom, AffAtom):
             if not self.keepdims and self.axis is not None:
                 result = result.flatten()
         else:
-            result = np.sum(values[0], axis=self.axis, keepdims=self.keepdims)
+            effective_axis = self._get_effective_axis(values[0])
+            result = np.sum(values[0], axis=effective_axis, keepdims=self.keepdims)
         return result
 
     def graph_implementation(self,

--- a/cvxpy/atoms/affine/trace.py
+++ b/cvxpy/atoms/affine/trace.py
@@ -64,7 +64,12 @@ class Trace(AffAtom):
     def numeric(self, values):
         """Sums the diagonal entries.
         """
-        return np.trace(values[0])
+        val = values[0]
+        # Handle batched values: trace over the last two dimensions
+        batch_ndim = np.ndim(val) - len(self.args[0].shape)
+        if batch_ndim > 0:
+            return np.trace(val, axis1=-2, axis2=-1)
+        return np.trace(val)
 
     def validate_arguments(self) -> None:
         """Checks that the argument is a square matrix.

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -57,8 +57,15 @@ class upper_tri(AffAtom):
         """
         Vectorize the strictly upper triangular entries.
         """
-        upper_idx = np.triu_indices(n=values[0].shape[0], k=1, m=values[0].shape[1])
-        return values[0][upper_idx]
+        val = values[0]
+        # Handle batched values: extract upper triangular from last two dimensions
+        batch_ndim = np.ndim(val) - len(self.args[0].shape)
+        if batch_ndim > 0:
+            n = val.shape[-2]
+            upper_idx = np.triu_indices(n=n, k=1, m=val.shape[-1])
+            return val[..., upper_idx[0], upper_idx[1]]
+        upper_idx = np.triu_indices(n=val.shape[0], k=1, m=val.shape[1])
+        return val[upper_idx]
 
     def validate_arguments(self) -> None:
         """Checks that the argument is a square matrix.

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -26,6 +26,7 @@ import cvxpy.lin_ops.lin_utils as lu
 import cvxpy.settings as s
 from cvxpy import interface as intf
 from cvxpy import utilities as u
+from cvxpy.error import BatchedValueError
 from cvxpy.expressions import cvxtypes
 from cvxpy.expressions.constants import Constant
 from cvxpy.expressions.expression import Expression
@@ -397,8 +398,13 @@ class Atom(Expression):
                 arg_val = arg._value_impl()
                 if arg_val is None and not self.is_constant():
                     return None
-                else:
-                    arg_values.append(arg_val)
+                # Check if arg has batched values (more dims than expected)
+                if arg_val is not None and arg_val.ndim > len(arg.shape):
+                    raise BatchedValueError(
+                        "Cannot compute expression.value when variables have batched values. "
+                        "Access variable values directly (e.g., x.value) and compute using numpy."
+                    )
+                arg_values.append(arg_val)
             result = self.numeric(arg_values)
         return result
 

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -26,7 +26,6 @@ import cvxpy.lin_ops.lin_utils as lu
 import cvxpy.settings as s
 from cvxpy import interface as intf
 from cvxpy import utilities as u
-from cvxpy.error import BatchedValueError
 from cvxpy.expressions import cvxtypes
 from cvxpy.expressions.constants import Constant
 from cvxpy.expressions.expression import Expression
@@ -398,12 +397,6 @@ class Atom(Expression):
                 arg_val = arg._value_impl()
                 if arg_val is None and not self.is_constant():
                     return None
-                # Check if arg has batched values (more dims than expected)
-                if arg_val is not None and arg_val.ndim > len(arg.shape):
-                    raise BatchedValueError(
-                        "Cannot compute expression.value when variables have batched values. "
-                        "Access variable values directly (e.g., x.value) and compute using numpy."
-                    )
                 arg_values.append(arg_val)
             result = self.numeric(arg_values)
         return result

--- a/cvxpy/atoms/cummax.py
+++ b/cvxpy/atoms/cummax.py
@@ -32,7 +32,8 @@ class cummax(AxisAtom):
     def numeric(self, values):
         """Returns the largest entry in x.
         """
-        return np.maximum.accumulate(values[0], axis=self.axis)
+        effective_axis = self._get_effective_axis(values[0])
+        return np.maximum.accumulate(values[0], axis=effective_axis)
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """The same as the input.

--- a/cvxpy/atoms/cumprod.py
+++ b/cvxpy/atoms/cumprod.py
@@ -41,7 +41,8 @@ class cumprod(AffAtom, AxisAtom):
         """
         Returns the cumulative product of the elements of the expression.
         """
-        return np.cumprod(values[0], axis=self.axis)
+        effective_axis = self._get_effective_axis(values[0])
+        return np.cumprod(values[0], axis=effective_axis)
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """The same as the input."""

--- a/cvxpy/atoms/log_sum_exp.py
+++ b/cvxpy/atoms/log_sum_exp.py
@@ -35,7 +35,8 @@ class log_sum_exp(AxisAtom):
     def numeric(self, values):
         """Evaluates e^x elementwise, sums, and takes the log.
         """
-        return logsumexp(values[0], axis=self.axis, keepdims=self.keepdims)
+        effective_axis = self._get_effective_axis(values[0])
+        return logsumexp(values[0], axis=effective_axis, keepdims=self.keepdims)
 
     def _grad(self, values):
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.

--- a/cvxpy/atoms/max.py
+++ b/cvxpy/atoms/max.py
@@ -45,7 +45,8 @@ class max(AxisAtom):
     def numeric(self, values):
         """Returns the largest entry in x.
         """
-        return values[0].max(axis=self.axis, keepdims=self.keepdims)
+        effective_axis = self._get_effective_axis(values[0])
+        return values[0].max(axis=effective_axis, keepdims=self.keepdims)
 
     def _grad(self, values):
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.

--- a/cvxpy/atoms/min.py
+++ b/cvxpy/atoms/min.py
@@ -45,7 +45,8 @@ class min(AxisAtom):
     def numeric(self, values):
         """Returns the smallest entry in x.
         """
-        return values[0].min(axis=self.axis, keepdims=self.keepdims)
+        effective_axis = self._get_effective_axis(values[0])
+        return values[0].min(axis=effective_axis, keepdims=self.keepdims)
 
     def _grad(self, values):
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.

--- a/cvxpy/atoms/norm1.py
+++ b/cvxpy/atoms/norm1.py
@@ -28,11 +28,20 @@ class norm1(AxisAtom):
     def numeric(self, values):
         """Returns the one norm of x.
         """
+        val = np.array(values[0])
         if self.axis is None:
-            values = np.array(values[0]).flatten()
+            # Handle batched values: flatten only problem dimensions
+            batch_ndim = val.ndim - len(self.args[0].shape)
+            if batch_ndim > 0:
+                batch_shape = val.shape[:batch_ndim]
+                val = val.reshape(batch_shape + (-1,))
+                return np.linalg.norm(val, 1, axis=-1, keepdims=self.keepdims)
+            else:
+                val = val.flatten()
+                return np.linalg.norm(val, 1, keepdims=self.keepdims)
         else:
-            values = np.array(values[0])
-        return np.linalg.norm(values, 1, axis=self.axis, keepdims=self.keepdims)
+            effective_axis = self._get_effective_axis(val)
+            return np.linalg.norm(val, 1, axis=effective_axis, keepdims=self.keepdims)
 
     def sign_from_args(self) -> Tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.

--- a/cvxpy/atoms/norm_nuc.py
+++ b/cvxpy/atoms/norm_nuc.py
@@ -32,8 +32,13 @@ class normNuc(Atom):
 
     def numeric(self, values):
         """Returns the nuclear norm (i.e. the sum of the singular values) of A.
+
+        Supports batched inputs: (..., M, N) -> (...)
         """
-        return np.linalg.norm(values[0], 'nuc')
+        # np.linalg.svd supports batch: (..., M, N) -> (..., min(M,N))
+        s = np.linalg.svd(values[0], compute_uv=False)
+        # Sum singular values along last axis
+        return np.sum(s, axis=-1)
 
     def _grad(self, values):
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.

--- a/cvxpy/atoms/prod.py
+++ b/cvxpy/atoms/prod.py
@@ -84,6 +84,7 @@ class Prod(AxisAtom):
         """Takes the product of the entries of value.
         """
         if intf.is_sparse(values[0]):
+            # Sparse handling doesn't support batching
             sp_mat = values[0]
             if self.axis is None:
                 if sp_mat.nnz == sp_mat.shape[0] * sp_mat.shape[1]:
@@ -104,7 +105,8 @@ class Prod(AxisAtom):
             else:
                 raise UserWarning("cp.prod does not support axis > 1 for sparse matrices.")
         else:
-            result = np.prod(values[0], axis=self.axis, keepdims=self.keepdims)
+            effective_axis = self._get_effective_axis(values[0])
+            result = np.prod(values[0], axis=effective_axis, keepdims=self.keepdims)
         return result
 
     def _column_grad(self, value):

--- a/cvxpy/atoms/sigma_max.py
+++ b/cvxpy/atoms/sigma_max.py
@@ -40,8 +40,13 @@ class sigma_max(Atom):
     @Atom.numpy_numeric
     def numeric(self, values):
         """Returns the largest singular value of A.
+
+        Supports batched inputs: (..., M, N) -> (...)
         """
-        return LA.norm(values[0], 2)
+        # np.linalg.svd supports batch: (..., M, N) -> (..., min(M,N))
+        # Singular values are returned in descending order
+        s = np.linalg.svd(values[0], compute_uv=False)
+        return s[..., 0]
 
     def _grad(self, values):
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.

--- a/cvxpy/constraints/constraint.py
+++ b/cvxpy/constraints/constraint.py
@@ -308,9 +308,10 @@ class Constraint(u.Canonical):
         else:
             return dual_vals
 
-    def save_dual_value(self, value) -> None:
+    def save_dual_value(self, value, batch_shape=()) -> None:
         """Save the value of the dual variable for the constraint's parent.
         Args:
             value: The value of the dual variable.
+            batch_shape: The batch shape for batched problems.
         """
-        self.dual_variables[0].save_value(value)
+        self.dual_variables[0].save_value(value, batch_shape=batch_shape)

--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -136,15 +136,15 @@ class ExpCone(Cone):
         s = (3,) + self.x.shape
         return s
 
-    def save_dual_value(self, value) -> None:
+    def save_dual_value(self, value, batch_shape=()) -> None:
         # TODO(akshaya,SteveDiamond): verify that reshaping below works correctly
         value = np.reshape(value, (-1, 3))
         dv0 = np.reshape(value[:, 0], self.x.shape)
         dv1 = np.reshape(value[:, 1], self.y.shape)
         dv2 = np.reshape(value[:, 2], self.z.shape)
-        self.dual_variables[0].save_value(dv0)
-        self.dual_variables[1].save_value(dv1)
-        self.dual_variables[2].save_value(dv2)
+        self.dual_variables[0].save_value(dv0, batch_shape=batch_shape)
+        self.dual_variables[1].save_value(dv1, batch_shape=batch_shape)
+        self.dual_variables[2].save_value(dv2, batch_shape=batch_shape)
 
     def _dual_cone(self, *args):
         """Implements the dual cone of the exponential cone
@@ -272,7 +272,7 @@ class RelEntrConeQuad(Cone):
         s = (3,) + self.x.shape
         return s
 
-    def save_dual_value(self, value) -> None:
+    def save_dual_value(self, value, batch_shape=()) -> None:
         # TODO: implement me.
         pass
 
@@ -389,6 +389,6 @@ class OpRelEntrConeQuad(Cone):
         s = (3,) + self.X.shape
         return s
 
-    def save_dual_value(self, value) -> None:
+    def save_dual_value(self, value, batch_shape=()) -> None:
         # TODO: implement me.
         pass

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -130,14 +130,14 @@ class PowCone3D(Cone):
         # Note: this can be a 3-tuple of x.ndim == 2.
         return s
 
-    def save_dual_value(self, value) -> None:
+    def save_dual_value(self, value, batch_shape=()) -> None:
         value = np.reshape(value, (3, -1))
         dv0 = np.reshape(value[0, :], self.x.shape)
         dv1 = np.reshape(value[1, :], self.y.shape)
         dv2 = np.reshape(value[2, :], self.z.shape)
-        self.dual_variables[0].save_value(dv0)
-        self.dual_variables[1].save_value(dv1)
-        self.dual_variables[2].save_value(dv2)
+        self.dual_variables[0].save_value(dv0, batch_shape=batch_shape)
+        self.dual_variables[1].save_value(dv1, batch_shape=batch_shape)
+        self.dual_variables[2].save_value(dv2, batch_shape=batch_shape)
         # TODO: figure out why the reshaping had to be done differently,
         #   relative to ExpCone constraints.
 
@@ -284,7 +284,7 @@ class PowConeND(Cone):
     def is_dqcp(self) -> bool:
         return self.is_dcp()
 
-    def save_dual_value(self, value) -> None:
+    def save_dual_value(self, value, batch_shape=()) -> None:
         dW = value[:, :-1]
         dz = value[:, -1]
         if self.axis == 0:
@@ -295,8 +295,8 @@ class PowConeND(Cone):
             # (n, 1) --- dropping the extra dimension is crucial for
             # the `_dual_cone` and `dual_residual` methods to work properly
             dW = np.squeeze(dW)
-        self.dual_variables[0].save_value(dW)
-        self.dual_variables[1].save_value(dz)
+        self.dual_variables[0].save_value(dW, batch_shape=batch_shape)
+        self.dual_variables[1].save_value(dz, batch_shape=batch_shape)
 
     def _dual_cone(self, *args):
         """Implements the dual cone of PowConeND See Pg 85

--- a/cvxpy/constraints/second_order.py
+++ b/cvxpy/constraints/second_order.py
@@ -156,15 +156,15 @@ class SOC(Cone):
     def is_dqcp(self) -> bool:
         return self.is_dcp()
 
-    def save_dual_value(self, value) -> None:
+    def save_dual_value(self, value, batch_shape=()) -> None:
         cone_size = 1 + self.args[1].shape[self.axis]
         value = np.reshape(value, (-1, cone_size))
         t = value[:, 0]
         X = value[:, 1:]
         if self.axis == 0:
             X = X.T
-        self.dual_variables[0].save_value(t)
-        self.dual_variables[1].save_value(X)
+        self.dual_variables[0].save_value(t, batch_shape=batch_shape)
+        self.dual_variables[1].save_value(X, batch_shape=batch_shape)
 
     def _dual_cone(self, *args):
         """Implements the dual cone of the second-order cone

--- a/cvxpy/constraints/zero.py
+++ b/cvxpy/constraints/zero.py
@@ -83,13 +83,14 @@ class Zero(Constraint):
         """
         return self.dual_variables[0].value
 
-    def save_dual_value(self, value) -> None:
+    def save_dual_value(self, value, batch_shape=()) -> None:
         """Save the value of the dual variable for the constraint's parent.
 
         Args:
             value: The value of the dual variable.
+            batch_shape: The batch shape for batched problems.
         """
-        self.dual_variables[0].save_value(value)
+        self.dual_variables[0].save_value(value, batch_shape=batch_shape)
 
 
 class Equality(Constraint):
@@ -162,10 +163,11 @@ class Equality(Constraint):
         """
         return self.dual_variables[0].value
 
-    def save_dual_value(self, value) -> None:
+    def save_dual_value(self, value, batch_shape=()) -> None:
         """Save the value of the dual variable for the constraint's parent.
 
         Args:
             value: The value of the dual variable.
+            batch_shape: The batch shape for batched problems.
         """
-        self.dual_variables[0].save_value(value)
+        self.dual_variables[0].save_value(value, batch_shape=batch_shape)

--- a/cvxpy/error.py
+++ b/cvxpy/error.py
@@ -60,3 +60,12 @@ class DQCPError(Exception):
 class ParameterError(Exception):
     """Error thrown for accessing the value of an unspecified parameter.
     """
+
+
+class BatchedValueError(Exception):
+    """Error thrown when accessing .value on expressions with batched variables.
+
+    In batch mode, expression .value is not supported because atoms would need
+    batch-aware numeric implementations. Access variable values directly instead
+    (e.g., x.value) and compute expressions using numpy operations.
+    """

--- a/cvxpy/expressions/constants/parameter.py
+++ b/cvxpy/expressions/constants/parameter.py
@@ -123,13 +123,6 @@ class Parameter(Leaf):
             self._batch_shape = ()
             self.value = val  # Use the property setter for validation
 
-    @Leaf.value.setter
-    def value(self, val) -> None:
-        """Set value without batching (clears batch_shape)."""
-        self._batch_shape = ()
-        # Call parent's save_value with validation
-        self.save_value(self._validate_value(val))
-
     def get_data(self):
         """Returns info needed to reconstruct the expression besides the args.
         """

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -159,8 +159,19 @@ class Leaf(expression.Expression):
             )
         self.args = []
         self.bounds = self._ensure_valid_bounds(bounds)
+        self._batch_shape: tuple[int, ...] = ()
         if value is not None:
             self.value = value
+
+    @property
+    def batch_shape(self) -> tuple[int, ...]:
+        """Batch dimensions, () if not batched."""
+        return self._batch_shape
+
+    @property
+    def is_batched(self) -> bool:
+        """True if leaf has batch dimensions."""
+        return len(self._batch_shape) > 0
 
     def _validate_indices(self, indices: list[tuple[int]] | tuple[np.ndarray]) -> tuple[np.ndarray]:
         """

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -488,6 +488,8 @@ class Leaf(expression.Expression):
 
     @value.setter
     def value(self, val) -> None:
+        # Clear batch shape when setting value directly (non-batched assignment)
+        self._batch_shape = ()
         if self.sparse_idx is not None and self._sparse_high_fill_in:
             warnings.warn('Writing to a sparse CVXPY expression via `.value` is discouraged.'
                           ' Use `.value_sparse` instead', RuntimeWarning, 1)

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -462,7 +462,8 @@ class Leaf(expression.Expression):
             return val
 
     # Getter and setter for parameter value.
-    def save_value(self, val, sparse_path=False) -> None:
+    def save_value(self, val, sparse_path=False, batch_shape=()) -> None:
+        self._batch_shape = batch_shape if val is not None else ()
         if val is None:
             self._value = None
         elif self.sparse_idx is not None and not sparse_path:

--- a/cvxpy/problems/objective.py
+++ b/cvxpy/problems/objective.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 import cvxpy.lin_ops.lin_utils as lu
 import cvxpy.utilities as u
-from cvxpy.error import DCPError
+from cvxpy.error import BatchedValueError, DCPError
 from cvxpy.expressions.expression import Expression
 from cvxpy.interface.matrix_utilities import scalar_value
 from cvxpy.utilities import scopes
@@ -97,7 +97,17 @@ class Objective(u.Canonical):
     @property
     def value(self):
         """The value of the objective expression.
+
+        Raises BatchedValueError if any variable has batched values.
+        For batched problems, use problem.value instead.
         """
+        # Check if any variable is batched
+        for var in self.args[0].variables():
+            if var.is_batched:
+                raise BatchedValueError(
+                    "Cannot compute objective.value when variables have batched values. "
+                    "Use problem.value instead, or access variable values directly."
+                )
         v = self.args[0].value
         if v is None:
             return None

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -1528,13 +1528,15 @@ class Problem(u.Canonical):
             If the solution object has an invalid status
         """
         if solution.has_solution():
+            batch_shape = solution.batch_shape
             for v in self.variables():
-                v.save_value(solution.primal_vars[v.id])
+                v.save_value(solution.primal_vars[v.id], batch_shape=batch_shape)
             for c in self.constraints:
                 if c.id in solution.dual_vars:
-                    c.save_dual_value(solution.dual_vars[c.id])
-            # For batched solves, use solution.opt_val directly.
-            # For non-batched, use self.objective.value to avoid confusion.
+                    c.save_dual_value(solution.dual_vars[c.id], batch_shape=batch_shape)
+            # For batched solves, use solution.opt_val directly since
+            # expression .value doesn't support batched variables.
+            # For non-batched, compute from objective expression.
             if solution.is_batched:
                 self._value = solution.opt_val
             else:

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -1244,8 +1244,8 @@ class Problem(u.Canonical):
             solver, gp, enforce_dpp, ignore_dpp, verbose, canon_backend, kwargs
         )
 
-        # Store batch_shape from problem data
-        self._batch_shape = data.get(s.BATCH_SHAPE, ())
+        # Store batch_shape from the problem's parameters
+        self._batch_shape = self._compute_batch_shape()
 
         if verbose:
             print(_NUM_SOLVER_STR)

--- a/cvxpy/reductions/solution.py
+++ b/cvxpy/reductions/solution.py
@@ -92,3 +92,49 @@ class Solution:
                                              self.primal_vars,
                                              self.dual_vars,
                                              self.attr)
+
+    @property
+    def batch_shape(self) -> tuple:
+        """Return the batch shape from attr, or () if not batched."""
+        return self.attr.get(s.BATCH_SHAPE, ())
+
+    @property
+    def is_batched(self) -> bool:
+        """Return True if this is a batched solution."""
+        return len(self.batch_shape) > 0
+
+    def has_solution(self) -> bool:
+        """Check if any solution is present (status in SOLUTION_PRESENT)."""
+        if self.is_batched:
+            return bool(np.any(np.isin(self.status, list(s.SOLUTION_PRESENT))))
+        return self.status in s.SOLUTION_PRESENT
+
+    def has_inf_or_unb(self) -> bool:
+        """Check if any solution is infeasible or unbounded."""
+        if self.is_batched:
+            return bool(np.any(np.isin(self.status, list(s.INF_OR_UNB))))
+        return self.status in s.INF_OR_UNB
+
+    def has_error(self) -> bool:
+        """Check if any solution has an error."""
+        if self.is_batched:
+            return bool(np.any(np.isin(self.status, list(s.ERROR))))
+        return self.status in s.ERROR
+
+    def all_not_error(self) -> bool:
+        """Check if all solutions are not errors (for opt_val negation)."""
+        if self.is_batched:
+            return bool(np.all(~np.isin(self.status, list(s.ERROR))))
+        return self.status not in s.ERROR
+
+    def has_inaccurate(self) -> bool:
+        """Check if any solution is inaccurate."""
+        if self.is_batched:
+            return bool(np.any(np.isin(self.status, list(s.INACCURATE))))
+        return self.status in s.INACCURATE
+
+    def has_infeasible_or_unbounded(self) -> bool:
+        """Check if any solution has INFEASIBLE_OR_UNBOUNDED status."""
+        if self.is_batched:
+            return bool(np.any(self.status == s.INFEASIBLE_OR_UNBOUNDED))
+        return self.status == s.INFEASIBLE_OR_UNBOUNDED

--- a/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
+++ b/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
@@ -378,12 +378,15 @@ class ConicSolver(Solver):
 
         problem, data, inv_data = self._prepare_data_and_inv_data(problem)
 
+        # Get batch_shape from problem (empty tuple if not batched)
+        batch_shape = problem.batch_shape
+
         # Apply parameter values.
         # Obtain A, b such that Ax + s = b, s \in cones.
         if problem.P is None:
-            c, d, A, b = problem.apply_parameters()
+            c, d, A, b = problem.apply_parameters(batch_shape=batch_shape)
         else:
-            P, c, d, A, b = problem.apply_parameters(quad_obj=True)
+            P, c, d, A, b = problem.apply_parameters(batch_shape=batch_shape, quad_obj=True)
             data[s.P] = P
         data[s.C] = c
         inv_data[s.OFFSET] = d
@@ -391,4 +394,9 @@ class ConicSolver(Solver):
         data[s.B] = b
         data[s.LOWER_BOUNDS] = problem.lower_bounds
         data[s.UPPER_BOUNDS] = problem.upper_bounds
+
+        # Include batch_shape in data and inverse_data
+        data[s.BATCH_SHAPE] = batch_shape
+        inv_data[s.BATCH_SHAPE] = batch_shape
+
         return data, inv_data

--- a/cvxpy/reductions/solvers/solver.py
+++ b/cvxpy/reductions/solvers/solver.py
@@ -35,6 +35,7 @@ class Solver(Reduction):
     MIP_CAPABLE = False
     BOUNDED_VARIABLES = False
     SOC_DIM3_ONLY = False
+    BATCH_CAPABLE = False
 
     # Keys for inverse data.
     VAR_ID = 'var_id'

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -168,6 +168,7 @@ F = "F"
 DIMS = "dims"
 BOOL_IDX = "bool_vars_idx"
 INT_IDX = "int_vars_idx"
+BATCH_SHAPE = "batch_shape"
 
 # Keys for curvature and sign.
 CONSTANT = "CONSTANT"

--- a/cvxpy/tests/test_batched.py
+++ b/cvxpy/tests/test_batched.py
@@ -1,0 +1,224 @@
+"""
+Copyright 2025, the CVXPY developers
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import numpy as np
+import pytest
+
+import cvxpy as cp
+
+
+class TestBatchedParameterAPI:
+    """Tests for the batched parameter API."""
+
+    def test_set_value_batch_1d_param(self):
+        """Test set_value with batch=True for 1D parameter."""
+        param = cp.Parameter(5)
+        batch_data = np.random.randn(10, 5)
+
+        param.set_value(batch_data, batch=True)
+
+        assert param.batch_shape == (10,)
+        assert param.is_batched
+        assert param.value.shape == (10, 5)
+        np.testing.assert_array_equal(param.value, batch_data)
+
+    def test_set_value_batch_2d_param(self):
+        """Test set_value with batch=True for 2D parameter."""
+        param = cp.Parameter((3, 4))
+        batch_data = np.random.randn(10, 3, 4)
+
+        param.set_value(batch_data, batch=True)
+
+        assert param.batch_shape == (10,)
+        assert param.is_batched
+        assert param.value.shape == (10, 3, 4)
+        np.testing.assert_array_equal(param.value, batch_data)
+
+    def test_set_value_batch_scalar_param(self):
+        """Test set_value with batch=True for scalar parameter."""
+        param = cp.Parameter()
+        batch_data = np.random.randn(10)
+
+        param.set_value(batch_data, batch=True)
+
+        assert param.batch_shape == (10,)
+        assert param.is_batched
+        assert param.value.shape == (10,)
+        np.testing.assert_array_equal(param.value, batch_data)
+
+    def test_set_value_batch_multiple_batch_dims(self):
+        """Test set_value with multiple batch dimensions."""
+        param = cp.Parameter((3, 4))
+        batch_data = np.random.randn(5, 10, 3, 4)
+
+        param.set_value(batch_data, batch=True)
+
+        assert param.batch_shape == (5, 10)
+        assert param.is_batched
+        assert param.value.shape == (5, 10, 3, 4)
+
+    def test_set_value_non_batch_clears_batch_shape(self):
+        """Test that setting value without batch=True clears batch_shape."""
+        param = cp.Parameter((3, 4))
+
+        # First set batched value
+        batch_data = np.random.randn(10, 3, 4)
+        param.set_value(batch_data, batch=True)
+        assert param.is_batched
+
+        # Then set non-batched value
+        single_data = np.random.randn(3, 4)
+        param.value = single_data
+        assert not param.is_batched
+        assert param.batch_shape == ()
+
+    def test_set_value_batch_invalid_shape(self):
+        """Test that set_value raises error for invalid shape."""
+        param = cp.Parameter((3, 4))
+        # Wrong problem dimensions
+        bad_data = np.random.randn(10, 4, 3)
+
+        with pytest.raises(ValueError, match="problem shape"):
+            param.set_value(bad_data, batch=True)
+
+    def test_set_value_batch_insufficient_dims(self):
+        """Test error when value has fewer dims than parameter."""
+        param = cp.Parameter((3, 4))
+        # Only 1D but parameter is 2D
+        bad_data = np.random.randn(10)
+
+        with pytest.raises(ValueError, match="dimensions"):
+            param.set_value(bad_data, batch=True)
+
+    def test_set_value_none_clears_batch(self):
+        """Test that setting value to None clears batch_shape."""
+        param = cp.Parameter((3, 4))
+        batch_data = np.random.randn(10, 3, 4)
+        param.set_value(batch_data, batch=True)
+
+        param.set_value(None)
+
+        assert param.value is None
+        assert param.batch_shape == ()
+        assert not param.is_batched
+
+
+class TestBatchedLeafProperties:
+    """Tests for batch_shape and is_batched on Leaf classes."""
+
+    def test_variable_batch_shape_default(self):
+        """Test that Variable has empty batch_shape by default."""
+        var = cp.Variable((3, 4))
+        assert var.batch_shape == ()
+        assert not var.is_batched
+
+    def test_constant_batch_shape_default(self):
+        """Test that Constant has empty batch_shape by default."""
+        const = cp.Constant(np.random.randn(3, 4))
+        assert const.batch_shape == ()
+        assert not const.is_batched
+
+    def test_parameter_batch_shape_default(self):
+        """Test that Parameter has empty batch_shape by default."""
+        param = cp.Parameter((3, 4))
+        param.value = np.random.randn(3, 4)
+        assert param.batch_shape == ()
+        assert not param.is_batched
+
+
+class TestProblemBatchShape:
+    """Tests for Problem batch shape computation."""
+
+    def test_problem_no_batched_params(self):
+        """Test _compute_batch_shape with no batched parameters."""
+        x = cp.Variable(3)
+        param = cp.Parameter(3)
+        param.value = np.ones(3)
+
+        prob = cp.Problem(cp.Minimize(cp.sum(param @ x)))
+
+        assert prob._compute_batch_shape() == ()
+
+    def test_problem_single_batched_param(self):
+        """Test _compute_batch_shape with one batched parameter."""
+        x = cp.Variable(3)
+        param = cp.Parameter(3)
+        param.set_value(np.random.randn(10, 3), batch=True)
+
+        prob = cp.Problem(cp.Minimize(cp.sum(param @ x)))
+
+        assert prob._compute_batch_shape() == (10,)
+
+    def test_problem_multiple_batched_params_same_shape(self):
+        """Test _compute_batch_shape with multiple batched params, same batch shape."""
+        x = cp.Variable(3)
+        A = cp.Parameter((3, 3))
+        b = cp.Parameter(3)
+
+        A.set_value(np.random.randn(10, 3, 3), batch=True)
+        b.set_value(np.random.randn(10, 3), batch=True)
+
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(A @ x - b)))
+
+        assert prob._compute_batch_shape() == (10,)
+
+    def test_problem_batched_params_broadcasting(self):
+        """Test _compute_batch_shape with broadcastable batch shapes."""
+        x = cp.Variable(3)
+        A = cp.Parameter((3, 3))
+        b = cp.Parameter(3)
+
+        # A has shape (5, 1, 3, 3), b has shape (1, 10, 3)
+        # Should broadcast to (5, 10)
+        A.set_value(np.random.randn(5, 1, 3, 3), batch=True)
+        b.set_value(np.random.randn(1, 10, 3), batch=True)
+
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(A @ x - b)))
+
+        assert prob._compute_batch_shape() == (5, 10)
+
+    def test_problem_batched_params_incompatible(self):
+        """Test _compute_batch_shape raises error for incompatible shapes."""
+        x = cp.Variable(3)
+        A = cp.Parameter((3, 3))
+        b = cp.Parameter(3)
+
+        # A has shape (5, 3, 3), b has shape (7, 3)
+        # These are not broadcastable
+        A.set_value(np.random.randn(5, 3, 3), batch=True)
+        b.set_value(np.random.randn(7, 3), batch=True)
+
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(A @ x - b)))
+
+        with pytest.raises(ValueError, match="Incompatible batch shapes"):
+            prob._compute_batch_shape()
+
+    def test_problem_mixed_batched_non_batched(self):
+        """Test _compute_batch_shape with mixed batched and non-batched params."""
+        x = cp.Variable(3)
+        A = cp.Parameter((3, 3))
+        b = cp.Parameter(3)
+        c = cp.Parameter()
+
+        # A is batched, b and c are not
+        A.set_value(np.random.randn(10, 3, 3), batch=True)
+        b.value = np.random.randn(3)
+        c.value = 1.0
+
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(A @ x - b) + c))
+
+        # Only A is batched, so batch shape is (10,)
+        assert prob._compute_batch_shape() == (10,)

--- a/cvxpy/tests/test_batched.py
+++ b/cvxpy/tests/test_batched.py
@@ -16,8 +16,150 @@ limitations under the License.
 
 import numpy as np
 import pytest
+import scipy.sparse as sp
 
 import cvxpy as cp
+import cvxpy.settings as s
+from cvxpy.reductions.solvers.conic_solvers.clarabel_conif import (
+    CLARABEL,
+    dims_to_solver_cones,
+)
+from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
+
+
+class BatchSolution:
+    """Container for batched solution results from BATCH_CLARABEL."""
+
+    def __init__(self, statuses, obj_vals, xs, zs, solve_times, iterations):
+        self.statuses = statuses
+        self.obj_vals = obj_vals
+        self.xs = xs
+        self.zs = zs
+        self.solve_times = solve_times
+        self.iterations = iterations
+
+    @property
+    def status(self):
+        return self.statuses
+
+    @property
+    def obj_val(self):
+        return self.obj_vals
+
+    @property
+    def x(self):
+        return self.xs
+
+    @property
+    def z(self):
+        return self.zs
+
+    @property
+    def solve_time(self):
+        return np.sum(self.solve_times)
+
+
+class BATCH_CLARABEL(CLARABEL):
+    """Test-only batch-capable solver that wraps CLARABEL in a loop."""
+
+    BATCH_CAPABLE = True
+
+    def name(self):
+        return 'BATCH_CLARABEL'
+
+    def solve_via_data(self, data, warm_start: bool, verbose: bool,
+                       solver_opts, solver_cache=None):
+        """Solve batched problem by looping over instances."""
+        import clarabel
+
+        batch_shape = data.get('batch_shape')
+
+        if batch_shape is None or len(batch_shape) == 0:
+            # Non-batch: use parent implementation
+            return super().solve_via_data(
+                data, warm_start, verbose, solver_opts, solver_cache
+            )
+
+        # Batch mode
+        q_batch = data[s.C]
+        b_batch = data[s.B]
+        A_batch = data[s.A]
+        P_batch = data.get(s.P)
+
+        cone_dims = data[ConicSolver.DIMS]
+        cones = dims_to_solver_cones(cone_dims)
+
+        n_batch = int(np.prod(batch_shape))
+        n_var = q_batch.shape[-1]
+        n_constr = b_batch.shape[-1]
+
+        q_flat = q_batch.reshape(n_batch, n_var)
+        b_flat = b_batch.reshape(n_batch, n_constr)
+        A_flat = A_batch.reshape(n_batch, n_constr, n_var)
+        P_flat = P_batch.reshape(n_batch, n_var, n_var) if P_batch is not None else None
+
+        settings = self.parse_solver_opts(verbose, solver_opts)
+
+        statuses = []
+        obj_vals = np.full(n_batch, np.nan)
+        xs = np.full((n_batch, n_var), np.nan)
+        zs = np.full((n_batch, n_constr), np.nan)
+        solve_times = np.zeros(n_batch)
+        iterations = np.zeros(n_batch, dtype=int)
+
+        for i in range(n_batch):
+            q_i = q_flat[i]
+            b_i = b_flat[i]
+            A_i = sp.csc_array(A_flat[i])
+            P_i = sp.triu(sp.csc_array(P_flat[i])).tocsc() if P_flat is not None \
+                else sp.csc_array((n_var, n_var))
+
+            solver = clarabel.DefaultSolver(P_i, q_i, A_i, b_i, cones, settings)
+            result = solver.solve()
+
+            statuses.append(str(result.status))
+            obj_vals[i] = result.obj_val
+            if result.x is not None:
+                xs[i] = result.x
+            if result.z is not None:
+                zs[i] = result.z
+            solve_times[i] = result.solve_time
+            iterations[i] = result.iterations
+
+        statuses = np.array(statuses).reshape(batch_shape)
+        obj_vals = obj_vals.reshape(batch_shape)
+        xs = xs.reshape(batch_shape + (n_var,))
+        zs = zs.reshape(batch_shape + (n_constr,))
+        solve_times = solve_times.reshape(batch_shape)
+        iterations = iterations.reshape(batch_shape)
+
+        return BatchSolution(statuses, obj_vals, xs, zs, solve_times, iterations)
+
+    def invert(self, solution, inverse_data):
+        """Invert batched solution."""
+        from cvxpy.reductions.solution import Solution
+
+        batch_shape = inverse_data.get('batch_shape')
+
+        if batch_shape is None or len(batch_shape) == 0:
+            return super().invert(solution, inverse_data)
+
+        status_map = self.STATUS_MAP.copy()
+        statuses = np.vectorize(lambda st: status_map.get(st, s.SOLVER_ERROR))(
+            solution.statuses
+        )
+
+        opt_vals = solution.obj_vals + inverse_data[s.OFFSET]
+
+        primal_vars = {inverse_data[self.VAR_ID]: solution.xs}
+
+        attr = {
+            s.SOLVE_TIME: solution.solve_time,
+            s.NUM_ITERS: solution.iterations,
+            'batch_shape': batch_shape,
+        }
+
+        return Solution(statuses, opt_vals, primal_vars, {}, attr)
 
 
 class TestBatchedParameterAPI:
@@ -312,8 +454,7 @@ class TestBatchedApplyParameters:
 
         # ParamConeProg is cached in prob._cache.param_prog
         param_cone_prog = prob._cache.param_prog
-        if param_cone_prog is None:
-            pytest.skip("Could not find ParamConeProg")
+        assert param_cone_prog is not None, "ParamConeProg should be cached"
 
         # Now set batched values and test apply_parameters with batch_shape
         batch_shape = (3,)
@@ -349,8 +490,7 @@ class TestBatchedApplyParameters:
         prob.get_problem_data(solver=cp.SCS)
 
         param_cone_prog = prob._cache.param_prog
-        if param_cone_prog is None:
-            pytest.skip("Could not find ParamConeProg")
+        assert param_cone_prog is not None, "ParamConeProg should be cached"
 
         # Set 2D batched values
         batch_shape = (3, 4)
@@ -367,3 +507,313 @@ class TestBatchedApplyParameters:
         assert d_batch.shape == (3, 4)
         assert A_batch.shape == (3, 4, param_cone_prog.constr_size, param_cone_prog.x.size)
         assert b_batch.shape == (3, 4, param_cone_prog.constr_size)
+
+
+class TestBatchClarabelSolver:
+    """End-to-end tests for BATCH_CLARABEL solver."""
+
+    def test_batch_clarabel_lp_matches_individual_solves(self):
+        """Test that BATCH_CLARABEL results match individual CLARABEL solves."""
+        n = 3
+        x = cp.Variable(n)
+        c = cp.Parameter(n)
+
+        prob = cp.Problem(cp.Minimize(c @ x), [x >= 0, cp.sum(x) == 1])
+
+        # Generate batch of cost vectors
+        batch_size = 5
+        np.random.seed(42)
+        c_vals = np.random.randn(batch_size, n)
+
+        # Get param_cone_prog first
+        c.value = c_vals[0]
+        prob.get_problem_data(solver=cp.CLARABEL)
+        param_cone_prog = prob._cache.param_prog
+        assert param_cone_prog is not None
+
+        # Individual solves using CLARABEL directly on param_cone_prog data
+        clarabel_solver = CLARABEL()
+        individual_obj_vals = []
+        individual_x_vals = []
+        for i in range(batch_size):
+            c.value = c_vals[i]
+            q, d, A, b = param_cone_prog.apply_parameters()
+            data = {
+                s.C: q,
+                s.B: b,
+                s.A: A,
+                ConicSolver.DIMS: param_cone_prog.cone_dims,
+            }
+            result = clarabel_solver.solve_via_data(data, False, False, {})
+            individual_obj_vals.append(result.obj_val + d)
+            individual_x_vals.append(result.x.copy())
+
+        individual_obj_vals = np.array(individual_obj_vals)
+        individual_x_vals = np.array(individual_x_vals)
+
+        # Batched solve using BATCH_CLARABEL
+        batch_shape = (batch_size,)
+        c.set_value(c_vals, batch=True)
+
+        q_batch, d_batch, A_batch, b_batch = param_cone_prog.apply_parameters(
+            batch_shape=batch_shape
+        )
+
+        data = {
+            s.C: q_batch,
+            s.B: b_batch,
+            s.A: A_batch,
+            ConicSolver.DIMS: param_cone_prog.cone_dims,
+            'batch_shape': batch_shape,
+        }
+
+        batch_solver = BATCH_CLARABEL()
+        batch_solution = batch_solver.solve_via_data(data, False, False, {})
+
+        # Verify results match
+        np.testing.assert_allclose(
+            batch_solution.obj_vals + d_batch,
+            individual_obj_vals,
+            rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            batch_solution.xs,
+            individual_x_vals,
+            rtol=1e-5
+        )
+
+    def test_batch_clarabel_qp_with_use_quad_obj(self):
+        """Test BATCH_CLARABEL with quadratic objective (use_quad_obj=True)."""
+        n = 2
+        x = cp.Variable(n)
+        c = cp.Parameter(n)
+
+        # Use sum_squares which is DPP-compliant
+        prob = cp.Problem(
+            cp.Minimize(0.5 * cp.sum_squares(x) + c @ x),
+            [x >= -1, x <= 1]
+        )
+
+        # Generate batch of parameters
+        batch_size = 4
+        np.random.seed(123)
+        c_vals = np.random.randn(batch_size, n)
+
+        # Get problem data first
+        c.value = c_vals[0]
+        prob.get_problem_data(solver=cp.CLARABEL)
+        param_cone_prog = prob._cache.param_prog
+        assert param_cone_prog is not None
+
+        # Individual solves using CLARABEL directly
+        clarabel_solver = CLARABEL()
+        individual_obj_vals = []
+        individual_x_vals = []
+        for i in range(batch_size):
+            c.value = c_vals[i]
+            P, q, d, A, b = param_cone_prog.apply_parameters(quad_obj=True)
+            data = {
+                s.P: P,
+                s.C: q,
+                s.B: b,
+                s.A: A,
+                ConicSolver.DIMS: param_cone_prog.cone_dims,
+            }
+            result = clarabel_solver.solve_via_data(data, False, False, {})
+            individual_obj_vals.append(result.obj_val + d)
+            individual_x_vals.append(result.x.copy())
+
+        individual_obj_vals = np.array(individual_obj_vals)
+        individual_x_vals = np.array(individual_x_vals)
+
+        # Batched solve
+        batch_shape = (batch_size,)
+        c.set_value(c_vals, batch=True)
+
+        P_batch, q_batch, d_batch, A_batch, b_batch = param_cone_prog.apply_parameters(
+            batch_shape=batch_shape, quad_obj=True
+        )
+
+        data = {
+            s.P: P_batch,
+            s.C: q_batch,
+            s.B: b_batch,
+            s.A: A_batch,
+            ConicSolver.DIMS: param_cone_prog.cone_dims,
+            'batch_shape': batch_shape,
+        }
+
+        batch_solver = BATCH_CLARABEL()
+        batch_solution = batch_solver.solve_via_data(data, False, False, {})
+
+        # Verify results match
+        np.testing.assert_allclose(
+            batch_solution.obj_vals + d_batch,
+            individual_obj_vals,
+            rtol=1e-4
+        )
+        np.testing.assert_allclose(
+            batch_solution.xs,
+            individual_x_vals,
+            rtol=1e-4
+        )
+
+    def test_batch_clarabel_2d_batch_shape(self):
+        """Test BATCH_CLARABEL with 2D batch shape."""
+        n = 2
+        x = cp.Variable(n)
+        c = cp.Parameter(n)
+
+        prob = cp.Problem(cp.Minimize(c @ x), [x >= 0, cp.sum(x) == 1])
+
+        # 2D batch shape
+        batch_shape = (3, 4)
+        np.random.seed(456)
+        c_vals = np.random.randn(*batch_shape, n)
+
+        # Get problem data first
+        c.value = c_vals[0, 0]
+        prob.get_problem_data(solver=cp.CLARABEL)
+        param_cone_prog = prob._cache.param_prog
+        assert param_cone_prog is not None
+
+        # Individual solves using CLARABEL directly
+        clarabel_solver = CLARABEL()
+        individual_obj_vals = np.zeros(batch_shape)
+        individual_x_vals = np.zeros(batch_shape + (param_cone_prog.x.size,))
+        for i in range(batch_shape[0]):
+            for j in range(batch_shape[1]):
+                c.value = c_vals[i, j]
+                q, d, A, b = param_cone_prog.apply_parameters()
+                data = {
+                    s.C: q,
+                    s.B: b,
+                    s.A: A,
+                    ConicSolver.DIMS: param_cone_prog.cone_dims,
+                }
+                result = clarabel_solver.solve_via_data(data, False, False, {})
+                individual_obj_vals[i, j] = result.obj_val + d
+                individual_x_vals[i, j] = result.x
+
+        # Batched solve
+        c.set_value(c_vals, batch=True)
+
+        q_batch, d_batch, A_batch, b_batch = param_cone_prog.apply_parameters(
+            batch_shape=batch_shape
+        )
+
+        data = {
+            s.C: q_batch,
+            s.B: b_batch,
+            s.A: A_batch,
+            ConicSolver.DIMS: param_cone_prog.cone_dims,
+            'batch_shape': batch_shape,
+        }
+
+        batch_solver = BATCH_CLARABEL()
+        batch_solution = batch_solver.solve_via_data(data, False, False, {})
+
+        # Verify shapes
+        assert batch_solution.obj_vals.shape == batch_shape
+        assert batch_solution.xs.shape == batch_shape + (param_cone_prog.x.size,)
+
+        # Verify results match
+        np.testing.assert_allclose(
+            batch_solution.obj_vals + d_batch,
+            individual_obj_vals,
+            rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            batch_solution.xs,
+            individual_x_vals,
+            rtol=1e-5
+        )
+
+    def test_batch_clarabel_all_optimal(self):
+        """Test that all batch instances return optimal status."""
+        n = 2
+        x = cp.Variable(n)
+        c = cp.Parameter(n)
+
+        prob = cp.Problem(cp.Minimize(c @ x), [x >= 0, cp.sum(x) == 1])
+
+        batch_size = 5
+        c_vals = np.random.randn(batch_size, n)
+
+        c.value = c_vals[0]
+        prob.get_problem_data(solver=cp.CLARABEL)
+
+        param_cone_prog = prob._cache.param_prog
+        assert param_cone_prog is not None
+
+        batch_shape = (batch_size,)
+        c.set_value(c_vals, batch=True)
+
+        q_batch, d_batch, A_batch, b_batch = param_cone_prog.apply_parameters(
+            batch_shape=batch_shape
+        )
+
+        data = {
+            s.C: q_batch,
+            s.B: b_batch,
+            s.A: A_batch,
+            ConicSolver.DIMS: param_cone_prog.cone_dims,
+            'batch_shape': batch_shape,
+        }
+
+        solver = BATCH_CLARABEL()
+        batch_solution = solver.solve_via_data(data, False, False, {})
+
+        # All should be "Solved"
+        assert all(status == "Solved" for status in batch_solution.statuses)
+
+    def test_batch_clarabel_invert(self):
+        """Test BATCH_CLARABEL invert method."""
+        n = 2
+        x = cp.Variable(n)
+        c = cp.Parameter(n)
+
+        prob = cp.Problem(cp.Minimize(c @ x), [x >= 0, cp.sum(x) == 1])
+
+        batch_size = 3
+        c_vals = np.random.randn(batch_size, n)
+
+        c.value = c_vals[0]
+        prob.get_problem_data(solver=cp.CLARABEL)
+
+        param_cone_prog = prob._cache.param_prog
+        assert param_cone_prog is not None
+
+        batch_shape = (batch_size,)
+        c.set_value(c_vals, batch=True)
+
+        q_batch, d_batch, A_batch, b_batch = param_cone_prog.apply_parameters(
+            batch_shape=batch_shape
+        )
+
+        data = {
+            s.C: q_batch,
+            s.B: b_batch,
+            s.A: A_batch,
+            ConicSolver.DIMS: param_cone_prog.cone_dims,
+            'batch_shape': batch_shape,
+        }
+
+        solver = BATCH_CLARABEL()
+        batch_solution = solver.solve_via_data(data, False, False, {})
+
+        # Create inverse_data
+        inverse_data = {
+            solver.VAR_ID: x.id,
+            ConicSolver.DIMS: param_cone_prog.cone_dims,
+            s.OFFSET: d_batch,
+            'batch_shape': batch_shape,
+        }
+
+        # Invert the solution
+        solution = solver.invert(batch_solution, inverse_data)
+
+        # Check that solution has batched values
+        assert solution.opt_val.shape == batch_shape
+        assert x.id in solution.primal_vars
+        assert solution.primal_vars[x.id].shape == batch_shape + (n,)


### PR DESCRIPTION
## Description
This is an exploration of one possible way to add batch support. I followed approach 2 from #2485:

```
var = cp.Variable(n)
param = cp.Parameter(m, n)
param.set_value(np.ones([batch_size, m, n]), batch=True)
...
prob.solve()

# solution is stored in:
var.value  # shape [batch_size, n]

# optimal value is stored as:
prob.value  # shape [batch_size]
```

I considered a lot of different ways to add batch support and this approach seemed the most consistent with the existing CVXPY API. But it would be helpful to discuss alternatives. Some topics that came up while exploring this change:

1. Do we allow only one batch dimension or an arbitrary number? I felt that adding an arbitrary number of batch dimensions was more consistent with NumPy and a similar amount of work to implement, but I'm not sure about this.
2. Do we only allow solvers that support batching to work in batch mode? Or do we implement some kind of loop or parallelization over solvers without batch support? My perspective is that the implementation of batching is a solver concern, and that CVXPY should only allow batch mode with solvers that support batching natively.
3. Do we make expression.value work fully with batch mode? This is a major code change but very compatible with NumPy so maybe ok.
4. How do we handle batched sparse parameters?

Issue link (if applicable): #2485 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.