### PR TITLE
Fix CUCLARABEL ignoring verbose flag

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/cuclarabel_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cuclarabel_conif.py
@@ -197,10 +197,15 @@ class CUCLARABEL(ConicSolver):
 
         dims_to_solver_cones(jl, cones)
 
-        results = jl.seval("""
-        settings = Clarabel.Settings(direct_solve_method = :cudss)
-        solver   = Clarabel.Solver(settings)
-        solver   = Clarabel.setup!(solver, P,q,A,b,cones)
+        solver_verbose = solver_opts.get("verbose", verbose)
+        jl_verbose = "true" if solver_verbose else "false"
+        results = jl.seval(f"""
+        settings = Clarabel.Settings(
+            direct_solve_method = :cudss,
+            verbose = {jl_verbose}    
+        )
+        solver = Clarabel.Solver(settings)
+        solver = Clarabel.setup!(solver, P, q, A, b, cones)
         Clarabel.solve!(solver)
         """)
         return results

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import contextlib
+import io
 import math
 import os
 import re
@@ -595,7 +596,21 @@ class TestCuClarabel(BaseTest):
         # consecutive solves, no data update
         result1 = prob.solve(solver=cp.CLARABEL, warm_start=False)
         self.assertAlmostEqual(result1, result2)
-
+    
+    def test_cuclarabel_respects_verbose_flag(self):
+        """CUCLARABEL should not print solver output when verbose=False."""
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(x), [x >= 1])
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            prob.solve(solver=cp.CUCLARABEL, verbose=False)
+            output = sys.stdout.getvalue()
+        finally:
+            sys.stdout = old_stdout
+        # Clarabel prints iteration logs when verbose=True
+        # with verbose=False, output should be empty
+        assert output.strip() == ""
 
     def test_clarabel_lp_0(self) -> None:
         StandardTestLPs.test_lp_0(solver=cp.CUCLARABEL)


### PR DESCRIPTION
## Description
This PR ensures that the verbose flag passed to prob.solve() is correctly respected by the CUCLARABEL solver.
Earlier , **CUCLARABEL**  used Clarabel’s default verbosity, which could result in solver output being printed even when **_verbose=False._** My proposed change explicitly forwards the verbosity setting to Clarabel via its Settings object.

Issue link : #3059 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.