### PR TITLE
Recover dual variables from NLP solvers

### DIFF
--- a/cvxpy/reductions/solvers/nlp_solvers/copt_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/copt_nlpif.py
@@ -71,7 +71,10 @@ class COPT(NLPsolver):
                 shape = inverse_data.var_shapes[id]
                 size = np.prod(shape, dtype=int)
                 primal_vars[id] = np.reshape(x_opt[offset:offset+size], shape, order='F')
-            return Solution(status, opt_val, primal_vars, {}, attr)
+            dual_vars = self._extract_dual_vars(
+                solution.get('lambda'), inverse_data
+            )
+            return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
             return failure_solution(status, attr)
 

--- a/cvxpy/reductions/solvers/nlp_solvers/ipopt_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/ipopt_nlpif.py
@@ -99,7 +99,10 @@ class IPOPT(NLPsolver):
                 shape = inverse_data.var_shapes[id]
                 size = np.prod(shape, dtype=int)
                 primal_vars[id] = np.reshape(x_opt[offset:offset+size], shape, order='F')
-            return Solution(status, opt_val, primal_vars, {}, attr)
+            dual_vars = self._extract_dual_vars(
+                solution.get('mult_g'), inverse_data
+            )
+            return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
             return failure_solution(status, attr)
 

--- a/cvxpy/reductions/solvers/nlp_solvers/knitro_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/knitro_nlpif.py
@@ -131,7 +131,15 @@ class KNITRO(NLPsolver):
                 shape = inverse_data.var_shapes[id]
                 size = np.prod(shape, dtype=int)
                 primal_vars[id] = np.reshape(x_opt[offset:offset+size], shape, order='F')
-            return Solution(status, opt_val, primal_vars, {}, attr)
+            # Knitro's lambda has n variable bound duals followed by
+            # m constraint duals.  Extract the constraint portion.
+            lambda_all = solution.get('lambda')
+            mult_g = None
+            if lambda_all is not None:
+                n = inverse_data.x_length
+                mult_g = lambda_all[n:]
+            dual_vars = self._extract_dual_vars(mult_g, inverse_data)
+            return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
             return failure_solution(status, attr)
 

--- a/cvxpy/reductions/solvers/nlp_solvers/nlp_solver.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/nlp_solver.py
@@ -49,6 +49,34 @@ class NLPsolver(Solver):
         """
         return problem.is_dnlp()
 
+    @staticmethod
+    def _extract_dual_vars(mult_g, inverse_data):
+        """Extract per-constraint dual variables from a flat multiplier vector.
+
+        Parameters
+        ----------
+        mult_g : np.ndarray or None
+            Flat vector of constraint multipliers from the NLP solver.
+        inverse_data : InverseData
+            Must have ``cons_offsets`` and ``cons_shapes`` attributes
+            (set by ``_prepare_data_and_inv_data``).
+
+        Returns
+        -------
+        dict
+            Mapping from constraint id to dual value (np.ndarray).
+        """
+        dual_vars = {}
+        if mult_g is None or not hasattr(inverse_data, 'cons_offsets'):
+            return dual_vars
+        for con_id, offset in inverse_data.cons_offsets.items():
+            shape = inverse_data.cons_shapes[con_id]
+            size = int(np.prod(shape))
+            dual_vars[con_id] = np.reshape(
+                mult_g[offset:offset + size], shape, order='F'
+            )
+        return dual_vars
+
     def apply(self, problem: Problem) -> tuple[dict, InverseData]:
         """
         Construct NLP problem data stored in a dictionary.
@@ -70,6 +98,9 @@ class NLPsolver(Solver):
         bounds = Bounds(problem)
         inverse_data = InverseData(bounds.new_problem)
         inverse_data.offset = 0.0
+        # Store constraint offset/shape maps for dual variable recovery.
+        inverse_data.cons_offsets = bounds.cons_offsets
+        inverse_data.cons_shapes = bounds.cons_shapes
         data["problem"] = bounds.new_problem
         data["cl"], data["cu"] = bounds.cl, bounds.cu
         data["lb"], data["ub"] = bounds.lb, bounds.ub
@@ -102,10 +133,18 @@ class Bounds:
         Also converts inequalities to nonneg form,
         as well as equalities to zero constraints and forms
         a new problem from the canonicalized problem.
+
+        Tracks per-constraint offsets and shapes in the flat g(x)
+        vector so that dual variables can be recovered after solve.
         """
         lower, upper = [], []
         new_constr = []
+        cons_offsets = {}
+        cons_shapes = {}
+        offset = 0
         for constraint in self.problem.constraints:
+            cons_offsets[constraint.id] = offset
+            cons_shapes[constraint.id] = constraint.shape
             if isinstance(constraint, Equality):
                 lower.extend([0.0] * constraint.size)
                 upper.extend([0.0] * constraint.size)
@@ -114,6 +153,9 @@ class Bounds:
                 lower.extend([0.0] * constraint.size)
                 upper.extend([np.inf] * constraint.size)
                 new_constr.append(lower_ineq_to_nonneg(constraint))
+            offset += constraint.size
+        self.cons_offsets = cons_offsets
+        self.cons_shapes = cons_shapes
         canonicalized_prob = self.problem.copy([self.problem.objective, new_constr])
         self.new_problem = canonicalized_prob
         self.cl = np.array(lower)

--- a/cvxpy/reductions/solvers/nlp_solvers/uno_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/uno_nlpif.py
@@ -91,7 +91,10 @@ class UNO(NLPsolver):
                 shape = inverse_data.var_shapes[id]
                 size = np.prod(shape, dtype=int)
                 primal_vars[id] = np.reshape(x_opt[offset:offset+size], shape, order='F')
-            return Solution(status, opt_val, primal_vars, {}, attr)
+            dual_vars = self._extract_dual_vars(
+                solution.get('constraint_dual'), inverse_data
+            )
+            return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
             return failure_solution(status, attr)
 

--- a/cvxpy/tests/nlp_tests/test_dnlp_duals.py
+++ b/cvxpy/tests/nlp_tests/test_dnlp_duals.py
@@ -1,0 +1,151 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import numpy as np
+import pytest
+
+import cvxpy as cp
+from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS
+
+
+@pytest.mark.skipif(
+    'IPOPT' not in INSTALLED_SOLVERS,
+    reason='IPOPT is not installed.'
+)
+class TestDNLPDualRecovery:
+    """Test that dual variables are correctly recovered from NLP solvers.
+
+    These tests verify that the constraint multipliers returned by the
+    NLP solver are properly sliced, reshaped, and propagated back through
+    the reduction chain so that ``constraint.dual_value`` is populated
+    after a solve.
+    """
+
+    def test_lp_dual_values(self):
+        """Verify duals on a simple LP solved via IPOPT.
+
+        minimize   -4*x[0] - 5*x[1]
+        subject to  2*x[0] +   x[1] <= 3
+                      x[0] + 2*x[1] <= 3
+                    x >= 0
+
+        Optimal: x = [1, 1], obj = -9
+        LP duals: lambda_1 = 1, lambda_2 = 2
+        """
+        x = cp.Variable(2, nonneg=True)
+        c1 = 2 * x[0] + x[1] <= 3
+        c2 = x[0] + 2 * x[1] <= 3
+        prob = cp.Problem(cp.Minimize(-4 * x[0] - 5 * x[1]), [c1, c2])
+        prob.solve(solver=cp.IPOPT, nlp=True)
+
+        assert prob.status == cp.OPTIMAL
+        np.testing.assert_allclose(x.value, [1.0, 1.0], atol=1e-5)
+
+        # Dual variables should be populated (not None).
+        assert c1.dual_value is not None
+        assert c2.dual_value is not None
+
+        # LP duals for this problem are 1 and 2.
+        np.testing.assert_allclose(c1.dual_value, 1.0, atol=1e-4)
+        np.testing.assert_allclose(c2.dual_value, 2.0, atol=1e-4)
+
+    def test_equality_constraint_dual(self):
+        """Verify dual recovery for an equality constraint.
+
+        minimize   (x - 3)^2
+        subject to  x == 1
+
+        Optimal: x = 1, obj = 4
+        KKT stationarity: 2*(x - 3) + lambda = 0  =>  lambda = 4
+        """
+        x = cp.Variable()
+        c_eq = x == 1
+        prob = cp.Problem(cp.Minimize((x - 3) ** 2), [c_eq])
+        prob.solve(solver=cp.IPOPT, nlp=True)
+
+        assert prob.status == cp.OPTIMAL
+        np.testing.assert_allclose(x.value, 1.0, atol=1e-5)
+        assert c_eq.dual_value is not None
+        np.testing.assert_allclose(c_eq.dual_value, 4.0, atol=1e-4)
+
+    def test_smooth_nlp_duals_nonzero(self):
+        """Verify that duals are populated for a smooth NLP.
+
+        minimize   exp(x) + exp(y)
+        subject to  x + y == 1
+
+        At optimum x = y = 0.5,  dual = -exp(0.5) ≈ -1.6487
+        (stationarity: exp(x) + lambda = 0 => lambda = -exp(0.5))
+        """
+        x = cp.Variable()
+        y = cp.Variable()
+        c_eq = x + y == 1
+        prob = cp.Problem(cp.Minimize(cp.exp(x) + cp.exp(y)), [c_eq])
+        x.value = 0.5
+        y.value = 0.5
+        prob.solve(solver=cp.IPOPT, nlp=True)
+
+        assert prob.status == cp.OPTIMAL
+        np.testing.assert_allclose(x.value, 0.5, atol=1e-5)
+        assert c_eq.dual_value is not None
+        np.testing.assert_allclose(
+            c_eq.dual_value, -np.exp(0.5), atol=1e-4
+        )
+
+    def test_multiple_constraint_shapes(self):
+        """Duals are correctly reshaped for vector constraints."""
+        x = cp.Variable(3)
+        c_ineq = x <= 2
+        c_eq = cp.sum(x) == 3
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(x)), [c_ineq, c_eq])
+        prob.solve(solver=cp.IPOPT, nlp=True)
+
+        assert prob.status == cp.OPTIMAL
+        # x should be [1, 1, 1]
+        np.testing.assert_allclose(x.value, [1.0, 1.0, 1.0], atol=1e-5)
+
+        # Inequality not active => dual should be ~0
+        assert c_ineq.dual_value is not None
+        assert c_ineq.dual_value.shape == (3,)
+        np.testing.assert_allclose(c_ineq.dual_value, 0.0, atol=1e-4)
+
+        # Equality dual should be non-None
+        assert c_eq.dual_value is not None
+
+    def test_no_constraints_no_crash(self):
+        """Unconstrained problem: no dual variables to recover."""
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize((x - 5) ** 2))
+        prob.solve(solver=cp.IPOPT, nlp=True)
+
+        assert prob.status == cp.OPTIMAL
+        np.testing.assert_allclose(x.value, 5.0, atol=1e-5)
+
+    def test_esr_atom_user_duals_propagated(self):
+        """Duals propagate through ESR (abs) canonicalization.
+
+        The abs atom introduces auxiliary constraints internally.
+        Only user-visible constraint duals should be populated.
+        """
+        x = cp.Variable()
+        c_eq = x == -2
+        prob = cp.Problem(cp.Minimize(cp.abs(x)), [c_eq])
+        prob.solve(solver=cp.IPOPT, nlp=True)
+
+        assert prob.status == cp.OPTIMAL
+        np.testing.assert_allclose(x.value, -2.0, atol=1e-5)
+        # The user constraint should have a dual value.
+        assert c_eq.dual_value is not None


### PR DESCRIPTION
## Description                                                                                                                      
                                         
  Draft PoC for my GSoC 2026 proposal  :**Post-solver feasibility and optimality checks**.                                            
                                                                                                                                      
  One of the goals of the project is extending KKT optimality checks to DNLP problems. While exploring the codebase I noticed that all four NLP solvers pass `{}` as `dual_vars` in their `invert()` methods, even though the solvers already compute and return multipliers. Without duals, KKT checks can't work for DNLP.                                                                         
                                                            
  This PR recovers dual variables by:

  - Tracking constraint offsets/shapes in the flat `g(x)` vector during bound construction
  - Adding a shared `_extract_dual_vars()` helper on `NLPsolver` that slices the flat multiplier vector back into per-constraint duals
  - Wiring up each solver's `invert()` with its multiplier key (`mult_g` for IPOPT, `lambda[n:]` for Knitro, `lambda` for COPT,       
  `constraint_dual` for Uno)                                                                                                          
                                                                                                                                      
  The existing chain inversion via `cons_id_map` in `Dnlp2Smooth` and `CvxAttr2Constr` already handles propagating duals to user      
  constraints , only the solver-level extraction was missing.

  Added 6 tests covering LP duals, equality duals, smooth NLP, vector reshaping, unconstrained problems, and ESR atom propagation.    
   
  Happy to iterate on this based on feedback.                                                                                         
                                                            
  ## Type of change
  - [x] New feature (backwards compatible)

  ## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)                                   
  - [x] Add our license to new files.
  - [x] Check that your code adheres to our coding style.                                                                             
  - [x] Write unittests.                                    
  - [ ] Run the unittests and check that they're passing.                                                                             
  - [ ] Run the benchmarks to make sure your change doesn't introduce a regression.
                                                                                            