### PR TITLE
Update docs to clarify warm start/initial guess support (#2912)

### DIFF
--- a/doc/source/tutorial/solvers/index.rst
+++ b/doc/source/tutorial/solvers/index.rst
@@ -291,6 +291,8 @@ warm start would only be a good initial point.
 
 Warm start can also be used to provide an initial guess the first time a problem is solved.
 The initial guess is constructed from the ``value`` field of the problem variables.
+Note that many solvers do not support providing an initial guess, and will ignore
+the ``value`` field of the variables.
 If the same problem is solved a second time, the initial guess is constructed from the
 cached previous solution as described above (rather than from the ``value`` field).
 


### PR DESCRIPTION

Updated "Warm start" documentation to clarify that providing an initial guess via the [value](cci:1://file:///d:/downloads/all%20projects/new4/cvxpy/cvxpy/expressions/expression.py:131:4-136:35) field is not supported by many solvers.

Issue link: #2912

## Type of change
- [ ] Bug fix
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Other (Documentation)

## [Contribution checklist]
- [x] Check that your code adheres to our coding style.
- [x] Run the unittests and check that they’re passing (N/A for docs).
