### PR TITLE
Fix clarabel keyerror 3276

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
@@ -85,7 +85,7 @@ class CLARABEL(ConicSolver):
     NUMERICAL_ERROR = "NumericalError"
     INSUFFICIENT_PROGRESS = "InsufficientProgress"
     ACCEPT_UNKNOWN = "accept_unknown"
-
+    UNSOLVED = "Unsolved"
     STATUS_MAP = {
                     SOLVED: s.OPTIMAL,
                     PRIMAL_INFEASIBLE: s.INFEASIBLE,
@@ -97,7 +97,7 @@ class CLARABEL(ConicSolver):
                     MAX_TIME: s.USER_LIMIT,
                     NUMERICAL_ERROR: s.SOLVER_ERROR,
                     INSUFFICIENT_PROGRESS: s.SOLVER_ERROR,
-                    "Unsolved": s.SOLVER_ERROR,
+                    UNSOLVED: s.SOLVER_ERROR,
                 }
 
     # Order of exponential cone arguments for solver.

--- a/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/clarabel_conif.py
@@ -96,7 +96,8 @@ class CLARABEL(ConicSolver):
                     MAX_ITERATIONS: s.USER_LIMIT,
                     MAX_TIME: s.USER_LIMIT,
                     NUMERICAL_ERROR: s.SOLVER_ERROR,
-                    INSUFFICIENT_PROGRESS: s.SOLVER_ERROR
+                    INSUFFICIENT_PROGRESS: s.SOLVER_ERROR,
+                    "Unsolved": s.SOLVER_ERROR,
                 }
 
     # Order of exponential cone arguments for solver.
@@ -130,7 +131,7 @@ class CLARABEL(ConicSolver):
             CLARABEL.ACCEPT_UNKNOWN in inverse_data.solver_options and\
             solution.x is not None and solution.z is not None:
             status_map["InsufficientProgress"] = s.OPTIMAL_INACCURATE
-        status = status_map[str(solution.status)]
+        status = status_map.get(str(solution.status), s.SOLVER_ERROR)
         attr[s.SOLVE_TIME] = solution.solve_time
         attr[s.NUM_ITERS] = solution.iterations
         # more detailed statistics here when available

--- a/cvxpy/tests/test_clarabel.py
+++ b/cvxpy/tests/test_clarabel.py
@@ -114,12 +114,9 @@ class ClarabelTest(BaseTest):
         Test that the Clarabel interface correctly handles the 'Unsolved'
         status without raising a KeyError.
         """
-        import cvxpy.settings as s
-        from cvxpy.reductions.solvers.conic_solvers.clarabel_conif import CLARABEL
-
         solver = CLARABEL()
         mock_solution = SimpleNamespace(
-            status="Unsolved",
+            status=CLARABEL.UNSOLVED,
             solve_time=0.01,
             iterations=0,
             x=None,

--- a/cvxpy/tests/test_clarabel.py
+++ b/cvxpy/tests/test_clarabel.py
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from types import SimpleNamespace
+
 import clarabel
 import numpy as np
 
@@ -107,3 +109,23 @@ class ClarabelTest(BaseTest):
         solution = solver.invert(self.solution, solver_inverse_data)
         self.assertEqual(s.SOLVER_ERROR, solution.status)
 
+    def test_unsolved_status_handling(self):
+        """
+        Test that the Clarabel interface correctly handles the 'Unsolved'
+        status without raising a KeyError.
+        """
+        import cvxpy.settings as s
+        from cvxpy.reductions.solvers.conic_solvers.clarabel_conif import CLARABEL
+
+        solver = CLARABEL()
+        mock_solution = SimpleNamespace(
+            status="Unsolved",
+            solve_time=0.01,
+            iterations=0,
+            x=None,
+            z=None,
+            attr={}
+        )
+        mock_inverse_data = SimpleNamespace(solver_options={})
+        sol = solver.invert(mock_solution, mock_inverse_data)
+        self.assertEqual(sol.status, s.SOLVER_ERROR)


### PR DESCRIPTION
## Description
Clarabel 0.10.0 introduced a new `Unsolved` status. Because this status was missing from CVXPY's `STATUS_MAP` in `clarabel_conif.py`, it caused an unhandled `KeyError` when unpacking results, leading to a library-wide crash instead of a standard `SolverError`.

**Changes:**
* Added `"Unsolved"` to `CLARABEL.STATUS_MAP` mapped to `s.SOLVER_ERROR`.
* Updated the status lookup in `invert()` to use `.get()` with a `s.SOLVER_ERROR` fallback. This ensures the interface remains stable even if the solver introduces additional statuses in future versions.
* Added a mock regression test in `cvxpy/tests/test_clarabel.py` to verify handling of the `Unsolved` state.

**Issue link:** Fixes #3276

**AI Disclosure:** AI was used to assist with the PR description and test boilerplate, while the technical logic and status mappings were manually implemented and verified.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.