### PR TITLE
Fix backward/derivative crash for Hermitian parameters

### DIFF
--- a/cvxpy/reductions/complex2real/complex2real.py
+++ b/cvxpy/reductions/complex2real/complex2real.py
@@ -36,6 +36,12 @@ from cvxpy.reductions.complex2real.canonicalizers import (
 from cvxpy.reductions.complex2real.canonicalizers import (
     Complex2RealCanonMethods,
 )
+from cvxpy.reductions.cvx_attr2constr import (
+    SYMMETRIC_ATTRIBUTES,
+    attributes_present,
+    lower_value,
+    recover_value_for_leaf,
+)
 from cvxpy.reductions.reduction import Reduction
 
 
@@ -114,7 +120,15 @@ class Complex2Real(Reduction):
         real_param, imag_param = self.canon_methods._parameters[param]
         grad = 0.0
         if real_param is not None and real_param.id in dparams:
-            grad = grad + dparams[real_param.id]
+            real_grad = dparams[real_param.id]
+            # For Hermitian params, the real part is symmetric and may have
+            # been lowered to compact (upper-triangle) form by CvxAttr2Constr.
+            # Recover to full matrix form before combining with imaginary grad.
+            if param.is_hermitian() and attributes_present(
+                    [real_param], SYMMETRIC_ATTRIBUTES):
+                real_grad = recover_value_for_leaf(
+                    real_param, real_grad, project=False)
+            grad = grad + real_grad
         if imag_param is not None and imag_param.id in dparams:
             imag_grad = dparams[imag_param.id]
             if param.is_hermitian():
@@ -148,7 +162,14 @@ class Complex2Real(Reduction):
         real_param, imag_param = self.canon_methods._parameters[param]
         result = {}
         if real_param is not None:
-            result[real_param.id] = np.real(np.asarray(delta, dtype=np.complex128))
+            real_delta = np.real(np.asarray(delta, dtype=np.complex128))
+            # For Hermitian params, the real part is symmetric and may have
+            # been lowered to compact (upper-triangle) form by CvxAttr2Constr.
+            # Lower the full real delta to match the expected compact form.
+            if param.is_hermitian() and attributes_present(
+                    [real_param], SYMMETRIC_ATTRIBUTES):
+                real_delta = lower_value(real_param, real_delta)
+            result[real_param.id] = real_delta
         if imag_param is not None:
             imag_delta = np.imag(np.asarray(delta, dtype=np.complex128))
             if param.is_hermitian():

--- a/cvxpy/tests/test_derivative.py
+++ b/cvxpy/tests/test_derivative.py
@@ -470,6 +470,34 @@ class TestBackwardComplex(BaseTest):
         self.assertTrue(np.isscalar(x.delta) or x.delta.size == 1)
 
 
+    def test_hermitian_param_backward_derivative(self) -> None:
+        """backward() and derivative() with Hermitian parameters.
+
+        Regression: Complex2Real received real gradient in compact form
+        from CvxAttr2Constr but tried to combine with full imaginary gradient.
+        """
+        P = cp.Parameter((2, 2), hermitian=True)
+        x = cp.Variable(2, complex=True)
+        prob = cp.Problem(
+            cp.Minimize(
+                cp.sum_squares(cp.real(x - P @ np.array([1., 0.])))
+                + cp.sum_squares(cp.imag(x - P @ np.array([1., 0.])))
+            ),
+        )
+        P.value = np.array([[2, 0.5 + 1j], [0.5 - 1j, 1]])
+        prob.solve(requires_grad=True, solver=cp.SCS, eps=1e-9)
+        self.assertEqual(prob.status, cp.OPTIMAL)
+
+        prob.backward()
+        self.assertEqual(P.gradient.shape, (2, 2))
+        np.testing.assert_allclose(
+            P.gradient, np.conj(P.gradient.T), atol=1e-6)
+
+        P.delta = np.array([[0.01, 0.02 + 0.01j], [0.02 - 0.01j, 0.03]])
+        prob.derivative()
+        self.assertEqual(x.delta.shape, (2,))
+
+
 class TestBackwardDgp(BaseTest):
     """Test problem.backward() and problem.derivative()."""
     def setUp(self) -> None:


### PR DESCRIPTION
## Description
I ran into a bug where `backward()` and `derivative()` blow up with a `ValueError` when you have a Hermitian `cp.Parameter` and `requires_grad=True`.

What's going on is `Complex2Real` and `CvxAttr2Constr` both touch the same intermediate real parameter but disagree on its shape. `CvxAttr2Constr` compacts the real gradient into upper-triangle form on the way back, but `Complex2Real` doesn't know that — it just tries to add the compact `(3,)` array to the full `(2,2)` imaginary gradient and you get a shape mismatch. Same thing in reverse during the forward pass.

The fix is straightforward: in `param_backward`, I use `recover_value_for_leaf` to expand the compact real gradient back to a full matrix before combining. In `param_forward`, I use `lower_value` to pack the real delta into compact form before passing it along. Both functions already existed in `cvx_attr2constr` — I just wasn't calling them.

Added a regression test that hits both code paths with a 2×2 Hermitian parameter.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.