### PR TITLE
fix: support ortools 9.15.x versions (fixes #3285) and adds warning instead of raising error

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
@@ -53,9 +53,9 @@ class GLOP(ConicSolver):
         if Version(ortools.__version__) < Version('9.5.0'):
             raise RuntimeError(f'Version of ortools ({ortools.__version__}) '
                                f'is too old. Expected >= 9.5.0.')
-        if Version(ortools.__version__) >= Version('9.15.0'):
+        if Version(ortools.__version__) >= Version('9.16.0'):
             raise RuntimeError('Unrecognized new version of ortools '
-                               f'({ortools.__version__}). Expected < 9.15.0. '
+                               f'({ortools.__version__}). Expected < 9.16.0. '
                                'Please open a feature request on cvxpy to '
                                'enable support for this version.')
 

--- a/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
@@ -17,8 +17,6 @@ limitations under the License.
 import logging
 from typing import Any
 
-from cvxpy.utilities.warn import warn
-
 from numpy import array, ndarray
 from scipy.sparse import csr_array
 
@@ -31,6 +29,7 @@ from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.utilities.citations import CITATION_DICT
 from cvxpy.utilities.versioning import Version
+from cvxpy.utilities.warn import warn
 
 log = logging.getLogger(__name__)
 

--- a/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/glop_conif.py
@@ -17,6 +17,8 @@ limitations under the License.
 import logging
 from typing import Any
 
+from cvxpy.utilities.warn import warn
+
 from numpy import array, ndarray
 from scipy.sparse import csr_array
 
@@ -54,10 +56,12 @@ class GLOP(ConicSolver):
             raise RuntimeError(f'Version of ortools ({ortools.__version__}) '
                                f'is too old. Expected >= 9.5.0.')
         if Version(ortools.__version__) >= Version('9.16.0'):
-            raise RuntimeError('Unrecognized new version of ortools '
-                               f'({ortools.__version__}). Expected < 9.16.0. '
-                               'Please open a feature request on cvxpy to '
-                               'enable support for this version.')
+            warn(
+                f'Unrecognized version of ortools ({ortools.__version__}). '
+                'Version support has been tested up to 9.15.x. '
+                'Newer versions may work but are not officially supported. '
+                'Please open a feature request on cvxpy if you encounter issues.'
+            )
 
     def apply(self, problem: ParamConeProg) -> tuple[dict, dict]:
         """Returns a new problem and data for inverting the new solution."""

--- a/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
@@ -53,9 +53,9 @@ class PDLP(ConicSolver):
         if Version(ortools.__version__) < Version('9.7.0'):
             raise RuntimeError(f'Version of ortools ({ortools.__version__}) '
                                f'is too old. Expected >= 9.7.0.')
-        if Version(ortools.__version__) >= Version('9.15.0'):
+        if Version(ortools.__version__) >= Version('9.16.0'):
             raise RuntimeError('Unrecognized new version of ortools '
-                               f'({ortools.__version__}). Expected < 9.15.0. '
+                               f'({ortools.__version__}). Expected < 9.16.0. '
                                'Please open a feature request on cvxpy to '
                                'enable support for this version.')
 

--- a/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
@@ -17,8 +17,6 @@ limitations under the License.
 import logging
 from typing import Any
 
-from cvxpy.utilities.warn import warn
-
 import numpy as np
 from scipy.sparse import csr_array
 
@@ -31,6 +29,7 @@ from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.utilities.citations import CITATION_DICT
 from cvxpy.utilities.versioning import Version
+from cvxpy.utilities.warn import warn
 
 log = logging.getLogger(__name__)
 

--- a/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/pdlp_conif.py
@@ -17,6 +17,8 @@ limitations under the License.
 import logging
 from typing import Any
 
+from cvxpy.utilities.warn import warn
+
 import numpy as np
 from scipy.sparse import csr_array
 
@@ -54,10 +56,12 @@ class PDLP(ConicSolver):
             raise RuntimeError(f'Version of ortools ({ortools.__version__}) '
                                f'is too old. Expected >= 9.7.0.')
         if Version(ortools.__version__) >= Version('9.16.0'):
-            raise RuntimeError('Unrecognized new version of ortools '
-                               f'({ortools.__version__}). Expected < 9.16.0. '
-                               'Please open a feature request on cvxpy to '
-                               'enable support for this version.')
+            warn(
+                f'Unrecognized version of ortools ({ortools.__version__}). '
+                'Version support has been tested up to 9.15.x. '
+                'Newer versions may work but are not officially supported. '
+                'Please open a feature request on cvxpy if you encounter issues.'
+            )
 
     def apply(self, problem: ParamConeProg) -> tuple[dict, dict]:
         """Returns a new problem and data for inverting the new solution."""


### PR DESCRIPTION
## Summary

Bumps the upper version bound for OR-Tools from `9.15.0` to `9.16.0` in both:

- `cvxpy/reductions/solvers/conic_solvers/glop_conif.py`
- `cvxpy/redections/solvers/conic_solvers/pdlp_conif.py`

## Context

OR-Tools `9.15.6755` is required by Protobuf v6.33.5 (to address [GHSA-7gcm-887-7qv7](https://github.com/advisories/GHSA-7gcm-887-7qv7)), but CVXPY rejects any version >= 9.15.0 with:

```
RuntimeError('Unrecognized new version of ortools (9.15.6755). Expected < 9.15.0.')
```

This change allows all 9.15.x patch releases while still gating on 9.16.0+ for proper evaluation.

## Changes

- 2 files, 4 lines changed (version bound + error message update)

Fixes #3285
Fixes #2470 