### PR TITLE
Replace square brackets with parentheses in HiGHS LP column names

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
@@ -31,14 +31,14 @@ from cvxpy.utilities.citations import CITATION_DICT
 
 PYTHON_LIST_SLICE_PATTERN = compile(r", \d+:\d+")
 VALID_COLUMN_NAME_PATTERN = compile(
-    r"^(?!st$|bounds$|min$|max$|bin$|binary$|gen$|semi$|end$)[a-df-zA-DF-Z\"!#$%&/}{,;?@_‘’'`|~]{1}[a-zA-Z0-9\"!#$%&/}{,;?@_‘’'`|~.=()<>[\]]{,254}$"
+    r"^(?!st$|bounds$|min$|max$|bin$|binary$|gen$|semi$|end$)[a-df-zA-DF-Z\"!#$%&/}{,;?@_‘’'`|~]{1}[a-zA-Z0-9\"!#$%&/}{,;?@_‘’'`|~.=()<>]{,254}$"
 )
 INVALID_COLUMN_NAME_MESSAGE_TEMPLATE = (
     "Invalid column name: {name}"
     "\nA column name must:"
     "\n- not be equal to one of the keywords: st, bounds, min, max, bin, binary, gen, semi or end"
     "\n- not begin with a number, the letter e or E or any of the following characters: .=()<>[]"
-    "\n- be alphanumeric (a-z, A-Z, 0-9) or one of these symbols: \"!#$%&/}}{{,;?@_‘’'`|~.=()<>[]"
+    "\n- be alphanumeric (a-z, A-Z, 0-9) or one of these symbols: \"!#$%&/}}{{,;?@_‘’'`|~.=()<>"
     "\n- be no longer than 255 characters."
 )
 
@@ -57,13 +57,23 @@ def strip_column_name_of_python_list_slice_notation(name: str) -> str:
     return PYTHON_LIST_SLICE_PATTERN.sub("", name)
 
 
+def sanitize_column_name(name: str) -> str:
+    """Replace square brackets with parentheses for HiGHS LP file compatibility.
+
+    HiGHS does not allow square brackets in column names in LP files because
+    they are used to define quadratic objectives.
+    """
+    return name.replace("[", "(").replace("]", ")")
+
+
 def collect_column_names(variable, column_names):
     """Recursively collect variable names."""
     if variable.ndim == 0:  # scalar
-        column_names.append(variable.name())
+        column_names.append(sanitize_column_name(variable.name()))
     elif variable.ndim == 1:  # simple array
         var_name_prefix = strip_column_name_of_python_list_slice_notation(variable.name())
-        column_names.extend([f"{var_name_prefix}[{v}]" for v in range(variable.size)])
+        var_name_prefix = sanitize_column_name(var_name_prefix)
+        column_names.extend([f"{var_name_prefix}({v})" for v in range(variable.size)])
     else:  # multi-dimensional array
         for var in variable:
             collect_column_names(var, column_names)  # recursive call

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2604,7 +2604,7 @@ class TestHIGHS:
             ["st", "bounds", "min", "max", "bin", "binary", "gen", "semi", "end"]
         )
         must_not_begin_with = set(string.digits + "eE.=()<>[]")
-        may_contain = set(string.ascii_letters + string.digits + "\"!#$%&/}{,;?@_‘’'`|~.=()<>[]")
+        may_contain = set(string.ascii_letters + string.digits + "\"!#$%&/}{,;?@_‘’'`|~.=()<>")
         must_not_contain = set(string.printable) - set(may_contain)
         may_begin_with = (set(may_contain) - set(must_not_begin_with)).union(
             set(must_not_be_a_keyword) - set(["end"])
@@ -2689,14 +2689,16 @@ class TestHIGHS:
                         f"in the model file."
                     )
                 else:
-                    # Array variables appear as name[idx] entries.
+                    # Array variables appear as name(idx) entries (parentheses,
+                    # not brackets, because HiGHS uses [] for quadratic objectives).
+                    sanitized_name = expected_var.name().replace("[", "(").replace("]", ")")
                     actual_var_count = len(re.findall(
-                        re.escape(expected_var.name()) + r"\[", model
+                        re.escape(sanitized_name) + r"\(", model
                     ))
                     # Each element appears at least twice (objective + constraint),
                     # and possibly once more in the bounds section.
                     assert actual_var_count >= expected_var.size, (
-                        f"Expected variable {expected_var.name()} to appear "
+                        f"Expected variable {sanitized_name} to appear "
                         f"at least {expected_var.size} times in the model file "
                         f"but found {actual_var_count}."
                     )


### PR DESCRIPTION
## Description
HiGHS 1.14.0 no longer allows square brackets (`[`, `]`) in column names in LP files because they are used to define quadratic objectives (see [CPLEX LP format conventions](https://www.ibm.com/docs/en/icos/22.1.2?topic=cplex-lp-file-format-algebraic-representation)). This causes `write_model_file` to produce generic names (`c0`, `c1`, ...) instead of the user-defined variable names.

This PR replaces `[`/`]` with `(`/`)` in generated column names so that variable indexing remains readable (e.g., `x(0)` instead of `x[0]`) while staying within the set of characters HiGHS allows.

Changes:
- Add `sanitize_column_name()` helper that replaces brackets with parentheses
- Apply sanitization in `collect_column_names()`
- Remove `[]` from the valid column name regex and error message
- Update tests to expect parenthesized names

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)