### PR TITLE
Fix constant bmat Hermitian metadata

### DIFF
--- a/cvxpy/atoms/affine/bmat.py
+++ b/cvxpy/atoms/affine/bmat.py
@@ -14,8 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numpy as np
+
+from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.atoms.affine.hstack import hstack
 from cvxpy.atoms.affine.vstack import vstack
+from cvxpy.expressions.constants import Constant
 
 
 def bmat(block_lists):
@@ -34,5 +38,15 @@ def bmat(block_lists):
     CVXPY expression
         The CVXPY expression representing the block matrix.
     """
+    block_lists = [
+        [AffAtom.cast_to_const(block) for block in block_list]
+        for block_list in block_lists
+    ]
+    if all(block.is_constant() for block_list in block_lists for block in block_list):
+        return Constant(np.block([
+            [block.value for block in block_list]
+            for block_list in block_lists
+        ]))
+
     row_blocks = [hstack(blocks) for blocks in block_lists]
     return vstack(row_blocks)

--- a/cvxpy/atoms/affine/bmat.py
+++ b/cvxpy/atoms/affine/bmat.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import numpy as np
+import scipy.sparse as sp
 
 from cvxpy.atoms.affine.affine_atom import AffAtom
 from cvxpy.atoms.affine.hstack import hstack
@@ -42,11 +43,18 @@ def bmat(block_lists):
         [AffAtom.cast_to_const(block) for block in block_list]
         for block_list in block_lists
     ]
-    if all(block.is_constant() for block_list in block_lists for block in block_list):
-        return Constant(np.block([
+    if all(
+        block.is_constant() and not block.parameters()
+        for block_list in block_lists
+        for block in block_list
+    ):
+        block_values = [
             [block.value for block in block_list]
             for block_list in block_lists
-        ]))
+        ]
+        if any(sp.issparse(value) for block_list in block_values for value in block_list):
+            return Constant(sp.bmat(block_values, format="csc"))
+        return Constant(np.block(block_values))
 
     row_blocks = [hstack(blocks) for blocks in block_lists]
     return vstack(row_blocks)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1420,14 +1420,33 @@ class TestAtoms(BaseTest):
         """Test the bmat atom.
         """
         v_np = np.ones((3, 1))
-        expr = np.vstack([np.hstack([v_np, v_np]),
-                          np.hstack([np.zeros((2, 1)),
-                                     np.array([[1, 2]]).T])])
+        expected = np.vstack([np.hstack([v_np, v_np]),
+                              np.hstack([np.zeros((2, 1)),
+                                         np.array([[1, 2]]).T])])
+        expr = cp.bmat([[v_np, v_np],
+                        [np.zeros((2, 1)), np.array([[1, 2]]).T]])
         self.assertEqual(expr.shape, (5, 2))
-        const = np.vstack([np.hstack([v_np, v_np]),
-                           np.hstack([np.zeros((2, 1)),
-                                      np.array([[1, 2]]).T])])
-        self.assertItemsAlmostEqual(expr, const)
+        self.assertTrue(expr.is_constant())
+        self.assertItemsAlmostEqual(expr.value, expected)
+
+    def test_bmat_constant_preserves_hermitian_structure(self) -> None:
+        """Constant bmat should preserve symmetric/Hermitian metadata."""
+        real_psd = cp.bmat([[2, -2], [-2, 2]])
+        self.assertTrue(real_psd.is_constant())
+        self.assertTrue(real_psd.is_symmetric())
+        self.assertTrue(real_psd.is_hermitian())
+
+        x = cp.Variable((2, 1))
+        expr = cp.quad_form(x, real_psd)
+        self.assertTrue(expr.is_dcp())
+
+        hermitian = cp.bmat([[1, 1j], [-1j, 2]])
+        self.assertTrue(hermitian.is_constant())
+        self.assertTrue(hermitian.is_hermitian())
+
+        z = cp.Variable(2, complex=True)
+        complex_expr = cp.quad_form(z, hermitian)
+        self.assertTrue(complex_expr.is_dcp())
 
     def test_conv(self) -> None:
         """Test the conv atom.

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1448,6 +1448,36 @@ class TestAtoms(BaseTest):
         complex_expr = cp.quad_form(z, hermitian)
         self.assertTrue(complex_expr.is_dcp())
 
+    def test_bmat_sparse_constants_preserve_hermitian_structure(self) -> None:
+        """Sparse constant bmat should preserve symmetric/Hermitian metadata."""
+        real_psd = cp.bmat([[sp.csc_array([[2]]), sp.csc_array([[-2]])],
+                            [sp.csc_array([[-2]]), sp.csc_array([[2]])]])
+        self.assertTrue(real_psd.is_constant())
+        self.assertTrue(real_psd.is_symmetric())
+        self.assertTrue(real_psd.is_hermitian())
+
+        x = cp.Variable((2, 1))
+        expr = cp.quad_form(x, real_psd)
+        self.assertTrue(expr.is_dcp())
+
+    def test_bmat_parameters_remain_parameterized(self) -> None:
+        """Parameter-only bmat should keep its parameter dependencies."""
+        p11 = cp.Parameter((1, 1))
+        p12 = cp.Parameter((1, 1))
+        expr = cp.bmat([[p11, p12],
+                        [p12, p11]])
+
+        self.assertEqual(expr.shape, (2, 2))
+        self.assertEqual(set(expr.parameters()), {p11, p12})
+
+        p11.value = np.array([[1]])
+        p12.value = np.array([[2]])
+        self.assertItemsAlmostEqual(expr.value, np.array([[1, 2], [2, 1]]))
+
+        p11.value = np.array([[3]])
+        p12.value = np.array([[4]])
+        self.assertItemsAlmostEqual(expr.value, np.array([[3, 4], [4, 3]]))
+
     def test_conv(self) -> None:
         """Test the conv atom.
         """


### PR DESCRIPTION
## Description

Fixes `cp.bmat(...)` for constant-only block matrices so the result preserves symmetric/Hermitian metadata.

Previously, `bmat` always assembled blocks through `hstack`/`vstack`, which produced a `Vstack` expression even when every block was constant. That dropped the constant matrix metadata used by `quad_form`, so symmetric/Hermitian block matrices built with `cp.bmat` were rejected with:

```text
ValueError: Quadratic form matrices must be symmetric/Hermitian.
```

This change casts blocks up front and constant-folds all-constant block matrices via `np.block(...)`, returning a `Constant` instead of a stacked affine expression. That preserves the correct symmetric/Hermitian properties.

Issue link (if applicable): Fixes #2786

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files. No new files were added.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

## Tests
- `python -m pytest cvxpy/tests/test_atoms.py`
- `python -m pytest cvxpy/tests/test_complex.py -k quad_form`
