### PR TITLE
Map cuOpt UnboundedOrInfeasible status to INFEASIBLE_OR_UNBOUNDED

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/cuopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cuopt_conif.py
@@ -71,6 +71,7 @@ class CUOPT(ConicSolver):
             MILPTerminationStatus.Infeasible: s.INFEASIBLE,
             MILPTerminationStatus.Unbounded: s.UNBOUNDED,
             MILPTerminationStatus.TimeLimit: s.USER_LIMIT,
+            MILPTerminationStatus.UnboundedOrInfeasible: s.INFEASIBLE_OR_UNBOUNDED,
         }
         return STATUS_MAP_MIP[cuopt_status]
 
@@ -84,6 +85,7 @@ class CUOPT(ConicSolver):
             LPTerminationStatus.IterationLimit: s.USER_LIMIT,
             LPTerminationStatus.TimeLimit: s.USER_LIMIT,
             LPTerminationStatus.PrimalFeasible: s.USER_LIMIT,
+            LPTerminationStatus.UnboundedOrInfeasible: s.INFEASIBLE_OR_UNBOUNDED,
         }
         return STATUS_MAP_LP[cuopt_status]
 


### PR DESCRIPTION
## Summary

cuOpt added a new termination status \`UnboundedOrInfeasible\` (enum value 11) for both LP and MILP results, returned by its PSLP presolver when the two cases cannot be disambiguated. The existing \`STATUS_MAP_LP\` / \`STATUS_MAP_MIP\` in the CUOPT adapter do not handle it, producing \`KeyError: <LPTerminationStatus.UnboundedOrInfeasible: 11>\` on any unbounded-or-infeasible LP.

Adds the mapping to \`s.INFEASIBLE_OR_UNBOUNDED\` in both tables (matches how HiGHS handles \`kUnboundedOrInfeasible\`).

Tracked upstream in NVIDIA/cuopt#1114.