### PR TITLE
Tightened reltol for `TestQOCO.test_qoco_socp_1`

### DIFF
--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1687,7 +1687,7 @@ class TestQOCO(BaseTest):
     def test_qoco_socp_0(self) -> None:
         StandardTestSOCPs.test_socp_0(solver='QOCO')
     def test_qoco_socp_1(self) -> None:
-        StandardTestSOCPs.test_socp_1(solver='QOCO')
+        StandardTestSOCPs.test_socp_1(solver='QOCO', reltol=1e-8)
     def test_qoco_socp_2(self) -> None:
         StandardTestSOCPs.test_socp_2(solver='QOCO')
     def test_qoco_socp_3(self) -> None:


### PR DESCRIPTION
## Description
QOCO v0.2.7 fails on `TestQOCO.test_qoco_socp_1` but previous versions of QOCO do not fail.

In QOCO v0.2.7, an exact linesearch is employed for second-order cones (PR: https://github.com/qoco-org/qoco/pull/59) rather than bisection search. When prior versions of QOCO use a large number of bisection iterations (making the behavior nearly identical to exact linesearch), these same issues are observed, so QOCO v0.2.7 did not introduce an error. 

To fix this test failure, the relative tolerance is tightened from `1e-7` (default) to `1e-8` making this test pass.

Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.