### PR TITLE
Run backend tests as uv matrix

### DIFF
--- a/.github/workflows/test_backends.yml
+++ b/.github/workflows/test_backends.yml
@@ -11,24 +11,28 @@ on:
 jobs:
   test_backends:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [SCIPY, COO]
     steps:
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
-      - uses: actions/checkout@v5
+          enable-cache: true
+
       - name: Install cvxpy dependencies
         run: |
-          pip install -e .
-          pip install pytest hypothesis
-      - name: Run tests with SCIPY backend
-        run : |
-          export CVXPY_DEFAULT_CANON_BACKEND="SCIPY"
-          python -c "from cvxpy.cvxcore.python.canonInterface import get_default_canon_backend; print(get_default_canon_backend())"
-          python -c "from cvxpy.cvxcore.python.canonInterface import get_default_canon_backend; assert get_default_canon_backend() == 'SCIPY'"
-          pytest
-      - name: Run tests with COO backend
-        run : |
-          export CVXPY_DEFAULT_CANON_BACKEND="COO"
-          python -c "from cvxpy.cvxcore.python.canonInterface import get_default_canon_backend; print(get_default_canon_backend())"
-          python -c "from cvxpy.cvxcore.python.canonInterface import get_default_canon_backend; assert get_default_canon_backend() == 'COO'"
-          pytest
+          uv venv
+          uv pip install -e ".[testing]"
+
+      - name: Run tests with ${{ matrix.backend }} backend
+        env:
+          CVXPY_DEFAULT_CANON_BACKEND: ${{ matrix.backend }}
+        run: |
+          uv run python -c "from cvxpy.cvxcore.python.canonInterface import get_default_canon_backend; print(get_default_canon_backend())"
+          uv run python -c "from cvxpy.cvxcore.python.canonInterface import get_default_canon_backend; assert get_default_canon_backend() == '${{ matrix.backend }}'"
+          uv run pytest


### PR DESCRIPTION
## Description
Run the SCIPY and COO canonicalization backend test suites as separate matrix jobs and switch the workflow dependency install to uv.

This keeps the same backend assertions and full pytest invocation, but makes failures easier to identify and lets the two backend suites run independently.

Issue link (if applicable): N/A

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files. N/A, no new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests. N/A, CI workflow-only change.
- [ ] Run the unittests and check that they’re passing. Not run locally; the workflow change is validated by CI.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression. N/A, CI workflow-only change.
