### PR TITLE
Accept INFEASIBLE_OR_UNBOUNDED status in TestCUOPT::test_cuopt_lp_3

### DIFF
--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -3350,7 +3350,17 @@ class TestCUOPT(unittest.TestCase):
         StandardTestLPs.test_lp_2(solver="CUOPT", duals=True, places=4, **TestCUOPT.kwargs)
 
     def test_cuopt_lp_3(self) -> None:
-        StandardTestLPs.test_lp_3(solver="CUOPT", duals=True, places=4, **TestCUOPT.kwargs)
+        # cuOpt's PSLP presolve returns UnboundedOrInfeasible for this
+        # unbounded LP, which maps to INFEASIBLE_OR_UNBOUNDED (prob.value
+        # is None rather than -inf). Assert status directly instead of
+        # calling verify_objective (which would assertAlmostEqual(None, -inf)).
+        # Precedent: test_pdlp_lp_4 handles the same situation for PDLP.
+        sth = sths.lp_3()
+        sth.solve(solver="CUOPT", duals=True, **TestCUOPT.kwargs)
+        self.assertIn(
+            sth.prob.status,
+            [cp.settings.UNBOUNDED, cp.settings.INFEASIBLE_OR_UNBOUNDED],
+        )
 
     def test_cuopt_lp_4(self) -> None:
         # In this case cuopt throws an exception because there are crossing


### PR DESCRIPTION
## Summary

- `TestCUOPT::test_cuopt_lp_3` still fails in cuOpt's nightly after #3295 landed: the `KeyError` is gone, but the test now throws `TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'` because `StandardTestLPs.test_lp_3` calls `verify_objective`, which runs `assertAlmostEqual(prob.value, -inf, 4)`. Under the mapped `INFEASIBLE_OR_UNBOUNDED` status `prob.value` is `None`, so the subtraction blows up.
- Assert `sth.prob.status` is `UNBOUNDED` or `INFEASIBLE_OR_UNBOUNDED` directly, following the precedent set by `test_pdlp_lp_4` at `cvxpy/tests/test_conic_solvers.py:1627-1631` for the same situation with PDLP.
- Tracked on the cuOpt side in NVIDIA/cuopt#1114.

Verified locally (cuOpt 26.06.00) that `min sum(x) s.t. x <= 1` returns `LPTerminationStatus.UnboundedOrInfeasible` from PDLP, Concurrent, and DualSimplex — this is cuOpt's expected behavior for this LP going forward, not a transient.

## Test plan

- [x] Patch follows the existing `test_pdlp_lp_4` convention for `INFEASIBLE_OR_UNBOUNDED`.
- [ ] CI runs `TestCUOPT::test_cuopt_lp_3` against a cuOpt build and it passes (local cvxpy install not available in my environment — relying on CI).
