### PR TITLE
Use triangular Hessian format when passing QP to HiGHS

### DIFF
--- a/cvxpy/reductions/solvers/qp_solvers/highs_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/highs_qpif.py
@@ -193,10 +193,15 @@ class HIGHS(QpSolver):
             hessian = model.hessian_
             hessian.dim_ = model.lp_.num_col_
             assert P.format == "csc"
-            hessian.format_ = hp.HessianFormat.kSquare
-            hessian.start_ = P.indptr
-            hessian.index_ = P.indices
-            hessian.value_ = P.data
+            # Use triangular format to avoid passing redundant off-diagonal
+            # entries whose upper and lower triangles may differ by floating-
+            # point epsilon after canonicalization, which HiGHS >= 1.14.0
+            # rejects as asymmetric.  See https://github.com/cvxpy/cvxpy/issues/3301
+            P_upper = sp.triu(P, format="csc")
+            hessian.format_ = hp.HessianFormat.kTriangular
+            hessian.start_ = P_upper.indptr
+            hessian.index_ = P_upper.indices
+            hessian.value_ = P_upper.data
 
         solver = hp.Highs()
 

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -877,6 +877,49 @@ class TestQp(QPTestBase):
     def test_highs_infeasible_lp_eq_constraints(self):
         StandardTestInfeasibleProblems.test_lp_eq_constraints(solver=cp.HIGHS)
 
+    def test_highs_dense_quad_form(self) -> None:
+        """Regression test for https://github.com/cvxpy/cvxpy/issues/3301.
+
+        A dense quad_form applied to a linear expression (not a raw Variable)
+        produces a Hessian whose upper and lower triangles may differ by
+        floating-point epsilon after canonicalization. Passing such a Hessian
+        in square format to HiGHS >= 1.14.0 triggers an asymmetry error
+        and native heap corruption. Using triangular format avoids this.
+        """
+        if cp.HIGHS not in INSTALLED_SOLVERS:
+            return
+
+        rng = np.random.default_rng(42)
+        n_vars, n_nodes = 60, 20
+
+        # Sparse mapping from decision variables to a smaller space.
+        rows, cols, vals = [], [], []
+        for i in range(n_vars):
+            j, k = rng.choice(n_nodes, size=2, replace=False)
+            rows += [i, i]
+            cols += [j, k]
+            vals += [1.0, -1.0]
+        M = sp.csr_matrix((vals, (rows, cols)), shape=(n_vars, n_nodes))
+
+        # Dense PSD matrix via eigenvalue clamping (typical in practice).
+        A = rng.standard_normal((n_nodes, n_nodes))
+        raw = A @ A.T + rng.standard_normal((n_nodes, n_nodes)) * 0.01
+        sym = 0.5 * (raw + raw.T)
+        eigvals, eigvecs = np.linalg.eigh(sym)
+        eigvals = np.maximum(eigvals, 0.0)
+        Sigma = eigvecs @ np.diag(eigvals) @ eigvecs.T
+
+        x = cp.Variable(n_vars, nonneg=True)
+        y = x @ M
+        prob = cp.Problem(
+            cp.Maximize(
+                cp.sum(x) - 0.1 * cp.quad_form(y, Sigma)
+            ),
+            [x <= 10],
+        )
+        prob.solve(solver=cp.HIGHS)
+        self.assertEqual(prob.status, cp.OPTIMAL)
+
 
 class TestConicQuadObj(QPTestBase):
     """Test conic solvers with use_quad_obj=True."""


### PR DESCRIPTION
## Description

Switches the Hessian format used in the HiGHS QP interface from square to triangle. Currently, cvxpy's canonicalization can produce square Hessians where upper and lower triangles have floating-point asymmetries. HiGHS >= 1.14.0 added a strict symmetry check (https://github.com/ERGO-Code/HiGHS/pull/2857) that rejects such matrices, and the subsequent error-handling path causes native heap corruption (SIGABRT/SIGSEGV), killing the Python process. See https://github.com/ERGO-Code/HiGHS/issues/2979 for the full report.

While the heap corruption is ultimately a HiGHS bug, enforcing square Hessian symmetry is not strictly a bug, and using a triangle Hessian is common behavior, so it seems appropriate to make this change.

Issue link (if applicable): #3301 

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.