### PR TITLE
Fall back to dense eigh in sparse_cholesky for rank-deficient PSD inputs

### DIFF
--- a/cvxpy/tests/test_linalg_utils.py
+++ b/cvxpy/tests/test_linalg_utils.py
@@ -136,6 +136,22 @@ class TestSparseCholesky(BaseTest):
         with self.assertRaises(ValueError, msg=lau.SparseCholeskyMessages.INDEFINITE):
             lau.sparse_cholesky(A, 0.0)
 
+    def test_rank_deficient_full_diagonal(self):
+        # [[1,1],[1,1]] is rank-1 PSD with no zero diagonal entries; QDLDL
+        # alone cannot factor it, so this exercises the eigh fallback.
+        A = sp.csc_array(np.array([[1.0, 1.0], [1.0, 1.0]]))
+        sign, L, p = lau.sparse_cholesky(A)
+        self.assertEqual(sign, 1.0)
+        self.assertEqual(L.shape, (2, 1))
+        self.check_gram(L[p, :], A)
+
+    def test_nsd_rank_deficient_full_diagonal(self):
+        A = sp.csc_array(-np.array([[1.0, 1.0], [1.0, 1.0]]))
+        sign, L, p = lau.sparse_cholesky(A)
+        self.assertEqual(sign, -1.0)
+        self.assertEqual(L.shape, (2, 1))
+        self.check_gram(L[p, :], -A)
+
     def test_nonsingular_indefinite(self):
         np.random.seed(0)
         n = 5

--- a/cvxpy/utilities/linalg.py
+++ b/cvxpy/utilities/linalg.py
@@ -301,7 +301,19 @@ def sparse_cholesky(A, sym_tol=settings.CHOL_SYM_TOL, assume_psd=False):
 
     except ValueError:
         raise
-    except Exception as e:
-        raise ValueError(
-            f"{SparseCholeskyMessages.FACTORIZATION_FAILED}: {e}"
-        ) from e
+    except Exception:
+        # QDLDL has no pivoting and fails when a zero pivot appears
+        # mid-elimination on rank-deficient PSD/NSD inputs (e.g. [[1,1],[1,1]]).
+        # Fall back to a dense symmetric eigendecomposition.
+        w, V = np.linalg.eigh(A.toarray())
+        scale = np.max(np.abs(w))
+        if scale == 0:
+            return 1.0, sp.csr_array((n, 0)), np.arange(n)
+        is_psd = np.all(w >= -tol * scale)
+        is_nsd = np.all(w <= tol * scale)
+        if not (is_psd or is_nsd):
+            raise ValueError(SparseCholeskyMessages.INDEFINITE)
+        sign = 1.0 if is_psd else -1.0
+        mask = np.abs(w) > tol * scale
+        L = V[:, mask] * np.sqrt(np.abs(w[mask]))
+        return sign, sp.csr_array(L), np.arange(n)


### PR DESCRIPTION
## Description
Please include a short summary of the change.
`sparse_cholesky` (added in #3070, partially patched in #3270) raises                    
`ValueError: Cholesky factorization failed` on simple rank-deficient PSD
inputs such as `[[1, 1], [1, 1]]`. The root cause is that QDLDL has no                   
pivoting and bails out as soon as a zero pivot appears mid-elimination —                 
which the existing rank-deficient handling in #3270 doesn't cover (it                    
only special-cases all-zero rows and zero pivots that land last in                       
QDLDL's elimination order).                                                              
                                                                                         
This adds a dense `numpy.linalg.eigh` fallback inside                                    
`sparse_cholesky`'s existing `except Exception` branch. When QDLDL fails,                
we eigendecompose `A`, classify it as PSD/NSD/indefinite using the same                  
tolerance logic as the QDLDL branch, and return an `n × rank(A)` sparse                  
factor built from the nonzero eigenpairs. The function's documented                      
contract (`L[p,:] @ L[p,:].T == sign * A`, `k = rank(A)`) now holds for                  
all PSD/NSD inputs. 

Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.