### PR TITLE
Fix sparse_cholesky fallback for rank-deficient PSD/NSD inputs

### DIFF
--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -17,7 +17,6 @@ limitations under the License.
 
 import numpy as np
 import scipy.sparse as sp
-from scipy import linalg as LA
 
 from cvxpy.atoms.affine.wraps import psd_wrap
 from cvxpy.atoms.atom import Atom
@@ -25,7 +24,7 @@ from cvxpy.expressions.constants.parameter import is_param_affine, is_param_free
 from cvxpy.expressions.expression import Expression
 from cvxpy.interface.matrix_utilities import is_sparse
 from cvxpy.utilities import scopes
-from cvxpy.utilities.linalg import sparse_cholesky
+from cvxpy.utilities.linalg import dense_ldl_decomp, sparse_cholesky
 from cvxpy.utilities.warn import warn
 
 
@@ -264,27 +263,7 @@ def decomp_quad(P, cond=None, rcond=None, lower=True, check_finite: bool = True)
                 return 1.0, np.empty((0, 0)), L[p, :]
         except ValueError:
             P = P.toarray()  # make dense (needs to happen for ldl).
-    lu, d, _perm = LA.ldl(P, lower=lower, check_finite=check_finite)
-
-    # Extract effective diagonal values from D, handling any 2x2 blocks.
-    # For PSD/NSD matrices D is diagonal (no 2x2 blocks). For indefinite
-    # matrices, Bunch-Kaufman pivoting may introduce 2x2 blocks which we
-    # resolve by batching all 2x2 blocks into a single eigh call.
-    sub_diag = np.diag(d, -1)
-    block_starts = np.nonzero(sub_diag)[0]
-    diag_vals = np.real(np.diag(d)).copy()
-    if len(block_starts) > 0:
-        bs = block_starts
-        idx = bs[:, None] + np.arange(2)[None, :]  # (k, 2)
-        blocks = d[idx[:, :, None], idx[:, None, :]]  # (k, 2, 2)
-        eigvals, eigvecs = np.linalg.eigh(blocks)  # (k, 2), (k, 2, 2)
-        diag_vals[bs] = eigvals[:, 0]
-        diag_vals[bs + 1] = eigvals[:, 1]
-        # Apply eigenvector rotations to lu columns
-        lu_i = lu[:, bs].copy()
-        lu_ip1 = lu[:, bs + 1].copy()
-        lu[:, bs] = lu_i * eigvecs[:, 0, 0] + lu_ip1 * eigvecs[:, 1, 0]
-        lu[:, bs + 1] = lu_i * eigvecs[:, 0, 1] + lu_ip1 * eigvecs[:, 1, 1]
+    diag_vals, lu = dense_ldl_decomp(P, lower=lower, check_finite=check_finite)
 
     if rcond is not None:
         cond = rcond

--- a/cvxpy/tests/test_linalg_utils.py
+++ b/cvxpy/tests/test_linalg_utils.py
@@ -145,3 +145,39 @@ class TestSparseCholesky(BaseTest):
         A = sp.diags_array([offdiag, diag, offdiag], offsets=[-1, 0, 1])
         with self.assertRaises(ValueError, msg=lau.SparseCholeskyMessages.INDEFINITE):
             lau.sparse_cholesky(A, 0.0)
+
+    def test_qdldl_throws_falls_back_to_dense_ldl(self):
+        # Random low-rank PSD inputs that QDLDL refuses to factor as
+        # "not quasi-definite" — the dense eigh fallback must succeed.
+        # Seeds 3 and 16 trigger the QDLDL failure for n=6, k=2.
+        for seed in (3, 16):
+            np.random.seed(seed)
+            B = np.random.randn(6, 2)
+            A = sp.csc_array(B @ B.T)
+            sign, L, p = lau.sparse_cholesky(A)
+            self.assertEqual(sign, 1.0)
+            self.assertEqual(L.shape[1], 2)
+            self.check_gram(L[p, :], A)
+
+    def test_qdldl_silent_drop_falls_back_to_dense_ldl(self):
+        # Seed 128 makes QDLDL return tiny pivots paired with huge L
+        # entries (|L| ~ 1e13).  The dropped column's contribution is
+        # non-negligible (~0.02), so the masked product disagrees with
+        # A; the residual check must catch this and fall back.
+        np.random.seed(128)
+        B = np.random.randn(6, 2)
+        A = sp.csc_array(B @ B.T)
+        sign, L, p = lau.sparse_cholesky(A)
+        self.assertEqual(sign, 1.0)
+        self.check_gram(L[p, :], A)
+
+    def test_singular_leading_minor_falls_back_to_dense_ldl(self):
+        # PSD with eigenvalues [0, 1, 2]; QDLDL fails on the singular
+        # leading 2x2 minor.  Dense eigh handles it.
+        A = sp.csc_array(np.array([[1.0, 1.0, 0.0],
+                                   [1.0, 1.0, 0.0],
+                                   [0.0, 0.0, 1.0]]))
+        sign, L, p = lau.sparse_cholesky(A)
+        self.assertEqual(sign, 1.0)
+        self.assertEqual(L.shape[1], 2)
+        self.check_gram(L[p, :], A)

--- a/cvxpy/utilities/linalg.py
+++ b/cvxpy/utilities/linalg.py
@@ -342,9 +342,10 @@ def sparse_cholesky(A, sym_tol=settings.CHOL_SYM_TOL, assume_psd=False):
     try:
         solver = qdldl.Solver(A_upper, upper=True)
         L_unit, D, p = solver.factors()
-    except Exception:
+    except RuntimeError:
         # QDLDL refused to factorize (typically "not quasi-definite" on
-        # rank-deficient PSD/NSD inputs).  Fall back to dense eigh.
+        # rank-deficient PSD/NSD inputs, or AMD / elimination-tree
+        # failures).  Fall back to dense pivoted LDL.
         return _dense_ldl_factor(A, tol)
 
     # QDLDL returns: A[p,:][:,p] = (I + L) @ diag(D) @ (I + L).T
@@ -378,7 +379,7 @@ def sparse_cholesky(A, sym_tol=settings.CHOL_SYM_TOL, assume_psd=False):
     # If we dropped any columns (rank-deficient case), QDLDL may have
     # paired tiny pivots with huge L entries whose D[j]*L[:,j]L[:,j].T
     # contribution is non-negligible; the masked product then differs
-    # from sign*A by O(1).  Validate, and fall back to dense eigh if so.
+    # from sign*A by O(1).  Validate, and fall back to dense LDL if so.
     if not mask.all():
         A_norm = la.norm(A.data) if A.nnz else 0.0
         residual_tol = np.sqrt(tol) * (A_norm + 1.0)

--- a/cvxpy/utilities/linalg.py
+++ b/cvxpy/utilities/linalg.py
@@ -191,6 +191,74 @@ class SparseCholeskyMessages:
     NOT_REAL = 'Input matrix must be real.'
 
 
+def dense_ldl_decomp(P, lower: bool = True, check_finite: bool = True):
+    """Bunch-Kaufman LDL of a dense symmetric matrix, with 2x2 blocks resolved.
+
+    Returns ``(diag_vals, lu)`` such that ``P = lu @ diag(diag_vals) @ lu.T``,
+    where ``lu`` is the row-permuted (unit) triangular factor returned by
+    ``scipy.linalg.ldl`` and any 2x2 blocks in ``D`` have been diagonalized
+    via ``eigh`` (with the corresponding pair of columns of ``lu`` rotated
+    to absorb the block's eigenvectors).  Used as a shared building block
+    by :func:`sparse_cholesky` (when its QDLDL path fails) and
+    :func:`cvxpy.atoms.quad_form.decomp_quad`.
+    """
+    lu, d, _perm = la.ldl(P, lower=lower, check_finite=check_finite)
+    sub_diag = np.diag(d, -1)
+    block_starts = np.nonzero(sub_diag)[0]
+    diag_vals = np.real(np.diag(d)).copy()
+    if block_starts.size:
+        bs = block_starts
+        idx = bs[:, None] + np.arange(2)[None, :]
+        blocks = d[idx[:, :, None], idx[:, None, :]]
+        eigvals, eigvecs = np.linalg.eigh(blocks)
+        diag_vals[bs] = eigvals[:, 0]
+        diag_vals[bs + 1] = eigvals[:, 1]
+        lu_i = lu[:, bs].copy()
+        lu_ip1 = lu[:, bs + 1].copy()
+        lu[:, bs] = lu_i * eigvecs[:, 0, 0] + lu_ip1 * eigvecs[:, 1, 0]
+        lu[:, bs + 1] = lu_i * eigvecs[:, 0, 1] + lu_ip1 * eigvecs[:, 1, 1]
+    return diag_vals, lu
+
+
+def _dense_ldl_factor(A, tol):
+    """Fallback factor via dense pivoted LDL (Bunch-Kaufman, ``scipy.linalg.ldl``).
+
+    Used when QDLDL cannot factor the matrix — either because it throws
+    "not quasi-definite" (singular leading minors), or because it returns
+    near-zero pivots paired with huge L entries whose dropped contribution
+    is non-negligible.  Returns ``(sign, L, p)`` matching the
+    ``sparse_cholesky`` contract.
+    """
+    A_dense = A.toarray() if sp.issparse(A) else np.asarray(A)
+    n = A_dense.shape[0]
+    diag_vals, lu = dense_ldl_decomp(A_dense, lower=True, check_finite=False)
+    scale = np.max(np.abs(diag_vals)) if diag_vals.size else 0.0
+    if scale == 0:
+        return 1.0, sp.csr_array((n, 0)), np.arange(n)
+    d_rel = diag_vals / scale
+    pos = d_rel > tol
+    neg = d_rel < -tol
+    if pos.any() and neg.any():
+        raise ValueError(SparseCholeskyMessages.INDEFINITE)
+    if pos.any():
+        sign = 1.0
+        L = lu[:, pos] * np.sqrt(diag_vals[pos])
+    else:
+        sign = -1.0
+        L = lu[:, neg] * np.sqrt(-diag_vals[neg])
+    return sign, sp.csr_array(L), np.arange(n)
+
+
+def _qdldl_residual_norm(A, sign, L, p):
+    """Frobenius norm of (sign * A - L[p, :] @ L[p, :].T), used to validate
+    QDLDL's factorization when zero-pivot columns were dropped."""
+    Lp = L[p, :]
+    resid = sign * A - (Lp @ Lp.T)
+    if sp.issparse(resid):
+        resid = resid.toarray()
+    return np.linalg.norm(resid)
+
+
 def sparse_cholesky(A, sym_tol=settings.CHOL_SYM_TOL, assume_psd=False):
     """
     The input matrix A must be real and symmetric. If A is positive (semi)definite
@@ -207,6 +275,12 @@ def sparse_cholesky(A, sym_tol=settings.CHOL_SYM_TOL, assume_psd=False):
     we certify indefiniteness before calling QDLDL. While checking for
     indefiniteness, we also check that
      ||A - A'||_Fro / sqrt(n) <= sym_tol, where n is the order of the matrix.
+
+    QDLDL is designed for quasi-definite matrices; on rank-deficient PSD/NSD
+    inputs it can either throw "not quasi-definite" or silently return tiny
+    pivots paired with huge L entries whose contribution to ``L D L.T`` is
+    non-negligible.  Both modes trigger a fallback to a dense pivoted LDL
+    (``scipy.linalg.ldl``) factorization.
     """
     import cvxpy.expressions.cvxtypes as cvxtypes
 
@@ -268,40 +342,47 @@ def sparse_cholesky(A, sym_tol=settings.CHOL_SYM_TOL, assume_psd=False):
     try:
         solver = qdldl.Solver(A_upper, upper=True)
         L_unit, D, p = solver.factors()
+    except Exception:
+        # QDLDL refused to factorize (typically "not quasi-definite" on
+        # rank-deficient PSD/NSD inputs).  Fall back to dense eigh.
+        return _dense_ldl_factor(A, tol)
 
-        # QDLDL returns: A[p,:][:,p] = (I + L) @ diag(D) @ (I + L).T
-        # Determine sign from D: all D >= 0 means PSD, all D <= 0 means NSD.
-        scale = np.max(np.abs(D))
-        if scale == 0:
-            # All pivots are zero — zero matrix.
-            return 1.0, sp.csr_array((n, 0)), np.arange(n)
+    # QDLDL returns: A[p,:][:,p] = (I + L) @ diag(D) @ (I + L).T
+    # Determine sign from D: all D >= 0 means PSD, all D <= 0 means NSD.
+    scale = np.max(np.abs(D))
+    if scale == 0:
+        # All pivots are zero — zero matrix.
+        return 1.0, sp.csr_array((n, 0)), np.arange(n)
 
-        is_psd = np.all(D >= -tol * scale)
-        is_nsd = np.all(D <= tol * scale)
-        if not (is_psd or is_nsd):
-            raise ValueError(SparseCholeskyMessages.INDEFINITE)
+    is_psd = np.all(D >= -tol * scale)
+    is_nsd = np.all(D <= tol * scale)
+    if not (is_psd or is_nsd):
+        raise ValueError(SparseCholeskyMessages.INDEFINITE)
 
-        sign = 1.0 if is_psd else -1.0
+    sign = 1.0 if is_psd else -1.0
 
-        # Build L_chol = (I + L_unit) @ diag(sqrt(|D|)), keeping only columns
-        # where |D| is significantly nonzero to get an n-by-rank(A) factor.
-        abs_D = np.abs(D)
-        mask = abs_D > tol * scale
-        sqrt_D_vals = np.sqrt(np.maximum(abs_D[mask], 0))
-        I_plus_L = sp.eye_array(n, format='csr') + sp.csr_array(L_unit)
-        L_chol = I_plus_L[:, mask] @ sp.diags_array(sqrt_D_vals, format='csr')
-        L_chol = sp.csr_array(L_chol)
+    # Build L_chol = (I + L_unit) @ diag(sqrt(|D|)), keeping only columns
+    # where |D| is significantly nonzero to get an n-by-rank(A) factor.
+    abs_D = np.abs(D)
+    mask = abs_D > tol * scale
+    sqrt_D_vals = np.sqrt(np.maximum(abs_D[mask], 0))
+    I_plus_L = sp.eye_array(n, format='csr') + sp.csr_array(L_unit)
+    L_chol = I_plus_L[:, mask] @ sp.diags_array(sqrt_D_vals, format='csr')
+    L_chol = sp.csr_array(L_chol)
 
-        # QDLDL's permutation p satisfies A[p,:][:,p] = L_full @ L_full.T.
-        # The caller expects L_out[p_out, :] @ L_out[p_out, :].T == sign * A,
-        # so we need p_out = argsort(p) (the inverse permutation).
-        p_inv = np.argsort(p)
+    # QDLDL's permutation p satisfies A[p,:][:,p] = L_full @ L_full.T.
+    # The caller expects L_out[p_out, :] @ L_out[p_out, :].T == sign * A,
+    # so we need p_out = argsort(p) (the inverse permutation).
+    p_inv = np.argsort(p)
 
-        return sign, L_chol, p_inv
+    # If we dropped any columns (rank-deficient case), QDLDL may have
+    # paired tiny pivots with huge L entries whose D[j]*L[:,j]L[:,j].T
+    # contribution is non-negligible; the masked product then differs
+    # from sign*A by O(1).  Validate, and fall back to dense eigh if so.
+    if not mask.all():
+        A_norm = la.norm(A.data) if A.nnz else 0.0
+        residual_tol = np.sqrt(tol) * (A_norm + 1.0)
+        if _qdldl_residual_norm(A, sign, L_chol, p_inv) > residual_tol:
+            return _dense_ldl_factor(A, tol)
 
-    except ValueError:
-        raise
-    except Exception as e:
-        raise ValueError(
-            f"{SparseCholeskyMessages.FACTORIZATION_FAILED}: {e}"
-        ) from e
+    return sign, L_chol, p_inv


### PR DESCRIPTION
## Description
QDLDL is designed for quasi-definite matrices and fails on rank-deficient PSD/NSD inputs in two ways:

1. **Throws "not quasi-definite"** outright — happens for ~18% of random low-rank PSD seeds (e.g. `n=6, k=2`, seeds 3, 16, 22, 24, …) and for benign cases like `[[1,1,0],[1,1,0],[0,0,1]]` (eigenvalues `[0, 1, 2]`). The previous code re-raised this as `Cholesky factorization failed` with no fallback.
2. **Silently returns a wrong factorization** — for some inputs (e.g. seed 128, `n=6, k=2`), QDLDL returns tiny pivots like `D[j]=-3.6e-30` paired with huge L entries (`|L|~7.5e13`) from internal division by those pivots. The previous "low-rank" path masked out columns where `|D[j]| < tol*scale` — but that drops a `D[j]·L[:,j]L[:,j]^T` contribution of magnitude `~0.02`, producing a wrong factorization without warning.

Both modes now fall back to a dense pivoted LDL via `scipy.linalg.ldl` (Bunch-Kaufman). The LDL+2x2-block-resolution logic was already implemented inline in `decomp_quad`; this PR extracts it into a shared `dense_ldl_decomp` helper in `cvxpy.utilities.linalg` that both call sites use.

After QDLDL succeeds, we additionally validate the residual `‖sign·A − L[p,:]L[p,:]^T‖_F` whenever any columns were dropped (rank-deficient case); full-rank PD inputs skip the residual check since the QDLDL identity is exact.

Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)