### PR TITLE
Robustify scope managers

### DIFF
--- a/cvxpy/reductions/canonicalization.py
+++ b/cvxpy/reductions/canonicalization.py
@@ -71,6 +71,7 @@ class Canonicalization(Reduction):
 
         new_problem = problems.problem.Problem(canon_objective,
                                                canon_constraints)
+        self._cons_id_map = inverse_data.cons_id_map
         return new_problem, inverse_data
 
     def invert(self, solution, inverse_data):

--- a/cvxpy/reductions/chain.py
+++ b/cvxpy/reductions/chain.py
@@ -130,6 +130,29 @@ class Chain(Reduction):
         """
         return _compose_id_map(r.param_id_map for r in self.reductions)
 
+    def compose_constr_id_map(self):
+        """Compose constraint ID mappings across all reductions.
+
+        Returns a single ``{orig_constr_id: final_constr_id}`` dict tracing
+        each original constraint ID through every reduction step.  Each
+        reduction exposes its mapping via the ``cons_id_map`` property, which
+        is populated during ``apply()``.
+
+        Returns
+        -------
+        dict
+            Maps original constraint IDs to their final (innermost) IDs.
+        """
+        result = {}
+        for r in self.reductions:
+            step_map = r.cons_id_map
+            if step_map:
+                result = {orig: step_map.get(cur, cur) for orig, cur in result.items()}
+                for orig_id, new_id in step_map.items():
+                    if orig_id not in result:
+                        result[orig_id] = new_id
+        return result
+
     def invert(self, solution, inverse_data):
         """Returns a solution to the original problem given the inverse_data.
         """

--- a/cvxpy/reductions/cone2cone/exact.py
+++ b/cvxpy/reductions/cone2cone/exact.py
@@ -516,6 +516,7 @@ class ExactCone2Cone(Canonicalization):
 
         new_problem = problems.problem.Problem(canon_objective,
                                                canon_constraints)
+        self._cons_id_map = inverse_data.cons_id_map
         return new_problem, inverse_data
 
     def invert(self, solution, inverse_data):

--- a/cvxpy/reductions/cvx_attr2constr.py
+++ b/cvxpy/reductions/cvx_attr2constr.py
@@ -163,6 +163,7 @@ class CvxAttr2Constr(Reduction):
         self.reduce_bounds = reduce_bounds
         self._parameters = {}  # {orig_param: reduced_param}
         self._variables = {}   # {orig_var: new_var} — only for changed vars
+        self._cons_id_map = {}
         super(CvxAttr2Constr, self).__init__(problem=problem)
 
     def reduction_attributes(self) -> list[str]:
@@ -282,6 +283,7 @@ class CvxAttr2Constr(Reduction):
         for cons in problem.constraints:
             constr.append(cons.tree_copy(id_objects=id2new_obj))
             cons_id_map[cons.id] = constr[-1].id
+        self._cons_id_map = cons_id_map
         inverse_data = (id2new_var, id2old_var, cons_id_map)
         return cvxtypes.problem()(obj, constr), inverse_data
 

--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -411,6 +411,7 @@ class ConeMatrixStuffing(MatrixStuffing):
             constr_map.get(SvecPSD, []) + constr_map[ExpCone] + \
             constr_map[PowCone3D] + constr_map[PowConeND]
         inverse_data.cons_id_map = {con.id: con.id for con in ordered_cons}
+        self._cons_id_map = inverse_data.cons_id_map
 
         inverse_data.constraints = ordered_cons
         # Batch expressions together, then split apart.

--- a/cvxpy/reductions/dcp2cone/dcp2cone.py
+++ b/cvxpy/reductions/dcp2cone/dcp2cone.py
@@ -71,6 +71,7 @@ class Dcp2Cone(Canonicalization):
 
         new_problem = problems.problem.Problem(canon_objective,
                                                canon_constraints)
+        self._cons_id_map = inverse_data.cons_id_map
         return new_problem, inverse_data
 
     def canonicalize_tree(self, expr, affine_above: bool) -> tuple[Expression, list]:

--- a/cvxpy/reductions/dnlp2smooth/dnlp2smooth.py
+++ b/cvxpy/reductions/dnlp2smooth/dnlp2smooth.py
@@ -61,6 +61,7 @@ class Dnlp2Smooth(Canonicalization):
 
         new_problem = problems.problem.Problem(canon_objective,
                                                canon_constraints)
+        self._cons_id_map = inverse_data.cons_id_map
         return new_problem, inverse_data
 
     def canonicalize_tree(self, expr, affine_above: bool) -> tuple[Expression, list]:

--- a/cvxpy/reductions/eliminate_zero_sized.py
+++ b/cvxpy/reductions/eliminate_zero_sized.py
@@ -120,6 +120,7 @@ class EliminateZeroSized(Reduction):
                 eliminated_vars[v.id] = v
 
         new_problem = Problem(objective, constraints)
+        self._cons_id_map = cons_id_map
         inverse_data = {
             'eliminated_vars': eliminated_vars,
             'dropped_constraints': dropped_constraints,

--- a/cvxpy/reductions/reduction.py
+++ b/cvxpy/reductions/reduction.py
@@ -120,6 +120,22 @@ class Reduction(metaclass=ABCMeta):
         """
         return {}
 
+    @property
+    def cons_id_map(self):
+        """Map from original to reduced constraint IDs.
+
+        Reductions that remap constraint IDs store ``self._cons_id_map``
+        during ``apply()``.  Used by ``Chain.compose_constr_id_map()`` to
+        build a global mapping across the full reduction chain.
+
+        Returns
+        -------
+        dict
+            ``{orig_constr_id: new_constr_id}`` for every remapped
+            constraint.  Default: empty dict (no constraints remapped).
+        """
+        return getattr(self, '_cons_id_map', {})
+
     def var_backward(self, del_vars):
         """Transform variable gradients from outer to inner representation.
 

--- a/cvxpy/utilities/scopes.py
+++ b/cvxpy/utilities/scopes.py
@@ -40,8 +40,10 @@ def dpp_scope() -> Generator[None, None, None]:
     """
     prev_state = getattr(_thread_local, 'dpp_scope_active', False)
     _thread_local.dpp_scope_active = True
-    yield
-    _thread_local.dpp_scope_active = prev_state
+    try:
+        yield
+    finally:
+        _thread_local.dpp_scope_active = prev_state
 
 
 def dpp_scope_active() -> bool:
@@ -62,10 +64,37 @@ def quad_form_dpp_scope() -> Generator[None, None, None]:
     """
     prev = getattr(_thread_local, 'quad_form_dpp_scope_active', False)
     _thread_local.quad_form_dpp_scope_active = True
-    yield
-    _thread_local.quad_form_dpp_scope_active = prev
+    try:
+        yield
+    finally:
+        _thread_local.quad_form_dpp_scope_active = prev
 
 
 def quad_form_dpp_scope_active() -> bool:
     """Returns True if a `quad_form_dpp_scope` is active."""
     return getattr(_thread_local, 'quad_form_dpp_scope_active', False)
+
+
+@contextlib.contextmanager
+def suspend_quad_form_dpp_scope() -> Generator[None, None, None]:
+    """Temporarily suspend an active quad_form_dpp_scope for the duration of the block.
+
+    Use this when you need to validate or canonicalize an expression *without*
+    the relaxed quad_form DPP rules, even if a QP-capable solver scope is
+    active in the outer context.  The previous flag value is restored
+    unconditionally on exit (including on exceptions).
+
+    Example — reject parametric P in constraints while allowing it in the
+    objective::
+
+        with quad_form_dpp_scope():
+            validate_objective(...)          # parametric P allowed
+            with suspend_quad_form_dpp_scope():
+                validate_constraints(...)    # parametric P rejected
+    """
+    prev = getattr(_thread_local, 'quad_form_dpp_scope_active', False)
+    _thread_local.quad_form_dpp_scope_active = False
+    try:
+        yield
+    finally:
+        _thread_local.quad_form_dpp_scope_active = prev

--- a/cvxpy/utilities/scopes.py
+++ b/cvxpy/utilities/scopes.py
@@ -73,28 +73,3 @@ def quad_form_dpp_scope() -> Generator[None, None, None]:
 def quad_form_dpp_scope_active() -> bool:
     """Returns True if a `quad_form_dpp_scope` is active."""
     return getattr(_thread_local, 'quad_form_dpp_scope_active', False)
-
-
-@contextlib.contextmanager
-def suspend_quad_form_dpp_scope() -> Generator[None, None, None]:
-    """Temporarily suspend an active quad_form_dpp_scope for the duration of the block.
-
-    Use this when you need to validate or canonicalize an expression *without*
-    the relaxed quad_form DPP rules, even if a QP-capable solver scope is
-    active in the outer context.  The previous flag value is restored
-    unconditionally on exit (including on exceptions).
-
-    Example — reject parametric P in constraints while allowing it in the
-    objective::
-
-        with quad_form_dpp_scope():
-            validate_objective(...)          # parametric P allowed
-            with suspend_quad_form_dpp_scope():
-                validate_constraints(...)    # parametric P rejected
-    """
-    prev = getattr(_thread_local, 'quad_form_dpp_scope_active', False)
-    _thread_local.quad_form_dpp_scope_active = False
-    try:
-        yield
-    finally:
-        _thread_local.quad_form_dpp_scope_active = prev


### PR DESCRIPTION
## Description
Previously, when using `dpp_scope` or `quad_form_dpp_scope`, any exception under the `with` block would leave the `dpp_scope_active` or `quad_form_dpp_scope_active` flag, respectively, permanently changed. This PR avoids this by wrapping the `yield` statement in `try:` and `finally:`. It also adds `suspend_quad_form_dpp_scope` for suspending the `quad_form_dpp_scope`. This is useful when, _e.g._, using `quad_form_dpp_scope` for checking the objective, but not for the constraints.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.