### PR TITLE
Make solver_path fall back on non-optimal statuses

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -547,7 +547,10 @@ class Problem(u.Canonical):
                             self, *args, solver=solver_name, **solver_kwargs, **kwargs)
                 else:
                     raise ValueError(ENTRY_ERROR_MSG)
-                s.LOGGER.info("Solver %s succeeds", solver_name)
+                if self.status == s.OPTIMAL:
+                    s.LOGGER.info("Solver %s succeeds", solver_name)
+                else:
+                    continue
                 return solution
             except error.SolverError as e:
                 s.LOGGER.info("Solver %s failed: %s", solver_name, e)

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -550,6 +550,10 @@ class Problem(u.Canonical):
                 if self.status == s.OPTIMAL:
                     s.LOGGER.info("Solver %s succeeds", solver_name)
                 else:
+                    s.LOGGER.info("Solver %s returned non-optimal status %s",
+                                  solver_name,
+                                  self.status
+                                  )
                     continue
                 return solution
             except error.SolverError as e:
@@ -1051,7 +1055,7 @@ class Problem(u.Canonical):
                     if bibtex:
                         print(_CITATION_STR)
                         print(CITATION_DICT["CVXPY"])
-                        print(CITATION_DICT["DQCP"])                             
+                        print(CITATION_DICT["DQCP"])
                 reductions = [dqcp2dcp.Dqcp2Dcp()]
                 start = time.time()
                 if type(self.objective) == Maximize:
@@ -1089,9 +1093,9 @@ class Problem(u.Canonical):
 
             # Cite problem grammar.
             if self.is_dcp():
-                print(CITATION_DICT["DCP"]) 
+                print(CITATION_DICT["DCP"])
             if gp:
-                print(CITATION_DICT["DGP"]) 
+                print(CITATION_DICT["DGP"])
 
             # Cite solver.
             print(solving_chain.reductions[-1].cite(data))
@@ -1429,10 +1433,10 @@ class Problem(u.Canonical):
             for constr in self.constraints[1:]:
                 lines += [len(subject_to) * " " + str(constr)]
             return '\n'.join(lines)
-    
+
     def format_labeled(self):
         """Format problem with labels where available.
-        
+
         Shows labels for both the objective expression and constraints.
         """
         if len(self.constraints) == 0:

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1544,6 +1544,7 @@ class TestProblem(BaseTest):
         problem = Problem(cp.Minimize(
             cp.sum_squares(cp.matmul(A, cp.Variable(40)) - b)))
         problem.solve(solver_path=[(s.OSQP, {'max_iter': 1}), s.CLARABEL])
+        self.assertEqual(problem.solver_stats.solver_name, s.CLARABEL)
         self.assertEqual(problem.status, s.OPTIMAL)
         # valid input, raise SolverError
         solvers = [(s.OSQP, {'max_iter':1})]

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1540,15 +1540,17 @@ class TestProblem(BaseTest):
             self.assertIsNotNone(Problem(cp.Minimize(
                 cp.sum_squares(cp.matmul(A, cp.Variable(40)) - b))).solve(
                 solver_path=solvers))
-
+        # valid input, non-optimal first solver falls back to next solver
+        problem = Problem(cp.Minimize(
+            cp.sum_squares(cp.matmul(A, cp.Variable(40)) - b)))
+        problem.solve(solver_path=[(s.OSQP, {'max_iter': 1}), s.CLARABEL])
+        self.assertEqual(problem.status, s.OPTIMAL)
         # valid input, raise SolverError
         solvers = [(s.OSQP, {'max_iter':1})]
-
         with self.assertRaises(SolverError):
             Problem(cp.Minimize(cp.quad_form(cp.Variable(1) + 1, np.array([[-1]]), True))).solve(
                 solver_path=solvers
             )
-
         # invalid input, raise ValueError
         solvers_invalid_inner_input = [{'str':{}}, 'str', [], [1], [()], [(1)], [(1,{})],
                                         [(s.OSQP,[])], [(s.OSQP,)]]


### PR DESCRIPTION
## Description
This PR updates `solver_path` fallback behavior so that a solver is only accepted when the resulting problem status is `OPTIMAL`. If a solver returns a non-optimal status, such as `user_limit`, the next solver in the path is tried, similar to the existing fallback behavior for `SolverError`.

Closes #3307.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.