### PR TITLE
Improve solver_path tests

### DIFF
--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -21,7 +21,7 @@ import warnings
 from contextlib import redirect_stdout
 from fractions import Fraction
 from io import StringIO
-from unittest.mock import call, patch
+from unittest.mock import DEFAULT, call, patch
 
 import numpy
 import numpy as np
@@ -1559,6 +1559,20 @@ class TestProblem(BaseTest):
                     expected_calls.append(call(problem, solver=solver, **solver_kwargs))
 
                 self.assertEqual(mock_solve_func.mock_calls, expected_calls)
+
+        # If the first solver results in a SolverError, we should fall back to the next solver.
+        with patch.object(
+                Problem,
+                "_solve",
+                wraps=Problem._solve,
+                side_effect=[SolverError("Mock solver error"), DEFAULT],
+        ) as mock_solve_func:
+            problem = Problem(cp.Minimize(0), [cp.Variable(1) == 1])
+            problem.solve(solver_path=[cp.OSQP, cp.CLARABEL])
+            expected_calls = [call(problem, solver=cp.OSQP), call(problem, solver=cp.CLARABEL)]
+            self.assertEqual(mock_solve_func.mock_calls, expected_calls)
+            self.assertEqual(problem.solver_stats.solver_name, s.CLARABEL)
+            self.assertEqual(problem.status, s.OPTIMAL)
 
         # valid input, raise SolverError
         solvers = [(s.OSQP, {'max_iter':1})]

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1560,12 +1560,6 @@ class TestProblem(BaseTest):
 
                 self.assertEqual(mock_solve_func.mock_calls, expected_calls)
 
-        # valid input, non-optimal first solver falls back to next solver
-        problem = Problem(cp.Minimize(
-            cp.sum_squares(cp.matmul(A, cp.Variable(40)) - b)))
-        problem.solve(solver_path=[(s.OSQP, {'max_iter': 1}), s.CLARABEL])
-        self.assertEqual(problem.solver_stats.solver_name, s.CLARABEL)
-        self.assertEqual(problem.status, s.OPTIMAL)
         # valid input, raise SolverError
         solvers = [(s.OSQP, {'max_iter':1})]
         with self.assertRaises(SolverError):

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1543,6 +1543,7 @@ class TestProblem(BaseTest):
             with patch.object(Problem, "_solve", wraps=Problem._solve) as mock_solve_func:
                 problem = Problem(cp.Minimize(cp.sum_squares(cp.matmul(A, cp.Variable(40)) - b)))
                 self.assertIsNotNone(problem.solve(solver_path=solvers))
+                self.assertEqual(problem.status, s.OPTIMAL)
 
                 expected_calls = []
                 for solver_spec in solvers:

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1539,9 +1539,9 @@ class TestProblem(BaseTest):
         solvers_wrong_case=[("osqp", {'max_iter':1}), "Clarabel"]
 
         for solvers in [solvers_with_str, solvers_empty_dict, solvers_wrong_case]:
-            self.assertIsNotNone(Problem(cp.Minimize(
-                cp.sum_squares(cp.matmul(A, cp.Variable(40)) - b))).solve(
-                solver_path=solvers))
+            problem = Problem(cp.Minimize(cp.sum_squares(cp.matmul(A, cp.Variable(40)) - b)))
+            self.assertIsNotNone(problem.solve(solver_path=solvers))
+
         # valid input, non-optimal first solver falls back to next solver
         problem = Problem(cp.Minimize(
             cp.sum_squares(cp.matmul(A, cp.Variable(40)) - b)))

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1534,7 +1534,7 @@ class TestProblem(BaseTest):
         A = numpy.random.randn(40, 40)
         b = cp.matmul(A, numpy.random.randn(40))
 
-        # valid input, return solution
+        # If the first solver yields a non-optimal status, we should fall back to the next solver.
         solvers_with_str=[(s.OSQP, {'max_iter':1}), s.CLARABEL]
         solvers_empty_dict=[(s.OSQP, {'max_iter':1}), (s.CLARABEL, {})]
         solvers_wrong_case=[("osqp", {'max_iter':1}), "Clarabel"]

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -21,6 +21,7 @@ import warnings
 from contextlib import redirect_stdout
 from fractions import Fraction
 from io import StringIO
+from unittest.mock import call, patch
 
 import numpy
 import numpy as np
@@ -1539,8 +1540,24 @@ class TestProblem(BaseTest):
         solvers_wrong_case=[("osqp", {'max_iter':1}), "Clarabel"]
 
         for solvers in [solvers_with_str, solvers_empty_dict, solvers_wrong_case]:
-            problem = Problem(cp.Minimize(cp.sum_squares(cp.matmul(A, cp.Variable(40)) - b)))
-            self.assertIsNotNone(problem.solve(solver_path=solvers))
+            with patch.object(Problem, "_solve", wraps=Problem._solve) as mock_solve_func:
+                problem = Problem(cp.Minimize(cp.sum_squares(cp.matmul(A, cp.Variable(40)) - b)))
+                self.assertIsNotNone(problem.solve(solver_path=solvers))
+
+                expected_calls = []
+                for solver_spec in solvers:
+                    if isinstance(solver_spec, str):
+                        solver = solver_spec
+                        solver_kwargs = {}
+                    elif isinstance(solver_spec, tuple):
+                        solver, solver_kwargs = solver_spec
+                    else:
+                        msg = f"Unexpected solver specification {solver_spec}."
+                        raise ValueError(msg)
+
+                    expected_calls.append(call(problem, solver=solver, **solver_kwargs))
+
+                self.assertEqual(mock_solve_func.mock_calls, expected_calls)
 
         # valid input, non-optimal first solver falls back to next solver
         problem = Problem(cp.Minimize(


### PR DESCRIPTION
## Description
This improves the tests for the `solver_path` option by:
1. Explicitly verifying the sequence of calls to `Problem._solve`.
2. Adding a test to verify that we proceed to the next solver upon encountering a `SolverError`.  The existing tests did not actually cover this case.
3. Removing a redundant test.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.