### PR TITLE
Begin development of CVXPY 1.10

### DIFF
--- a/PROCEDURES.md
+++ b/PROCEDURES.md
@@ -124,7 +124,7 @@ For minor releases, the script automatically excludes PRs that were cherry-picke
 
 The web documentation is built and deployed using a GitHub action that can be found [here](https://github.com/cvxpy/cvxpy/blob/master/.github/workflows/docs.yml).
 
-To deploy the docs for a specific version, navigate to the [actions tab](https://github.com/cvxpy/cvxpy/actions) and select the `docs` workflow.
+To deploy the docs for a specific version, navigate to the [actions tab](https://github.com/cvxpy/cvxpy/actions) and select the `doc_deploy` workflow.
 Under `Use workflow from`, select the **Tags** tab and choose the version you want to deploy the docs for.
 This builds the docs and commits them to the `gh-pages` branch. This in turn triggers the deployment through the `github-pages bot`, which can also be monitored in the [actions tab](https://github.com/cvxpy/cvxpy/actions).
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -223,6 +223,11 @@ html_theme_options = {
             "aliases": [],
         },
         {
+            "version": "https://www.cvxpy.org/version/1.10",
+            "title": "1.10",
+            "aliases": [],
+        },
+        {
             "version": "https://www.cvxpy.org/version/1.9",
             "title": "1.9",
             "aliases": [],

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to CVXPY 1.9
-====================
+Welcome to CVXPY 1.10
+=====================
 
 .. meta::
    :description: An open source Python-embedded modeling language for convex optimization problems.

--- a/setup/versioning.py
+++ b/setup/versioning.py
@@ -32,7 +32,7 @@ import subprocess
 #
 
 MAJOR = 1
-MINOR = 9
+MINOR = 10
 MICRO = 0
 IS_RELEASED = False
 IS_RELEASE_BRANCH = False


### PR DESCRIPTION
## Description
Post-1.9.0 release bookkeeping on master, per `PROCEDURES.md` steps 4–6:
- Bump `MINOR` from 9 to 10 in `setup/versioning.py` (master is now a pre-release of 1.10.0).
- Update `doc/source/index.rst` to "Welcome to CVXPY 1.10".
- Extend `version_info` in `doc/source/conf.py`.

## Type of change
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.