### PR TITLE
Fix is_mosek_available: use trivial solve instead of getlicense()

### DIFF
--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -914,11 +914,9 @@ def is_mosek_available():
     if 'MOSEK' not in INSTALLED_SOLVERS:
         return False
     try:
-        import mosek  # type: ignore
-        env = mosek.Env()
-        # Try to get license status (returns 0 if OK)
-        status = env.getlicense()
-        return status == mosek.rescode.ok
+        x = cp.Variable()
+        cp.Problem(cp.Minimize(x), [x >= 0]).solve(solver=cp.MOSEK)
+        return True
     except Exception:
         return False
 


### PR DESCRIPTION
## Description

`Env.getlicense()` changed semantics in MOSEK 11: it returns a license token, not a `rescode`. The current check in `is_mosek_available()` always considers the license unavailable on MOSEK 11, causing every `TestMosek` test to skip on systems with MOSEK 11 installed (visible in CI on the macOS `test_optional_solvers` job).

Replace the `getlicense()` call with a trivial CVXPY solve (`min x s.t. x >= 0` via MOSEK). If MOSEK can solve a 1-variable LP, the license is valid.

Cherry-picked from `ptn/dualize-pipeline` (`9b74ca212`).

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)