### PR TITLE
Update xpress.getversion() to getVersion() for Xpress 9.9

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
@@ -64,7 +64,10 @@ class XPRESS(ConicSolver):
         """Imports the solver.
         """
         import xpress
-        self.version = xpress.getversion()
+        try:
+            self.version = xpress.getVersion()
+        except AttributeError:
+            self.version = xpress.getversion()
 
     def accepts(self, problem) -> bool:
         """Can Xpress solve the problem?


### PR DESCRIPTION
## Description
`xpress.getversion()` was deprecated in Xpress 9.9 in favour of `xpress.getVersion()`.
Updates `import_solver` to use the new API with a fallback for users on Xpress 9.8 and earlier.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## Contribution checklist
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.
