### PR TITLE
add new status of COPT

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -47,7 +47,8 @@ class COPT(ConicSolver):
                   7: s.OPTIMAL_INACCURATE,  # imprecise
                   8: s.USER_LIMIT,          # time out
                   9: s.SOLVER_ERROR,        # unfinished
-                  10: s.USER_LIMIT          # interrupted
+                 10: s.USER_LIMIT,          # interrupted
+                 11: s.USER_LIMIT           # iteration limit
                  }
 
     def name(self):

--- a/cvxpy/reductions/solvers/nlp_solvers/copt_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/copt_nlpif.py
@@ -37,7 +37,10 @@ class COPT(NLPsolver):
                   7: s.OPTIMAL_INACCURATE,  # imprecise
                   8: s.USER_LIMIT,          # time out
                   9: s.SOLVER_ERROR,        # unfinished
-                  10: s.USER_LIMIT          # interrupted
+                  10: s.USER_LIMIT,         # interrupted
+                  11: s.USER_LIMIT,         # iteration limit
+                  20: s.OPTIMAL,            # local optimal
+                  21: s.INFEASIBLE          # local infeasible
                  }
 
     def name(self):

--- a/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
@@ -33,7 +33,8 @@ class COPT(QpSolver):
                   7: s.OPTIMAL_INACCURATE,  # imprecise
                   8: s.USER_LIMIT,          # time out
                   9: s.SOLVER_ERROR,        # unfinished
-                  10: s.USER_LIMIT          # interrupted
+                 10: s.USER_LIMIT,          # interrupted
+                 11: s.USER_LIMIT           # iteration limit
                  }
 
     def name(self):


### PR DESCRIPTION
## Description
Add the mapping of the new status in COPT
11 -> iteration limit
20 -> local optimal
21 -> local infeasible

PS: We found the test **test_copt_sdp_bound_attr** will fail with the error message 'invalid objective coefficient '-inf' for column 5', and we are trying to figure out how to fix this issue.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.