### PR TITLE
Fix COPT PSD bounds with unbounded variables and NLP interface 

### DIFF
--- a/.github/workflows/test_nlp_solvers.yml
+++ b/.github/workflows/test_nlp_solvers.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install COPT solver
         run: uv pip install -e ".[COPT]"
       - name: Install Uno solver
-        run: uv pip install unopy
+        run: uv pip install -e ".[UNO]"
       - name: Verify Uno import
         run: uv run python -c "import unopy; print('unopy imported successfully')"
       - name: Install KNITRO solver

--- a/.github/workflows/test_nlp_solvers.yml
+++ b/.github/workflows/test_nlp_solvers.yml
@@ -29,8 +29,10 @@ jobs:
       - name: Install dependencies
         run: |
           uv venv
-          uv pip install -e ".[testing,COPT]"
+          uv pip install -e ".[testing]"
           uv pip install cyipopt
+      - name: Install COPT solver
+        run: uv pip install -e ".[COPT]"
       - name: Install Uno solver
         run: uv pip install unopy
       - name: Verify Uno import

--- a/.github/workflows/test_nlp_solvers.yml
+++ b/.github/workflows/test_nlp_solvers.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv venv
-          uv pip install -e ".[testing]"
+          uv pip install -e ".[testing,COPT]"
           uv pip install cyipopt
       - name: Install Uno solver
         run: uv pip install unopy

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -43,18 +43,11 @@ jobs:
       - name: Install SuiteSparse (macOS)
         if: runner.os == 'macOS'
         run: brew install suite-sparse
-      # unopy (Uno solver) ships no macOS wheel, so uv builds it from an sdist
-      # whose CMake build calls enable_language(Fortran). Homebrew gcc installs
-      # gfortran only as a versioned binary (gfortran-NN), with no unversioned
-      # symlink, so point CMake at it explicitly via FC.
-      - name: Install Fortran compiler (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install gcc
-          fc=$(ls "$(brew --prefix)"/bin/gfortran-* | sort -V | tail -1)
-          echo "FC=$fc" >> "$GITHUB_ENV"
+      # Uno (unopy) is exercised by test_nlp_solvers, which installs it on its
+      # own with the IPOPT/OpenMP toolchain it needs. The conic and QP tests
+      # run here don't use it, so skip the extra to avoid a from-source build.
       - name: Install cvxpy dependencies and all optional solvers
-        run: uv sync --all-extras --dev
+        run: uv sync --all-extras --no-extra uno --dev
       - name: Install Moreau
         if: runner.os == 'Linux' && env.FURY_TOKEN != ''
         run: uv pip install moreau --extra-index-url https://${FURY_TOKEN}:@pypi.fury.io/optimalintellect/

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -44,10 +44,15 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install suite-sparse
       # unopy (Uno solver) ships no macOS wheel, so uv builds it from an sdist
-      # whose CMake build calls enable_language(Fortran).
+      # whose CMake build calls enable_language(Fortran). Homebrew gcc installs
+      # gfortran only as a versioned binary (gfortran-NN), with no unversioned
+      # symlink, so point CMake at it explicitly via FC.
       - name: Install Fortran compiler (macOS)
         if: runner.os == 'macOS'
-        run: brew install gcc
+        run: |
+          brew install gcc
+          fc=$(ls "$(brew --prefix)"/bin/gfortran-* | sort -V | tail -1)
+          echo "FC=$fc" >> "$GITHUB_ENV"
       - name: Install cvxpy dependencies and all optional solvers
         run: uv sync --all-extras --dev
       - name: Install Moreau

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -45,6 +45,8 @@ jobs:
         run: brew install suite-sparse
       - name: Install cvxpy dependencies and all optional solvers
         run: uv sync --all-extras --dev
+      - name: Install COPT
+        run: uv pip install coptpy
       - name: Install Moreau
         if: runner.os == 'Linux' && env.FURY_TOKEN != ''
         run: uv pip install moreau --extra-index-url https://${FURY_TOKEN}:@pypi.fury.io/optimalintellect/

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -45,8 +45,6 @@ jobs:
         run: brew install suite-sparse
       - name: Install cvxpy dependencies and all optional solvers
         run: uv sync --all-extras --dev
-      - name: Install COPT
-        run: uv pip install coptpy
       - name: Install Moreau
         if: runner.os == 'Linux' && env.FURY_TOKEN != ''
         run: uv pip install moreau --extra-index-url https://${FURY_TOKEN}:@pypi.fury.io/optimalintellect/

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Install SuiteSparse (macOS)
         if: runner.os == 'macOS'
         run: brew install suite-sparse
+      # unopy (Uno solver) ships no macOS wheel, so uv builds it from an sdist
+      # whose CMake build calls enable_language(Fortran).
+      - name: Install Fortran compiler (macOS)
+        if: runner.os == 'macOS'
+        run: brew install gcc
       - name: Install cvxpy dependencies and all optional solvers
         run: uv sync --all-extras --dev
       - name: Install Moreau

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -989,7 +989,7 @@ class Leaf(expression.Expression):
                 else:
                     lb_arr = np.maximum(lb_arr, 0)
             else:
-                lb_val = max(lb_val, 0)
+                lb_val = max(lb_val, 0.0)
         if self.attributes['nonpos'] or self.attributes['neg']:
             if ub_arr is not None:
                 if sp.issparse(ub_arr):
@@ -997,7 +997,7 @@ class Leaf(expression.Expression):
                 else:
                     ub_arr = np.minimum(ub_arr, 0)
             else:
-                ub_val = min(ub_val, 0)
+                ub_val = min(ub_val, 0.0)
 
         # For boolean variables, bounds are [0, 1]
         if self.attributes['boolean'] is True:
@@ -1007,14 +1007,14 @@ class Leaf(expression.Expression):
                 else:
                     lb_arr = np.maximum(lb_arr, 0)
             else:
-                lb_val = max(lb_val, 0)
+                lb_val = max(lb_val, 0.0)
             if ub_arr is not None:
                 if sp.issparse(ub_arr):
                     ub_arr = ub_arr.minimum(1)
                 else:
                     ub_arr = np.minimum(ub_arr, 1)
             else:
-                ub_val = min(ub_val, 1)
+                ub_val = min(ub_val, 1.0)
 
         # Build final bounds: use broadcast views for uniform scalars
         if lb_arr is not None:

--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -87,8 +87,10 @@ class COPT(ConicSolver):
                   7: s.OPTIMAL_INACCURATE,  # imprecise
                   8: s.USER_LIMIT,          # time out
                   9: s.SOLVER_ERROR,        # unfinished
-                 10: s.USER_LIMIT,          # interrupted
-                 11: s.USER_LIMIT           # iteration limit
+                  10: s.USER_LIMIT,         # interrupted
+                  11: s.USER_LIMIT,         # iteration limit
+                  20: s.OPTIMAL,            # local optimal
+                  21: s.INFEASIBLE          # local infeasible
                  }
 
     def name(self):

--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -16,6 +16,40 @@ from cvxpy.utilities.citations import CITATION_DICT
 from cvxpy.utilities.psd_utils import TriangleKind
 
 
+def _add_psd_bound_rows(A, b, dims, lb, ub):
+    """Add finite variable bounds as explicit inequality rows."""
+    n = A.shape[1]
+    extra_rows = []
+    extra_b = []
+
+    if ub is not None:
+        finite_ub = np.isfinite(ub)
+        n_ub = np.count_nonzero(finite_ub)
+        if n_ub:
+            extra_rows.append(_bound_selector(n_ub, n, np.flatnonzero(finite_ub), 1.0))
+            extra_b.append(ub[finite_ub])
+            dims[s.LEQ_DIM] += n_ub
+
+    if lb is not None:
+        finite_lb = np.isfinite(lb)
+        n_lb = np.count_nonzero(finite_lb)
+        if n_lb:
+            extra_rows.append(_bound_selector(n_lb, n, np.flatnonzero(finite_lb), -1.0))
+            extra_b.append(-lb[finite_lb])
+            dims[s.LEQ_DIM] += n_lb
+
+    if extra_rows:
+        A = sp.vstack([A] + extra_rows, format='csc')
+        b = np.concatenate([b] + extra_b)
+
+    return A, b
+
+
+def _bound_selector(num_rows, num_cols, cols, value):
+    return sp.csc_array((np.full(num_rows, value), (np.arange(num_rows), cols)),
+                        shape=(num_rows, num_cols))
+
+
 class COPT(ConicSolver):
     """
     An interface for the COPT solver.
@@ -182,21 +216,7 @@ class COPT(ConicSolver):
             psd_lb = data[s.LOWER_BOUNDS]
             psd_ub = data[s.UPPER_BOUNDS]
             if psd_lb is not None or psd_ub is not None:
-                n = c.shape[0]
-                extra_rows = []
-                extra_b = []
-                if psd_ub is not None:
-                    # x_i <= ub_i  =>  x_i <= ub_i  (LEQ constraint: I @ x <= ub)
-                    extra_rows.append(sp.eye_array(n, format='csc'))
-                    extra_b.append(psd_ub)
-                    dims[s.LEQ_DIM] += n
-                if psd_lb is not None:
-                    # x_i >= lb_i  =>  -x_i <= -lb_i  (LEQ constraint: -I @ x <= -lb)
-                    extra_rows.append(-sp.eye_array(n, format='csc'))
-                    extra_b.append(-psd_lb)
-                    dims[s.LEQ_DIM] += n
-                A = sp.vstack([A] + extra_rows, format='csc')
-                b = np.concatenate([b] + extra_b)
+                A, b = _add_psd_bound_rows(A, b, dims, psd_lb, psd_ub)
 
             # Solve the dualized problem
             # TODO switch to `A.transpose().tocsc()` when COPT supports sparray

--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -43,7 +43,7 @@ def _add_psd_bound_rows(A, b, dims, lb, ub):
 
     if extra_rows:
         insert_at = dims[s.EQ_DIM] + dims[s.LEQ_DIM]
-        bound_block = sp.vstack(extra_rows, format='csc')
+        bound_block = sp.vstack(extra_rows, format='csr')
         A = sp.vstack([A[:insert_at], bound_block, A[insert_at:]], format='csc')
         b = np.concatenate([b[:insert_at], *extra_b, b[insert_at:]])
         dims[s.LEQ_DIM] += bound_block.shape[0]
@@ -52,7 +52,7 @@ def _add_psd_bound_rows(A, b, dims, lb, ub):
 
 
 def _bound_selector(num_rows, num_cols, cols, value):
-    return sp.csc_array((np.full(num_rows, value), (np.arange(num_rows), cols)),
+    return sp.csr_array((np.full(num_rows, value), (np.arange(num_rows), cols)),
                         shape=(num_rows, num_cols))
 
 

--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -17,30 +17,36 @@ from cvxpy.utilities.psd_utils import TriangleKind
 
 
 def _add_psd_bound_rows(A, b, dims, lb, ub):
-    """Add finite variable bounds as explicit inequality rows."""
+    """Add finite variable bounds as explicit inequality rows.
+
+    The rows are inserted right after the existing NonNeg (LEQ) block so the
+    cone partition passed to ``loadConeMatrix`` stays contiguous: COPT expects
+    rows ordered as free, linear, SOC, exponential, PSD.
+    """
     n = A.shape[1]
     extra_rows = []
     extra_b = []
 
     if ub is not None:
         finite_ub = np.isfinite(ub)
-        n_ub = np.count_nonzero(finite_ub)
+        n_ub = int(np.count_nonzero(finite_ub))
         if n_ub:
             extra_rows.append(_bound_selector(n_ub, n, np.flatnonzero(finite_ub), 1.0))
             extra_b.append(ub[finite_ub])
-            dims[s.LEQ_DIM] += n_ub
 
     if lb is not None:
         finite_lb = np.isfinite(lb)
-        n_lb = np.count_nonzero(finite_lb)
+        n_lb = int(np.count_nonzero(finite_lb))
         if n_lb:
             extra_rows.append(_bound_selector(n_lb, n, np.flatnonzero(finite_lb), -1.0))
             extra_b.append(-lb[finite_lb])
-            dims[s.LEQ_DIM] += n_lb
 
     if extra_rows:
-        A = sp.vstack([A] + extra_rows, format='csc')
-        b = np.concatenate([b] + extra_b)
+        insert_at = dims[s.EQ_DIM] + dims[s.LEQ_DIM]
+        bound_block = sp.vstack(extra_rows, format='csc')
+        A = sp.vstack([A[:insert_at], bound_block, A[insert_at:]], format='csc')
+        b = np.concatenate([b[:insert_at], *extra_b, b[insert_at:]])
+        dims[s.LEQ_DIM] += bound_block.shape[0]
 
     return A, b
 

--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -225,8 +225,7 @@ class COPT(ConicSolver):
                 A, b = _add_psd_bound_rows(A, b, dims, psd_lb, psd_ub)
 
             # Solve the dualized problem
-            # TODO switch to `A.transpose().tocsc()` when COPT supports sparray
-            rowmap = model.loadConeMatrix(-b, sp.csc_matrix(A.transpose()), -c, dims)
+            rowmap = model.loadConeMatrix(-b, A.transpose().tocsc(), -c, dims)
             model.objsense = copt.COPT.MAXIMIZE
         else:
             # Build problem data
@@ -311,8 +310,7 @@ class COPT(ConicSolver):
                     vtype = np.append(vtype, [copt.COPT.CONTINUOUS] * nexpconedim)
 
             # Load matrix data
-            # TODO remove `sp.csc_matrix` when COPT starts supporting sparray
-            model.loadMatrix(c, sp.csc_matrix(A), lhs, rhs, lb, ub, vtype)
+            model.loadMatrix(c, A.tocsc(), lhs, rhs, lb, ub, vtype)
 
             # Load cone data
             if dims[s.SOC_DIM]:

--- a/cvxpy/reductions/solvers/nlp_solvers/copt_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/copt_nlpif.py
@@ -205,12 +205,10 @@ class COPT(NLPsolver):
         # Pass through verbosity
         model.setParam(copt.COPT.Param.Logging, verbose)
 
-        # Get the NLP problem data. Cast bounds to float so the infinite
-        # entries can be replaced with COPT's finite infinity sentinel even
-        # when cvxpy hands us integer-typed bounds (e.g. nonneg variables).
+        # Get the NLP problem data
         x0 = data['x0']
-        lb, ub = data['lb'].astype(float), data['ub'].astype(float)
-        cl, cu = data['cl'].astype(float), data['cu'].astype(float)
+        lb, ub = data['lb'].copy(), data['ub'].copy()
+        cl, cu = data['cl'].copy(), data['cu'].copy()
 
         lb[lb == -np.inf] = -copt.COPT.INFINITY
         ub[ub == +np.inf] = +copt.COPT.INFINITY

--- a/cvxpy/reductions/solvers/nlp_solvers/copt_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/copt_nlpif.py
@@ -205,10 +205,12 @@ class COPT(NLPsolver):
         # Pass through verbosity
         model.setParam(copt.COPT.Param.Logging, verbose)
 
-        # Get the NLP problem data
+        # Get the NLP problem data. Cast bounds to float so the infinite
+        # entries can be replaced with COPT's finite infinity sentinel even
+        # when cvxpy hands us integer-typed bounds (e.g. nonneg variables).
         x0 = data['x0']
-        lb, ub = data['lb'].copy(), data['ub'].copy()
-        cl, cu = data['cl'].copy(), data['cu'].copy()
+        lb, ub = data['lb'].astype(float), data['ub'].astype(float)
+        cl, cu = data['cl'].astype(float), data['cu'].astype(float)
 
         lb[lb == -np.inf] = -copt.COPT.INFINITY
         ub[ub == +np.inf] = +copt.COPT.INFINITY
@@ -255,6 +257,15 @@ class COPT(NLPsolver):
         # Set parameters
         for key, value in solver_opts.items():
             model.setParam(key, value)
+
+        # COPT may evaluate the gradient/Jacobian/Hessian callbacks at the
+        # initial point before calling the objective/constraint callbacks.
+        # The oracles cache intermediate values from a forward pass, so prime
+        # them here to ensure the first derivative evaluation uses correct
+        # values rather than stale defaults.
+        oracles.objective(x0)
+        if m > 0:
+            oracles.constraints(x0)
 
         # Solve problem
         model.solve()

--- a/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
@@ -170,8 +170,7 @@ class COPT(QpSolver):
                 vtype[data[s.INT_IDX]] = copt.COPT.INTEGER
 
         # Load matrix data
-        # TODO remove `sp.csc_matrix` when COPT starts supporting sparray
-        model.loadMatrix(q, sp.csc_matrix(Amat), lhs, rhs, lb, ub, vtype)
+        model.loadMatrix(q, Amat.tocsc(), lhs, rhs, lb, ub, vtype)
 
         # Load Q data
         if P.count_nonzero():

--- a/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
@@ -33,8 +33,10 @@ class COPT(QpSolver):
                   7: s.OPTIMAL_INACCURATE,  # imprecise
                   8: s.USER_LIMIT,          # time out
                   9: s.SOLVER_ERROR,        # unfinished
-                 10: s.USER_LIMIT,          # interrupted
-                 11: s.USER_LIMIT           # iteration limit
+                  10: s.USER_LIMIT,         # interrupted
+                  11: s.USER_LIMIT,         # iteration limit
+                  20: s.OPTIMAL,            # local optimal
+                  21: s.INFEASIBLE          # local infeasible
                  }
 
     def name(self):

--- a/cvxpy/tests/nlp_tests/derivative_checker.py
+++ b/cvxpy/tests/nlp_tests/derivative_checker.py
@@ -136,8 +136,13 @@ class DerivativeChecker:
         if duals is None:
             duals = np.random.rand(len(self.cl))
 
-        # must run gradient because for logistic it fills some values
+        # Establish the evaluation point at x: eval_hessian_vals_coo_lower_tri
+        # reads back whatever point the last forward passes were run at, so it
+        # must be pinned here rather than inherited from a previous check.
         self._init_coo()
+        self.c_problem.objective_forward(x)
+        self.c_problem.constraint_forward(x)
+        # must run gradient because for logistic it fills some values
         self.c_problem.gradient()
         c_hess_vals = self.c_problem.eval_hessian_vals_coo_lower_tri(obj_factor, duals)
         n_vars = len(x)
@@ -204,8 +209,16 @@ class DerivativeChecker:
 
         return match
 
-    def check_gradient(self, x=None, epsilon=1e-8):
-        """ Compare C-based gradient with numerical approximation using finite differences. """
+    def check_gradient(self, x=None, epsilon=1e-6):
+        """ Compare C-based gradient with numerical approximation using finite differences.
+
+        The central-difference step is ~eps_machine**(1/3), which balances
+        truncation error (O(epsilon**2)) against floating-point cancellation
+        (O(eps_machine * |objective| / epsilon)). A smaller step such as 1e-8
+        makes the cancellation term dominate: for problems with a large
+        objective value it swamps small gradient components and the check
+        fails spuriously.
+        """
         if x is None:
             x = self.x0
         # Get gradient from C implementation

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -3017,7 +3017,9 @@ class TestCOPT(unittest.TestCase):
         StandardTestECPs.test_expcone_1(solver='COPT')
 
     def test_copt_exp_soc_1(self) -> None:
-        StandardTestMixedCPs.test_exp_soc_1(solver='COPT')
+        # Tighten tolerances so the exponential-cone dual values converge
+        # to the 3 decimal places the test checks.
+        StandardTestMixedCPs.test_exp_soc_1(solver='COPT', FeasTol=1e-9, DualTol=1e-9)
 
     def test_copt_mi_lp_0(self) -> None:
         StandardTestLPs.test_mi_lp_0(solver='COPT')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ SCS = []
 XPRESS = ["xpress>=9.5"]
 DAQP = ["daqp"]
 KNITRO = ["knitro"]
+UNO = ["unopy"]
 # IPOPT = ["cyipopt"]  # requires system IPOPT; excluded from --all-extras
 testing = ["pytest", "hypothesis"]
 doc = ["sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,9 +103,10 @@ dynamic = ["version"]
 # Solver names as in cvxpy.settings = pip-installable distribution providing it
 CBC = ["cylp>=0.91.5"]
 CLARABEL = []
-# coptpy >= 7.2.5 accepts scipy sparse arrays (csc_array) in loadMatrix /
-# loadConeMatrix; earlier versions require the legacy csc_matrix.
-COPT = ["coptpy>=7.2.5"]
+# coptpy >= 8.0.3 provides the NLP callback API (NlpCallbackBase, loadNlData)
+# the COPT NLP interface relies on. It also accepts scipy sparse arrays
+# (csc_array) in loadMatrix / loadConeMatrix, supported since 7.2.5.
+COPT = ["coptpy>=8.0.3"]
 # CUOPT dependency group is disabled since it was breaking uv sync.
 # CUOPT = ["cuopt-cu12>=25.5", "nvidia-cuda-runtime-cu12>=12.8,<13.0"]
 CVXOPT = ["cvxopt"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,9 @@ dynamic = ["version"]
 # Solver names as in cvxpy.settings = pip-installable distribution providing it
 CBC = ["cylp>=0.91.5"]
 CLARABEL = []
-COPT = ["coptpy"]
+# coptpy >= 7.2.5 accepts scipy sparse arrays (csc_array) in loadMatrix /
+# loadConeMatrix; earlier versions require the legacy csc_matrix.
+COPT = ["coptpy>=7.2.5"]
 # CUOPT dependency group is disabled since it was breaking uv sync.
 # CUOPT = ["cuopt-cu12>=25.5", "nvidia-cuda-runtime-cu12>=12.8,<13.0"]
 CVXOPT = ["cvxopt"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ dynamic = ["version"]
 # Solver names as in cvxpy.settings = pip-installable distribution providing it
 CBC = ["cylp>=0.91.5"]
 CLARABEL = []
+COPT = ["coptpy"]
 # CUOPT dependency group is disabled since it was breaking uv sync.
 # CUOPT = ["cuopt-cu12>=25.5", "nvidia-cuda-runtime-cu12>=12.8,<13.0"]
 CVXOPT = ["cvxopt"]


### PR DESCRIPTION
## Description

We currently dualize PSD problems before passing it to COPT, which is a problem when not all variables are bounded because we end up with infinite values in the problem we pass COPT. This is both unsupported on their side, and bad style on ours.

This fixes that. I don't have a COPT license right now so @terryweng03 can you run the tests on this branch?

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.