### PR TITLE
Add KNITRO to the nlp solvers CI job

### DIFF
--- a/.github/workflows/test_nlp_solvers.yml
+++ b/.github/workflows/test_nlp_solvers.yml
@@ -35,7 +35,17 @@ jobs:
         run: uv pip install unopy
       - name: Verify Uno import
         run: uv run python -c "import unopy; print('unopy imported successfully')"
+      - name: Install KNITRO solver
+        run: uv pip install knitro
+      - name: Set up KNITRO license
+        if: env.KNITRO_LICENSE != ''
+        run: |
+          echo "$KNITRO_LICENSE" > ~/artelys_lic.txt
+          echo "ARTELYS_LICENSE=$HOME" >> $GITHUB_ENV
       - name: Print installed solvers
         run: uv run python -c "import cvxpy; print(cvxpy.installed_solvers())"
       - name: Run nlp tests
         run: uv run pytest -s -v cvxpy/tests/nlp_tests/
+
+    env:
+      KNITRO_LICENSE: ${{ secrets.KNITRO_LICENSE }}

--- a/.github/workflows/test_nlp_solvers.yml
+++ b/.github/workflows/test_nlp_solvers.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Print installed solvers
         run: uv run python -c "import cvxpy; print(cvxpy.installed_solvers())"
       - name: Run nlp tests
-        run: uv run pytest -s -v cvxpy/tests/nlp_tests/
+        run: uv run pytest -v cvxpy/tests/nlp_tests/
 
     env:
       KNITRO_LICENSE: ${{ secrets.KNITRO_LICENSE }}

--- a/.github/workflows/test_nlp_solvers.yml
+++ b/.github/workflows/test_nlp_solvers.yml
@@ -45,7 +45,12 @@ jobs:
       - name: Print installed solvers
         run: uv run python -c "import cvxpy; print(cvxpy.installed_solvers())"
       - name: Run nlp tests
-        run: uv run pytest -v cvxpy/tests/nlp_tests/
+        run: uv run pytest -v -m "not knitro" cvxpy/tests/nlp_tests/
+      # KNITRO bundles its own OpenMP runtime; loading it in the same
+      # process as IPOPT segfaults on macOS. Run KNITRO tests separately.
+      - name: Run KNITRO nlp tests
+        if: always()
+        run: uv run pytest -v -m knitro cvxpy/tests/nlp_tests/
 
     env:
       KNITRO_LICENSE: ${{ secrets.KNITRO_LICENSE }}

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -26,6 +26,9 @@ jobs:
           echo $MOSEK_CI_BASE64 | base64 -d > mosek.lic
           echo "MOSEKLM_LICENSE_FILE=$( [[ $RUNNER_OS == 'macOS' ]] && echo $(pwd)/mosek.lic || echo $(realpath mosek.lic) )" >> $GITHUB_ENV
           echo $KNITRO_LICENSE > ~/artelys_lic.txt
+          # is_knitro_available() gates on ARTELYS_LICENSE; only set it
+          # when a license secret is present so forks skip KNITRO tests.
+          if [ -n "$KNITRO_LICENSE" ]; then echo "ARTELYS_LICENSE=$HOME" >> $GITHUB_ENV; fi
 
       - uses: astral-sh/setup-uv@v7
         with:

--- a/cvxpy/reductions/solvers/conic_solvers/knitro_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/knitro_conif.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import importlib.util
+
 import numpy as np
 import scipy.sparse as sp
 
@@ -295,6 +297,16 @@ class KNITRO(ConicSolver):
     def name(self):
         """The name of the solver."""
         return s.KNITRO
+
+    def is_installed(self) -> bool:
+        """Checks for the ``knitro`` package without importing it.
+
+        Importing ``knitro`` loads the native KNITRO runtime (and, on macOS,
+        a bundled OpenMP library). Doing that eagerly from ``import cvxpy``
+        can crash other solvers that load their own OpenMP runtime, so
+        installation is detected via the import machinery instead.
+        """
+        return importlib.util.find_spec("knitro") is not None
 
     def import_solver(self) -> None:
         """Imports the solver."""

--- a/cvxpy/reductions/solvers/nlp_solvers/ipopt_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/ipopt_nlpif.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import importlib.util
+
 import numpy as np
 
 import cvxpy.settings as s
@@ -65,6 +67,17 @@ class IPOPT(NLPsolver):
         The name of solver.
         """
         return 'IPOPT'
+
+    def is_installed(self) -> bool:
+        """Checks for the ``cyipopt`` package without importing it.
+
+        Importing ``cyipopt`` loads the native IPOPT runtime (and a bundled
+        OpenMP library on macOS). Detecting installation via the import
+        machinery keeps ``import cvxpy`` from loading it, so it does not
+        share a process -- and an OpenMP runtime -- with other solvers
+        unless an IPOPT solve actually runs.
+        """
+        return importlib.util.find_spec("cyipopt") is not None
 
     def import_solver(self):
         """

--- a/cvxpy/reductions/solvers/nlp_solvers/knitro_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/knitro_nlpif.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import importlib.util
+
 import numpy as np
 
 import cvxpy.settings as s
@@ -106,6 +108,16 @@ class KNITRO(NLPsolver):
         The name of solver.
         """
         return 'KNITRO'
+
+    def is_installed(self) -> bool:
+        """Checks for the ``knitro`` package without importing it.
+
+        Importing ``knitro`` loads the native KNITRO runtime (and, on macOS,
+        a bundled OpenMP library). Doing that eagerly from ``import cvxpy``
+        can crash other solvers that load their own OpenMP runtime, so
+        installation is detected via the import machinery instead.
+        """
+        return importlib.util.find_spec("knitro") is not None
 
     def import_solver(self):
         """

--- a/cvxpy/reductions/solvers/nlp_solvers/nlp_solver.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/nlp_solver.py
@@ -136,8 +136,11 @@ class Bounds:
             ub_flat = np.asarray(ub).flatten(order='F')
             var_lower.extend(lb_flat)
             var_upper.extend(ub_flat)
-        self.lb = np.array(var_lower)
-        self.ub = np.array(var_upper)
+        # Force float dtype: all-integer bounds (e.g. nonneg=True gives lb 0)
+        # would otherwise infer an integer array, and replacing entries with a
+        # solver's infinity sentinel (~1e20) overflows int64.
+        self.lb = np.array(var_lower, dtype=float)
+        self.ub = np.array(var_upper, dtype=float)
 
     def construct_initial_point(self) -> None:
         """ Loop through all variables and collect the intial point."""

--- a/cvxpy/reductions/solvers/qp_solvers/knitro_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/knitro_qpif.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import importlib.util
+
 import numpy as np
 from scipy import sparse
 
@@ -130,6 +132,16 @@ class KNITRO(QpSolver):
 
     def name(self):
         return s.KNITRO
+
+    def is_installed(self) -> bool:
+        """Checks for the ``knitro`` package without importing it.
+
+        Importing ``knitro`` loads the native KNITRO runtime (and, on macOS,
+        a bundled OpenMP library). Doing that eagerly from ``import cvxpy``
+        can crash other solvers that load their own OpenMP runtime, so
+        installation is detected via the import machinery instead.
+        """
+        return importlib.util.find_spec("knitro") is not None
 
     def import_solver(self) -> None:
         """Imports the Knitro solver."""

--- a/cvxpy/tests/nlp_tests/test_interfaces.py
+++ b/cvxpy/tests/nlp_tests/test_interfaces.py
@@ -19,21 +19,10 @@ import pytest
 
 import cvxpy as cp
 from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS
+from cvxpy.tests.test_conic_solvers import is_knitro_available
 
 
-def is_knitro_available():
-    """Check if KNITRO is installed and a license is available."""
-    import os
-    if 'KNITRO' not in INSTALLED_SOLVERS:
-        return False
-    # Only run KNITRO tests if license env var is explicitly set
-    # This prevents hanging in CI when KNITRO is installed but not licensed
-    return bool(
-        os.environ.get('ARTELYS_LICENSE') or
-        os.environ.get('ARTELYS_LICENSE_NETWORK_ADDR')
-    )
-
-
+@pytest.mark.knitro
 @pytest.mark.skipif(
     not is_knitro_available(),
     reason='KNITRO is not installed or license is not available.'

--- a/cvxpy/tests/nlp_tests/test_nlp_solvers.py
+++ b/cvxpy/tests/nlp_tests/test_nlp_solvers.py
@@ -27,8 +27,8 @@ from cvxpy.tests.test_conic_solvers import is_knitro_available
 NLP_SOLVERS = [
     pytest.param('IPOPT', marks=pytest.mark.skipif(
         'IPOPT' not in INSTALLED_SOLVERS, reason='IPOPT is not installed.')),
-    pytest.param('KNITRO', marks=pytest.mark.skipif(
-        not is_knitro_available(), reason='KNITRO is not installed or license not available.')),
+    pytest.param('KNITRO', marks=[pytest.mark.knitro, pytest.mark.skipif(
+        not is_knitro_available(), reason='KNITRO is not installed or license not available.')]),
     pytest.param('UNO', marks=pytest.mark.skipif(
         'UNO' not in INSTALLED_SOLVERS, reason='UNO is not installed.')),
     pytest.param('COPT', marks=pytest.mark.skipif(

--- a/cvxpy/tests/nlp_tests/test_nlp_solvers.py
+++ b/cvxpy/tests/nlp_tests/test_nlp_solvers.py
@@ -144,8 +144,9 @@ class TestNLPExamples:
         checker = DerivativeChecker(problem)
         checker.run_and_assert()
 
-    @pytest.mark.skipif('UNO' in INSTALLED_SOLVERS, reason='UNO has an algorithmic error')
     def test_rosenbrock(self, solver):
+        if solver == 'UNO':
+            pytest.skip('UNO has an algorithmic error')
         x = cp.Variable(2, name='x')
         objective = cp.Minimize((1 - x[0])**2 + 100 * (x[1] - x[0]**2)**2)
         problem = cp.Problem(objective, [])
@@ -356,11 +357,12 @@ class TestNLPExamples:
         checker = DerivativeChecker(problem)
         checker.run_and_assert()
 
-    @pytest.mark.skipif('UNO' in INSTALLED_SOLVERS, reason='UNO finds a KKT point with worse obj')
     def test_circle_packing_formulation_two(self, solver):
         """Using norm_inf. This test revealed a very subtle bug in the unpacking of
         the ipopt solution. Some variables were mistakenly reordered. It was fixed
         in https://github.com/cvxgrp/cvxpy-ipopt/pull/82"""
+        if solver == 'UNO':
+            pytest.skip('UNO finds a KKT point with worse obj')
         rng = np.random.default_rng(5)
         n = 3
         radius = rng.uniform(1.0, 3.0, n)
@@ -424,8 +426,9 @@ class TestNLPExamples:
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
 
-    @pytest.mark.skipif('UNO' in INSTALLED_SOLVERS, reason='UNO reaches iteration limit')
     def test_geo_mean(self, solver):
+        if solver == 'UNO':
+            pytest.skip('UNO reaches iteration limit')
         x = cp.Variable(3, nonneg=True)
         geo_mean = cp.geo_mean(x)
         objective = cp.Maximize(geo_mean)
@@ -438,8 +441,9 @@ class TestNLPExamples:
         checker = DerivativeChecker(problem)
         checker.run_and_assert()
 
-    @pytest.mark.skipif('UNO' in INSTALLED_SOLVERS, reason='UNO reaches iteration limit')
     def test_geo_mean2(self, solver):
+        if solver == 'UNO':
+            pytest.skip('UNO reaches iteration limit')
         p = np.array([.07, .12, .23, .19, .39])
         x = cp.Variable(5, nonneg=True)
         prob = cp.Problem(cp.Maximize(cp.geo_mean(x, p)), [cp.sum(x) <= 1])

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -3191,19 +3191,20 @@ class TestCOSMO(BaseTest):
         print(time > time2)
 
 def is_knitro_available():
-    """Check if KNITRO is installed and a license is available."""
+    """Check if KNITRO is installed and a license is available.
+
+    Detection is intentionally based on environment variables rather than
+    importing ``knitro``: importing it loads the native KNITRO runtime (and
+    a bundled OpenMP library on macOS) into the test process, which can
+    crash other solvers -- e.g. an IPOPT solve segfaults on macOS once
+    knitro has been imported.
+    """
     if 'KNITRO' not in INSTALLED_SOLVERS:
         return False
-    try:
-        import knitro  # type: ignore
-        # Try to create and delete a Knitro solver instance
-        kc = knitro.KN_new()
-        if kc is None:
-            return False
-        knitro.KN_free(kc)
-        return True
-    except Exception:
-        return False
+    return bool(
+        os.environ.get('ARTELYS_LICENSE')
+        or os.environ.get('ARTELYS_LICENSE_NETWORK_ADDR')
+    )
 
 @unittest.skipUnless(is_knitro_available(), 'KNITRO is not installed or license is not available.')
 class TestKNITRO(BaseTest):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ reportOperatorIssue = false         # 22 errors
 testpaths = [
     "cvxpy/tests/"
 ]
+markers = [
+    "knitro: tests that load the native KNITRO runtime; run in a separate process from other native solvers (see test_nlp_solvers.yml)",
+]
 
 [build-system]
 requires = [


### PR DESCRIPTION
## Description
Adds KNITRO to the `test_nlp_solvers` CI job so the KNITRO-gated tests under `cvxpy/tests/nlp_tests/` run instead of being skipped, and fixes the issues that surfaced from doing so.

### CI
- Install the `knitro` package and write the CI license from the existing `KNITRO_LICENSE` secret (guarded so forks without the secret skip cleanly).
- Drop `-s` from the nlp `pytest` invocation. `-s` disabled output capture, flooding the log with ~35k lines per OS leg of IPOPT/diff-engine output; without it pytest only replays output for failing tests.
- Run KNITRO nlp tests in a **separate pytest process** (`-m knitro`) from the rest (`-m "not knitro"`).

### Native-library fix
`import cvxpy` eagerly built `INSTALLED_SOLVERS` by importing every solver, which loaded the native KNITRO runtime — and on macOS its bundled `libomp.dylib` — into every process. With a second OpenMP runtime present, an IPOPT solve segfaults on macOS.

- `KNITRO` (conic/qp/nlp) and `IPOPT` solver classes now override `is_installed()` to detect their package with `importlib.util.find_spec()` instead of importing it. The native library loads only on an actual solve.
- `is_knitro_available()` in `test_conic_solvers.py` now detects KNITRO via env vars instead of `import knitro`, so collecting the nlp suite no longer loads the native library. `test_interfaces.py`'s duplicate definition is removed in favour of the shared one.
- `test_optional_solvers.yml` exports `ARTELYS_LICENSE` when the license secret is present, since `is_knitro_available()` now gates on it.

Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)