### PR TITLE
Isolate KNITRO conic tests and warn on OpenMP-runtime conflicts

### DIFF
--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -50,8 +50,15 @@ jobs:
         run: uv pip install moreau --extra-index-url https://${FURY_TOKEN}:@pypi.fury.io/optimalintellect/
       - name: Print installed solvers
         run: uv run python -c "import cvxpy; print(cvxpy.installed_solvers())"
+      # KNITRO bundles LLVM libomp; CVXOPT bundles GNU libgomp via its
+      # OpenBLAS dependency. Loading both in one process can crash inside
+      # KNITRO's KN_solve on macOS, so run KNITRO tests in a separate
+      # process (mirrors test_nlp_solvers.yml).
       - name: Run test_conic_solvers
-        run: uv run pytest -rs cvxpy/tests/test_conic_solvers.py
+        run: uv run pytest -rs -m "not knitro" cvxpy/tests/test_conic_solvers.py
+      - name: Run test_conic_solvers (KNITRO)
+        if: always()
+        run: uv run pytest -rs -m knitro cvxpy/tests/test_conic_solvers.py
       - name: Run test_qp_solvers
         if: always()
         run: uv run pytest -rs cvxpy/tests/test_qp_solvers.py

--- a/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
@@ -26,6 +26,7 @@ from cvxpy.constraints import PSD, SOC, NonNeg, Zero
 from cvxpy.reductions.solvers.compr_matrix import compress_matrix
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.kktsolver import setup_ldl_factor
+from cvxpy.reductions.solvers.openmp_conflict import warn_if_omp_conflict
 from cvxpy.utilities.citations import CITATION_DICT
 
 
@@ -73,6 +74,7 @@ class CVXOPT(ConicSolver):
     def import_solver(self) -> None:
         """Imports the solver.
         """
+        warn_if_omp_conflict("cvxopt")
         import cvxopt  # noqa F401
 
     def accepts(self, problem) -> bool:

--- a/cvxpy/reductions/solvers/conic_solvers/knitro_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/knitro_conif.py
@@ -25,6 +25,7 @@ from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ParamConeProg
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver, dims_to_solver_dict
+from cvxpy.reductions.solvers.openmp_conflict import warn_if_omp_conflict
 from cvxpy.utilities.citations import CITATION_DICT
 
 
@@ -310,6 +311,7 @@ class KNITRO(ConicSolver):
 
     def import_solver(self) -> None:
         """Imports the solver."""
+        warn_if_omp_conflict("knitro")
         import knitro  # noqa: F401
 
     def supports_quad_obj(self):

--- a/cvxpy/reductions/solvers/nlp_solvers/ipopt_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/ipopt_nlpif.py
@@ -21,6 +21,7 @@ import numpy as np
 import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.nlp_solvers.nlp_solver import NLPsolver
+from cvxpy.reductions.solvers.openmp_conflict import warn_if_omp_conflict
 from cvxpy.utilities.citations import CITATION_DICT
 
 
@@ -83,6 +84,7 @@ class IPOPT(NLPsolver):
         """
         Imports the solver.
         """
+        warn_if_omp_conflict("cyipopt")
         import cyipopt  # noqa F401
 
     def invert(self, solution, inverse_data):

--- a/cvxpy/reductions/solvers/nlp_solvers/knitro_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/knitro_nlpif.py
@@ -21,6 +21,7 @@ import numpy as np
 import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.nlp_solvers.nlp_solver import NLPsolver
+from cvxpy.reductions.solvers.openmp_conflict import warn_if_omp_conflict
 from cvxpy.utilities.citations import CITATION_DICT
 
 
@@ -123,6 +124,7 @@ class KNITRO(NLPsolver):
         """
         Imports the solver.
         """
+        warn_if_omp_conflict("knitro")
         import knitro  # noqa F401
 
     def invert(self, solution, inverse_data):

--- a/cvxpy/reductions/solvers/openmp_conflict.py
+++ b/cvxpy/reductions/solvers/openmp_conflict.py
@@ -1,0 +1,61 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+import warnings
+
+# Packages whose macOS wheels bundle their own OpenMP runtime. Loading two of
+# these into one process can crash inside a solver's parallel section:
+#   - knitro and cyipopt each bundle LLVM ``libomp.dylib``
+#   - cvxopt bundles a parallel OpenBLAS that links GNU ``libgomp.1.dylib``
+# LLVM libomp and GNU libgomp were never designed to coexist in one process,
+# and even two copies of libomp share no global state across instances.
+_OMP_BUNDLING_PACKAGES: tuple[str, ...] = ("knitro", "cyipopt", "cvxopt")
+
+
+def warn_if_omp_conflict(importing: str) -> None:
+    """Warn if importing ``importing`` would put two OMP-bundling solvers in
+    one process.
+
+    Call this immediately before importing the solver's native bindings, so the
+    user sees the warning before any subsequent crash. The check looks at
+    ``sys.modules`` for already-imported sibling packages and does not import
+    anything itself.
+
+    Parameters
+    ----------
+    importing : str
+        Top-level package name about to be imported, e.g. ``"knitro"``.
+    """
+    if importing not in _OMP_BUNDLING_PACKAGES:
+        return
+    already_loaded = [
+        pkg for pkg in _OMP_BUNDLING_PACKAGES
+        if pkg != importing and pkg in sys.modules
+    ]
+    if not already_loaded:
+        return
+    warnings.warn(
+        f"Loading {importing!r} into a process that has already imported "
+        f"{', '.join(repr(p) for p in already_loaded)}. Each of these "
+        "packages ships its own OpenMP runtime in its macOS wheel (LLVM "
+        "libomp for knitro and cyipopt; GNU libgomp for cvxopt via its "
+        "OpenBLAS dependency), and mixing them in one process can crash "
+        "inside a solver's parallel section. If you hit a segfault, run "
+        "each of these solvers in a separate Python process.",
+        RuntimeWarning,
+        stacklevel=3,
+    )

--- a/cvxpy/reductions/solvers/openmp_conflict.py
+++ b/cvxpy/reductions/solvers/openmp_conflict.py
@@ -15,7 +15,8 @@ limitations under the License.
 """
 
 import sys
-import warnings
+
+from cvxpy.utilities.warn import warn
 
 # Packages whose macOS wheels bundle their own OpenMP runtime. Loading two of
 # these into one process can crash inside a solver's parallel section:
@@ -23,23 +24,32 @@ import warnings
 #   - cvxopt bundles a parallel OpenBLAS that links GNU ``libgomp.1.dylib``
 # LLVM libomp and GNU libgomp were never designed to coexist in one process,
 # and even two copies of libomp share no global state across instances.
+#
+# The conflict is macOS-specific: on Linux, auditwheel-built wheels typically
+# share a single system libgomp via symbol versioning, and we have not observed
+# a crash from this combination in CI.
 _OMP_BUNDLING_PACKAGES: tuple[str, ...] = ("knitro", "cyipopt", "cvxopt")
 
 
 def warn_if_omp_conflict(importing: str) -> None:
     """Warn if importing ``importing`` would put two OMP-bundling solvers in
-    one process.
+    one process on macOS.
 
     Call this immediately before importing the solver's native bindings, so the
     user sees the warning before any subsequent crash. The check looks at
     ``sys.modules`` for already-imported sibling packages and does not import
     anything itself.
 
+    No-op on non-macOS platforms, where the bundled-OpenMP conflict does not
+    manifest as a crash in practice.
+
     Parameters
     ----------
     importing : str
         Top-level package name about to be imported, e.g. ``"knitro"``.
     """
+    if not sys.platform.startswith("darwin"):
+        return
     if importing not in _OMP_BUNDLING_PACKAGES:
         return
     already_loaded = [
@@ -48,7 +58,7 @@ def warn_if_omp_conflict(importing: str) -> None:
     ]
     if not already_loaded:
         return
-    warnings.warn(
+    warn(
         f"Loading {importing!r} into a process that has already imported "
         f"{', '.join(repr(p) for p in already_loaded)}. Each of these "
         "packages ships its own OpenMP runtime in its macOS wheel (LLVM "
@@ -57,5 +67,4 @@ def warn_if_omp_conflict(importing: str) -> None:
         "inside a solver's parallel section. If you hit a segfault, run "
         "each of these solvers in a separate Python process.",
         RuntimeWarning,
-        stacklevel=3,
     )

--- a/cvxpy/reductions/solvers/qp_solvers/knitro_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/knitro_qpif.py
@@ -22,6 +22,7 @@ from scipy import sparse
 import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
+from cvxpy.reductions.solvers.openmp_conflict import warn_if_omp_conflict
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 from cvxpy.utilities.citations import CITATION_DICT
 
@@ -145,6 +146,7 @@ class KNITRO(QpSolver):
 
     def import_solver(self) -> None:
         """Imports the Knitro solver."""
+        warn_if_omp_conflict("knitro")
         import knitro  # noqa: F401
 
     def apply(self, problem):

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -3211,6 +3211,7 @@ def is_knitro_available():
         or os.environ.get('ARTELYS_LICENSE_NETWORK_ADDR')
     )
 
+@pytest.mark.knitro
 @unittest.skipUnless(is_knitro_available(), 'KNITRO is not installed or license is not available.')
 class TestKNITRO(BaseTest):
 

--- a/cvxpy/tests/test_openmp_conflict.py
+++ b/cvxpy/tests/test_openmp_conflict.py
@@ -23,31 +23,36 @@ from cvxpy.reductions.solvers.openmp_conflict import warn_if_omp_conflict
 
 
 @pytest.fixture
-def isolated_modules(monkeypatch):
-    """Strip the OMP-bundling packages from sys.modules for the test."""
+def darwin_isolated(monkeypatch):
+    """Pretend to be macOS with no OMP-bundling packages loaded.
+
+    The conflict warning is gated on ``sys.platform == "darwin"``, so to
+    exercise it on Linux/Windows CI runners we monkeypatch the platform.
+    """
+    monkeypatch.setattr(sys, "platform", "darwin")
     for pkg in ("knitro", "cyipopt", "cvxopt"):
         monkeypatch.delitem(sys.modules, pkg, raising=False)
 
 
-def test_no_warning_when_alone(isolated_modules) -> None:
+def test_no_warning_when_alone(darwin_isolated) -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error")  # turn any warning into an exception
         warn_if_omp_conflict("knitro")
 
 
-def test_warns_when_cvxopt_already_loaded(isolated_modules, monkeypatch) -> None:
+def test_warns_when_cvxopt_already_loaded(darwin_isolated, monkeypatch) -> None:
     monkeypatch.setitem(sys.modules, "cvxopt", object())
     with pytest.warns(RuntimeWarning, match=r"knitro.*cvxopt"):
         warn_if_omp_conflict("knitro")
 
 
-def test_warns_when_knitro_already_loaded(isolated_modules, monkeypatch) -> None:
+def test_warns_when_knitro_already_loaded(darwin_isolated, monkeypatch) -> None:
     monkeypatch.setitem(sys.modules, "knitro", object())
     with pytest.warns(RuntimeWarning, match=r"cyipopt.*knitro"):
         warn_if_omp_conflict("cyipopt")
 
 
-def test_lists_all_loaded_siblings(isolated_modules, monkeypatch) -> None:
+def test_lists_all_loaded_siblings(darwin_isolated, monkeypatch) -> None:
     monkeypatch.setitem(sys.modules, "knitro", object())
     monkeypatch.setitem(sys.modules, "cyipopt", object())
     with pytest.warns(RuntimeWarning) as record:
@@ -56,8 +61,17 @@ def test_lists_all_loaded_siblings(isolated_modules, monkeypatch) -> None:
     assert "knitro" in msg and "cyipopt" in msg
 
 
-def test_silent_for_unrelated_package(isolated_modules, monkeypatch) -> None:
+def test_silent_for_unrelated_package(darwin_isolated, monkeypatch) -> None:
     monkeypatch.setitem(sys.modules, "knitro", object())
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         warn_if_omp_conflict("numpy")  # not an OMP-bundling package
+
+
+def test_silent_on_non_darwin(monkeypatch) -> None:
+    """On Linux/Windows the gate short-circuits even when a conflict exists."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setitem(sys.modules, "cvxopt", object())
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_if_omp_conflict("knitro")

--- a/cvxpy/tests/test_openmp_conflict.py
+++ b/cvxpy/tests/test_openmp_conflict.py
@@ -1,0 +1,63 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+import warnings
+
+import pytest
+
+from cvxpy.reductions.solvers.openmp_conflict import warn_if_omp_conflict
+
+
+@pytest.fixture
+def isolated_modules(monkeypatch):
+    """Strip the OMP-bundling packages from sys.modules for the test."""
+    for pkg in ("knitro", "cyipopt", "cvxopt"):
+        monkeypatch.delitem(sys.modules, pkg, raising=False)
+
+
+def test_no_warning_when_alone(isolated_modules) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # turn any warning into an exception
+        warn_if_omp_conflict("knitro")
+
+
+def test_warns_when_cvxopt_already_loaded(isolated_modules, monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "cvxopt", object())
+    with pytest.warns(RuntimeWarning, match=r"knitro.*cvxopt"):
+        warn_if_omp_conflict("knitro")
+
+
+def test_warns_when_knitro_already_loaded(isolated_modules, monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "knitro", object())
+    with pytest.warns(RuntimeWarning, match=r"cyipopt.*knitro"):
+        warn_if_omp_conflict("cyipopt")
+
+
+def test_lists_all_loaded_siblings(isolated_modules, monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "knitro", object())
+    monkeypatch.setitem(sys.modules, "cyipopt", object())
+    with pytest.warns(RuntimeWarning) as record:
+        warn_if_omp_conflict("cvxopt")
+    msg = str(record[0].message)
+    assert "knitro" in msg and "cyipopt" in msg
+
+
+def test_silent_for_unrelated_package(isolated_modules, monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "knitro", object())
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_if_omp_conflict("numpy")  # not an OMP-bundling package


### PR DESCRIPTION
## Description
Fixes the `test_optional_solvers (macos-14)` job which began segfaulting after #3340. Also adds a runtime warning when two OpenMP-bundling solvers are about to coexist in one process.

### Root cause
Among the ~20 wheels installed by `uv sync --all-extras --dev`, exactly two ship an OpenMP runtime in their macOS arm64 wheel:

| Wheel | OpenMP runtime | Where |
|---|---|---|
| `knitro` | LLVM `libomp.dylib` | `knitro/lib/libomp.dylib` |
| `cvxopt` | GNU `libgomp.1.dylib` | `cvxopt/.dylibs/libgomp.1.dylib` (pulled in by `libopenblasp-r0.3.24.dylib`, which every cvxopt extension links) |

LLVM libomp and GNU libgomp were never designed to coexist in one process.

Pre-#3340, `TestKNITRO`'s `@unittest.skipUnless(is_knitro_available(), ...)` decorator did `import knitro; KN_new(); KN_free()` at pytest **collection time**, so KNITRO's libomp was the first OpenMP loaded. CVXOPT/GLPK tests then loaded libgomp second, and the suite finished.

After #3340 the order reverses: `is_knitro_available()` now only reads env vars and runs `find_spec`, so cvxopt loads libgomp first (early in the test run), and when `TestKNITRO::test_knitro_lp_0` finally executes at ~76% of the suite, KNITRO loads libomp second and `KN_solve` segfaults on its first parallel section.

### Changes
1. **CI split.** `TestKNITRO` in `test_conic_solvers.py` gets `@pytest.mark.knitro`, and `test_optional_solvers.yml` runs `-m "not knitro"` and `-m knitro` as separate pytest processes for `test_conic_solvers.py`. Mirrors the existing pattern in `test_nlp_solvers.yml`.
2. **Runtime warning.** New `cvxpy/reductions/solvers/openmp_conflict.py` exposes `warn_if_omp_conflict(importing)`. Called from `import_solver()` on the KNITRO (conic / QP / NLP), IPOPT, and CVXOPT solver classes. Detects the conflict via `sys.modules` (does not import anything itself) and emits a `RuntimeWarning` naming the conflicting packages and runtimes.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.
