### PR TITLE
Patch/1.9.1

### DIFF
--- a/.github/workflows/test_nlp_solvers.yml
+++ b/.github/workflows/test_nlp_solvers.yml
@@ -35,7 +35,22 @@ jobs:
         run: uv pip install unopy
       - name: Verify Uno import
         run: uv run python -c "import unopy; print('unopy imported successfully')"
+      - name: Install KNITRO solver
+        run: uv pip install knitro
+      - name: Set up KNITRO license
+        if: env.KNITRO_LICENSE != ''
+        run: |
+          echo "$KNITRO_LICENSE" > ~/artelys_lic.txt
+          echo "ARTELYS_LICENSE=$HOME" >> $GITHUB_ENV
       - name: Print installed solvers
         run: uv run python -c "import cvxpy; print(cvxpy.installed_solvers())"
       - name: Run nlp tests
-        run: uv run pytest -s -v cvxpy/tests/nlp_tests/
+        run: uv run pytest -v -m "not knitro" cvxpy/tests/nlp_tests/
+      # KNITRO bundles its own OpenMP runtime; loading it in the same
+      # process as IPOPT segfaults on macOS. Run KNITRO tests separately.
+      - name: Run KNITRO nlp tests
+        if: always()
+        run: uv run pytest -v -m knitro cvxpy/tests/nlp_tests/
+
+    env:
+      KNITRO_LICENSE: ${{ secrets.KNITRO_LICENSE }}

--- a/.github/workflows/test_nlp_solvers.yml
+++ b/.github/workflows/test_nlp_solvers.yml
@@ -31,8 +31,10 @@ jobs:
           uv venv
           uv pip install -e ".[testing]"
           uv pip install cyipopt
+      - name: Install COPT solver
+        run: uv pip install -e ".[COPT]"
       - name: Install Uno solver
-        run: uv pip install unopy
+        run: uv pip install -e ".[UNO]"
       - name: Verify Uno import
         run: uv run python -c "import unopy; print('unopy imported successfully')"
       - name: Install KNITRO solver

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -50,8 +50,15 @@ jobs:
         run: uv pip install moreau --extra-index-url https://${FURY_TOKEN}:@pypi.fury.io/optimalintellect/
       - name: Print installed solvers
         run: uv run python -c "import cvxpy; print(cvxpy.installed_solvers())"
+      # KNITRO bundles LLVM libomp; CVXOPT bundles GNU libgomp via its
+      # OpenBLAS dependency. Loading both in one process can crash inside
+      # KNITRO's KN_solve on macOS, so run KNITRO tests in a separate
+      # process (mirrors test_nlp_solvers.yml).
       - name: Run test_conic_solvers
-        run: uv run pytest -rs cvxpy/tests/test_conic_solvers.py
+        run: uv run pytest -rs -m "not knitro" cvxpy/tests/test_conic_solvers.py
+      - name: Run test_conic_solvers (KNITRO)
+        if: always()
+        run: uv run pytest -rs -m knitro cvxpy/tests/test_conic_solvers.py
       - name: Run test_qp_solvers
         if: always()
         run: uv run pytest -rs cvxpy/tests/test_qp_solvers.py

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -26,6 +26,9 @@ jobs:
           echo $MOSEK_CI_BASE64 | base64 -d > mosek.lic
           echo "MOSEKLM_LICENSE_FILE=$( [[ $RUNNER_OS == 'macOS' ]] && echo $(pwd)/mosek.lic || echo $(realpath mosek.lic) )" >> $GITHUB_ENV
           echo $KNITRO_LICENSE > ~/artelys_lic.txt
+          # is_knitro_available() gates on ARTELYS_LICENSE; only set it
+          # when a license secret is present so forks skip KNITRO tests.
+          if [ -n "$KNITRO_LICENSE" ]; then echo "ARTELYS_LICENSE=$HOME" >> $GITHUB_ENV; fi
 
       - uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -43,8 +43,11 @@ jobs:
       - name: Install SuiteSparse (macOS)
         if: runner.os == 'macOS'
         run: brew install suite-sparse
+      # Uno (unopy) is exercised by test_nlp_solvers, which installs it on its
+      # own with the IPOPT/OpenMP toolchain it needs. The conic and QP tests
+      # run here don't use it, so skip the extra to avoid a from-source build.
       - name: Install cvxpy dependencies and all optional solvers
-        run: uv sync --all-extras --dev
+        run: uv sync --all-extras --no-extra uno --dev
       - name: Install Moreau
         if: runner.os == 'Linux' && env.FURY_TOKEN != ''
         run: uv pip install moreau --extra-index-url https://${FURY_TOKEN}:@pypi.fury.io/optimalintellect/

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -989,7 +989,7 @@ class Leaf(expression.Expression):
                 else:
                     lb_arr = np.maximum(lb_arr, 0)
             else:
-                lb_val = max(lb_val, 0)
+                lb_val = max(lb_val, 0.0)
         if self.attributes['nonpos'] or self.attributes['neg']:
             if ub_arr is not None:
                 if sp.issparse(ub_arr):
@@ -997,7 +997,7 @@ class Leaf(expression.Expression):
                 else:
                     ub_arr = np.minimum(ub_arr, 0)
             else:
-                ub_val = min(ub_val, 0)
+                ub_val = min(ub_val, 0.0)
 
         # For boolean variables, bounds are [0, 1]
         if self.attributes['boolean'] is True:
@@ -1007,14 +1007,14 @@ class Leaf(expression.Expression):
                 else:
                     lb_arr = np.maximum(lb_arr, 0)
             else:
-                lb_val = max(lb_val, 0)
+                lb_val = max(lb_val, 0.0)
             if ub_arr is not None:
                 if sp.issparse(ub_arr):
                     ub_arr = ub_arr.minimum(1)
                 else:
                     ub_arr = np.minimum(ub_arr, 1)
             else:
-                ub_val = min(ub_val, 1)
+                ub_val = min(ub_val, 1.0)
 
         # Build final bounds: use broadcast views for uniform scalars
         if lb_arr is not None:

--- a/cvxpy/reductions/cone2cone/affine2direct.py
+++ b/cvxpy/reductions/cone2cone/affine2direct.py
@@ -21,7 +21,7 @@ from cvxpy import settings as s
 from cvxpy.constraints.exponential import ExpCone as ExpCone_obj
 from cvxpy.constraints.nonpos import NonNeg as NonNeg_obj
 from cvxpy.constraints.power import PowCone3D as PowCone_obj
-from cvxpy.constraints.psd import PSD as PSD_obj
+from cvxpy.constraints.psd import SvecPSD as SvecPSD_obj
 from cvxpy.constraints.second_order import SOC as SOC_obj
 from cvxpy.constraints.zero import Zero as Zero_obj
 from cvxpy.reductions.solution import Solution
@@ -154,9 +154,12 @@ class Dualize:
         to the second-order-cone under the CVXPY standard ({ z : z[0] >= || z[1:] || }).
         We map these variables back to dual variables for SOC constraints in (P-Opt).
 
-        solution.primal_vars[PSD] is a list of symmetric positive semidefinite matrices
-        which result by lifting the vectorized PSD blocks of "y" back into matrix form.
-        We assign these as dual variables to PSD constraints appearing in (P-Opt).
+        solution.primal_vars[PSD] is a list of triangular (svec) vectors: the
+        column-major lower-triangular entries of the PSD blocks of "y", one vector
+        per cone. PSD constraints reach a dualizing solver in this triangular form
+        via the PSDToSvecPSD reduction (see #3268), so we concatenate the cones
+        belonging to each SvecPSD constraint and assign the result as that
+        constraint's dual variable in (P-Opt).
 
         solution.primal_vars[DUAL_EXP] is a vector of concatenated length-3 slices of y, where
         each constituent length-3 slice belongs to dual exponential cone as implied by the CVXPY
@@ -190,9 +193,17 @@ class Dualize:
                 dv = np.concatenate(direct_prims[SOC][i:i + block_len])
                 dual_vars[con.id] = dv
                 i += block_len
-            for i, con in enumerate(constr_map[PSD_obj]):
-                dv = direct_prims[PSD][i]
-                dual_vars[con.id] = dv
+            # direct_prims[PSD] holds one triangular (svec) vector per cone,
+            # ordered to match ConeDims.psd; a batched SvecPSD constraint spans
+            # con.num_cones() consecutive cones. Concatenating those cones gives
+            # the constraint's dual in the svec form PSDToSvecPSD.recover_dual
+            # expects.
+            psd_idx = 0
+            for con in constr_map[SvecPSD_obj]:
+                k = con.num_cones()
+                blocks = direct_prims[PSD][psd_idx:psd_idx + k]
+                dual_vars[con.id] = np.concatenate(blocks)
+                psd_idx += k
             i = 0
             for con in constr_map[ExpCone_obj]:
                 dv = direct_prims[DUAL_EXP][i:i + con.size]

--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -469,11 +469,13 @@ class ConeMatrixStuffing(MatrixStuffing):
                 shape = con_obj.shape
                 dual_value = solution.dual_vars.get(new_con)
                 # TODO rationalize Exponential.
-                if dual_value is not None:
-                    if shape == () or isinstance(con_obj, (ExpCone, SOC)):
-                        dual_vars[old_con] = dual_value
-                    else:
-                        dual_vars[old_con] = np.reshape(dual_value, shape, order="F")
+                if dual_value is None:
+                    continue
+                if shape == () or isinstance(con_obj, (ExpCone, SOC)) or \
+                        (isinstance(con_obj, PSD) and con_obj.num_cones() > 1):
+                    dual_vars[old_con] = dual_value
+                else:
+                    dual_vars[old_con] = np.reshape(dual_value, shape, order="F")
 
         primal_vars = {}
         if solution.status not in s.SOLUTION_PRESENT:
@@ -485,22 +487,6 @@ class ConeMatrixStuffing(MatrixStuffing):
             shape = inverse_data.var_shapes[var_id]
             size = np.prod(shape, dtype=int)
             primal_vars[var_id] = np.reshape(x_opt[offset: offset + size], shape, order="F")
-
-        # Remap dual variables if dual exists (problem is convex).
-        if solution.dual_vars is not None:
-            for old_con, new_con in con_map.items():
-                con_obj = inverse_data.id2cons[old_con]
-                shape = con_obj.shape
-                # TODO rationalize Exponential.
-                if shape == () or isinstance(con_obj, (ExpCone, SOC)) or \
-                        (isinstance(con_obj, PSD) and con_obj.num_cones() > 1):
-                    dual_vars[old_con] = solution.dual_vars[new_con]
-                else:
-                    dual_vars[old_con] = np.reshape(
-                        solution.dual_vars[new_con],
-                        shape,
-                        order='F'
-                    )
 
         return Solution(solution.status, opt_val, primal_vars, dual_vars,
                         solution.attr)

--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -16,6 +16,46 @@ from cvxpy.utilities.citations import CITATION_DICT
 from cvxpy.utilities.psd_utils import TriangleKind
 
 
+def _add_psd_bound_rows(A, b, dims, lb, ub):
+    """Add finite variable bounds as explicit inequality rows.
+
+    The rows are inserted right after the existing NonNeg (LEQ) block so the
+    cone partition passed to ``loadConeMatrix`` stays contiguous: COPT expects
+    rows ordered as free, linear, SOC, exponential, PSD.
+    """
+    n = A.shape[1]
+    extra_rows = []
+    extra_b = []
+
+    if ub is not None:
+        finite_ub = np.isfinite(ub)
+        n_ub = int(np.count_nonzero(finite_ub))
+        if n_ub:
+            extra_rows.append(_bound_selector(n_ub, n, np.flatnonzero(finite_ub), 1.0))
+            extra_b.append(ub[finite_ub])
+
+    if lb is not None:
+        finite_lb = np.isfinite(lb)
+        n_lb = int(np.count_nonzero(finite_lb))
+        if n_lb:
+            extra_rows.append(_bound_selector(n_lb, n, np.flatnonzero(finite_lb), -1.0))
+            extra_b.append(-lb[finite_lb])
+
+    if extra_rows:
+        insert_at = dims[s.EQ_DIM] + dims[s.LEQ_DIM]
+        bound_block = sp.vstack(extra_rows, format='csr')
+        A = sp.vstack([A[:insert_at], bound_block, A[insert_at:]], format='csc')
+        b = np.concatenate([b[:insert_at], *extra_b, b[insert_at:]])
+        dims[s.LEQ_DIM] += bound_block.shape[0]
+
+    return A, b
+
+
+def _bound_selector(num_rows, num_cols, cols, value):
+    return sp.csr_array((np.full(num_rows, value), (np.arange(num_rows), cols)),
+                        shape=(num_rows, num_cols))
+
+
 class COPT(ConicSolver):
     """
     An interface for the COPT solver.
@@ -47,8 +87,10 @@ class COPT(ConicSolver):
                   7: s.OPTIMAL_INACCURATE,  # imprecise
                   8: s.USER_LIMIT,          # time out
                   9: s.SOLVER_ERROR,        # unfinished
-                 10: s.USER_LIMIT,          # interrupted
-                 11: s.USER_LIMIT           # iteration limit
+                  10: s.USER_LIMIT,         # interrupted
+                  11: s.USER_LIMIT,         # iteration limit
+                  20: s.OPTIMAL,            # local optimal
+                  21: s.INFEASIBLE          # local infeasible
                  }
 
     def name(self):
@@ -182,25 +224,10 @@ class COPT(ConicSolver):
             psd_lb = data[s.LOWER_BOUNDS]
             psd_ub = data[s.UPPER_BOUNDS]
             if psd_lb is not None or psd_ub is not None:
-                n = c.shape[0]
-                extra_rows = []
-                extra_b = []
-                if psd_ub is not None:
-                    # x_i <= ub_i  =>  x_i <= ub_i  (LEQ constraint: I @ x <= ub)
-                    extra_rows.append(sp.eye_array(n, format='csc'))
-                    extra_b.append(psd_ub)
-                    dims[s.LEQ_DIM] += n
-                if psd_lb is not None:
-                    # x_i >= lb_i  =>  -x_i <= -lb_i  (LEQ constraint: -I @ x <= -lb)
-                    extra_rows.append(-sp.eye_array(n, format='csc'))
-                    extra_b.append(-psd_lb)
-                    dims[s.LEQ_DIM] += n
-                A = sp.vstack([A] + extra_rows, format='csc')
-                b = np.concatenate([b] + extra_b)
+                A, b = _add_psd_bound_rows(A, b, dims, psd_lb, psd_ub)
 
             # Solve the dualized problem
-            # TODO switch to `A.transpose().tocsc()` when COPT supports sparray
-            rowmap = model.loadConeMatrix(-b, sp.csc_matrix(A.transpose()), -c, dims)
+            rowmap = model.loadConeMatrix(-b, A.transpose().tocsc(), -c, dims)
             model.objsense = copt.COPT.MAXIMIZE
         else:
             # Build problem data
@@ -285,8 +312,7 @@ class COPT(ConicSolver):
                     vtype = np.append(vtype, [copt.COPT.CONTINUOUS] * nexpconedim)
 
             # Load matrix data
-            # TODO remove `sp.csc_matrix` when COPT starts supporting sparray
-            model.loadMatrix(c, sp.csc_matrix(A), lhs, rhs, lb, ub, vtype)
+            model.loadMatrix(c, A.tocsc(), lhs, rhs, lb, ub, vtype)
 
             # Load cone data
             if dims[s.SOC_DIM]:

--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -47,7 +47,8 @@ class COPT(ConicSolver):
                   7: s.OPTIMAL_INACCURATE,  # imprecise
                   8: s.USER_LIMIT,          # time out
                   9: s.SOLVER_ERROR,        # unfinished
-                  10: s.USER_LIMIT          # interrupted
+                 10: s.USER_LIMIT,          # interrupted
+                 11: s.USER_LIMIT           # iteration limit
                  }
 
     def name(self):

--- a/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cvxopt_conif.py
@@ -26,6 +26,7 @@ from cvxpy.constraints import PSD, SOC, NonNeg, Zero
 from cvxpy.reductions.solvers.compr_matrix import compress_matrix
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.kktsolver import setup_ldl_factor
+from cvxpy.reductions.solvers.openmp_conflict import warn_if_omp_conflict
 from cvxpy.utilities.citations import CITATION_DICT
 
 
@@ -73,6 +74,7 @@ class CVXOPT(ConicSolver):
     def import_solver(self) -> None:
         """Imports the solver.
         """
+        warn_if_omp_conflict("cvxopt")
         import cvxopt  # noqa F401
 
     def accepts(self, problem) -> bool:

--- a/cvxpy/reductions/solvers/conic_solvers/knitro_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/knitro_conif.py
@@ -25,6 +25,7 @@ from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ParamConeProg
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver, dims_to_solver_dict
+from cvxpy.reductions.solvers.openmp_conflict import warn_if_omp_conflict
 from cvxpy.utilities.citations import CITATION_DICT
 
 
@@ -310,6 +311,7 @@ class KNITRO(ConicSolver):
 
     def import_solver(self) -> None:
         """Imports the solver."""
+        warn_if_omp_conflict("knitro")
         import knitro  # noqa: F401
 
     def supports_quad_obj(self):

--- a/cvxpy/reductions/solvers/conic_solvers/knitro_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/knitro_conif.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import importlib.util
+
 import numpy as np
 import scipy.sparse as sp
 
@@ -295,6 +297,16 @@ class KNITRO(ConicSolver):
     def name(self):
         """The name of the solver."""
         return s.KNITRO
+
+    def is_installed(self) -> bool:
+        """Checks for the ``knitro`` package without importing it.
+
+        Importing ``knitro`` loads the native KNITRO runtime (and, on macOS,
+        a bundled OpenMP library). Doing that eagerly from ``import cvxpy``
+        can crash other solvers that load their own OpenMP runtime, so
+        installation is detected via the import machinery instead.
+        """
+        return importlib.util.find_spec("knitro") is not None
 
     def import_solver(self) -> None:
         """Imports the solver."""

--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -45,20 +45,6 @@ For example, replace mosek.iparam.num_threads with 'MSK_IPAR_NUM_THREADS'
 """
 
 
-def vectorized_lower_tri_to_mat(v, dim):
-    """
-    :param v: a list of length (dim * (dim + 1) / 2)
-    :param dim: the number of rows (equivalently, columns) in the output array.
-    :return: Return the symmetric 2D array defined by taking "v" to
-      specify its lower triangular entries.
-    """
-    rows, cols, vals = vectorized_lower_tri_to_triples(v, dim)
-    A = sp.sparse.coo_matrix((vals, (rows, cols)), shape=(dim, dim)).toarray()
-    d = np.diag(np.diag(A))
-    A = A + A.T - d
-    return A
-
-
 def vectorized_lower_tri_to_triples(A: sp.sparse.coo_matrix | sp.sparse.sparray |
                                         list[float] | np.ndarray, dim: int) \
                                     -> tuple[list[int], list[int], list[float]]:
@@ -603,11 +589,13 @@ class MOSEK(ConicSolver):
             idx += (3 * num_dpow)
         num_psd = len(K_dir[a2d.PSD])
         if num_psd > 0:
+            # getbarxj returns each PSD block as column-major lower-triangular
+            # entries; Dualize consumes this svec form directly (see #3268).
             psd_vars = []
             for j, dim in enumerate(K_dir[a2d.PSD]):
                 xj = [0.] * (dim * (dim + 1) // 2)
                 task.getbarxj(sol, j, xj)
-                psd_vars.append(vectorized_lower_tri_to_mat(xj, dim))
+                psd_vars.append(np.array(xj))
             prim_vars[a2d.PSD] = psd_vars
         return prim_vars
 

--- a/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
@@ -64,7 +64,10 @@ class XPRESS(ConicSolver):
         """Imports the solver.
         """
         import xpress
-        self.version = xpress.getversion()
+        try:
+            self.version = xpress.getVersion()
+        except AttributeError:
+            self.version = xpress.getversion()
 
     def accepts(self, problem) -> bool:
         """Can Xpress solve the problem?

--- a/cvxpy/reductions/solvers/nlp_solvers/copt_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/copt_nlpif.py
@@ -256,6 +256,15 @@ class COPT(NLPsolver):
         for key, value in solver_opts.items():
             model.setParam(key, value)
 
+        # COPT may evaluate the gradient/Jacobian/Hessian callbacks at the
+        # initial point before calling the objective/constraint callbacks.
+        # The oracles cache intermediate values from a forward pass, so prime
+        # them here to ensure the first derivative evaluation uses correct
+        # values rather than stale defaults.
+        oracles.objective(x0)
+        if m > 0:
+            oracles.constraints(x0)
+
         # Solve problem
         model.solve()
 

--- a/cvxpy/reductions/solvers/nlp_solvers/copt_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/copt_nlpif.py
@@ -37,7 +37,10 @@ class COPT(NLPsolver):
                   7: s.OPTIMAL_INACCURATE,  # imprecise
                   8: s.USER_LIMIT,          # time out
                   9: s.SOLVER_ERROR,        # unfinished
-                  10: s.USER_LIMIT          # interrupted
+                  10: s.USER_LIMIT,         # interrupted
+                  11: s.USER_LIMIT,         # iteration limit
+                  20: s.OPTIMAL,            # local optimal
+                  21: s.INFEASIBLE          # local infeasible
                  }
 
     def name(self):

--- a/cvxpy/reductions/solvers/nlp_solvers/ipopt_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/ipopt_nlpif.py
@@ -21,6 +21,7 @@ import numpy as np
 import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.nlp_solvers.nlp_solver import NLPsolver
+from cvxpy.reductions.solvers.openmp_conflict import warn_if_omp_conflict
 from cvxpy.utilities.citations import CITATION_DICT
 
 
@@ -83,6 +84,7 @@ class IPOPT(NLPsolver):
         """
         Imports the solver.
         """
+        warn_if_omp_conflict("cyipopt")
         import cyipopt  # noqa F401
 
     def invert(self, solution, inverse_data):

--- a/cvxpy/reductions/solvers/nlp_solvers/ipopt_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/ipopt_nlpif.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import importlib.util
+
 import numpy as np
 
 import cvxpy.settings as s
@@ -65,6 +67,17 @@ class IPOPT(NLPsolver):
         The name of solver.
         """
         return 'IPOPT'
+
+    def is_installed(self) -> bool:
+        """Checks for the ``cyipopt`` package without importing it.
+
+        Importing ``cyipopt`` loads the native IPOPT runtime (and a bundled
+        OpenMP library on macOS). Detecting installation via the import
+        machinery keeps ``import cvxpy`` from loading it, so it does not
+        share a process -- and an OpenMP runtime -- with other solvers
+        unless an IPOPT solve actually runs.
+        """
+        return importlib.util.find_spec("cyipopt") is not None
 
     def import_solver(self):
         """

--- a/cvxpy/reductions/solvers/nlp_solvers/knitro_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/knitro_nlpif.py
@@ -21,6 +21,7 @@ import numpy as np
 import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers.nlp_solvers.nlp_solver import NLPsolver
+from cvxpy.reductions.solvers.openmp_conflict import warn_if_omp_conflict
 from cvxpy.utilities.citations import CITATION_DICT
 
 
@@ -123,6 +124,7 @@ class KNITRO(NLPsolver):
         """
         Imports the solver.
         """
+        warn_if_omp_conflict("knitro")
         import knitro  # noqa F401
 
     def invert(self, solution, inverse_data):

--- a/cvxpy/reductions/solvers/nlp_solvers/knitro_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/knitro_nlpif.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import importlib.util
+
 import numpy as np
 
 import cvxpy.settings as s
@@ -106,6 +108,16 @@ class KNITRO(NLPsolver):
         The name of solver.
         """
         return 'KNITRO'
+
+    def is_installed(self) -> bool:
+        """Checks for the ``knitro`` package without importing it.
+
+        Importing ``knitro`` loads the native KNITRO runtime (and, on macOS,
+        a bundled OpenMP library). Doing that eagerly from ``import cvxpy``
+        can crash other solvers that load their own OpenMP runtime, so
+        installation is detected via the import machinery instead.
+        """
+        return importlib.util.find_spec("knitro") is not None
 
     def import_solver(self):
         """

--- a/cvxpy/reductions/solvers/nlp_solvers/nlp_solver.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/nlp_solver.py
@@ -136,8 +136,11 @@ class Bounds:
             ub_flat = np.asarray(ub).flatten(order='F')
             var_lower.extend(lb_flat)
             var_upper.extend(ub_flat)
-        self.lb = np.array(var_lower)
-        self.ub = np.array(var_upper)
+        # Force float dtype: all-integer bounds (e.g. nonneg=True gives lb 0)
+        # would otherwise infer an integer array, and replacing entries with a
+        # solver's infinity sentinel (~1e20) overflows int64.
+        self.lb = np.array(var_lower, dtype=float)
+        self.ub = np.array(var_upper, dtype=float)
 
     def construct_initial_point(self) -> None:
         """ Loop through all variables and collect the intial point."""

--- a/cvxpy/reductions/solvers/openmp_conflict.py
+++ b/cvxpy/reductions/solvers/openmp_conflict.py
@@ -1,0 +1,70 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+
+from cvxpy.utilities.warn import warn
+
+# Packages whose macOS wheels bundle their own OpenMP runtime. Loading two of
+# these into one process can crash inside a solver's parallel section:
+#   - knitro and cyipopt each bundle LLVM ``libomp.dylib``
+#   - cvxopt bundles a parallel OpenBLAS that links GNU ``libgomp.1.dylib``
+# LLVM libomp and GNU libgomp were never designed to coexist in one process,
+# and even two copies of libomp share no global state across instances.
+#
+# The conflict is macOS-specific: on Linux, auditwheel-built wheels typically
+# share a single system libgomp via symbol versioning, and we have not observed
+# a crash from this combination in CI.
+_OMP_BUNDLING_PACKAGES: tuple[str, ...] = ("knitro", "cyipopt", "cvxopt")
+
+
+def warn_if_omp_conflict(importing: str) -> None:
+    """Warn if importing ``importing`` would put two OMP-bundling solvers in
+    one process on macOS.
+
+    Call this immediately before importing the solver's native bindings, so the
+    user sees the warning before any subsequent crash. The check looks at
+    ``sys.modules`` for already-imported sibling packages and does not import
+    anything itself.
+
+    No-op on non-macOS platforms, where the bundled-OpenMP conflict does not
+    manifest as a crash in practice.
+
+    Parameters
+    ----------
+    importing : str
+        Top-level package name about to be imported, e.g. ``"knitro"``.
+    """
+    if not sys.platform.startswith("darwin"):
+        return
+    if importing not in _OMP_BUNDLING_PACKAGES:
+        return
+    already_loaded = [
+        pkg for pkg in _OMP_BUNDLING_PACKAGES
+        if pkg != importing and pkg in sys.modules
+    ]
+    if not already_loaded:
+        return
+    warn(
+        f"Loading {importing!r} into a process that has already imported "
+        f"{', '.join(repr(p) for p in already_loaded)}. Each of these "
+        "packages ships its own OpenMP runtime in its macOS wheel (LLVM "
+        "libomp for knitro and cyipopt; GNU libgomp for cvxopt via its "
+        "OpenBLAS dependency), and mixing them in one process can crash "
+        "inside a solver's parallel section. If you hit a segfault, run "
+        "each of these solvers in a separate Python process.",
+        RuntimeWarning,
+    )

--- a/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
@@ -33,8 +33,10 @@ class COPT(QpSolver):
                   7: s.OPTIMAL_INACCURATE,  # imprecise
                   8: s.USER_LIMIT,          # time out
                   9: s.SOLVER_ERROR,        # unfinished
-                 10: s.USER_LIMIT,          # interrupted
-                 11: s.USER_LIMIT           # iteration limit
+                  10: s.USER_LIMIT,         # interrupted
+                  11: s.USER_LIMIT,         # iteration limit
+                  20: s.OPTIMAL,            # local optimal
+                  21: s.INFEASIBLE          # local infeasible
                  }
 
     def name(self):
@@ -170,8 +172,7 @@ class COPT(QpSolver):
                 vtype[data[s.INT_IDX]] = copt.COPT.INTEGER
 
         # Load matrix data
-        # TODO remove `sp.csc_matrix` when COPT starts supporting sparray
-        model.loadMatrix(q, sp.csc_matrix(Amat), lhs, rhs, lb, ub, vtype)
+        model.loadMatrix(q, Amat.tocsc(), lhs, rhs, lb, ub, vtype)
 
         # Load Q data
         if P.count_nonzero():

--- a/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
@@ -33,7 +33,8 @@ class COPT(QpSolver):
                   7: s.OPTIMAL_INACCURATE,  # imprecise
                   8: s.USER_LIMIT,          # time out
                   9: s.SOLVER_ERROR,        # unfinished
-                  10: s.USER_LIMIT          # interrupted
+                 10: s.USER_LIMIT,          # interrupted
+                 11: s.USER_LIMIT           # iteration limit
                  }
 
     def name(self):

--- a/cvxpy/reductions/solvers/qp_solvers/knitro_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/knitro_qpif.py
@@ -22,6 +22,7 @@ from scipy import sparse
 import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
+from cvxpy.reductions.solvers.openmp_conflict import warn_if_omp_conflict
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 from cvxpy.utilities.citations import CITATION_DICT
 
@@ -145,6 +146,7 @@ class KNITRO(QpSolver):
 
     def import_solver(self) -> None:
         """Imports the Knitro solver."""
+        warn_if_omp_conflict("knitro")
         import knitro  # noqa: F401
 
     def apply(self, problem):

--- a/cvxpy/reductions/solvers/qp_solvers/knitro_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/knitro_qpif.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import importlib.util
+
 import numpy as np
 from scipy import sparse
 
@@ -130,6 +132,16 @@ class KNITRO(QpSolver):
 
     def name(self):
         return s.KNITRO
+
+    def is_installed(self) -> bool:
+        """Checks for the ``knitro`` package without importing it.
+
+        Importing ``knitro`` loads the native KNITRO runtime (and, on macOS,
+        a bundled OpenMP library). Doing that eagerly from ``import cvxpy``
+        can crash other solvers that load their own OpenMP runtime, so
+        installation is detected via the import machinery instead.
+        """
+        return importlib.util.find_spec("knitro") is not None
 
     def import_solver(self) -> None:
         """Imports the Knitro solver."""

--- a/cvxpy/tests/nlp_tests/derivative_checker.py
+++ b/cvxpy/tests/nlp_tests/derivative_checker.py
@@ -136,8 +136,13 @@ class DerivativeChecker:
         if duals is None:
             duals = np.random.rand(len(self.cl))
 
-        # must run gradient because for logistic it fills some values
+        # Establish the evaluation point at x: eval_hessian_vals_coo_lower_tri
+        # reads back whatever point the last forward passes were run at, so it
+        # must be pinned here rather than inherited from a previous check.
         self._init_coo()
+        self.c_problem.objective_forward(x)
+        self.c_problem.constraint_forward(x)
+        # must run gradient because for logistic it fills some values
         self.c_problem.gradient()
         c_hess_vals = self.c_problem.eval_hessian_vals_coo_lower_tri(obj_factor, duals)
         n_vars = len(x)
@@ -204,8 +209,16 @@ class DerivativeChecker:
 
         return match
 
-    def check_gradient(self, x=None, epsilon=1e-8):
-        """ Compare C-based gradient with numerical approximation using finite differences. """
+    def check_gradient(self, x=None, epsilon=1e-6):
+        """ Compare C-based gradient with numerical approximation using finite differences.
+
+        The central-difference step is ~eps_machine**(1/3), which balances
+        truncation error (O(epsilon**2)) against floating-point cancellation
+        (O(eps_machine * |objective| / epsilon)). A smaller step such as 1e-8
+        makes the cancellation term dominate: for problems with a large
+        objective value it swamps small gradient components and the check
+        fails spuriously.
+        """
         if x is None:
             x = self.x0
         # Get gradient from C implementation

--- a/cvxpy/tests/nlp_tests/test_interfaces.py
+++ b/cvxpy/tests/nlp_tests/test_interfaces.py
@@ -19,21 +19,10 @@ import pytest
 
 import cvxpy as cp
 from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS
+from cvxpy.tests.test_conic_solvers import is_knitro_available
 
 
-def is_knitro_available():
-    """Check if KNITRO is installed and a license is available."""
-    import os
-    if 'KNITRO' not in INSTALLED_SOLVERS:
-        return False
-    # Only run KNITRO tests if license env var is explicitly set
-    # This prevents hanging in CI when KNITRO is installed but not licensed
-    return bool(
-        os.environ.get('ARTELYS_LICENSE') or
-        os.environ.get('ARTELYS_LICENSE_NETWORK_ADDR')
-    )
-
-
+@pytest.mark.knitro
 @pytest.mark.skipif(
     not is_knitro_available(),
     reason='KNITRO is not installed or license is not available.'

--- a/cvxpy/tests/nlp_tests/test_nlp_solvers.py
+++ b/cvxpy/tests/nlp_tests/test_nlp_solvers.py
@@ -27,8 +27,8 @@ from cvxpy.tests.test_conic_solvers import is_knitro_available
 NLP_SOLVERS = [
     pytest.param('IPOPT', marks=pytest.mark.skipif(
         'IPOPT' not in INSTALLED_SOLVERS, reason='IPOPT is not installed.')),
-    pytest.param('KNITRO', marks=pytest.mark.skipif(
-        not is_knitro_available(), reason='KNITRO is not installed or license not available.')),
+    pytest.param('KNITRO', marks=[pytest.mark.knitro, pytest.mark.skipif(
+        not is_knitro_available(), reason='KNITRO is not installed or license not available.')]),
     pytest.param('UNO', marks=pytest.mark.skipif(
         'UNO' not in INSTALLED_SOLVERS, reason='UNO is not installed.')),
     pytest.param('COPT', marks=pytest.mark.skipif(
@@ -144,8 +144,9 @@ class TestNLPExamples:
         checker = DerivativeChecker(problem)
         checker.run_and_assert()
 
-    @pytest.mark.skipif('UNO' in INSTALLED_SOLVERS, reason='UNO has an algorithmic error')
     def test_rosenbrock(self, solver):
+        if solver == 'UNO':
+            pytest.skip('UNO has an algorithmic error')
         x = cp.Variable(2, name='x')
         objective = cp.Minimize((1 - x[0])**2 + 100 * (x[1] - x[0]**2)**2)
         problem = cp.Problem(objective, [])
@@ -356,11 +357,12 @@ class TestNLPExamples:
         checker = DerivativeChecker(problem)
         checker.run_and_assert()
 
-    @pytest.mark.skipif('UNO' in INSTALLED_SOLVERS, reason='UNO finds a KKT point with worse obj')
     def test_circle_packing_formulation_two(self, solver):
         """Using norm_inf. This test revealed a very subtle bug in the unpacking of
         the ipopt solution. Some variables were mistakenly reordered. It was fixed
         in https://github.com/cvxgrp/cvxpy-ipopt/pull/82"""
+        if solver == 'UNO':
+            pytest.skip('UNO finds a KKT point with worse obj')
         rng = np.random.default_rng(5)
         n = 3
         radius = rng.uniform(1.0, 3.0, n)
@@ -424,8 +426,9 @@ class TestNLPExamples:
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
 
-    @pytest.mark.skipif('UNO' in INSTALLED_SOLVERS, reason='UNO reaches iteration limit')
     def test_geo_mean(self, solver):
+        if solver == 'UNO':
+            pytest.skip('UNO reaches iteration limit')
         x = cp.Variable(3, nonneg=True)
         geo_mean = cp.geo_mean(x)
         objective = cp.Maximize(geo_mean)
@@ -438,8 +441,9 @@ class TestNLPExamples:
         checker = DerivativeChecker(problem)
         checker.run_and_assert()
 
-    @pytest.mark.skipif('UNO' in INSTALLED_SOLVERS, reason='UNO reaches iteration limit')
     def test_geo_mean2(self, solver):
+        if solver == 'UNO':
+            pytest.skip('UNO reaches iteration limit')
         p = np.array([.07, .12, .23, .19, .39])
         x = cp.Variable(5, nonneg=True)
         prob = cp.Problem(cp.Maximize(cp.geo_mean(x, p)), [cp.sum(x) <= 1])

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -914,11 +914,9 @@ def is_mosek_available():
     if 'MOSEK' not in INSTALLED_SOLVERS:
         return False
     try:
-        import mosek  # type: ignore
-        env = mosek.Env()
-        # Try to get license status (returns 0 if OK)
-        status = env.getlicense()
-        return status == mosek.rescode.ok
+        x = cp.Variable()
+        cp.Problem(cp.Minimize(x), [x >= 0]).solve(solver=cp.MOSEK)
+        return True
     except Exception:
         return False
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -3211,6 +3211,7 @@ def is_knitro_available():
         or os.environ.get('ARTELYS_LICENSE_NETWORK_ADDR')
     )
 
+@pytest.mark.knitro
 @unittest.skipUnless(is_knitro_available(), 'KNITRO is not installed or license is not available.')
 class TestKNITRO(BaseTest):
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -944,6 +944,11 @@ class TestMosek(unittest.TestCase):
     def test_mosek_lp_5(self) -> None:
         StandardTestLPs.test_lp_5(solver='MOSEK')
 
+    @pytest.mark.xfail(
+        reason="MOSEK does not support native variable bounds yet "
+               "(BOUNDED_VARIABLES is False); bounds are desugared to constraints.",
+        strict=True,
+    )
     def test_mosek_lp_bound_attr(self) -> None:
         StandardTestLPs.test_lp_bound_attr(solver='MOSEK')
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -3191,19 +3191,20 @@ class TestCOSMO(BaseTest):
         print(time > time2)
 
 def is_knitro_available():
-    """Check if KNITRO is installed and a license is available."""
+    """Check if KNITRO is installed and a license is available.
+
+    Detection is intentionally based on environment variables rather than
+    importing ``knitro``: importing it loads the native KNITRO runtime (and
+    a bundled OpenMP library on macOS) into the test process, which can
+    crash other solvers -- e.g. an IPOPT solve segfaults on macOS once
+    knitro has been imported.
+    """
     if 'KNITRO' not in INSTALLED_SOLVERS:
         return False
-    try:
-        import knitro  # type: ignore
-        # Try to create and delete a Knitro solver instance
-        kc = knitro.KN_new()
-        if kc is None:
-            return False
-        knitro.KN_free(kc)
-        return True
-    except Exception:
-        return False
+    return bool(
+        os.environ.get('ARTELYS_LICENSE')
+        or os.environ.get('ARTELYS_LICENSE_NETWORK_ADDR')
+    )
 
 @unittest.skipUnless(is_knitro_available(), 'KNITRO is not installed or license is not available.')
 class TestKNITRO(BaseTest):

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -3017,7 +3017,9 @@ class TestCOPT(unittest.TestCase):
         StandardTestECPs.test_expcone_1(solver='COPT')
 
     def test_copt_exp_soc_1(self) -> None:
-        StandardTestMixedCPs.test_exp_soc_1(solver='COPT')
+        # Tighten tolerances so the exponential-cone dual values converge
+        # to the 3 decimal places the test checks.
+        StandardTestMixedCPs.test_exp_soc_1(solver='COPT', FeasTol=1e-9, DualTol=1e-9)
 
     def test_copt_mi_lp_0(self) -> None:
         StandardTestLPs.test_mi_lp_0(solver='COPT')

--- a/cvxpy/tests/test_openmp_conflict.py
+++ b/cvxpy/tests/test_openmp_conflict.py
@@ -1,0 +1,77 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+import warnings
+
+import pytest
+
+from cvxpy.reductions.solvers.openmp_conflict import warn_if_omp_conflict
+
+
+@pytest.fixture
+def darwin_isolated(monkeypatch):
+    """Pretend to be macOS with no OMP-bundling packages loaded.
+
+    The conflict warning is gated on ``sys.platform == "darwin"``, so to
+    exercise it on Linux/Windows CI runners we monkeypatch the platform.
+    """
+    monkeypatch.setattr(sys, "platform", "darwin")
+    for pkg in ("knitro", "cyipopt", "cvxopt"):
+        monkeypatch.delitem(sys.modules, pkg, raising=False)
+
+
+def test_no_warning_when_alone(darwin_isolated) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # turn any warning into an exception
+        warn_if_omp_conflict("knitro")
+
+
+def test_warns_when_cvxopt_already_loaded(darwin_isolated, monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "cvxopt", object())
+    with pytest.warns(RuntimeWarning, match=r"knitro.*cvxopt"):
+        warn_if_omp_conflict("knitro")
+
+
+def test_warns_when_knitro_already_loaded(darwin_isolated, monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "knitro", object())
+    with pytest.warns(RuntimeWarning, match=r"cyipopt.*knitro"):
+        warn_if_omp_conflict("cyipopt")
+
+
+def test_lists_all_loaded_siblings(darwin_isolated, monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "knitro", object())
+    monkeypatch.setitem(sys.modules, "cyipopt", object())
+    with pytest.warns(RuntimeWarning) as record:
+        warn_if_omp_conflict("cvxopt")
+    msg = str(record[0].message)
+    assert "knitro" in msg and "cyipopt" in msg
+
+
+def test_silent_for_unrelated_package(darwin_isolated, monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "knitro", object())
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_if_omp_conflict("numpy")  # not an OMP-bundling package
+
+
+def test_silent_on_non_darwin(monkeypatch) -> None:
+    """On Linux/Windows the gate short-circuits even when a conflict exists."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setitem(sys.modules, "cvxopt", object())
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_if_omp_conflict("knitro")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ reportOperatorIssue = false         # 22 errors
 testpaths = [
     "cvxpy/tests/"
 ]
+markers = [
+    "knitro: tests that load the native KNITRO runtime; run in a separate process from other native solvers (see test_nlp_solvers.yml)",
+]
 
 [build-system]
 requires = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,10 @@ dynamic = ["version"]
 # Solver names as in cvxpy.settings = pip-installable distribution providing it
 CBC = ["cylp>=0.91.5"]
 CLARABEL = []
+# coptpy >= 8.0.3 provides the NLP callback API (NlpCallbackBase, loadNlData)
+# the COPT NLP interface relies on. It also accepts scipy sparse arrays
+# (csc_array) in loadMatrix / loadConeMatrix, supported since 7.2.5.
+COPT = ["coptpy>=8.0.3"]
 # CUOPT dependency group is disabled since it was breaking uv sync.
 # CUOPT = ["cuopt-cu12>=25.5", "nvidia-cuda-runtime-cu12>=12.8,<13.0"]
 CVXOPT = ["cvxopt"]
@@ -127,6 +131,7 @@ SCS = []
 XPRESS = ["xpress>=9.5"]
 DAQP = ["daqp"]
 KNITRO = ["knitro"]
+UNO = ["unopy"]
 # IPOPT = ["cyipopt"]  # requires system IPOPT; excluded from --all-extras
 testing = ["pytest", "hypothesis"]
 doc = ["sphinx",


### PR DESCRIPTION
## Description
Backport of bug fixes and CI updates from `master` to `release/1.9.x` for the 1.9.1 patch release. Cherry-picks the seven PRs labeled "PR backport needed" that were merged to master after v1.9.0:

- #3332 — Fix `is_mosek_available`: `getlicense()` changed in MOSEK 11
- #3334 — Update `xpress.getversion()` → `getVersion()` for Xpress 9.9 compatibility
- #3336 — Add new status of COPT
- #3340 — Add KNITRO to the nlp solvers CI job
- #3335 — Fix MOSEK conic interface: SDP dual KeyError + xfail unsupported bounds test
- #3341 — Isolate KNITRO conic tests and warn on OpenMP-runtime conflicts
- #3338 — Fix COPT PSD bounds with unbounded variables and NLP interface (also adds the COPT and UNO optional-dependency extras and the corresponding workflow plumbing)

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.