### PR TITLE
Apply MOSEK/KNITRO fixes to test_qp_solvers, rewrite as pytest

### DIFF
--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -64,7 +64,10 @@ jobs:
         run: uv run pytest -rs -m knitro cvxpy/tests/test_conic_solvers.py
       - name: Run test_qp_solvers
         if: always()
-        run: uv run pytest -rs cvxpy/tests/test_qp_solvers.py
+        run: uv run pytest -rs -m "not knitro" cvxpy/tests/test_qp_solvers.py
+      - name: Run test_qp_solvers (KNITRO)
+        if: always()
+        run: uv run pytest -rs -m knitro cvxpy/tests/test_qp_solvers.py
 
     env:
       RUNNER_OS: ${{ matrix.os }}

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -14,9 +14,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import os
 import unittest
 
 import numpy as np
+import pytest
 import scipy.sparse as sp
 from scipy.linalg import lstsq
 
@@ -49,6 +51,48 @@ from cvxpy.tests.solver_test_helpers import (
     StandardTestLPs,
     StandardTestQPs,
 )
+
+
+def is_mosek_available():
+    """Check if MOSEK is installed and a license is available."""
+    if 'MOSEK' not in INSTALLED_SOLVERS:
+        return False
+    try:
+        x = cp.Variable()
+        cp.Problem(cp.Minimize(x), [x >= 0]).solve(solver=cp.MOSEK)
+        return True
+    except Exception:
+        return False
+
+
+def is_knitro_available():
+    """Check if KNITRO is installed and a license is available.
+
+    Detection is intentionally based on environment variables rather than
+    importing ``knitro``: importing it loads the native KNITRO runtime (and
+    a bundled OpenMP library on macOS) into the test process, which can
+    crash other solvers -- e.g. an IPOPT solve segfaults on macOS once
+    knitro has been imported.
+    """
+    if 'KNITRO' not in INSTALLED_SOLVERS:
+        return False
+    return bool(
+        os.environ.get('ARTELYS_LICENSE')
+        or os.environ.get('ARTELYS_LICENSE_NETWORK_ADDR')
+    )
+
+
+def is_xpress_available():
+    """Check if XPRESS is installed and a license is available."""
+    if 'XPRESS' not in INSTALLED_SOLVERS:
+        return False
+    try:
+        import xpress  # type: ignore
+        env = xpress.env()
+        status = env.getlicense()
+        return status == 0
+    except Exception:
+        return False
 
 
 class QPTestBase(BaseTest):
@@ -85,56 +129,14 @@ class QPTestBase(BaseTest):
         """Override in subclasses."""
         raise NotImplementedError
 
-    # License checking helpers - shared by subclasses
-    @staticmethod
-    def is_mosek_available():
-        """Check if MOSEK is installed and a license is available."""
-        if 'MOSEK' not in INSTALLED_SOLVERS:
-            return False
-        try:
-            import mosek  # type: ignore
-            env = mosek.Env()
-            status = env.getlicense()
-            return status == mosek.rescode.ok
-        except Exception:
-            return False
-
-    @staticmethod
-    def is_knitro_available():
-        """Check if KNITRO is installed and a license is available."""
-        if 'KNITRO' not in INSTALLED_SOLVERS:
-            return False
-        try:
-            import knitro  # type: ignore
-            kc = knitro.KN_new()
-            if kc is None:
-                return False
-            knitro.KN_free(kc)
-            return True
-        except Exception:
-            return False
-
-    @staticmethod
-    def is_xpress_available():
-        """Check if XPRESS is installed and a license is available."""
-        if 'XPRESS' not in INSTALLED_SOLVERS:
-            return False
-        try:
-            import xpress  # type: ignore
-            env = xpress.env()
-            status = env.getlicense()
-            return status == 0
-        except Exception:
-            return False
-
     def filter_licensed_solvers(self, solvers):
         """Remove solvers that don't have valid licenses."""
         result = list(solvers)
-        if 'XPRESS' in result and not self.is_xpress_available():
+        if 'XPRESS' in result and not is_xpress_available():
             result.remove('XPRESS')
-        if 'MOSEK' in result and not self.is_mosek_available():
+        if 'MOSEK' in result and not is_mosek_available():
             result.remove('MOSEK')
-        if 'KNITRO' in result and not self.is_knitro_available():
+        if 'KNITRO' in result and not is_knitro_available():
             result.remove('KNITRO')
         return result
 
@@ -497,13 +499,20 @@ class QPTestBase(BaseTest):
 
 
 class TestQp(QPTestBase):
-    """Test native QP solvers."""
+    """Test native QP solvers.
+
+    KNITRO is excluded here and exercised separately by ``TestKNITROQp``
+    so its native runtime (and bundled OpenMP library on macOS) only
+    loads in a KNITRO-only pytest invocation.
+    """
 
     def setUp(self) -> None:
         super().setUp()
 
-        # Check for all installed QP solvers
-        self.solvers = [x for x in QP_SOLVERS if x in INSTALLED_SOLVERS]
+        # Check for all installed QP solvers (KNITRO is run separately).
+        self.solvers = [
+            x for x in QP_SOLVERS if x in INSTALLED_SOLVERS and x != cp.KNITRO
+        ]
         self.solvers = self.filter_licensed_solvers(self.solvers)
 
     def solve_QP(self, problem, solver_name):
@@ -993,6 +1002,90 @@ class TestConicQuadObj(QPTestBase):
             self.equivalent_forms_1(solver)
             self.equivalent_forms_2(solver)
             self.equivalent_forms_3(solver)
+
+
+@pytest.mark.knitro
+@unittest.skipUnless(is_knitro_available(),
+                     'KNITRO is not installed or license is not available.')
+class TestKNITROQp(QPTestBase):
+    """Run the QP test suite against KNITRO in an isolated pytest invocation.
+
+    KNITRO bundles LLVM ``libomp.dylib`` in its macOS wheel; CVXOPT bundles
+    GNU ``libgomp.1.dylib`` via its OpenBLAS dependency. Loading both into
+    one process can crash inside KNITRO's KN_solve. Running this class
+    under ``-m knitro`` in a separate pytest process mirrors the conic
+    KNITRO split in ``test_conic_solvers.py``.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.solvers = [cp.KNITRO]
+
+    def solve_QP(self, problem, solver_name):
+        return problem.solve(solver=solver_name, verbose=False)
+
+    def test_all_solvers(self) -> None:
+        for solver in self.solvers:
+            self.quad_over_lin(solver)
+            self.power(solver)
+            self.power_matrix(solver)
+            self.square_affine(solver)
+            self.quad_form(solver)
+            self.affine_problem(solver)
+            self.maximize_problem(solver)
+            self.abs(solver)
+            self.quad_form_coeff(solver)
+            self.quad_form_bound(solver)
+            self.regression_1(solver)
+            self.regression_2(solver)
+            self.rep_quad_form(solver)
+            self.control(solver)
+            self.sparse_system(solver)
+            self.smooth_ridge(solver)
+            self.huber_small(solver)
+            self.huber(solver)
+            self.equivalent_forms_1(solver)
+            self.equivalent_forms_2(solver)
+            # equivalent_forms_3 is intentionally skipped for KNITRO; see
+            # the matching skip in TestQp.test_all_solvers.
+
+    def test_qp_bound_attr(self) -> None:
+        for solver in self.solvers:
+            solver_cls = SOLVER_MAP_QP.get(solver)
+            if solver_cls is not None and getattr(solver_cls, 'BOUNDED_VARIABLES', False):
+                StandardTestQPs.test_qp_bound_attr(solver=solver)
+
+    def test_parametric(self) -> None:
+        x = Variable()
+        a = 10
+        b_vec = [-10, -2.]
+
+        for solver in self.solvers:
+            x_full = []
+            obj_full = []
+            for b in b_vec:
+                obj = Minimize(a * (x ** 2) + b * x)
+                constraints = [0 <= x, x <= 1]
+                prob = Problem(obj, constraints)
+                prob.solve(solver=solver)
+                x_full += [x.value]
+                obj_full += [prob.value]
+
+            x_param = []
+            obj_param = []
+            b = Parameter()
+            obj = Minimize(a * (x ** 2) + b * x)
+            constraints = [0 <= x, x <= 1]
+            prob = Problem(obj, constraints)
+            for b_value in b_vec:
+                b.value = b_value
+                prob.solve(solver=solver)
+                x_param += [x.value]
+                obj_param += [prob.value]
+
+            for i in range(len(b_vec)):
+                self.assertItemsAlmostEqual(x_full[i], x_param[i], places=3)
+                self.assertAlmostEqual(obj_full[i], obj_param[i])
 
 
 @unittest.skipUnless('MPAX' in INSTALLED_SOLVERS, 'MPAX is not installed.')

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import os
-import unittest
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -36,7 +36,12 @@ from cvxpy.atoms import (
     sum,
     sum_squares,
 )
+from cvxpy.error import SolverError
 from cvxpy.expressions.variable import Variable
+from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
+from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
+from cvxpy.reductions.dcp2cone.dcp2cone import Dcp2Cone
+from cvxpy.reductions.flip_objective import FlipObjective
 from cvxpy.reductions.solvers.defines import (
     INSTALLED_CONIC_SOLVERS,
     INSTALLED_SOLVERS,
@@ -44,7 +49,7 @@ from cvxpy.reductions.solvers.defines import (
     SOLVER_MAP_CONIC,
     SOLVER_MAP_QP,
 )
-from cvxpy.tests.base_test import BaseTest
+from cvxpy.reductions.solvers.qp_solvers.osqp_qpif import OSQP
 from cvxpy.tests.solver_test_helpers import (
     SolverTestHelper,
     StandardTestInfeasibleProblems,
@@ -52,6 +57,9 @@ from cvxpy.tests.solver_test_helpers import (
     StandardTestQPs,
 )
 
+# --------------------------------------------------------------------------- #
+# License helpers
+# --------------------------------------------------------------------------- #
 
 def is_mosek_available():
     """Check if MOSEK is installed and a license is available."""
@@ -95,1126 +103,976 @@ def is_xpress_available():
         return False
 
 
-class QPTestBase(BaseTest):
-    """Base class with shared test helpers for QP-style problems."""
+# --------------------------------------------------------------------------- #
+# Solver parametrization
+# --------------------------------------------------------------------------- #
 
-    def setUp(self) -> None:
-        self.a = Variable(name='a')
-        self.b = Variable(name='b')
-        self.c = Variable(name='c')
+def _solver_param(solver):
+    """Build a ``pytest.param`` for ``solver`` with the right skip/knitro marks.
 
-        self.x = Variable(2, name='x')
-        self.y = Variable(3, name='y')
-        self.z = Variable(2, name='z')
-        self.w = Variable(5, name='w')
-
-        self.A = Variable((2, 2), name='A')
-        self.B = Variable((2, 2), name='B')
-        self.C = Variable((3, 2), name='C')
-
-        self.slope = Variable(1, name='slope')
-        self.offset = Variable(1, name='offset')
-        self.quadratic_coeff = Variable(1, name='quadratic_coeff')
-
-        T = 30
-        self.position = Variable((2, T), name='position')
-        self.velocity = Variable((2, T), name='velocity')
-        self.force = Variable((2, T - 1), name='force')
-
-        self.xs = Variable(80, name='xs')
-        self.xsr = Variable(50, name='xsr')
-        self.xef = Variable(80, name='xef')
-
-    def solve_QP(self, problem, solver_name):
-        """Override in subclasses."""
-        raise NotImplementedError
-
-    def filter_licensed_solvers(self, solvers):
-        """Remove solvers that don't have valid licenses."""
-        result = list(solvers)
-        if 'XPRESS' in result and not is_xpress_available():
-            result.remove('XPRESS')
-        if 'MOSEK' in result and not is_mosek_available():
-            result.remove('MOSEK')
-        if 'KNITRO' in result and not is_knitro_available():
-            result.remove('KNITRO')
-        return result
-
-    def _check_kkt(self, problem, places=4):
-        """Verify KKT conditions for a solved problem."""
-        obj_pair = (problem.objective, None)
-        var_pairs = [(v, None) for v in problem.variables()]
-        con_pairs = [(c, None) for c in problem.constraints]
-        sth = SolverTestHelper(obj_pair, var_pairs, con_pairs)
-        # Problem already solved, just use the same problem object
-        sth.prob = problem
-        sth.check_primal_feasibility(places)
-        sth.check_complementarity(places)
-        sth.check_dual_domains(places)
-        sth.check_stationary_lagrangian(places)
-
-    # Test helper methods - shared by all subclasses
-    def quad_over_lin(self, solver) -> None:
-        p = Problem(Minimize(0.5 * quad_over_lin(abs(self.x-1), 1)),
-                    [self.x <= -1])
-        self.solve_QP(p, solver)
-        for var in p.variables():
-            self.assertItemsAlmostEqual(np.array([-1., -1.]),
-                                        var.value, places=4)
-        for con in p.constraints:
-            self.assertItemsAlmostEqual(np.array([2., 2.]),
-                                        con.dual_value, places=4)
-        self._check_kkt(p, places=3)
-
-    def abs(self, solver) -> None:
-        u = Variable(2)
-        constr = []
-        constr += [abs(u[1] - u[0]) <= 100]
-        prob = Problem(Minimize(sum_squares(u)), constr)
-        print("The problem is QP: ", prob.is_qp())
-        self.assertEqual(prob.is_qp(), True)
-        result = prob.solve(solver=solver)
-        self.assertAlmostEqual(result, 0)
-
-    def power(self, solver) -> None:
-        p = Problem(Minimize(sum(power(self.x, 2))), [])
-        self.solve_QP(p, solver)
-        for var in p.variables():
-            self.assertItemsAlmostEqual([0., 0.], var.value, places=4)
-
-    def power_matrix(self, solver) -> None:
-        p = Problem(Minimize(sum(power(self.A - 3., 2))), [])
-        self.solve_QP(p, solver)
-        for var in p.variables():
-            self.assertItemsAlmostEqual([3., 3., 3., 3.],
-                                        var.value, places=4)
-
-    def square_affine(self, solver) -> None:
-        A = np.random.randn(10, 2)
-        b = np.random.randn(10)
-        p = Problem(Minimize(sum_squares(A @ self.x - b)))
-        self.solve_QP(p, solver)
-        for var in p.variables():
-            self.assertItemsAlmostEqual(lstsq(A, b)[0].flatten(order='F'), var.value,
-                                        places=1)
-
-    def quad_form(self, solver) -> None:
-        np.random.seed(0)
-        A = np.random.randn(5, 5)
-        z = np.random.randn(5)
-        P = A.T.dot(A)
-        q = -2*P.dot(z)
-        p = Problem(Minimize(QuadForm(self.w, P) + q.T @ self.w))
-        self.solve_QP(p, solver)
-        for var in p.variables():
-            self.assertItemsAlmostEqual(z, var.value, places=4)
-
-    def rep_quad_form(self, solver) -> None:
-        """A problem where the quad_form term is used multiple times.
-        """
-        np.random.seed(0)
-        A = np.random.randn(5, 5)
-        z = np.random.randn(5)
-        P = A.T.dot(A)
-        q = -2*P.dot(z)
-        qf = QuadForm(self.w, P)
-        p = Problem(Minimize(0.5*qf + 0.5*qf + q.T @ self.w))
-        self.solve_QP(p, solver)
-        for var in p.variables():
-            self.assertItemsAlmostEqual(z, var.value, places=4)
-
-    def affine_problem(self, solver) -> None:
-        np.random.seed(0)
-        A = np.random.randn(5, 2)
-        A = np.maximum(A, 0)
-        b = np.random.randn(5)
-        b = np.maximum(b, 0)
-        p = Problem(Minimize(sum(self.x)), [self.x >= 0, A @ self.x <= b])
-        self.solve_QP(p, solver)
-        for var in p.variables():
-            self.assertItemsAlmostEqual([0., 0.], var.value, places=3)
-        self._check_kkt(p, places=3)
-
-    def maximize_problem(self, solver) -> None:
-        np.random.seed(0)
-        A = np.random.randn(5, 2)
-        A = np.maximum(A, 0)
-        b = np.random.randn(5)
-        b = np.maximum(b, 0)
-        p = Problem(Maximize(-sum(self.x)), [self.x >= 0, A @ self.x <= b])
-        self.solve_QP(p, solver)
-        for var in p.variables():
-            self.assertItemsAlmostEqual([0., 0.], var.value, places=3)
-        self._check_kkt(p, places=3)
-
-    def norm_2(self, solver) -> None:
-        A = np.random.randn(10, 5)
-        b = np.random.randn(10)
-        p = Problem(Minimize(norm(A @ self.w - b, 2)))
-        self.solve_QP(p, solver)
-        for var in p.variables():
-            self.assertItemsAlmostEqual(lstsq(A, b)[0].flatten(order='F'), var.value,
-                                        places=1)
-
-    def mat_norm_2(self, solver) -> None:
-        A = np.random.randn(5, 3)
-        B = np.random.randn(5, 2)
-        p = Problem(Minimize(norm(A @ self.C - B, 2)))
-        s = self.solve_QP(p, solver)
-        for var in p.variables():
-            self.assertItemsAlmostEqual(lstsq(A, B)[0],
-                                        s.primal_vars[var.id], places=1)
-
-    def quad_form_coeff(self, solver) -> None:
-        np.random.seed(0)
-        A = np.random.randn(5, 5)
-        z = np.random.randn(5)
-        P = A.T.dot(A)
-        q = -2*P.dot(z)
-        p = Problem(Minimize(QuadForm(self.w, P) + q.T @ self.w))
-        self.solve_QP(p, solver)
-        for var in p.variables():
-            self.assertItemsAlmostEqual(z, var.value, places=4)
-
-    def quad_form_bound(self, solver) -> None:
-        P = np.array([[13, 12, -2], [12, 17, 6], [-2, 6, 12]])
-        q = np.array([[-22], [-14.5], [13]])
-        r = 1
-        y_star = np.array([[1], [0.5], [-1]])
-        p = Problem(Minimize(0.5*QuadForm(self.y, P) + q.T @ self.y + r),
-                    [self.y >= -1, self.y <= 1])
-        self.solve_QP(p, solver)
-        for var in p.variables():
-            self.assertItemsAlmostEqual(y_star, var.value, places=4)
-        self._check_kkt(p)
-
-    def regression_1(self, solver) -> None:
-        np.random.seed(1)
-        # Number of examples to use
-        n = 100
-        # Specify the true value of the variable
-        true_coeffs = np.array([[2, -2, 0.5]]).T
-        # Generate data
-        x_data = np.random.rand(n) * 5
-        x_data = np.atleast_2d(x_data)
-        x_data_expanded = np.vstack([np.power(x_data, i)
-                                     for i in range(1, 4)])
-        x_data_expanded = np.atleast_2d(x_data_expanded)
-        y_data = x_data_expanded.T.dot(true_coeffs) + 0.5 * np.random.rand(n, 1)
-        y_data = np.atleast_2d(y_data)
-
-        line = self.offset + x_data * self.slope
-        residuals = line.T - y_data
-        fit_error = sum_squares(residuals)
-        p = Problem(Minimize(fit_error), [])
-        self.solve_QP(p, solver)
-        self.assertAlmostEqual(1171.60037715, p.value, places=4)
-
-    def regression_2(self, solver) -> None:
-        np.random.seed(1)
-        # Number of examples to use
-        n = 100
-        # Specify the true value of the variable
-        true_coeffs = np.array([2, -2, 0.5])
-        # Generate data
-        x_data = np.random.rand(n) * 5
-        x_data_expanded = np.vstack([np.power(x_data, i)
-                                     for i in range(1, 4)])
-        print(x_data_expanded.shape, true_coeffs.shape)
-        y_data = x_data_expanded.T.dot(true_coeffs) + 0.5 * np.random.rand(n)
-
-        quadratic = self.offset + x_data * self.slope + \
-            self.quadratic_coeff*np.power(x_data, 2)
-        residuals = quadratic.T - y_data
-        fit_error = sum_squares(residuals)
-        p = Problem(Minimize(fit_error), [])
-        self.solve_QP(p, solver)
-
-        self.assertAlmostEqual(139.225660756, p.value, places=4)
-
-    def control(self, solver) -> None:
-        # Some constraints on our motion
-        # The object should start from the origin, and end at rest
-        initial_velocity = np.array([-20, 100])
-        final_position = np.array([100, 100])
-        T = 30  # The number of timesteps
-        h = 0.1  # The time between time intervals
-        mass = 1  # Mass of object
-        drag = 0.1  # Drag on object
-        g = np.array([0, -9.8])  # Gravity on object
-        # Create a problem instance
-        constraints = []
-        # Add constraints on our variables
-        for i in range(T - 1):
-            constraints += [self.position[:, i + 1] == self.position[:, i] +
-                            h * self.velocity[:, i]]
-            acceleration = self.force[:, i]/mass + g - \
-                drag * self.velocity[:, i]
-            constraints += [self.velocity[:, i + 1] == self.velocity[:, i] +
-                            h * acceleration]
-
-        # Add position constraints
-        constraints += [self.position[:, 0] == 0]
-        constraints += [self.position[:, -1] == final_position]
-        # Add velocity constraints
-        constraints += [self.velocity[:, 0] == initial_velocity]
-        constraints += [self.velocity[:, -1] == 0]
-        # Solve the problem
-        p = Problem(Minimize(.01 * sum_squares(self.force)), constraints)
-        self.solve_QP(p, solver)
-        self.assertAlmostEqual(1059.616, p.value, places=1)
-        # KKT check skipped: check_stationary_lagrangian fails for 2D matrix
-        # variables due to inconsistent gradient ordering (sum_squares uses
-        # C order, constraint terms use F order). TODO fix this
-        # self._check_kkt(p, places=3)
-
-    def sparse_system(self, solver) -> None:
-        m = 100
-        n = 80
-        np.random.seed(1)
-        density = 0.4
-        A = sp.random_array((m, n), density=density)
-        b = np.random.randn(m)
-
-        p = Problem(Minimize(sum_squares(A @ self.xs - b)), [self.xs == 0])
-        self.solve_QP(p, solver)
-        self.assertAlmostEqual(b.T.dot(b), p.value, places=4)
-
-    def smooth_ridge(self, solver) -> None:
-        np.random.seed(1)
-        n = 50
-        k = 20
-        eta = 1
-
-        A = np.ones((k, n))
-        b = np.ones((k))
-        obj = sum_squares(A @ self.xsr - b) + \
-            eta*sum_squares(self.xsr[:-1]-self.xsr[1:])
-        p = Problem(Minimize(obj), [])
-        self.solve_QP(p, solver)
-        self.assertAlmostEqual(0, p.value, places=4)
-
-    def huber_small(self, solver, places=4) -> None:
-        # Solve the Huber regression problem
-        x = Variable(3)
-        objective = sum(huber(x))
-
-        # Solve problem with QP
-        p = Problem(Minimize(objective), [x[2] >= 3])
-        self.solve_QP(p, solver)
-        self.assertAlmostEqual(3, x.value[2], places=places)
-        self.assertAlmostEqual(5, objective.value, places=places)
-        self._check_kkt(p, places=places)
-
-    def huber(self, solver) -> None:
-        # Generate problem data
-        n = 3
-        m = 5
-        data = [0.89, 0.39, 0.96, 0.34, 0.68, 0.18, 0.63, 0.42, 0.51, 0.66, 0.43, 0.77]
-        indices = [0, 1, 2, 3, 4, 2, 3, 0, 1, 2, 3, 4]
-        indptr = [0, 5, 7, 12]
-        A = sp.csc_array((data, indices, indptr), shape=(m, n))
-        x_true = np.random.randn(n) / np.sqrt(n)
-        ind95 = (np.random.rand(m) < 0.95).astype(float)
-        b = A.dot(x_true) + np.multiply(0.5*np.random.randn(m), ind95) \
-            + np.multiply(10.*np.random.rand(m), 1. - ind95)
-
-        # Solve the Huber regression problem
-        x = Variable(n)
-        objective = sum(huber(A @ x - b))
-
-        # Solve problem with QP
-        p = Problem(Minimize(objective))
-        self.solve_QP(p, solver)
-        self.assertAlmostEqual(1.452797819667, objective.value, places=3)
-        self.assertItemsAlmostEqual(x.value,
-                                    [1.20524645, -0.85271489, -0.50838494],
-                                    places=3)
-
-    def equivalent_forms_1(self, solver) -> None:
-        m = 100
-        n = 80
-        r = 70
-        np.random.seed(1)
-        A = np.random.randn(m, n)
-        b = np.random.randn(m)
-        G = np.random.randn(r, n)
-        h = np.random.randn(r)
-
-        obj1 = .1 * sum((A @ self.xef - b) ** 2)
-        cons = [G @ self.xef == h]
-
-        p1 = Problem(Minimize(obj1), cons)
-        self.solve_QP(p1, solver)
-        self.assertAlmostEqual(p1.value, 68.1119420108, places=4)
-        self._check_kkt(p1, places=4)
-
-    def equivalent_forms_2(self, solver) -> None:
-        m = 100
-        n = 80
-        r = 70
-        np.random.seed(1)
-        A = np.random.randn(m, n)
-        b = np.random.randn(m)
-        G = np.random.randn(r, n)
-        h = np.random.randn(r)
-
-        # ||Ax-b||^2 = x^T (A^T A) x - 2(A^T b)^T x + ||b||^2
-        P = np.dot(A.T, A)
-        q = -2*np.dot(A.T, b)
-        r = np.dot(b.T, b)
-
-        obj2 = .1*(QuadForm(self.xef, P)+q.T @ self.xef+r)
-        cons = [G @ self.xef == h]
-
-        p2 = Problem(Minimize(obj2), cons)
-        self.solve_QP(p2, solver)
-        self.assertAlmostEqual(p2.value, 68.1119420108, places=4)
-        self._check_kkt(p2, places=4)
-
-    def equivalent_forms_3(self, solver) -> None:
-        m = 100
-        n = 80
-        r = 70
-        np.random.seed(1)
-        A = np.random.randn(m, n)
-        b = np.random.randn(m)
-        G = np.random.randn(r, n)
-        h = np.random.randn(r)
-
-        # ||Ax-b||^2 = x^T (A^T A) x - 2(A^T b)^T x + ||b||^2
-        P = np.dot(A.T, A)
-        q = -2*np.dot(A.T, b)
-        r = np.dot(b.T, b)
-        Pinv = np.linalg.inv(P)
-
-        obj3 = .1 * (matrix_frac(self.xef, Pinv)+q.T @ self.xef+r)
-        cons = [G @ self.xef == h]
-
-        p3 = Problem(Minimize(obj3), cons)
-        self.solve_QP(p3, solver)
-        print(solver)
-        self.assertAlmostEqual(p3.value, 68.1119420108, places=4)
-        self._check_kkt(p3, places=4)
-
-
-class TestQp(QPTestBase):
-    """Test native QP solvers.
-
-    KNITRO is excluded here and exercised separately by ``TestKNITROQp``
-    so its native runtime (and bundled OpenMP library on macOS) only
-    loads in a KNITRO-only pytest invocation.
+    Licenses are checked eagerly at module import time. Variants with a
+    missing license get an unconditional ``pytest.mark.skip``; KNITRO variants
+    additionally get ``pytest.mark.knitro`` so the CI workflow can run them
+    in their own process.
     """
-
-    def setUp(self) -> None:
-        super().setUp()
-
-        # Check for all installed QP solvers (KNITRO is run separately).
-        self.solvers = [
-            x for x in QP_SOLVERS if x in INSTALLED_SOLVERS and x != cp.KNITRO
-        ]
-        self.solvers = self.filter_licensed_solvers(self.solvers)
-
-    def solve_QP(self, problem, solver_name):
-        return problem.solve(solver=solver_name, verbose=False)
-
-    def test_all_solvers(self) -> None:
-        for solver in self.solvers:
-            self.quad_over_lin(solver)
-            self.power(solver)
-            self.power_matrix(solver)
-            self.square_affine(solver)
-            self.quad_form(solver)
-            self.affine_problem(solver)
-            self.maximize_problem(solver)
-            self.abs(solver)
-
-            # Do we need the following functionality?
-            # self.norm_2(solver)
-            # self.mat_norm_2(solver)
-
-            self.quad_form_coeff(solver)
-            self.quad_form_bound(solver)
-            self.regression_1(solver)
-            self.regression_2(solver)
-            self.rep_quad_form(solver)
-
-            # slow tests:
-            self.control(solver)
-            self.sparse_system(solver)
-            self.smooth_ridge(solver)
-            self.huber_small(solver)
-            self.huber(solver)
-            self.equivalent_forms_1(solver)
-            self.equivalent_forms_2(solver)
-            if solver != cp.KNITRO:
-                self.equivalent_forms_3(solver)
-
-    def test_qp_bound_attr(self) -> None:
-        for solver in self.solvers:
-            solver_cls = SOLVER_MAP_QP.get(solver)
-            if solver_cls is not None and getattr(solver_cls, 'BOUNDED_VARIABLES', False):
-                StandardTestQPs.test_qp_bound_attr(solver=solver)
-
-    def test_warm_start(self) -> None:
-        """Test warm start.
-        """
-        m = 200
-        n = 100
-        np.random.seed(1)
-        A = np.random.randn(m, n)
-        b = Parameter(m)
-
-        # Construct the problem.
-        x = Variable(n)
-        prob = Problem(Minimize(sum_squares(A @ x - b)))
-
-        b.value = np.random.randn(m)
-        result = prob.solve(solver="OSQP", warm_start=False)
-        result2 = prob.solve(solver="OSQP", warm_start=True)
-        self.assertAlmostEqual(result, result2)
-        b.value = np.random.randn(m)
-        result = prob.solve(solver="OSQP", warm_start=True)
-        result2 = prob.solve(solver="OSQP", warm_start=False)
-        self.assertAlmostEqual(result, result2)
-
-    def test_qpalm_warmstart(self) -> None:
-        """Test warm start.
-        """
-        if cp.QPALM in INSTALLED_SOLVERS:
-            m = 200
-            n = 100
-            np.random.seed(1)
-            A = np.random.randn(m, n)
-            b = Parameter(m)
-
-            # Construct the problem.
-            x = Variable(n)
-            prob = Problem(Minimize(sum_squares(A @ x - b)))
-
-            b.value = np.random.randn(m)
-            result = prob.solve(solver=cp.QPALM, warm_start=False)
-            result2 = prob.solve(solver=cp.QPALM, warm_start=True)
-            self.assertAlmostEqual(result, result2)
-            b.value = np.random.randn(m)
-            result = prob.solve(solver=cp.QPALM, warm_start=True)
-            result2 = prob.solve(solver=cp.QPALM, warm_start=False)
-            self.assertAlmostEqual(result, result2)
-
-    def test_gurobi_warmstart(self) -> None:
-        """Test Gurobi warm start with a user provided point.
-        """
-        if cp.GUROBI in INSTALLED_SOLVERS:
-            import gurobipy
-            m = 4
-            n = 3
-
-            y = Variable(nonneg=True)
-            X = Variable((m, n))
-            X_vals = np.reshape(np.arange(m*n), (m, n))
-            prob = Problem(Minimize(y**2 + cp.sum(X)), [X == X_vals])
-            X.value = X_vals + 1
-            prob.solve(solver=cp.GUROBI, warm_start=True)
-            # Check that "start" value was set appropriately.
-            model = prob.solver_stats.extra_stats
-            model_x = model.getVars()
-            assert gurobipy.GRB.UNDEFINED == model_x[0].start
-            assert np.isclose(0, model_x[0].x)
-            for i in range(1, X.size + 1):
-                row = (i - 1) % X.shape[0]
-                col = (i - 1) // X.shape[0]
-                assert X_vals[row, col] + 1 == model_x[i].start
-                assert np.isclose(X.value[row, col], model_x[i].x)
-
-    def test_xpress_warmstart(self) -> None:
-        """Test XPRESS warm start with a user provided point.
-        """
-        if cp.XPRESS in INSTALLED_SOLVERS:
-            m = 20
-            n = 10
-            np.random.seed(1)
-            A = np.random.randn(m, n)
-            b = Parameter(m)
-
-            # Construct the problem.
-            x = Variable(n, integer=True)
-            prob = Problem(Minimize(sum_squares(A @ x - b)))
-
-            b.value = np.random.randn(m)
-            result = prob.solve(solver=cp.XPRESS, warm_start=False)
-            result2 = prob.solve(solver=cp.XPRESS, warm_start=True)
-            self.assertAlmostEqual(result, result2)
-            x.value = x.value.astype(np.int64)
-
-            xprime = Variable(n, integer=True)
-            prob = Problem(Minimize(sum_squares(A @ xprime - b)))
-            xprime.value = x.value
-            result = prob.solve(solver=cp.XPRESS, warm_start=True)
-            result2 = prob.solve(solver=cp.XPRESS, warm_start=False)
-            self.assertAlmostEqual(result, result2)
-
-    def test_highs_warmstart(self) -> None:
-        """Test warm start.
-        """
-        if cp.HIGHS in INSTALLED_SOLVERS:
-            m = 200
-            n = 100
-            np.random.seed(1)
-            A = np.random.randn(m, n)
-            b = Parameter(m)
-
-            # Construct the problem.
-            x = Variable(n)
-            prob = Problem(Minimize(sum_squares(A @ x - b)))
-
-            b.value = np.random.randn(m)
-            result = prob.solve(solver=cp.HIGHS, warm_start=False)
-            result2 = prob.solve(solver=cp.HIGHS, warm_start=True)
-            self.assertAlmostEqual(result, result2)
-            b.value = np.random.randn(m)
-            result = prob.solve(solver=cp.HIGHS, warm_start=True)
-            result2 = prob.solve(solver=cp.HIGHS, warm_start=False)
-            self.assertAlmostEqual(result, result2)
-
-    def test_highs_cvar(self) -> None:
-        """Test problem with CVaR constraint from
-        https://github.com/cvxpy/cvxpy/issues/2836
-        """
-        if cp.HIGHS in INSTALLED_SOLVERS:
-            # Generate data
-            num_stocks = 5
-            num_samples = 25
-            np.random.seed(1)
-            pnl_samples = np.random.uniform(low=0.0, high=1.0, size=(num_samples, num_stocks))
-            pnl_expected = pnl_samples.mean(axis=0)
-
-            # Prepare to solve
-            quantile = 0.05
-            w = cp.Variable(num_stocks, nonneg=True)
-            cvar = cp.cvar(pnl_samples @ w, 1 - quantile)
-            pnl = w @ pnl_expected
-
-            # Solve
-            objective = cp.Maximize(pnl)
-            constraints = [cvar <= 0.5]
-            problem = cp.Problem(objective, constraints)
-            problem.solve(
-                solver=cp.HIGHS,
-            )
-            assert problem.status == cp.OPTIMAL
-
-    def test_piqp_warmstart(self) -> None:
-        """Test warm start.
-        """
-        if cp.PIQP in INSTALLED_SOLVERS:
-            m = 200
-            n = 100
-            np.random.seed(1)
-            A = np.random.randn(m, n)
-            b = Parameter(m)
-
-            # Construct the problem.
-            x = Variable(n)
-            prob = Problem(Minimize(sum_squares(A @ x - b)))
-
-            b.value = np.random.randn(m)
-            result = prob.solve(solver=cp.PIQP, warm_start=False)
-            result2 = prob.solve(solver=cp.PIQP, warm_start=True)
-            self.assertAlmostEqual(result, result2)
-            b.value = np.random.randn(m)
-            result = prob.solve(solver=cp.PIQP, warm_start=True)
-            result2 = prob.solve(solver=cp.PIQP, warm_start=False)
-            self.assertAlmostEqual(result, result2)
-
-    def test_copt_warmstart(self) -> None:
-        """Test warm start.
-        """
-        if cp.COPT in INSTALLED_SOLVERS:
-            m = 200
-            n = 100
-            np.random.seed(1)
-            A = np.random.randn(m, n)
-            b = Parameter(m)
-
-            # Construct the problem.
-            x = Variable(n)
-            prob = Problem(Minimize(sum_squares(A @ x - b)))
-
-            b.value = np.random.randn(m)
-            result = prob.solve(solver=cp.COPT, warm_start=False)
-            result2 = prob.solve(solver=cp.COPT, warm_start=True)
-            self.assertAlmostEqual(result, result2)
-            b.value = np.random.randn(m)
-            result = prob.solve(solver=cp.COPT, warm_start=True)
-            result2 = prob.solve(solver=cp.COPT, warm_start=False)
-            self.assertAlmostEqual(result, result2)
-
-    def test_parametric(self) -> None:
-        """Test solve parametric problem vs full problem"""
-        x = Variable()
-        a = 10
-        #  b_vec = [-10, -2., 2., 3., 10.]
-        b_vec = [-10, -2.]
-
-        for solver in self.solvers:
-
-            print(solver)
-            # Solve from scratch with no parameters
-            x_full = []
-            obj_full = []
-            for b in b_vec:
-                obj = Minimize(a * (x ** 2) + b * x)
-                constraints = [0 <= x, x <= 1]
-                prob = Problem(obj, constraints)
-                prob.solve(solver=solver)
-                x_full += [x.value]
-                obj_full += [prob.value]
-
-            # Solve parametric
-            x_param = []
-            obj_param = []
-            b = Parameter()
-            obj = Minimize(a * (x ** 2) + b * x)
-            constraints = [0 <= x, x <= 1]
-            prob = Problem(obj, constraints)
-            for b_value in b_vec:
-                b.value = b_value
-                prob.solve(solver=solver)
-                x_param += [x.value]
-                obj_param += [prob.value]
-
-            print(x_full)
-            print(x_param)
-            for i in range(len(b_vec)):
-                self.assertItemsAlmostEqual(x_full[i], x_param[i], places=3)
-                self.assertAlmostEqual(obj_full[i], obj_param[i])
-
-    def test_square_param(self) -> None:
-        """Test issue arising with square plus parameter.
-        """
-        a = Parameter(value=1)
-        b = Variable()
-
-        obj = Minimize(b ** 2 + abs(a))
-        prob = Problem(obj)
-        prob.solve(solver="SCS")
-        self.assertAlmostEqual(obj.value, 1.0)
-
-    def test_gurobi_time_limit_no_solution(self) -> None:
-        """Make sure that if Gurobi terminates due to a time limit before finding a solution:
-            1) no error is raised,
-            2) solver stats are returned.
-            The test is skipped if something changes on Gurobi's side so that:
-            - a solution is found despite a time limit of zero,
-            - a different termination criteria is hit first.
-        """
-        from cvxpy import GUROBI
-        if GUROBI in INSTALLED_SOLVERS:
-            import gurobipy
-            objective = Minimize(self.x[0])
-            constraints = [self.x[0] >= 1]
-            prob = Problem(objective, constraints)
-            try:
-                prob.solve(solver=GUROBI, TimeLimit=0.0)
-            except Exception as e:
-                self.fail("An exception %s is raised instead of returning a result." % e)
-
-            extra_stats = None
-            solver_stats = getattr(prob, "solver_stats", None)
-            if solver_stats:
-                extra_stats = getattr(solver_stats, "extra_stats", None)
-            self.assertTrue(extra_stats, "Solver stats have not been returned.")
-
-            nb_solutions = getattr(extra_stats, "SolCount", None)
-            if nb_solutions:
-                self.skipTest("Gurobi has found a solution, the test is not relevant anymore.")
-
-            solver_status = getattr(extra_stats, "Status", None)
-            if solver_status != gurobipy.GRB.TIME_LIMIT:
-                self.skipTest("Gurobi terminated for a different reason than reaching time limit, "
-                              "the test is not relevant anymore.")
-
-        else:
-            with self.assertRaises(Exception) as cm:
-                prob = Problem(Minimize(norm(self.x, 1)), [self.x == 0])
-                prob.solve(solver=GUROBI, TimeLimit=0)
-            self.assertEqual(str(cm.exception), "The solver %s is not installed." % GUROBI)
-
-    def test_gurobi_environment(self) -> None:
-        """Tests that Gurobi environments can be passed to Model.
-        Gurobi environments can include licensing and model parameter data.
-        """
-        from cvxpy import GUROBI
-        if GUROBI in INSTALLED_SOLVERS:
-            import gurobipy
-
-            # Set a few parameters to random values close to their defaults
-            params = {
-                'MIPGap': np.random.random(),  # range {0, INFINITY}
-                'AggFill': np.random.randint(10),  # range {-1, MAXINT}
-                'PerturbValue': np.random.random(),  # range: {0, INFINITY}
-            }
-
-            # Create a custom environment and set some parameters
-            custom_env = gurobipy.Env()
-            for k, v in params.items():
-                custom_env.setParam(k, v)
-
-            # Testing QP Solver Interface
-            sth = StandardTestLPs.test_lp_0(solver='GUROBI', env=custom_env)
-            model = sth.prob.solver_stats.extra_stats
-            for k, v in params.items():
-                # https://www.gurobi.com/documentation/9.1/refman/py_model_getparaminfo.html
-                name, p_type, p_val, p_min, p_max, p_def = model.getParamInfo(k)
-                self.assertEqual(v, p_val)
-
-        else:
-            with self.assertRaises(Exception) as cm:
-                prob = Problem(Minimize(norm(self.x, 1)), [self.x == 0])
-                prob.solve(solver=GUROBI, TimeLimit=0)
-            self.assertEqual(str(cm.exception), "The solver %s is not installed." % GUROBI)
-
-    def test_osqp_infeasible_lp_ineq_constraints(self):
-        StandardTestInfeasibleProblems.test_lp_ineq_constraints(solver=cp.OSQP)
-
-    def test_osqp_infeasible_lp_eq_constraints(self):
-        StandardTestInfeasibleProblems.test_lp_eq_constraints(solver=cp.OSQP)
-
-    def test_highs_infeasible_lp_ineq_constraints(self):
-        StandardTestInfeasibleProblems.test_lp_ineq_constraints(solver=cp.HIGHS)
-
-    def test_highs_infeasible_lp_eq_constraints(self):
-        StandardTestInfeasibleProblems.test_lp_eq_constraints(solver=cp.HIGHS)
-
-    def test_highs_dense_quad_form(self) -> None:
-        """Regression test for https://github.com/cvxpy/cvxpy/issues/3301
-        and a related silent wrong-answer bug on highspy < 1.14.0.
-
-        A dense quad_form applied to a linear expression (not a raw Variable)
-        produces a Hessian whose upper and lower triangles may differ by
-        floating-point epsilon after canonicalization. We pass it to HiGHS
-        in triangular format. HiGHS < 1.14.0 only honors the lower triangle
-        in that format and silently returns wrong solutions when given the
-        upper triangle, hence the `highspy >= 1.14.0` minimum in
-        pyproject.toml. Cross-check the objective against CLARABEL because
-        status alone (`kOptimal`) does not detect a wrong-QP solve.
-        """
-        if cp.HIGHS not in INSTALLED_SOLVERS:
-            return
-
-        rng = np.random.default_rng(42)
-        n_vars, n_nodes = 60, 20
-
-        # Sparse mapping from decision variables to a smaller space.
-        rows, cols, vals = [], [], []
-        for i in range(n_vars):
-            j, k = rng.choice(n_nodes, size=2, replace=False)
-            rows += [i, i]
-            cols += [j, k]
-            vals += [1.0, -1.0]
-        M = sp.csr_matrix((vals, (rows, cols)), shape=(n_vars, n_nodes))
-
-        # Dense PSD matrix via eigenvalue clamping (typical in practice).
-        A = rng.standard_normal((n_nodes, n_nodes))
-        raw = A @ A.T + rng.standard_normal((n_nodes, n_nodes)) * 0.01
-        sym = 0.5 * (raw + raw.T)
-        eigvals, eigvecs = np.linalg.eigh(sym)
-        eigvals = np.maximum(eigvals, 0.0)
-        Sigma = eigvecs @ np.diag(eigvals) @ eigvecs.T
-
-        x = cp.Variable(n_vars, nonneg=True)
-        y = x @ M
-        prob = cp.Problem(
-            cp.Maximize(
-                cp.sum(x) - 0.1 * cp.quad_form(y, Sigma)
-            ),
-            [x <= 10],
-        )
-        prob.solve(solver=cp.HIGHS)
-        self.assertEqual(prob.status, cp.OPTIMAL)
-        highs_value = prob.value
-
-        prob.solve(solver=cp.CLARABEL)
-        self.assertEqual(prob.status, cp.OPTIMAL)
-        self.assertAlmostEqual(highs_value, prob.value, places=4)
-
-
-class TestConicQuadObj(QPTestBase):
-    """Test conic solvers with use_quad_obj=True."""
-
-    def setUp(self) -> None:
-        super().setUp()
-
-        # Conic solvers that support quadratic objectives
-        # Exclude KNITRO - its conic interface with use_quad_obj is unstable in CI
-        self.solvers = [
-            solver for solver in INSTALLED_CONIC_SOLVERS
-            if solver in SOLVER_MAP_CONIC
-            and SOLVER_MAP_CONIC[solver].supports_quad_obj()
-            and solver != cp.KNITRO
-        ]
-        self.solvers = self.filter_licensed_solvers(self.solvers)
-
-    def solve_QP(self, problem, solver_name):
-        """Solve with use_quad_obj=True and verify no SOC cones are introduced."""
+    marks = []
+    if solver == cp.MOSEK and not is_mosek_available():
+        marks.append(pytest.mark.skip(reason='MOSEK license not available'))
+    if solver == cp.XPRESS and not is_xpress_available():
+        marks.append(pytest.mark.skip(reason='XPRESS license not available'))
+    if solver == cp.KNITRO:
+        marks.append(pytest.mark.knitro)
+        if not is_knitro_available():
+            marks.append(pytest.mark.skip(reason='KNITRO not available'))
+    return pytest.param(solver, marks=marks, id=solver)
+
+
+QP_SOLVER_PARAMS = [
+    _solver_param(s) for s in QP_SOLVERS if s in INSTALLED_SOLVERS
+]
+
+# Conic solvers that support quadratic objectives. KNITRO is excluded -- its
+# conic interface with ``use_quad_obj=True`` is unstable in CI.
+CONIC_QUAD_OBJ_PARAMS = [
+    _solver_param(s)
+    for s in INSTALLED_CONIC_SOLVERS
+    if s in SOLVER_MAP_CONIC
+    and SOLVER_MAP_CONIC[s].supports_quad_obj()
+    and s != cp.KNITRO
+]
+
+
+# --------------------------------------------------------------------------- #
+# Assertion helpers (replace BaseTest helpers used widely in this file)
+# --------------------------------------------------------------------------- #
+
+def _mat_to_list(mat):
+    if isinstance(mat, (np.matrix, np.ndarray)):
+        return np.asarray(mat).flatten('F').tolist()
+    return mat
+
+
+def assert_items_almost_equal(a, b, places: int = 5) -> None:
+    """List-aware almost-equal; matches ``BaseTest.assertItemsAlmostEqual``."""
+    a = [a] if np.isscalar(a) else _mat_to_list(a)
+    b = [b] if np.isscalar(b) else _mat_to_list(b)
+    assert len(a) == len(b), f"length mismatch: {len(a)} vs {len(b)}"
+    for ai, bi in zip(a, b):
+        assert round(ai - bi, places) == 0, f"{ai} != {bi} to {places} places"
+
+
+def assert_almost_equal(a, b, places: int = 5) -> None:
+    """Scalar almost-equal; matches ``unittest.TestCase.assertAlmostEqual``."""
+    assert round(a - b, places) == 0, f"{a} != {b} to {places} places"
+
+
+def check_kkt(problem, places: int = 4) -> None:
+    """Verify KKT conditions for a solved problem."""
+    obj_pair = (problem.objective, None)
+    var_pairs = [(v, None) for v in problem.variables()]
+    con_pairs = [(c, None) for c in problem.constraints]
+    sth = SolverTestHelper(obj_pair, var_pairs, con_pairs)
+    sth.prob = problem
+    sth.check_primal_feasibility(places)
+    sth.check_complementarity(places)
+    sth.check_dual_domains(places)
+    sth.check_stationary_lagrangian(places)
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def qp_vars():
+    """Fresh per-test bag of Variables used across the QP correctness helpers."""
+    T = 30
+    return SimpleNamespace(
+        a=Variable(name='a'),
+        b=Variable(name='b'),
+        c=Variable(name='c'),
+        x=Variable(2, name='x'),
+        y=Variable(3, name='y'),
+        z=Variable(2, name='z'),
+        w=Variable(5, name='w'),
+        A=Variable((2, 2), name='A'),
+        B=Variable((2, 2), name='B'),
+        C=Variable((3, 2), name='C'),
+        slope=Variable(1, name='slope'),
+        offset=Variable(1, name='offset'),
+        quadratic_coeff=Variable(1, name='quadratic_coeff'),
+        position=Variable((2, T), name='position'),
+        velocity=Variable((2, T), name='velocity'),
+        force=Variable((2, T - 1), name='force'),
+        xs=Variable(80, name='xs'),
+        xsr=Variable(50, name='xsr'),
+        xef=Variable(80, name='xef'),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Solve callables
+# --------------------------------------------------------------------------- #
+
+def _native_solve(solver):
+    """Plain ``problem.solve(solver=...)`` driver used for native QP solvers."""
+    def solve(problem):
+        return problem.solve(solver=solver, verbose=False)
+    return solve
+
+
+def _conic_quad_obj_solve(solver):
+    """Driver for conic solvers under ``use_quad_obj=True``.
+
+    Additionally asserts that the canonicalization introduces no SOC cones --
+    that's the whole point of the QP path through a conic solver.
+    """
+    def solve(problem):
         data, _, _ = problem.get_problem_data(
-            solver_name,
-            solver_opts={"use_quad_obj": True}
+            solver, solver_opts={"use_quad_obj": True}
         )
-        self.assertEqual(data["dims"].soc, [],
-            f"Problem should have no SOC cones for QP canonicalization with {solver_name}")
-        return problem.solve(solver=solver_name, use_quad_obj=True, verbose=False)
-
-    def test_all_solvers(self) -> None:
-        """Test conic solvers with use_quad_obj=True.
-
-        Only runs tests that have constraints (filtering out unconstrained
-        problems for solvers with REQUIRES_CONSTR=True).
-
-        Tests with m=0 after canonicalization (skip for REQUIRES_CONSTR solvers):
-        - power, quad_form, quad_form_coeff, rep_quad_form
-        """
-        for solver in self.solvers:
-            requires_constr = SOLVER_MAP_CONIC[solver].REQUIRES_CONSTR
-
-            self.quad_over_lin(solver)
-            if not requires_constr:
-                self.power(solver)
-            self.power_matrix(solver)
-            self.square_affine(solver)
-            if not requires_constr:
-                self.quad_form(solver)
-            self.affine_problem(solver)
-            self.maximize_problem(solver)
-            self.abs(solver)
-            if not requires_constr:
-                self.quad_form_coeff(solver)
-            self.quad_form_bound(solver)
-            self.regression_1(solver)
-            self.regression_2(solver)
-            if not requires_constr:
-                self.rep_quad_form(solver)
-            self.control(solver)
-            self.sparse_system(solver)
-            self.smooth_ridge(solver)
-            self.huber_small(solver, places=3)
-            self.huber(solver)
-            self.equivalent_forms_1(solver)
-            self.equivalent_forms_2(solver)
-            self.equivalent_forms_3(solver)
+        assert data["dims"].soc == [], (
+            f"Problem should have no SOC cones for QP canonicalization with {solver}"
+        )
+        return problem.solve(solver=solver, use_quad_obj=True, verbose=False)
+    return solve
 
 
-@pytest.mark.knitro
-@unittest.skipUnless(is_knitro_available(),
-                     'KNITRO is not installed or license is not available.')
-class TestKNITROQp(QPTestBase):
-    """Run the QP test suite against KNITRO in an isolated pytest invocation.
+# --------------------------------------------------------------------------- #
+# QP correctness helpers (one per problem shape).
+#
+# Each helper takes the ``qp_vars`` fixture and a solve callable. The matrix
+# test (``test_qp_correctness``) parameterizes both the helper and the solver.
+# --------------------------------------------------------------------------- #
 
-    KNITRO bundles LLVM ``libomp.dylib`` in its macOS wheel; CVXOPT bundles
-    GNU ``libgomp.1.dylib`` via its OpenBLAS dependency. Loading both into
-    one process can crash inside KNITRO's KN_solve. Running this class
-    under ``-m knitro`` in a separate pytest process mirrors the conic
-    KNITRO split in ``test_conic_solvers.py``.
+def _quad_over_lin(v, solve_qp):
+    p = Problem(Minimize(0.5 * quad_over_lin(abs(v.x - 1), 1)),
+                [v.x <= -1])
+    solve_qp(p)
+    for var in p.variables():
+        assert_items_almost_equal(np.array([-1., -1.]), var.value, places=4)
+    for con in p.constraints:
+        assert_items_almost_equal(np.array([2., 2.]), con.dual_value, places=4)
+    check_kkt(p, places=3)
+
+
+def _abs(v, solve_qp):
+    u = Variable(2)
+    constr = [abs(u[1] - u[0]) <= 100]
+    prob = Problem(Minimize(sum_squares(u)), constr)
+    assert prob.is_qp()
+    result = solve_qp(prob)
+    assert_almost_equal(result, 0)
+
+
+def _power(v, solve_qp):
+    p = Problem(Minimize(sum(power(v.x, 2))), [])
+    solve_qp(p)
+    for var in p.variables():
+        assert_items_almost_equal([0., 0.], var.value, places=4)
+
+
+def _power_matrix(v, solve_qp):
+    p = Problem(Minimize(sum(power(v.A - 3., 2))), [])
+    solve_qp(p)
+    for var in p.variables():
+        assert_items_almost_equal([3., 3., 3., 3.], var.value, places=4)
+
+
+def _square_affine(v, solve_qp):
+    A = np.random.randn(10, 2)
+    b = np.random.randn(10)
+    p = Problem(Minimize(sum_squares(A @ v.x - b)))
+    solve_qp(p)
+    for var in p.variables():
+        assert_items_almost_equal(
+            lstsq(A, b)[0].flatten(order='F'), var.value, places=1
+        )
+
+
+def _quad_form(v, solve_qp):
+    np.random.seed(0)
+    A = np.random.randn(5, 5)
+    z = np.random.randn(5)
+    P = A.T.dot(A)
+    q = -2 * P.dot(z)
+    p = Problem(Minimize(QuadForm(v.w, P) + q.T @ v.w))
+    solve_qp(p)
+    for var in p.variables():
+        assert_items_almost_equal(z, var.value, places=4)
+
+
+def _rep_quad_form(v, solve_qp):
+    """A problem where the quad_form term is used multiple times."""
+    np.random.seed(0)
+    A = np.random.randn(5, 5)
+    z = np.random.randn(5)
+    P = A.T.dot(A)
+    q = -2 * P.dot(z)
+    qf = QuadForm(v.w, P)
+    p = Problem(Minimize(0.5 * qf + 0.5 * qf + q.T @ v.w))
+    solve_qp(p)
+    for var in p.variables():
+        assert_items_almost_equal(z, var.value, places=4)
+
+
+def _affine_problem(v, solve_qp):
+    np.random.seed(0)
+    A = np.random.randn(5, 2)
+    A = np.maximum(A, 0)
+    b = np.random.randn(5)
+    b = np.maximum(b, 0)
+    p = Problem(Minimize(sum(v.x)), [v.x >= 0, A @ v.x <= b])
+    solve_qp(p)
+    for var in p.variables():
+        assert_items_almost_equal([0., 0.], var.value, places=3)
+    check_kkt(p, places=3)
+
+
+def _maximize_problem(v, solve_qp):
+    np.random.seed(0)
+    A = np.random.randn(5, 2)
+    A = np.maximum(A, 0)
+    b = np.random.randn(5)
+    b = np.maximum(b, 0)
+    p = Problem(Maximize(-sum(v.x)), [v.x >= 0, A @ v.x <= b])
+    solve_qp(p)
+    for var in p.variables():
+        assert_items_almost_equal([0., 0.], var.value, places=3)
+    check_kkt(p, places=3)
+
+
+def _quad_form_coeff(v, solve_qp):
+    np.random.seed(0)
+    A = np.random.randn(5, 5)
+    z = np.random.randn(5)
+    P = A.T.dot(A)
+    q = -2 * P.dot(z)
+    p = Problem(Minimize(QuadForm(v.w, P) + q.T @ v.w))
+    solve_qp(p)
+    for var in p.variables():
+        assert_items_almost_equal(z, var.value, places=4)
+
+
+def _quad_form_bound(v, solve_qp):
+    P = np.array([[13, 12, -2], [12, 17, 6], [-2, 6, 12]])
+    q = np.array([[-22], [-14.5], [13]])
+    r = 1
+    y_star = np.array([[1], [0.5], [-1]])
+    p = Problem(Minimize(0.5 * QuadForm(v.y, P) + q.T @ v.y + r),
+                [v.y >= -1, v.y <= 1])
+    solve_qp(p)
+    for var in p.variables():
+        assert_items_almost_equal(y_star, var.value, places=4)
+    check_kkt(p)
+
+
+def _regression_1(v, solve_qp):
+    np.random.seed(1)
+    n = 100
+    true_coeffs = np.array([[2, -2, 0.5]]).T
+    x_data = np.random.rand(n) * 5
+    x_data = np.atleast_2d(x_data)
+    x_data_expanded = np.vstack([np.power(x_data, i) for i in range(1, 4)])
+    x_data_expanded = np.atleast_2d(x_data_expanded)
+    y_data = x_data_expanded.T.dot(true_coeffs) + 0.5 * np.random.rand(n, 1)
+    y_data = np.atleast_2d(y_data)
+    line = v.offset + x_data * v.slope
+    residuals = line.T - y_data
+    fit_error = sum_squares(residuals)
+    p = Problem(Minimize(fit_error), [])
+    solve_qp(p)
+    assert_almost_equal(1171.60037715, p.value, places=4)
+
+
+def _regression_2(v, solve_qp):
+    np.random.seed(1)
+    n = 100
+    true_coeffs = np.array([2, -2, 0.5])
+    x_data = np.random.rand(n) * 5
+    x_data_expanded = np.vstack([np.power(x_data, i) for i in range(1, 4)])
+    y_data = x_data_expanded.T.dot(true_coeffs) + 0.5 * np.random.rand(n)
+    quadratic = (
+        v.offset + x_data * v.slope + v.quadratic_coeff * np.power(x_data, 2)
+    )
+    residuals = quadratic.T - y_data
+    fit_error = sum_squares(residuals)
+    p = Problem(Minimize(fit_error), [])
+    solve_qp(p)
+    assert_almost_equal(139.225660756, p.value, places=4)
+
+
+def _control(v, solve_qp):
+    initial_velocity = np.array([-20, 100])
+    final_position = np.array([100, 100])
+    T = 30
+    h = 0.1
+    mass = 1
+    drag = 0.1
+    g = np.array([0, -9.8])
+    constraints = []
+    for i in range(T - 1):
+        constraints += [
+            v.position[:, i + 1] == v.position[:, i] + h * v.velocity[:, i]
+        ]
+        acceleration = v.force[:, i] / mass + g - drag * v.velocity[:, i]
+        constraints += [
+            v.velocity[:, i + 1] == v.velocity[:, i] + h * acceleration
+        ]
+    constraints += [v.position[:, 0] == 0]
+    constraints += [v.position[:, -1] == final_position]
+    constraints += [v.velocity[:, 0] == initial_velocity]
+    constraints += [v.velocity[:, -1] == 0]
+    p = Problem(Minimize(.01 * sum_squares(v.force)), constraints)
+    solve_qp(p)
+    assert_almost_equal(1059.616, p.value, places=1)
+    # KKT check skipped: check_stationary_lagrangian fails for 2D matrix
+    # variables due to inconsistent gradient ordering (sum_squares uses
+    # C order, constraint terms use F order). TODO fix this
+
+
+def _sparse_system(v, solve_qp):
+    m, n = 100, 80
+    np.random.seed(1)
+    A = sp.random_array((m, n), density=0.4)
+    b = np.random.randn(m)
+    p = Problem(Minimize(sum_squares(A @ v.xs - b)), [v.xs == 0])
+    solve_qp(p)
+    assert_almost_equal(b.T.dot(b), p.value, places=4)
+
+
+def _smooth_ridge(v, solve_qp):
+    np.random.seed(1)
+    n = 50
+    k = 20
+    eta = 1
+    A = np.ones((k, n))
+    b = np.ones(k)
+    obj = sum_squares(A @ v.xsr - b) + eta * sum_squares(v.xsr[:-1] - v.xsr[1:])
+    p = Problem(Minimize(obj), [])
+    solve_qp(p)
+    assert_almost_equal(0, p.value, places=4)
+
+
+def _huber_small(v, solve_qp, places: int = 4):
+    x = Variable(3)
+    objective = sum(huber(x))
+    p = Problem(Minimize(objective), [x[2] >= 3])
+    solve_qp(p)
+    assert_almost_equal(3, x.value[2], places=places)
+    assert_almost_equal(5, objective.value, places=places)
+    check_kkt(p, places=places)
+
+
+def _huber(v, solve_qp):
+    n = 3
+    m = 5
+    data = [0.89, 0.39, 0.96, 0.34, 0.68, 0.18,
+            0.63, 0.42, 0.51, 0.66, 0.43, 0.77]
+    indices = [0, 1, 2, 3, 4, 2, 3, 0, 1, 2, 3, 4]
+    indptr = [0, 5, 7, 12]
+    A = sp.csc_array((data, indices, indptr), shape=(m, n))
+    x_true = np.random.randn(n) / np.sqrt(n)
+    ind95 = (np.random.rand(m) < 0.95).astype(float)
+    b = A.dot(x_true) + np.multiply(0.5 * np.random.randn(m), ind95) \
+        + np.multiply(10. * np.random.rand(m), 1. - ind95)
+    x = Variable(n)
+    objective = sum(huber(A @ x - b))
+    p = Problem(Minimize(objective))
+    solve_qp(p)
+    assert_almost_equal(1.452797819667, objective.value, places=3)
+    assert_items_almost_equal(
+        x.value, [1.20524645, -0.85271489, -0.50838494], places=3
+    )
+
+
+def _equivalent_forms_1(v, solve_qp):
+    m, n, r = 100, 80, 70
+    np.random.seed(1)
+    A = np.random.randn(m, n)
+    b = np.random.randn(m)
+    G = np.random.randn(r, n)
+    h = np.random.randn(r)
+    obj1 = .1 * sum((A @ v.xef - b) ** 2)
+    cons = [G @ v.xef == h]
+    p1 = Problem(Minimize(obj1), cons)
+    solve_qp(p1)
+    assert_almost_equal(p1.value, 68.1119420108, places=4)
+    check_kkt(p1, places=4)
+
+
+def _equivalent_forms_2(v, solve_qp):
+    m, n, r = 100, 80, 70
+    np.random.seed(1)
+    A = np.random.randn(m, n)
+    b = np.random.randn(m)
+    G = np.random.randn(r, n)
+    h = np.random.randn(r)
+    # ||Ax-b||^2 = x^T (A^T A) x - 2(A^T b)^T x + ||b||^2
+    P = np.dot(A.T, A)
+    q = -2 * np.dot(A.T, b)
+    r_val = np.dot(b.T, b)
+    obj2 = .1 * (QuadForm(v.xef, P) + q.T @ v.xef + r_val)
+    cons = [G @ v.xef == h]
+    p2 = Problem(Minimize(obj2), cons)
+    solve_qp(p2)
+    assert_almost_equal(p2.value, 68.1119420108, places=4)
+    check_kkt(p2, places=4)
+
+
+def _equivalent_forms_3(v, solve_qp):
+    m, n, r = 100, 80, 70
+    np.random.seed(1)
+    A = np.random.randn(m, n)
+    b = np.random.randn(m)
+    G = np.random.randn(r, n)
+    h = np.random.randn(r)
+    # ||Ax-b||^2 = x^T (A^T A) x - 2(A^T b)^T x + ||b||^2
+    P = np.dot(A.T, A)
+    q = -2 * np.dot(A.T, b)
+    r_val = np.dot(b.T, b)
+    Pinv = np.linalg.inv(P)
+    obj3 = .1 * (matrix_frac(v.xef, Pinv) + q.T @ v.xef + r_val)
+    cons = [G @ v.xef == h]
+    p3 = Problem(Minimize(obj3), cons)
+    solve_qp(p3)
+    assert_almost_equal(p3.value, 68.1119420108, places=4)
+    check_kkt(p3, places=4)
+
+
+# --------------------------------------------------------------------------- #
+# Matrix tests: (helper) x (solver).
+# --------------------------------------------------------------------------- #
+
+QP_HELPERS = [
+    ("quad_over_lin", _quad_over_lin),
+    ("power", _power),
+    ("power_matrix", _power_matrix),
+    ("square_affine", _square_affine),
+    ("quad_form", _quad_form),
+    ("affine_problem", _affine_problem),
+    ("maximize_problem", _maximize_problem),
+    ("abs", _abs),
+    ("quad_form_coeff", _quad_form_coeff),
+    ("quad_form_bound", _quad_form_bound),
+    ("regression_1", _regression_1),
+    ("regression_2", _regression_2),
+    ("rep_quad_form", _rep_quad_form),
+    ("control", _control),
+    ("sparse_system", _sparse_system),
+    ("smooth_ridge", _smooth_ridge),
+    ("huber_small", _huber_small),
+    ("huber", _huber),
+    ("equivalent_forms_1", _equivalent_forms_1),
+    ("equivalent_forms_2", _equivalent_forms_2),
+    ("equivalent_forms_3", _equivalent_forms_3),
+]
+
+_HELPER_IDS = [name for name, _ in QP_HELPERS]
+
+# Conic + use_quad_obj canonicalization yields m=0 for unconstrained problems,
+# which solvers with REQUIRES_CONSTR=True reject. Skip those helpers for those
+# solvers.
+_REQUIRES_CONSTR_INCOMPATIBLE = {
+    "power", "quad_form", "quad_form_coeff", "rep_quad_form",
+}
+
+
+@pytest.mark.parametrize("name,helper", QP_HELPERS, ids=_HELPER_IDS)
+@pytest.mark.parametrize("solver", QP_SOLVER_PARAMS)
+def test_qp_correctness(qp_vars, solver, name, helper):
+    """Run each QP correctness helper against each installed native QP solver."""
+    # KNITRO does not support matrix_frac, which equivalent_forms_3 uses.
+    if solver == cp.KNITRO and name == "equivalent_forms_3":
+        pytest.skip("KNITRO does not support matrix_frac")
+    helper(qp_vars, _native_solve(solver))
+
+
+@pytest.mark.parametrize("name,helper", QP_HELPERS, ids=_HELPER_IDS)
+@pytest.mark.parametrize("solver", CONIC_QUAD_OBJ_PARAMS)
+def test_conic_quad_obj_correctness(qp_vars, solver, name, helper):
+    """Run QP correctness helpers against conic solvers with use_quad_obj=True."""
+    if (
+        SOLVER_MAP_CONIC[solver].REQUIRES_CONSTR
+        and name in _REQUIRES_CONSTR_INCOMPATIBLE
+    ):
+        pytest.skip(
+            f"{solver} requires constraints; {name} is unconstrained"
+        )
+    if name == "huber_small":
+        # Conic + use_quad_obj has slightly looser precision.
+        helper(qp_vars, _conic_quad_obj_solve(solver), places=3)
+    else:
+        helper(qp_vars, _conic_quad_obj_solve(solver))
+
+
+@pytest.mark.parametrize("solver", QP_SOLVER_PARAMS)
+def test_qp_bound_attr(solver):
+    solver_cls = SOLVER_MAP_QP.get(solver)
+    if solver_cls is None or not getattr(solver_cls, "BOUNDED_VARIABLES", False):
+        pytest.skip(f"{solver} does not support bounded-variable attributes")
+    StandardTestQPs.test_qp_bound_attr(solver=solver)
+
+
+@pytest.mark.parametrize("solver", QP_SOLVER_PARAMS)
+def test_parametric(solver):
+    """Solve parametric problem vs full problem."""
+    x = Variable()
+    a = 10
+    b_vec = [-10, -2.]
+
+    x_full, obj_full = [], []
+    for b in b_vec:
+        obj = Minimize(a * (x ** 2) + b * x)
+        constraints = [0 <= x, x <= 1]
+        prob = Problem(obj, constraints)
+        prob.solve(solver=solver)
+        x_full.append(x.value)
+        obj_full.append(prob.value)
+
+    x_param, obj_param = [], []
+    b = Parameter()
+    obj = Minimize(a * (x ** 2) + b * x)
+    constraints = [0 <= x, x <= 1]
+    prob = Problem(obj, constraints)
+    for b_value in b_vec:
+        b.value = b_value
+        prob.solve(solver=solver)
+        x_param.append(x.value)
+        obj_param.append(prob.value)
+
+    for i in range(len(b_vec)):
+        assert_items_almost_equal(x_full[i], x_param[i], places=3)
+        assert_almost_equal(obj_full[i], obj_param[i])
+
+
+# --------------------------------------------------------------------------- #
+# Solver-specific tests
+# --------------------------------------------------------------------------- #
+
+def test_warm_start():
+    m, n = 200, 100
+    np.random.seed(1)
+    A = np.random.randn(m, n)
+    b = Parameter(m)
+    x = Variable(n)
+    prob = Problem(Minimize(sum_squares(A @ x - b)))
+
+    b.value = np.random.randn(m)
+    result = prob.solve(solver="OSQP", warm_start=False)
+    result2 = prob.solve(solver="OSQP", warm_start=True)
+    assert_almost_equal(result, result2)
+    b.value = np.random.randn(m)
+    result = prob.solve(solver="OSQP", warm_start=True)
+    result2 = prob.solve(solver="OSQP", warm_start=False)
+    assert_almost_equal(result, result2)
+
+
+@pytest.mark.skipif(cp.QPALM not in INSTALLED_SOLVERS, reason="QPALM is not installed")
+def test_qpalm_warmstart():
+    m, n = 200, 100
+    np.random.seed(1)
+    A = np.random.randn(m, n)
+    b = Parameter(m)
+    x = Variable(n)
+    prob = Problem(Minimize(sum_squares(A @ x - b)))
+
+    b.value = np.random.randn(m)
+    result = prob.solve(solver=cp.QPALM, warm_start=False)
+    result2 = prob.solve(solver=cp.QPALM, warm_start=True)
+    assert_almost_equal(result, result2)
+    b.value = np.random.randn(m)
+    result = prob.solve(solver=cp.QPALM, warm_start=True)
+    result2 = prob.solve(solver=cp.QPALM, warm_start=False)
+    assert_almost_equal(result, result2)
+
+
+@pytest.mark.skipif(cp.GUROBI not in INSTALLED_SOLVERS, reason="GUROBI is not installed")
+def test_gurobi_warmstart():
+    """Test Gurobi warm start with a user provided point."""
+    import gurobipy
+    m, n = 4, 3
+    y = Variable(nonneg=True)
+    X = Variable((m, n))
+    X_vals = np.reshape(np.arange(m * n), (m, n))
+    prob = Problem(Minimize(y ** 2 + cp.sum(X)), [X == X_vals])
+    X.value = X_vals + 1
+    prob.solve(solver=cp.GUROBI, warm_start=True)
+    model = prob.solver_stats.extra_stats
+    model_x = model.getVars()
+    assert gurobipy.GRB.UNDEFINED == model_x[0].start
+    assert np.isclose(0, model_x[0].x)
+    for i in range(1, X.size + 1):
+        row = (i - 1) % X.shape[0]
+        col = (i - 1) // X.shape[0]
+        assert X_vals[row, col] + 1 == model_x[i].start
+        assert np.isclose(X.value[row, col], model_x[i].x)
+
+
+@pytest.mark.skipif(cp.XPRESS not in INSTALLED_SOLVERS, reason="XPRESS is not installed")
+def test_xpress_warmstart():
+    """Test XPRESS warm start with a user provided point."""
+    m, n = 20, 10
+    np.random.seed(1)
+    A = np.random.randn(m, n)
+    b = Parameter(m)
+    x = Variable(n, integer=True)
+    prob = Problem(Minimize(sum_squares(A @ x - b)))
+
+    b.value = np.random.randn(m)
+    result = prob.solve(solver=cp.XPRESS, warm_start=False)
+    result2 = prob.solve(solver=cp.XPRESS, warm_start=True)
+    assert_almost_equal(result, result2)
+    x.value = x.value.astype(np.int64)
+
+    xprime = Variable(n, integer=True)
+    prob = Problem(Minimize(sum_squares(A @ xprime - b)))
+    xprime.value = x.value
+    result = prob.solve(solver=cp.XPRESS, warm_start=True)
+    result2 = prob.solve(solver=cp.XPRESS, warm_start=False)
+    assert_almost_equal(result, result2)
+
+
+@pytest.mark.skipif(cp.HIGHS not in INSTALLED_SOLVERS, reason="HIGHS is not installed")
+def test_highs_warmstart():
+    m, n = 200, 100
+    np.random.seed(1)
+    A = np.random.randn(m, n)
+    b = Parameter(m)
+    x = Variable(n)
+    prob = Problem(Minimize(sum_squares(A @ x - b)))
+
+    b.value = np.random.randn(m)
+    result = prob.solve(solver=cp.HIGHS, warm_start=False)
+    result2 = prob.solve(solver=cp.HIGHS, warm_start=True)
+    assert_almost_equal(result, result2)
+    b.value = np.random.randn(m)
+    result = prob.solve(solver=cp.HIGHS, warm_start=True)
+    result2 = prob.solve(solver=cp.HIGHS, warm_start=False)
+    assert_almost_equal(result, result2)
+
+
+@pytest.mark.skipif(cp.HIGHS not in INSTALLED_SOLVERS, reason="HIGHS is not installed")
+def test_highs_cvar():
+    """CVaR constraint regression for https://github.com/cvxpy/cvxpy/issues/2836."""
+    num_stocks = 5
+    num_samples = 25
+    np.random.seed(1)
+    pnl_samples = np.random.uniform(low=0.0, high=1.0, size=(num_samples, num_stocks))
+    pnl_expected = pnl_samples.mean(axis=0)
+
+    quantile = 0.05
+    w = cp.Variable(num_stocks, nonneg=True)
+    cvar = cp.cvar(pnl_samples @ w, 1 - quantile)
+    pnl = w @ pnl_expected
+
+    objective = cp.Maximize(pnl)
+    constraints = [cvar <= 0.5]
+    problem = cp.Problem(objective, constraints)
+    problem.solve(solver=cp.HIGHS)
+    assert problem.status == cp.OPTIMAL
+
+
+@pytest.mark.skipif(cp.PIQP not in INSTALLED_SOLVERS, reason="PIQP is not installed")
+def test_piqp_warmstart():
+    m, n = 200, 100
+    np.random.seed(1)
+    A = np.random.randn(m, n)
+    b = Parameter(m)
+    x = Variable(n)
+    prob = Problem(Minimize(sum_squares(A @ x - b)))
+
+    b.value = np.random.randn(m)
+    result = prob.solve(solver=cp.PIQP, warm_start=False)
+    result2 = prob.solve(solver=cp.PIQP, warm_start=True)
+    assert_almost_equal(result, result2)
+    b.value = np.random.randn(m)
+    result = prob.solve(solver=cp.PIQP, warm_start=True)
+    result2 = prob.solve(solver=cp.PIQP, warm_start=False)
+    assert_almost_equal(result, result2)
+
+
+@pytest.mark.skipif(cp.COPT not in INSTALLED_SOLVERS, reason="COPT is not installed")
+def test_copt_warmstart():
+    m, n = 200, 100
+    np.random.seed(1)
+    A = np.random.randn(m, n)
+    b = Parameter(m)
+    x = Variable(n)
+    prob = Problem(Minimize(sum_squares(A @ x - b)))
+
+    b.value = np.random.randn(m)
+    result = prob.solve(solver=cp.COPT, warm_start=False)
+    result2 = prob.solve(solver=cp.COPT, warm_start=True)
+    assert_almost_equal(result, result2)
+    b.value = np.random.randn(m)
+    result = prob.solve(solver=cp.COPT, warm_start=True)
+    result2 = prob.solve(solver=cp.COPT, warm_start=False)
+    assert_almost_equal(result, result2)
+
+
+def test_square_param():
+    """Issue arising with square plus parameter."""
+    a = Parameter(value=1)
+    b = Variable()
+    obj = Minimize(b ** 2 + abs(a))
+    prob = Problem(obj)
+    prob.solve(solver="SCS")
+    assert_almost_equal(obj.value, 1.0)
+
+
+def test_gurobi_time_limit_no_solution(qp_vars):
+    """If Gurobi hits its time limit before finding a solution, the solve
+    must return cleanly and expose solver stats.
+
+    The test is skipped if Gurobi terminates for a different reason or
+    actually finds a solution despite ``TimeLimit=0``.
     """
+    from cvxpy import GUROBI
+    if GUROBI in INSTALLED_SOLVERS:
+        import gurobipy
+        objective = Minimize(qp_vars.x[0])
+        constraints = [qp_vars.x[0] >= 1]
+        prob = Problem(objective, constraints)
+        try:
+            prob.solve(solver=GUROBI, TimeLimit=0.0)
+        except Exception as e:
+            pytest.fail(
+                f"An exception {e} is raised instead of returning a result."
+            )
 
-    def setUp(self) -> None:
-        super().setUp()
-        self.solvers = [cp.KNITRO]
+        extra_stats = None
+        solver_stats = getattr(prob, "solver_stats", None)
+        if solver_stats:
+            extra_stats = getattr(solver_stats, "extra_stats", None)
+        assert extra_stats, "Solver stats have not been returned."
 
-    def solve_QP(self, problem, solver_name):
-        return problem.solve(solver=solver_name, verbose=False)
+        nb_solutions = getattr(extra_stats, "SolCount", None)
+        if nb_solutions:
+            pytest.skip(
+                "Gurobi has found a solution, the test is not relevant anymore."
+            )
 
-    def test_all_solvers(self) -> None:
-        for solver in self.solvers:
-            self.quad_over_lin(solver)
-            self.power(solver)
-            self.power_matrix(solver)
-            self.square_affine(solver)
-            self.quad_form(solver)
-            self.affine_problem(solver)
-            self.maximize_problem(solver)
-            self.abs(solver)
-            self.quad_form_coeff(solver)
-            self.quad_form_bound(solver)
-            self.regression_1(solver)
-            self.regression_2(solver)
-            self.rep_quad_form(solver)
-            self.control(solver)
-            self.sparse_system(solver)
-            self.smooth_ridge(solver)
-            self.huber_small(solver)
-            self.huber(solver)
-            self.equivalent_forms_1(solver)
-            self.equivalent_forms_2(solver)
-            # equivalent_forms_3 is intentionally skipped for KNITRO; see
-            # the matching skip in TestQp.test_all_solvers.
-
-    def test_qp_bound_attr(self) -> None:
-        for solver in self.solvers:
-            solver_cls = SOLVER_MAP_QP.get(solver)
-            if solver_cls is not None and getattr(solver_cls, 'BOUNDED_VARIABLES', False):
-                StandardTestQPs.test_qp_bound_attr(solver=solver)
-
-    def test_parametric(self) -> None:
-        x = Variable()
-        a = 10
-        b_vec = [-10, -2.]
-
-        for solver in self.solvers:
-            x_full = []
-            obj_full = []
-            for b in b_vec:
-                obj = Minimize(a * (x ** 2) + b * x)
-                constraints = [0 <= x, x <= 1]
-                prob = Problem(obj, constraints)
-                prob.solve(solver=solver)
-                x_full += [x.value]
-                obj_full += [prob.value]
-
-            x_param = []
-            obj_param = []
-            b = Parameter()
-            obj = Minimize(a * (x ** 2) + b * x)
-            constraints = [0 <= x, x <= 1]
-            prob = Problem(obj, constraints)
-            for b_value in b_vec:
-                b.value = b_value
-                prob.solve(solver=solver)
-                x_param += [x.value]
-                obj_param += [prob.value]
-
-            for i in range(len(b_vec)):
-                self.assertItemsAlmostEqual(x_full[i], x_param[i], places=3)
-                self.assertAlmostEqual(obj_full[i], obj_param[i])
+        solver_status = getattr(extra_stats, "Status", None)
+        if solver_status != gurobipy.GRB.TIME_LIMIT:
+            pytest.skip(
+                "Gurobi terminated for a different reason than reaching time "
+                "limit, the test is not relevant anymore."
+            )
+    else:
+        with pytest.raises(Exception) as exc_info:
+            prob = Problem(Minimize(norm(qp_vars.x, 1)), [qp_vars.x == 0])
+            prob.solve(solver=GUROBI, TimeLimit=0)
+        assert str(exc_info.value) == f"The solver {GUROBI} is not installed."
 
 
-@unittest.skipUnless('MPAX' in INSTALLED_SOLVERS, 'MPAX is not installed.')
-class TestMPAX(unittest.TestCase):
+def test_gurobi_environment(qp_vars):
+    """Gurobi environments (with licensing/model parameter data) can be passed
+    through to the underlying Model.
+    """
+    from cvxpy import GUROBI
+    if GUROBI in INSTALLED_SOLVERS:
+        import gurobipy
 
-    def test_mpax_lp_0(self) -> None:
-        StandardTestLPs.test_lp_0(solver='MPAX')
+        params = {
+            'MIPGap': np.random.random(),       # range {0, INFINITY}
+            'AggFill': np.random.randint(10),   # range {-1, MAXINT}
+            'PerturbValue': np.random.random(), # range: {0, INFINITY}
+        }
+        custom_env = gurobipy.Env()
+        for k, v in params.items():
+            custom_env.setParam(k, v)
 
-    def test_mpax_lp_1(self) -> None:
-        StandardTestLPs.test_lp_1(solver='MPAX')
-
-    def test_mpax_lp_2(self) -> None:
-        StandardTestLPs.test_lp_2(solver='MPAX')
-
-    def test_mpax_lp_3(self) -> None:
-        sth = sths.lp_3()
-        with self.assertWarns(Warning):
-            sth.prob.solve(solver='MPAX')
-            self.assertEqual(sth.prob.status, cp.settings.INFEASIBLE_OR_UNBOUNDED)
-
-    def test_mpax_lp_4(self) -> None:
-            sth = sths.lp_4()
-            with self.assertWarns(Warning):
-                sth.prob.solve(solver='MPAX')
-                self.assertEqual(sth.prob.status, cp.settings.INFEASIBLE_OR_UNBOUNDED)
-
-    def test_mpax_lp_5(self) -> None:
-        StandardTestLPs.test_lp_5(solver='MPAX')
-
-    def test_mpax_lp_6(self) -> None:
-        StandardTestLPs.test_lp_6(solver='MPAX')
-
-    def test_mpax_warmstart(self) -> None:
-        x = cp.Variable(shape=(2,), name='x')
-        objective = cp.Minimize(-4 * x[0] - 5 * x[1])
-        constraints = [2 * x[0] + x[1] <= 3,
-                    x[0] + 2 * x[1] <= 3,
-                    x[0] >= 0,
-                    x[1] >= 0]
-        prob = cp.Problem(objective, constraints)
-        result1 = prob.solve(solver='MPAX', warm_start=False)
-        self.assertAlmostEqual(result1, -9, places=4)
-        result2 = prob.solve(solver='MPAX', warm_start=True)
-        self.assertAlmostEqual(result2, -9, places=4)
-
-    def test_MPAX_qp_0(self) -> None:
-        StandardTestQPs.test_qp_0(solver='MPAX')
+        sth = StandardTestLPs.test_lp_0(solver='GUROBI', env=custom_env)
+        model = sth.prob.solver_stats.extra_stats
+        for k, v in params.items():
+            # https://www.gurobi.com/documentation/9.1/refman/py_model_getparaminfo.html
+            _, _, p_val, _, _, _ = model.getParamInfo(k)
+            assert v == p_val
+    else:
+        with pytest.raises(Exception) as exc_info:
+            prob = Problem(Minimize(norm(qp_vars.x, 1)), [qp_vars.x == 0])
+            prob.solve(solver=GUROBI, TimeLimit=0)
+        assert str(exc_info.value) == f"The solver {GUROBI} is not installed."
 
 
-class TestQpSolverValidation(unittest.TestCase):
-    """Test QP solver validation of unsupported cone types."""
+def test_osqp_infeasible_lp_ineq_constraints():
+    StandardTestInfeasibleProblems.test_lp_ineq_constraints(solver=cp.OSQP)
 
-    def _apply_reductions(self, problem):
-        """Apply the full reduction chain to get a ParamConeProg."""
-        from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
-        from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
-        from cvxpy.reductions.dcp2cone.dcp2cone import Dcp2Cone
-        from cvxpy.reductions.flip_objective import FlipObjective
 
-        reductions = []
-        if isinstance(problem.objective, cp.Maximize):
-            reductions.append(FlipObjective())
-        reductions.extend([Dcp2Cone(), CvxAttr2Constr(), ConeMatrixStuffing()])
+def test_osqp_infeasible_lp_eq_constraints():
+    StandardTestInfeasibleProblems.test_lp_eq_constraints(solver=cp.OSQP)
 
-        reduced = problem
-        for reduction in reductions:
-            reduced = reduction.apply(reduced)[0]
-        return reduced
 
-    def test_qp_solver_rejects_exponential_cones(self) -> None:
-        """Test that QP solver rejects problems with exponential cones."""
-        from cvxpy.error import SolverError
-        from cvxpy.reductions.solvers.qp_solvers.osqp_qpif import OSQP
+def test_highs_infeasible_lp_ineq_constraints():
+    StandardTestInfeasibleProblems.test_lp_ineq_constraints(solver=cp.HIGHS)
 
-        # Create a problem with exponential cone (log)
-        x = cp.Variable()
-        prob = cp.Problem(cp.Maximize(cp.log(x)), [x <= 1])
 
-        # Apply reductions to get ParamConeProg
-        param_cone_prog = self._apply_reductions(prob)
+def test_highs_infeasible_lp_eq_constraints():
+    StandardTestInfeasibleProblems.test_lp_eq_constraints(solver=cp.HIGHS)
 
-        # Test accepts() returns False
-        osqp_solver = OSQP()
-        self.assertFalse(osqp_solver.accepts(param_cone_prog))
 
-        # Test apply() raises SolverError with helpful message
-        with self.assertRaises(SolverError) as cm:
-            osqp_solver.apply(param_cone_prog)
-        self.assertIn("exponential cones", str(cm.exception))
-        self.assertIn("OSQP", str(cm.exception))
+@pytest.mark.skipif(cp.HIGHS not in INSTALLED_SOLVERS, reason="HIGHS is not installed")
+def test_highs_dense_quad_form():
+    """Regression test for https://github.com/cvxpy/cvxpy/issues/3301.
 
-    def test_qp_solver_rejects_psd_cones(self) -> None:
-        """Test that QP solver rejects problems with PSD cones."""
-        from cvxpy.error import SolverError
-        from cvxpy.reductions.solvers.qp_solvers.osqp_qpif import OSQP
+    A dense quad_form applied to a linear expression (not a raw Variable)
+    produces a Hessian whose upper and lower triangles may differ by
+    floating-point epsilon after canonicalization. Passing such a Hessian
+    in square format to HiGHS >= 1.14.0 triggers an asymmetry error
+    and native heap corruption. Using triangular format avoids this.
+    """
+    rng = np.random.default_rng(42)
+    n_vars, n_nodes = 60, 20
 
-        # Create a problem with PSD cone
-        X = cp.Variable((2, 2), symmetric=True)
-        prob = cp.Problem(cp.Minimize(cp.trace(X)), [X >> 0, X[0, 0] >= 1])
+    # Sparse mapping from decision variables to a smaller space.
+    rows, cols, vals = [], [], []
+    for i in range(n_vars):
+        j, k = rng.choice(n_nodes, size=2, replace=False)
+        rows += [i, i]
+        cols += [j, k]
+        vals += [1.0, -1.0]
+    M = sp.csr_matrix((vals, (rows, cols)), shape=(n_vars, n_nodes))
 
-        # Apply reductions to get ParamConeProg
-        param_cone_prog = self._apply_reductions(prob)
+    # Dense PSD matrix via eigenvalue clamping (typical in practice).
+    A = rng.standard_normal((n_nodes, n_nodes))
+    raw = A @ A.T + rng.standard_normal((n_nodes, n_nodes)) * 0.01
+    sym = 0.5 * (raw + raw.T)
+    eigvals, eigvecs = np.linalg.eigh(sym)
+    eigvals = np.maximum(eigvals, 0.0)
+    Sigma = eigvecs @ np.diag(eigvals) @ eigvecs.T
 
-        # Test accepts() returns False
-        osqp_solver = OSQP()
-        self.assertFalse(osqp_solver.accepts(param_cone_prog))
+    x = cp.Variable(n_vars, nonneg=True)
+    y = x @ M
+    prob = cp.Problem(
+        cp.Maximize(cp.sum(x) - 0.1 * cp.quad_form(y, Sigma)),
+        [x <= 10],
+    )
+    prob.solve(solver=cp.HIGHS)
+    assert prob.status == cp.OPTIMAL
 
-        # Test apply() raises SolverError with helpful message
-        with self.assertRaises(SolverError) as cm:
-            osqp_solver.apply(param_cone_prog)
-        self.assertIn("PSD cones", str(cm.exception))
 
-    def test_qp_solver_rejects_soc_cones(self) -> None:
-        """Test that QP solver rejects problems with second-order cones."""
-        from cvxpy.error import SolverError
-        from cvxpy.reductions.solvers.qp_solvers.osqp_qpif import OSQP
+# --------------------------------------------------------------------------- #
+# MPAX tests
+# --------------------------------------------------------------------------- #
 
-        # Create a problem with SOC (norm)
-        x = cp.Variable(3)
-        prob = cp.Problem(cp.Minimize(cp.norm(x)), [cp.sum(x) == 1])
+mpax_skip = pytest.mark.skipif(
+    'MPAX' not in INSTALLED_SOLVERS, reason='MPAX is not installed.'
+)
 
-        # Apply reductions to get ParamConeProg
-        param_cone_prog = self._apply_reductions(prob)
 
-        # Test accepts() returns False
-        osqp_solver = OSQP()
-        self.assertFalse(osqp_solver.accepts(param_cone_prog))
+@mpax_skip
+def test_mpax_lp_0():
+    StandardTestLPs.test_lp_0(solver='MPAX')
 
-        # Test apply() raises SolverError with helpful message
-        with self.assertRaises(SolverError) as cm:
-            osqp_solver.apply(param_cone_prog)
-        self.assertIn("second-order cones", str(cm.exception))
+
+@mpax_skip
+def test_mpax_lp_1():
+    StandardTestLPs.test_lp_1(solver='MPAX')
+
+
+@mpax_skip
+def test_mpax_lp_2():
+    StandardTestLPs.test_lp_2(solver='MPAX')
+
+
+@mpax_skip
+def test_mpax_lp_3():
+    sth = sths.lp_3()
+    with pytest.warns(Warning):
+        sth.prob.solve(solver='MPAX')
+        assert sth.prob.status == cp.settings.INFEASIBLE_OR_UNBOUNDED
+
+
+@mpax_skip
+def test_mpax_lp_4():
+    sth = sths.lp_4()
+    with pytest.warns(Warning):
+        sth.prob.solve(solver='MPAX')
+        assert sth.prob.status == cp.settings.INFEASIBLE_OR_UNBOUNDED
+
+
+@mpax_skip
+def test_mpax_lp_5():
+    StandardTestLPs.test_lp_5(solver='MPAX')
+
+
+@mpax_skip
+def test_mpax_lp_6():
+    StandardTestLPs.test_lp_6(solver='MPAX')
+
+
+@mpax_skip
+def test_mpax_warmstart():
+    x = cp.Variable(shape=(2,), name='x')
+    objective = cp.Minimize(-4 * x[0] - 5 * x[1])
+    constraints = [
+        2 * x[0] + x[1] <= 3,
+        x[0] + 2 * x[1] <= 3,
+        x[0] >= 0,
+        x[1] >= 0,
+    ]
+    prob = cp.Problem(objective, constraints)
+    result1 = prob.solve(solver='MPAX', warm_start=False)
+    assert_almost_equal(result1, -9, places=4)
+    result2 = prob.solve(solver='MPAX', warm_start=True)
+    assert_almost_equal(result2, -9, places=4)
+
+
+@mpax_skip
+def test_mpax_qp_0():
+    StandardTestQPs.test_qp_0(solver='MPAX')
+
+
+# --------------------------------------------------------------------------- #
+# QP solver cone-type validation
+# --------------------------------------------------------------------------- #
+
+def _apply_reductions(problem):
+    """Apply the full reduction chain to get a ParamConeProg."""
+    reductions = []
+    if isinstance(problem.objective, cp.Maximize):
+        reductions.append(FlipObjective())
+    reductions.extend([Dcp2Cone(), CvxAttr2Constr(), ConeMatrixStuffing()])
+    reduced = problem
+    for reduction in reductions:
+        reduced = reduction.apply(reduced)[0]
+    return reduced
+
+
+def test_qp_solver_rejects_exponential_cones():
+    """QP solver rejects problems with exponential cones."""
+    x = cp.Variable()
+    prob = cp.Problem(cp.Maximize(cp.log(x)), [x <= 1])
+    param_cone_prog = _apply_reductions(prob)
+    osqp_solver = OSQP()
+    assert not osqp_solver.accepts(param_cone_prog)
+    with pytest.raises(SolverError) as exc_info:
+        osqp_solver.apply(param_cone_prog)
+    msg = str(exc_info.value)
+    assert "exponential cones" in msg
+    assert "OSQP" in msg
+
+
+def test_qp_solver_rejects_psd_cones():
+    """QP solver rejects problems with PSD cones."""
+    X = cp.Variable((2, 2), symmetric=True)
+    prob = cp.Problem(cp.Minimize(cp.trace(X)), [X >> 0, X[0, 0] >= 1])
+    param_cone_prog = _apply_reductions(prob)
+    osqp_solver = OSQP()
+    assert not osqp_solver.accepts(param_cone_prog)
+    with pytest.raises(SolverError) as exc_info:
+        osqp_solver.apply(param_cone_prog)
+    assert "PSD cones" in str(exc_info.value)
+
+
+def test_qp_solver_rejects_soc_cones():
+    """QP solver rejects problems with second-order cones."""
+    x = cp.Variable(3)
+    prob = cp.Problem(cp.Minimize(cp.norm(x)), [cp.sum(x) == 1])
+    param_cone_prog = _apply_reductions(prob)
+    osqp_solver = OSQP()
+    assert not osqp_solver.accepts(param_cone_prog)
+    with pytest.raises(SolverError) as exc_info:
+        osqp_solver.apply(param_cone_prog)
+    assert "second-order cones" in str(exc_info.value)

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -21,24 +21,13 @@ from scipy.linalg import lstsq
 
 import cvxpy as cp
 import cvxpy.tests.solver_test_helpers as sths
-from cvxpy import Maximize, Minimize, Parameter, Problem
-from cvxpy.atoms import (
-    QuadForm,
-    abs,
-    huber,
-    matrix_frac,
-    norm,
-    power,
-    quad_over_lin,
-    sum,
-    sum_squares,
-)
 from cvxpy.error import SolverError
-from cvxpy.expressions.variable import Variable
-from cvxpy.reductions.cvx_attr2constr import CvxAttr2Constr
-from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
-from cvxpy.reductions.dcp2cone.dcp2cone import Dcp2Cone
-from cvxpy.reductions.flip_objective import FlipObjective
+from cvxpy.reductions import (
+    ConeMatrixStuffing,
+    CvxAttr2Constr,
+    Dcp2Cone,
+    FlipObjective,
+)
 from cvxpy.reductions.solvers.defines import (
     INSTALLED_CONIC_SOLVERS,
     INSTALLED_SOLVERS,
@@ -160,8 +149,8 @@ def _skip_if_requires_constr(solver, use_quad_obj):
 
 @pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
 def test_quad_over_lin(solver, use_quad_obj):
-    x = Variable(2)
-    p = Problem(Minimize(0.5 * quad_over_lin(abs(x - 1), 1)), [x <= -1])
+    x = cp.Variable(2)
+    p = cp.Problem(cp.Minimize(0.5 * cp.quad_over_lin(cp.abs(x - 1), 1)), [x <= -1])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(x.value, [-1., -1.], atol=1e-4)
     np.testing.assert_allclose(p.constraints[0].dual_value, [2., 2.], atol=1e-4)
@@ -170,8 +159,8 @@ def test_quad_over_lin(solver, use_quad_obj):
 
 @pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
 def test_abs(solver, use_quad_obj):
-    u = Variable(2)
-    prob = Problem(Minimize(sum_squares(u)), [abs(u[1] - u[0]) <= 100])
+    u = cp.Variable(2)
+    prob = cp.Problem(cp.Minimize(cp.sum_squares(u)), [cp.abs(u[1] - u[0]) <= 100])
     assert prob.is_qp()
     result = _solve(prob, solver, use_quad_obj)
     np.testing.assert_allclose(result, 0, atol=1e-5)
@@ -180,26 +169,26 @@ def test_abs(solver, use_quad_obj):
 @pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
 def test_power(solver, use_quad_obj):
     _skip_if_requires_constr(solver, use_quad_obj)
-    x = Variable(2)
-    p = Problem(Minimize(sum(power(x, 2))), [])
+    x = cp.Variable(2)
+    p = cp.Problem(cp.Minimize(cp.sum(cp.power(x, 2))), [])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(x.value, [0., 0.], atol=1e-4)
 
 
 @pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
 def test_power_matrix(solver, use_quad_obj):
-    X = Variable((2, 2))
-    p = Problem(Minimize(sum(power(X - 3., 2))), [])
+    X = cp.Variable((2, 2))
+    p = cp.Problem(cp.Minimize(cp.sum(cp.power(X - 3., 2))), [])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(X.value, np.full((2, 2), 3.), atol=1e-4)
 
 
 @pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
 def test_square_affine(solver, use_quad_obj):
-    x = Variable(2)
+    x = cp.Variable(2)
     A = np.random.randn(10, 2)
     b = np.random.randn(10)
-    p = Problem(Minimize(sum_squares(A @ x - b)))
+    p = cp.Problem(cp.Minimize(cp.sum_squares(A @ x - b)))
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(x.value, lstsq(A, b)[0], atol=1e-1)
 
@@ -212,8 +201,8 @@ def test_quad_form(solver, use_quad_obj):
     z = np.random.randn(5)
     P = A.T @ A
     q = -2 * P @ z
-    w = Variable(5)
-    p = Problem(Minimize(QuadForm(w, P) + q.T @ w))
+    w = cp.Variable(5)
+    p = cp.Problem(cp.Minimize(cp.QuadForm(w, P) + q.T @ w))
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(w.value, z, atol=1e-4)
 
@@ -227,9 +216,9 @@ def test_rep_quad_form(solver, use_quad_obj):
     z = np.random.randn(5)
     P = A.T @ A
     q = -2 * P @ z
-    w = Variable(5)
-    qf = QuadForm(w, P)
-    p = Problem(Minimize(0.5 * qf + 0.5 * qf + q.T @ w))
+    w = cp.Variable(5)
+    qf = cp.QuadForm(w, P)
+    p = cp.Problem(cp.Minimize(0.5 * qf + 0.5 * qf + q.T @ w))
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(w.value, z, atol=1e-4)
 
@@ -239,8 +228,8 @@ def test_affine_problem(solver, use_quad_obj):
     np.random.seed(0)
     A = np.maximum(np.random.randn(5, 2), 0)
     b = np.maximum(np.random.randn(5), 0)
-    x = Variable(2)
-    p = Problem(Minimize(sum(x)), [x >= 0, A @ x <= b])
+    x = cp.Variable(2)
+    p = cp.Problem(cp.Minimize(cp.sum(x)), [x >= 0, A @ x <= b])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(x.value, [0., 0.], atol=1e-3)
     check_kkt(p, places=3)
@@ -251,8 +240,8 @@ def test_maximize_problem(solver, use_quad_obj):
     np.random.seed(0)
     A = np.maximum(np.random.randn(5, 2), 0)
     b = np.maximum(np.random.randn(5), 0)
-    x = Variable(2)
-    p = Problem(Maximize(-sum(x)), [x >= 0, A @ x <= b])
+    x = cp.Variable(2)
+    p = cp.Problem(cp.Maximize(-cp.sum(x)), [x >= 0, A @ x <= b])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(x.value, [0., 0.], atol=1e-3)
     check_kkt(p, places=3)
@@ -263,8 +252,8 @@ def test_quad_form_bound(solver, use_quad_obj):
     P = np.array([[13, 12, -2], [12, 17, 6], [-2, 6, 12]])
     q = np.array([[-22], [-14.5], [13]])
     y_star = np.array([1., 0.5, -1.])
-    y = Variable(3)
-    p = Problem(Minimize(0.5 * QuadForm(y, P) + q.T @ y + 1),
+    y = cp.Variable(3)
+    p = cp.Problem(cp.Minimize(0.5 * cp.QuadForm(y, P) + q.T @ y + 1),
                 [y >= -1, y <= 1])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(y.value, y_star, atol=1e-4)
@@ -283,10 +272,10 @@ def test_regression_1(solver, use_quad_obj):
     y_data = np.atleast_2d(
         x_data_expanded.T.dot(true_coeffs) + 0.5 * np.random.rand(n, 1)
     )
-    slope = Variable(1)
-    offset = Variable(1)
+    slope = cp.Variable(1)
+    offset = cp.Variable(1)
     line = offset + x_data * slope
-    p = Problem(Minimize(sum_squares(line.T - y_data)))
+    p = cp.Problem(cp.Minimize(cp.sum_squares(line.T - y_data)))
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(1171.60037715, p.value, atol=1e-4)
 
@@ -299,11 +288,11 @@ def test_regression_2(solver, use_quad_obj):
     x_data = np.random.rand(n) * 5
     x_data_expanded = np.vstack([np.power(x_data, i) for i in range(1, 4)])
     y_data = x_data_expanded.T.dot(true_coeffs) + 0.5 * np.random.rand(n)
-    slope = Variable(1)
-    offset = Variable(1)
-    quadratic_coeff = Variable(1)
+    slope = cp.Variable(1)
+    offset = cp.Variable(1)
+    quadratic_coeff = cp.Variable(1)
     quadratic = offset + x_data * slope + quadratic_coeff * np.power(x_data, 2)
-    p = Problem(Minimize(sum_squares(quadratic.T - y_data)))
+    p = cp.Problem(cp.Minimize(cp.sum_squares(quadratic.T - y_data)))
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(139.225660756, p.value, atol=1e-4)
 
@@ -315,9 +304,9 @@ def test_control(solver, use_quad_obj):
     mass = 1
     drag = 0.1
     g = np.array([0, -9.8])
-    position = Variable((2, T))
-    velocity = Variable((2, T))
-    force = Variable((2, T - 1))
+    position = cp.Variable((2, T))
+    velocity = cp.Variable((2, T))
+    force = cp.Variable((2, T - 1))
     constraints = []
     for i in range(T - 1):
         constraints += [position[:, i + 1] == position[:, i] + h * velocity[:, i]]
@@ -327,7 +316,7 @@ def test_control(solver, use_quad_obj):
     constraints += [position[:, -1] == np.array([100, 100])]
     constraints += [velocity[:, 0] == np.array([-20, 100])]
     constraints += [velocity[:, -1] == 0]
-    p = Problem(Minimize(.01 * sum_squares(force)), constraints)
+    p = cp.Problem(cp.Minimize(.01 * cp.sum_squares(force)), constraints)
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(1059.616, p.value, atol=1e-1)
     # KKT check skipped: check_stationary_lagrangian fails for 2D matrix
@@ -341,8 +330,8 @@ def test_sparse_system(solver, use_quad_obj):
     np.random.seed(1)
     A = sp.random_array((m, n), density=0.4)
     b = np.random.randn(m)
-    xs = Variable(n)
-    p = Problem(Minimize(sum_squares(A @ xs - b)), [xs == 0])
+    xs = cp.Variable(n)
+    p = cp.Problem(cp.Minimize(cp.sum_squares(A @ xs - b)), [xs == 0])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(b.T.dot(b), p.value, atol=1e-4)
 
@@ -354,9 +343,9 @@ def test_smooth_ridge(solver, use_quad_obj):
     k = 20
     A = np.ones((k, n))
     b = np.ones(k)
-    xsr = Variable(n)
-    obj = sum_squares(A @ xsr - b) + sum_squares(xsr[:-1] - xsr[1:])
-    p = Problem(Minimize(obj), [])
+    xsr = cp.Variable(n)
+    obj = cp.sum_squares(A @ xsr - b) + cp.sum_squares(xsr[:-1] - xsr[1:])
+    p = cp.Problem(cp.Minimize(obj), [])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(0, p.value, atol=1e-4)
 
@@ -365,9 +354,9 @@ def test_smooth_ridge(solver, use_quad_obj):
 def test_huber_small(solver, use_quad_obj):
     # The conic + use_quad_obj path has slightly looser precision.
     places = 3 if use_quad_obj else 4
-    x = Variable(3)
-    objective = sum(huber(x))
-    p = Problem(Minimize(objective), [x[2] >= 3])
+    x = cp.Variable(3)
+    objective = cp.sum(cp.huber(x))
+    p = cp.Problem(cp.Minimize(objective), [x[2] >= 3])
     _solve(p, solver, use_quad_obj)
     atol = 10 ** (-places)
     np.testing.assert_allclose(3, x.value[2], atol=atol)
@@ -389,9 +378,9 @@ def test_huber(solver, use_quad_obj):
     ind95 = (np.random.rand(m) < 0.95).astype(float)
     b = A.dot(x_true) + np.multiply(0.5 * np.random.randn(m), ind95) \
         + np.multiply(10. * np.random.rand(m), 1. - ind95)
-    x = Variable(n)
-    objective = sum(huber(A @ x - b))
-    p = Problem(Minimize(objective))
+    x = cp.Variable(n)
+    objective = cp.sum(cp.huber(A @ x - b))
+    p = cp.Problem(cp.Minimize(objective))
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(1.452797819667, objective.value, atol=1e-3)
     np.testing.assert_allclose(
@@ -412,8 +401,8 @@ def _equivalent_forms_setup(seed=1):
 @pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
 def test_equivalent_forms_1(solver, use_quad_obj):
     A, b, G, h = _equivalent_forms_setup()
-    xef = Variable(A.shape[1])
-    p = Problem(Minimize(.1 * sum((A @ xef - b) ** 2)), [G @ xef == h])
+    xef = cp.Variable(A.shape[1])
+    p = cp.Problem(cp.Minimize(.1 * cp.sum((A @ xef - b) ** 2)), [G @ xef == h])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(p.value, 68.1119420108, atol=1e-4)
     check_kkt(p, places=4)
@@ -426,9 +415,9 @@ def test_equivalent_forms_2(solver, use_quad_obj):
     P = A.T @ A
     q = -2 * A.T @ b
     r = b.T @ b
-    xef = Variable(A.shape[1])
-    obj = .1 * (QuadForm(xef, P) + q.T @ xef + r)
-    p = Problem(Minimize(obj), [G @ xef == h])
+    xef = cp.Variable(A.shape[1])
+    obj = .1 * (cp.QuadForm(xef, P) + q.T @ xef + r)
+    p = cp.Problem(cp.Minimize(obj), [G @ xef == h])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(p.value, 68.1119420108, atol=1e-4)
     check_kkt(p, places=4)
@@ -443,9 +432,9 @@ def test_equivalent_forms_3(solver, use_quad_obj):
     q = -2 * A.T @ b
     r = b.T @ b
     Pinv = np.linalg.inv(P)
-    xef = Variable(A.shape[1])
-    obj = .1 * (matrix_frac(xef, Pinv) + q.T @ xef + r)
-    p = Problem(Minimize(obj), [G @ xef == h])
+    xef = cp.Variable(A.shape[1])
+    obj = .1 * (cp.matrix_frac(xef, Pinv) + q.T @ xef + r)
+    p = cp.Problem(cp.Minimize(obj), [G @ xef == h])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(p.value, 68.1119420108, atol=1e-4)
     check_kkt(p, places=4)
@@ -464,20 +453,20 @@ def test_qp_bound_attr(solver):
 @pytest.mark.parametrize("solver", QP_SOLVER_PARAMS)
 def test_parametric(solver):
     """Solve parametric problem vs full problem."""
-    x = Variable()
+    x = cp.Variable()
     a = 10
     b_vec = [-10, -2.]
 
     x_full, obj_full = [], []
     for b in b_vec:
-        prob = Problem(Minimize(a * (x ** 2) + b * x), [0 <= x, x <= 1])
+        prob = cp.Problem(cp.Minimize(a * (x ** 2) + b * x), [0 <= x, x <= 1])
         prob.solve(solver=solver)
         x_full.append(x.value)
         obj_full.append(prob.value)
 
     x_param, obj_param = [], []
-    b = Parameter()
-    prob = Problem(Minimize(a * (x ** 2) + b * x), [0 <= x, x <= 1])
+    b = cp.Parameter()
+    prob = cp.Problem(cp.Minimize(a * (x ** 2) + b * x), [0 <= x, x <= 1])
     for b_value in b_vec:
         b.value = b_value
         prob.solve(solver=solver)
@@ -505,9 +494,9 @@ def test_warm_start(solver):
     m, n = 200, 100
     np.random.seed(1)
     A = np.random.randn(m, n)
-    b = Parameter(m)
-    x = Variable(n)
-    prob = Problem(Minimize(sum_squares(A @ x - b)))
+    b = cp.Parameter(m)
+    x = cp.Variable(n)
+    prob = cp.Problem(cp.Minimize(cp.sum_squares(A @ x - b)))
 
     b.value = np.random.randn(m)
     result = prob.solve(solver=solver, warm_start=False)
@@ -524,10 +513,10 @@ def test_gurobi_warmstart():
     """Test Gurobi warm start with a user provided point."""
     import gurobipy
     m, n = 4, 3
-    y = Variable(nonneg=True)
-    X = Variable((m, n))
+    y = cp.Variable(nonneg=True)
+    X = cp.Variable((m, n))
     X_vals = np.reshape(np.arange(m * n), (m, n))
-    prob = Problem(Minimize(y ** 2 + cp.sum(X)), [X == X_vals])
+    prob = cp.Problem(cp.Minimize(y ** 2 + cp.sum(X)), [X == X_vals])
     X.value = X_vals + 1
     prob.solve(solver=cp.GUROBI, warm_start=True)
     model = prob.solver_stats.extra_stats
@@ -547,9 +536,9 @@ def test_xpress_warmstart():
     m, n = 20, 10
     np.random.seed(1)
     A = np.random.randn(m, n)
-    b = Parameter(m)
-    x = Variable(n, integer=True)
-    prob = Problem(Minimize(sum_squares(A @ x - b)))
+    b = cp.Parameter(m)
+    x = cp.Variable(n, integer=True)
+    prob = cp.Problem(cp.Minimize(cp.sum_squares(A @ x - b)))
 
     b.value = np.random.randn(m)
     result = prob.solve(solver=cp.XPRESS, warm_start=False)
@@ -557,8 +546,8 @@ def test_xpress_warmstart():
     np.testing.assert_allclose(result, result2, atol=1e-5)
     x.value = x.value.astype(np.int64)
 
-    xprime = Variable(n, integer=True)
-    prob = Problem(Minimize(sum_squares(A @ xprime - b)))
+    xprime = cp.Variable(n, integer=True)
+    prob = cp.Problem(cp.Minimize(cp.sum_squares(A @ xprime - b)))
     xprime.value = x.value
     result = prob.solve(solver=cp.XPRESS, warm_start=True)
     result2 = prob.solve(solver=cp.XPRESS, warm_start=False)
@@ -583,9 +572,9 @@ def test_highs_cvar():
 
 def test_square_param():
     """Issue arising with square plus parameter."""
-    a = Parameter(value=1)
-    b = Variable()
-    prob = Problem(Minimize(b ** 2 + abs(a)))
+    a = cp.Parameter(value=1)
+    b = cp.Variable()
+    prob = cp.Problem(cp.Minimize(b ** 2 + cp.abs(a)))
     prob.solve(solver="SCS")
     np.testing.assert_allclose(prob.value, 1.0, atol=1e-5)
 
@@ -596,8 +585,8 @@ def test_gurobi_time_limit_no_solution():
     """
     if cp.GUROBI in INSTALLED_SOLVERS:
         import gurobipy
-        x = Variable(2)
-        prob = Problem(Minimize(x[0]), [x[0] >= 1])
+        x = cp.Variable(2)
+        prob = cp.Problem(cp.Minimize(x[0]), [x[0] >= 1])
         try:
             prob.solve(solver=cp.GUROBI, TimeLimit=0.0)
         except Exception as e:
@@ -615,8 +604,8 @@ def test_gurobi_time_limit_no_solution():
                 "the test is not relevant anymore."
             )
     else:
-        x = Variable(2)
-        prob = Problem(Minimize(norm(x, 1)), [x == 0])
+        x = cp.Variable(2)
+        prob = cp.Problem(cp.Minimize(cp.norm(x, 1)), [x == 0])
         with pytest.raises(Exception) as exc_info:
             prob.solve(solver=cp.GUROBI, TimeLimit=0)
         assert str(exc_info.value) == f"The solver {cp.GUROBI} is not installed."
@@ -644,8 +633,8 @@ def test_gurobi_environment():
             _, _, p_val, _, _, _ = model.getParamInfo(k)
             assert v == p_val
     else:
-        x = Variable(2)
-        prob = Problem(Minimize(norm(x, 1)), [x == 0])
+        x = cp.Variable(2)
+        prob = cp.Problem(cp.Minimize(cp.norm(x, 1)), [x == 0])
         with pytest.raises(Exception) as exc_info:
             prob.solve(solver=cp.GUROBI, TimeLimit=0)
         assert str(exc_info.value) == f"The solver {cp.GUROBI} is not installed."

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -57,8 +57,8 @@ from cvxpy.tests.test_conic_solvers import is_knitro_available, is_mosek_availab
 
 # --- License checks --- #
 
-# is_mosek_available / is_knitro_available are imported from test_conic_solvers
-# so the canonical, KNITRO-OpenMP-safe implementations live in one place.
+# is_mosek_available / is_knitro_available come from test_conic_solvers so the
+# canonical, KNITRO-OpenMP-safe implementations live in one place.
 
 def is_xpress_available():
     """Check if XPRESS is installed and a license is available."""
@@ -75,8 +75,8 @@ def is_xpress_available():
 
 # --- Solver parametrization --- #
 
-def _solver_param(solver):
-    """``pytest.param`` for ``solver`` with license-skip and knitro marks."""
+def _solver_marks(solver):
+    """License-skip and ``knitro`` marks for a single solver."""
     marks = []
     if solver == cp.MOSEK and not is_mosek_available():
         marks.append(pytest.mark.skip(reason='MOSEK license not available'))
@@ -86,23 +86,49 @@ def _solver_param(solver):
         marks.append(pytest.mark.knitro)
         if not is_knitro_available():
             marks.append(pytest.mark.skip(reason='KNITRO not available'))
-    return pytest.param(solver, marks=marks, id=solver)
+    return marks
 
 
-QP_SOLVER_PARAMS = [_solver_param(s) for s in QP_SOLVERS if s in INSTALLED_SOLVERS]
-
-# Conic solvers that support quadratic objectives. KNITRO is excluded -- its
-# conic interface with ``use_quad_obj=True`` is unstable in CI.
-CONIC_QUAD_OBJ_PARAMS = [
-    _solver_param(s)
-    for s in INSTALLED_CONIC_SOLVERS
-    if s in SOLVER_MAP_CONIC
-    and SOLVER_MAP_CONIC[s].supports_quad_obj()
-    and s != cp.KNITRO
+# Native QP solvers, used by tests that only run against the QP path
+# (warm-start tests, ``test_qp_bound_attr``, ``test_parametric``).
+QP_SOLVER_PARAMS = [
+    pytest.param(s, marks=_solver_marks(s), id=s)
+    for s in QP_SOLVERS if s in INSTALLED_SOLVERS
 ]
 
+# Every (solver, use_quad_obj) variant we want to run each QP correctness test
+# against: every native QP solver with use_quad_obj=False, plus every conic
+# solver that supports quadratic objectives with use_quad_obj=True. KNITRO is
+# excluded from the conic side -- its conic interface with use_quad_obj=True
+# is unstable in CI.
+QP_PARAMS = (
+    [pytest.param(s, False, marks=_solver_marks(s), id=s)
+     for s in QP_SOLVERS if s in INSTALLED_SOLVERS]
+    + [pytest.param(s, True, marks=_solver_marks(s), id=f"{s}-quadobj")
+       for s in INSTALLED_CONIC_SOLVERS
+       if s in SOLVER_MAP_CONIC
+       and SOLVER_MAP_CONIC[s].supports_quad_obj()
+       and s != cp.KNITRO]
+)
 
-# --- Assertion + solve helpers --- #
+
+# --- Solve + KKT helpers --- #
+
+def _solve(problem, solver, use_quad_obj):
+    """Solve ``problem``. With ``use_quad_obj=True`` additionally verify that
+    canonicalization introduces no SOC cones -- that's what the QP path
+    through a conic solver is supposed to guarantee.
+    """
+    if use_quad_obj:
+        data, _, _ = problem.get_problem_data(
+            solver, solver_opts={"use_quad_obj": True}
+        )
+        assert data["dims"].soc == [], (
+            f"Problem should have no SOC cones for QP canonicalization with {solver}"
+        )
+    kwargs = {"use_quad_obj": True} if use_quad_obj else {}
+    return problem.solve(solver=solver, verbose=False, **kwargs)
+
 
 def check_kkt(problem, places=4):
     """Verify KKT conditions for a solved problem.
@@ -121,25 +147,19 @@ def check_kkt(problem, places=4):
     sth.check_stationary_lagrangian(places)
 
 
-def _solve(problem, solver, use_quad_obj=False):
-    """Solve ``problem``. With ``use_quad_obj=True`` additionally verify that
-    canonicalization introduces no SOC cones -- that's what the QP path
-    through a conic solver is supposed to guarantee.
+def _skip_if_requires_constr(solver, use_quad_obj):
+    """Conic solvers with ``REQUIRES_CONSTR=True`` reject unconstrained
+    problems (those canonicalize to m=0). Skip such ``(solver, helper)``
+    combinations when running the conic + use_quad_obj path.
     """
-    if use_quad_obj:
-        data, _, _ = problem.get_problem_data(
-            solver, solver_opts={"use_quad_obj": True}
-        )
-        assert data["dims"].soc == [], (
-            f"Problem should have no SOC cones for QP canonicalization with {solver}"
-        )
-    kwargs = {"use_quad_obj": True} if use_quad_obj else {}
-    return problem.solve(solver=solver, verbose=False, **kwargs)
+    if use_quad_obj and SOLVER_MAP_CONIC[solver].REQUIRES_CONSTR:
+        pytest.skip(f"{solver} requires constraints; this problem is unconstrained")
 
 
-# --- QP correctness helpers (one per problem shape) --- #
+# --- QP correctness tests --- #
 
-def _quad_over_lin(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_quad_over_lin(solver, use_quad_obj):
     x = Variable(2)
     p = Problem(Minimize(0.5 * quad_over_lin(abs(x - 1), 1)), [x <= -1])
     _solve(p, solver, use_quad_obj)
@@ -148,7 +168,8 @@ def _quad_over_lin(solver, use_quad_obj=False):
     check_kkt(p, places=3)
 
 
-def _abs(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_abs(solver, use_quad_obj):
     u = Variable(2)
     prob = Problem(Minimize(sum_squares(u)), [abs(u[1] - u[0]) <= 100])
     assert prob.is_qp()
@@ -156,21 +177,25 @@ def _abs(solver, use_quad_obj=False):
     np.testing.assert_allclose(result, 0, atol=1e-5)
 
 
-def _power(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_power(solver, use_quad_obj):
+    _skip_if_requires_constr(solver, use_quad_obj)
     x = Variable(2)
     p = Problem(Minimize(sum(power(x, 2))), [])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(x.value, [0., 0.], atol=1e-4)
 
 
-def _power_matrix(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_power_matrix(solver, use_quad_obj):
     X = Variable((2, 2))
     p = Problem(Minimize(sum(power(X - 3., 2))), [])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(X.value, np.full((2, 2), 3.), atol=1e-4)
 
 
-def _square_affine(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_square_affine(solver, use_quad_obj):
     x = Variable(2)
     A = np.random.randn(10, 2)
     b = np.random.randn(10)
@@ -179,7 +204,9 @@ def _square_affine(solver, use_quad_obj=False):
     np.testing.assert_allclose(x.value, lstsq(A, b)[0], atol=1e-1)
 
 
-def _quad_form(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_quad_form(solver, use_quad_obj):
+    _skip_if_requires_constr(solver, use_quad_obj)
     np.random.seed(0)
     A = np.random.randn(5, 5)
     z = np.random.randn(5)
@@ -191,8 +218,10 @@ def _quad_form(solver, use_quad_obj=False):
     np.testing.assert_allclose(w.value, z, atol=1e-4)
 
 
-def _rep_quad_form(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_rep_quad_form(solver, use_quad_obj):
     """A problem where the quad_form term is used multiple times."""
+    _skip_if_requires_constr(solver, use_quad_obj)
     np.random.seed(0)
     A = np.random.randn(5, 5)
     z = np.random.randn(5)
@@ -205,7 +234,8 @@ def _rep_quad_form(solver, use_quad_obj=False):
     np.testing.assert_allclose(w.value, z, atol=1e-4)
 
 
-def _affine_problem(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_affine_problem(solver, use_quad_obj):
     np.random.seed(0)
     A = np.maximum(np.random.randn(5, 2), 0)
     b = np.maximum(np.random.randn(5), 0)
@@ -216,7 +246,8 @@ def _affine_problem(solver, use_quad_obj=False):
     check_kkt(p, places=3)
 
 
-def _maximize_problem(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_maximize_problem(solver, use_quad_obj):
     np.random.seed(0)
     A = np.maximum(np.random.randn(5, 2), 0)
     b = np.maximum(np.random.randn(5), 0)
@@ -227,7 +258,8 @@ def _maximize_problem(solver, use_quad_obj=False):
     check_kkt(p, places=3)
 
 
-def _quad_form_bound(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_quad_form_bound(solver, use_quad_obj):
     P = np.array([[13, 12, -2], [12, 17, 6], [-2, 6, 12]])
     q = np.array([[-22], [-14.5], [13]])
     y_star = np.array([1., 0.5, -1.])
@@ -239,7 +271,8 @@ def _quad_form_bound(solver, use_quad_obj=False):
     check_kkt(p)
 
 
-def _regression_1(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_regression_1(solver, use_quad_obj):
     np.random.seed(1)
     n = 100
     true_coeffs = np.array([[2, -2, 0.5]]).T
@@ -258,7 +291,8 @@ def _regression_1(solver, use_quad_obj=False):
     np.testing.assert_allclose(1171.60037715, p.value, atol=1e-4)
 
 
-def _regression_2(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_regression_2(solver, use_quad_obj):
     np.random.seed(1)
     n = 100
     true_coeffs = np.array([2, -2, 0.5])
@@ -274,7 +308,8 @@ def _regression_2(solver, use_quad_obj=False):
     np.testing.assert_allclose(139.225660756, p.value, atol=1e-4)
 
 
-def _control(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_control(solver, use_quad_obj):
     T = 30
     h = 0.1
     mass = 1
@@ -300,7 +335,8 @@ def _control(solver, use_quad_obj=False):
     # C order, constraint terms use F order). TODO fix this
 
 
-def _sparse_system(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_sparse_system(solver, use_quad_obj):
     m, n = 100, 80
     np.random.seed(1)
     A = sp.random_array((m, n), density=0.4)
@@ -311,7 +347,8 @@ def _sparse_system(solver, use_quad_obj=False):
     np.testing.assert_allclose(b.T.dot(b), p.value, atol=1e-4)
 
 
-def _smooth_ridge(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_smooth_ridge(solver, use_quad_obj):
     np.random.seed(1)
     n = 50
     k = 20
@@ -324,7 +361,10 @@ def _smooth_ridge(solver, use_quad_obj=False):
     np.testing.assert_allclose(0, p.value, atol=1e-4)
 
 
-def _huber_small(solver, use_quad_obj=False, places=4):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_huber_small(solver, use_quad_obj):
+    # The conic + use_quad_obj path has slightly looser precision.
+    places = 3 if use_quad_obj else 4
     x = Variable(3)
     objective = sum(huber(x))
     p = Problem(Minimize(objective), [x[2] >= 3])
@@ -335,7 +375,10 @@ def _huber_small(solver, use_quad_obj=False, places=4):
     check_kkt(p, places=places)
 
 
-def _huber(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_huber(solver, use_quad_obj):
+    # Expected values below were computed with this seed; do not change it.
+    np.random.seed(1)
     n, m = 3, 5
     data = [0.89, 0.39, 0.96, 0.34, 0.68, 0.18,
             0.63, 0.42, 0.51, 0.66, 0.43, 0.77]
@@ -366,17 +409,18 @@ def _equivalent_forms_setup(seed=1):
     return A, b, G, h
 
 
-def _equivalent_forms_1(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_equivalent_forms_1(solver, use_quad_obj):
     A, b, G, h = _equivalent_forms_setup()
-    n = A.shape[1]
-    xef = Variable(n)
+    xef = Variable(A.shape[1])
     p = Problem(Minimize(.1 * sum((A @ xef - b) ** 2)), [G @ xef == h])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(p.value, 68.1119420108, atol=1e-4)
     check_kkt(p, places=4)
 
 
-def _equivalent_forms_2(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_equivalent_forms_2(solver, use_quad_obj):
     A, b, G, h = _equivalent_forms_setup()
     # ||Ax-b||^2 = x^T (A^T A) x - 2(A^T b)^T x + ||b||^2
     P = A.T @ A
@@ -390,7 +434,10 @@ def _equivalent_forms_2(solver, use_quad_obj=False):
     check_kkt(p, places=4)
 
 
-def _equivalent_forms_3(solver, use_quad_obj=False):
+@pytest.mark.parametrize("solver,use_quad_obj", QP_PARAMS)
+def test_equivalent_forms_3(solver, use_quad_obj):
+    if solver == cp.KNITRO:
+        pytest.skip("KNITRO does not support matrix_frac")
     A, b, G, h = _equivalent_forms_setup()
     P = A.T @ A
     q = -2 * A.T @ b
@@ -404,67 +451,7 @@ def _equivalent_forms_3(solver, use_quad_obj=False):
     check_kkt(p, places=4)
 
 
-# --- Per-solver tests --- #
-
-@pytest.mark.parametrize("solver", QP_SOLVER_PARAMS)
-def test_qp_correctness(solver):
-    """Run all QP correctness helpers against one native QP solver."""
-    _quad_over_lin(solver)
-    _power(solver)
-    _power_matrix(solver)
-    _square_affine(solver)
-    _quad_form(solver)
-    _affine_problem(solver)
-    _maximize_problem(solver)
-    _abs(solver)
-    _quad_form_bound(solver)
-    _regression_1(solver)
-    _regression_2(solver)
-    _rep_quad_form(solver)
-    _control(solver)
-    _sparse_system(solver)
-    _smooth_ridge(solver)
-    _huber_small(solver)
-    _huber(solver)
-    _equivalent_forms_1(solver)
-    _equivalent_forms_2(solver)
-    if solver != cp.KNITRO:
-        # KNITRO does not support matrix_frac.
-        _equivalent_forms_3(solver)
-
-
-@pytest.mark.parametrize("solver", CONIC_QUAD_OBJ_PARAMS)
-def test_qp_conic_quad_obj(solver):
-    """Run QP correctness helpers via conic solvers with use_quad_obj=True.
-
-    Solvers with ``REQUIRES_CONSTR=True`` skip helpers whose problems are
-    unconstrained -- those canonicalize to m=0 and are rejected.
-    """
-    requires_constr = SOLVER_MAP_CONIC[solver].REQUIRES_CONSTR
-    _quad_over_lin(solver, use_quad_obj=True)
-    if not requires_constr:
-        _power(solver, use_quad_obj=True)
-    _power_matrix(solver, use_quad_obj=True)
-    _square_affine(solver, use_quad_obj=True)
-    if not requires_constr:
-        _quad_form(solver, use_quad_obj=True)
-    _affine_problem(solver, use_quad_obj=True)
-    _maximize_problem(solver, use_quad_obj=True)
-    _abs(solver, use_quad_obj=True)
-    _quad_form_bound(solver, use_quad_obj=True)
-    _regression_1(solver, use_quad_obj=True)
-    _regression_2(solver, use_quad_obj=True)
-    if not requires_constr:
-        _rep_quad_form(solver, use_quad_obj=True)
-    _control(solver, use_quad_obj=True)
-    _sparse_system(solver, use_quad_obj=True)
-    _smooth_ridge(solver, use_quad_obj=True)
-    _huber_small(solver, use_quad_obj=True, places=3)
-    _huber(solver, use_quad_obj=True)
-    _equivalent_forms_1(solver, use_quad_obj=True)
-    _equivalent_forms_2(solver, use_quad_obj=True)
-    _equivalent_forms_3(solver, use_quad_obj=True)
-
+# --- Other native-QP-only correctness tests --- #
 
 @pytest.mark.parametrize("solver", QP_SOLVER_PARAMS)
 def test_qp_bound_attr(solver):
@@ -498,8 +485,8 @@ def test_parametric(solver):
         obj_param.append(prob.value)
 
     for i in range(len(b_vec)):
-        np.testing.assert_allclose(x_full[i], x_param[i], atol=1e-3)
-        np.testing.assert_allclose(obj_full[i], obj_param[i], atol=1e-5)
+        np.testing.assert_allclose(x_param[i], x_full[i], atol=1e-3)
+        np.testing.assert_allclose(obj_param[i], obj_full[i], atol=1e-5)
 
 
 # --- Solver-specific tests --- #
@@ -837,8 +824,12 @@ def test_mpax_warmstart():
         cp.Minimize(-4 * x[0] - 5 * x[1]),
         [2 * x[0] + x[1] <= 3, x[0] + 2 * x[1] <= 3, x[0] >= 0, x[1] >= 0],
     )
-    np.testing.assert_allclose(prob.solve(solver='MPAX', warm_start=False), -9, atol=1e-4)
-    np.testing.assert_allclose(prob.solve(solver='MPAX', warm_start=True), -9, atol=1e-4)
+    np.testing.assert_allclose(
+        prob.solve(solver='MPAX', warm_start=False), -9, atol=1e-4
+    )
+    np.testing.assert_allclose(
+        prob.solve(solver='MPAX', warm_start=True), -9, atol=1e-4
+    )
 
 
 @mpax_skip

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -657,13 +657,17 @@ def test_infeasible_lp_eq_constraints(solver):
 
 @pytest.mark.skipif(cp.HIGHS not in INSTALLED_SOLVERS, reason="HIGHS is not installed")
 def test_highs_dense_quad_form():
-    """Regression test for https://github.com/cvxpy/cvxpy/issues/3301.
+    """Regression test for https://github.com/cvxpy/cvxpy/issues/3301
+    and a related silent wrong-answer bug on highspy < 1.14.0.
 
     A dense quad_form applied to a linear expression (not a raw Variable)
     produces a Hessian whose upper and lower triangles may differ by
-    floating-point epsilon after canonicalization. Passing such a Hessian
-    in square format to HiGHS >= 1.14.0 triggers an asymmetry error
-    and native heap corruption. Using triangular format avoids this.
+    floating-point epsilon after canonicalization. We pass it to HiGHS
+    in triangular format. HiGHS < 1.14.0 only honors the lower triangle
+    in that format and silently returns wrong solutions when given the
+    upper triangle, hence the ``highspy >= 1.14.0`` minimum in
+    pyproject.toml. Cross-check the objective against CLARABEL because
+    status alone (``kOptimal``) does not detect a wrong-QP solve.
     """
     rng = np.random.default_rng(42)
     n_vars, n_nodes = 60, 20
@@ -689,6 +693,11 @@ def test_highs_dense_quad_form():
     )
     prob.solve(solver=cp.HIGHS)
     assert prob.status == cp.OPTIMAL
+    highs_value = prob.value
+
+    prob.solve(solver=cp.CLARABEL)
+    assert prob.status == cp.OPTIMAL
+    np.testing.assert_allclose(highs_value, prob.value, atol=1e-4)
 
 
 # --- MPAX tests --- #

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -491,7 +491,17 @@ def test_parametric(solver):
 
 # --- Solver-specific tests --- #
 
-def test_warm_start():
+@pytest.mark.parametrize(
+    "solver",
+    [s for s in [cp.OSQP, cp.QPALM, cp.HIGHS, cp.PIQP, cp.COPT]
+     if s in INSTALLED_SOLVERS],
+)
+def test_warm_start(solver):
+    """Re-solving with ``warm_start`` toggled on/off should return the same
+    optimum. Covers OSQP, QPALM, HIGHS, PIQP, COPT -- XPRESS and GUROBI have
+    their own warm-start tests below because they exercise different code
+    paths (integer var / inspecting the gurobipy ``Model``).
+    """
     m, n = 200, 100
     np.random.seed(1)
     A = np.random.randn(m, n)
@@ -500,31 +510,12 @@ def test_warm_start():
     prob = Problem(Minimize(sum_squares(A @ x - b)))
 
     b.value = np.random.randn(m)
-    result = prob.solve(solver="OSQP", warm_start=False)
-    result2 = prob.solve(solver="OSQP", warm_start=True)
+    result = prob.solve(solver=solver, warm_start=False)
+    result2 = prob.solve(solver=solver, warm_start=True)
     np.testing.assert_allclose(result, result2, atol=1e-5)
     b.value = np.random.randn(m)
-    result = prob.solve(solver="OSQP", warm_start=True)
-    result2 = prob.solve(solver="OSQP", warm_start=False)
-    np.testing.assert_allclose(result, result2, atol=1e-5)
-
-
-@pytest.mark.skipif(cp.QPALM not in INSTALLED_SOLVERS, reason="QPALM is not installed")
-def test_qpalm_warmstart():
-    m, n = 200, 100
-    np.random.seed(1)
-    A = np.random.randn(m, n)
-    b = Parameter(m)
-    x = Variable(n)
-    prob = Problem(Minimize(sum_squares(A @ x - b)))
-
-    b.value = np.random.randn(m)
-    result = prob.solve(solver=cp.QPALM, warm_start=False)
-    result2 = prob.solve(solver=cp.QPALM, warm_start=True)
-    np.testing.assert_allclose(result, result2, atol=1e-5)
-    b.value = np.random.randn(m)
-    result = prob.solve(solver=cp.QPALM, warm_start=True)
-    result2 = prob.solve(solver=cp.QPALM, warm_start=False)
+    result = prob.solve(solver=solver, warm_start=True)
+    result2 = prob.solve(solver=solver, warm_start=False)
     np.testing.assert_allclose(result, result2, atol=1e-5)
 
 
@@ -575,25 +566,6 @@ def test_xpress_warmstart():
 
 
 @pytest.mark.skipif(cp.HIGHS not in INSTALLED_SOLVERS, reason="HIGHS is not installed")
-def test_highs_warmstart():
-    m, n = 200, 100
-    np.random.seed(1)
-    A = np.random.randn(m, n)
-    b = Parameter(m)
-    x = Variable(n)
-    prob = Problem(Minimize(sum_squares(A @ x - b)))
-
-    b.value = np.random.randn(m)
-    result = prob.solve(solver=cp.HIGHS, warm_start=False)
-    result2 = prob.solve(solver=cp.HIGHS, warm_start=True)
-    np.testing.assert_allclose(result, result2, atol=1e-5)
-    b.value = np.random.randn(m)
-    result = prob.solve(solver=cp.HIGHS, warm_start=True)
-    result2 = prob.solve(solver=cp.HIGHS, warm_start=False)
-    np.testing.assert_allclose(result, result2, atol=1e-5)
-
-
-@pytest.mark.skipif(cp.HIGHS not in INSTALLED_SOLVERS, reason="HIGHS is not installed")
 def test_highs_cvar():
     """CVaR constraint regression for https://github.com/cvxpy/cvxpy/issues/2836."""
     num_stocks, num_samples = 5, 25
@@ -607,44 +579,6 @@ def test_highs_cvar():
     problem = cp.Problem(cp.Maximize(w @ pnl_expected), [cvar <= 0.5])
     problem.solve(solver=cp.HIGHS)
     assert problem.status == cp.OPTIMAL
-
-
-@pytest.mark.skipif(cp.PIQP not in INSTALLED_SOLVERS, reason="PIQP is not installed")
-def test_piqp_warmstart():
-    m, n = 200, 100
-    np.random.seed(1)
-    A = np.random.randn(m, n)
-    b = Parameter(m)
-    x = Variable(n)
-    prob = Problem(Minimize(sum_squares(A @ x - b)))
-
-    b.value = np.random.randn(m)
-    result = prob.solve(solver=cp.PIQP, warm_start=False)
-    result2 = prob.solve(solver=cp.PIQP, warm_start=True)
-    np.testing.assert_allclose(result, result2, atol=1e-5)
-    b.value = np.random.randn(m)
-    result = prob.solve(solver=cp.PIQP, warm_start=True)
-    result2 = prob.solve(solver=cp.PIQP, warm_start=False)
-    np.testing.assert_allclose(result, result2, atol=1e-5)
-
-
-@pytest.mark.skipif(cp.COPT not in INSTALLED_SOLVERS, reason="COPT is not installed")
-def test_copt_warmstart():
-    m, n = 200, 100
-    np.random.seed(1)
-    A = np.random.randn(m, n)
-    b = Parameter(m)
-    x = Variable(n)
-    prob = Problem(Minimize(sum_squares(A @ x - b)))
-
-    b.value = np.random.randn(m)
-    result = prob.solve(solver=cp.COPT, warm_start=False)
-    result2 = prob.solve(solver=cp.COPT, warm_start=True)
-    np.testing.assert_allclose(result, result2, atol=1e-5)
-    b.value = np.random.randn(m)
-    result = prob.solve(solver=cp.COPT, warm_start=True)
-    result2 = prob.solve(solver=cp.COPT, warm_start=False)
-    np.testing.assert_allclose(result, result2, atol=1e-5)
 
 
 def test_square_param():
@@ -717,20 +651,19 @@ def test_gurobi_environment():
         assert str(exc_info.value) == f"The solver {cp.GUROBI} is not installed."
 
 
-def test_osqp_infeasible_lp_ineq_constraints():
-    StandardTestInfeasibleProblems.test_lp_ineq_constraints(solver=cp.OSQP)
+_INFEAS_QP_SOLVERS = [
+    s for s in [cp.OSQP, cp.HIGHS] if s in INSTALLED_SOLVERS
+]
 
 
-def test_osqp_infeasible_lp_eq_constraints():
-    StandardTestInfeasibleProblems.test_lp_eq_constraints(solver=cp.OSQP)
+@pytest.mark.parametrize("solver", _INFEAS_QP_SOLVERS)
+def test_infeasible_lp_ineq_constraints(solver):
+    StandardTestInfeasibleProblems.test_lp_ineq_constraints(solver=solver)
 
 
-def test_highs_infeasible_lp_ineq_constraints():
-    StandardTestInfeasibleProblems.test_lp_ineq_constraints(solver=cp.HIGHS)
-
-
-def test_highs_infeasible_lp_eq_constraints():
-    StandardTestInfeasibleProblems.test_lp_eq_constraints(solver=cp.HIGHS)
+@pytest.mark.parametrize("solver", _INFEAS_QP_SOLVERS)
+def test_infeasible_lp_eq_constraints(solver):
+    StandardTestInfeasibleProblems.test_lp_eq_constraints(solver=solver)
 
 
 @pytest.mark.skipif(cp.HIGHS not in INSTALLED_SOLVERS, reason="HIGHS is not installed")

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -132,28 +132,12 @@ CONIC_QUAD_OBJ_PARAMS = [
 
 # --- Assertion + solve helpers --- #
 
-def _mat_to_list(mat):
-    if isinstance(mat, (np.matrix, np.ndarray)):
-        return np.asarray(mat).flatten('F').tolist()
-    return mat
-
-
-def assert_items_almost_equal(a, b, places=5):
-    """List-aware almost-equal (matches the old ``BaseTest`` helper)."""
-    a = [a] if np.isscalar(a) else _mat_to_list(a)
-    b = [b] if np.isscalar(b) else _mat_to_list(b)
-    assert len(a) == len(b), f"length mismatch: {len(a)} vs {len(b)}"
-    for ai, bi in zip(a, b):
-        assert round(ai - bi, places) == 0, f"{ai} != {bi} to {places} places"
-
-
-def assert_almost_equal(a, b, places=5):
-    """Scalar almost-equal (matches ``unittest.TestCase.assertAlmostEqual``)."""
-    assert round(a - b, places) == 0, f"{a} != {b} to {places} places"
-
-
 def check_kkt(problem, places=4):
-    """Verify KKT conditions for a solved problem."""
+    """Verify KKT conditions for a solved problem.
+
+    Stays in ``places`` units because ``SolverTestHelper`` exposes its
+    tolerances as decimal places, not absolute tolerances.
+    """
     obj_pair = (problem.objective, None)
     var_pairs = [(v, None) for v in problem.variables()]
     con_pairs = [(c, None) for c in problem.constraints]
@@ -216,9 +200,9 @@ def _quad_over_lin(v, solver, use_quad_obj=False):
     p = Problem(Minimize(0.5 * quad_over_lin(abs(v.x - 1), 1)), [v.x <= -1])
     _solve(p, solver, use_quad_obj)
     for var in p.variables():
-        assert_items_almost_equal(np.array([-1., -1.]), var.value, places=4)
+        np.testing.assert_allclose(np.array([-1., -1.]), var.value, atol=1e-4)
     for con in p.constraints:
-        assert_items_almost_equal(np.array([2., 2.]), con.dual_value, places=4)
+        np.testing.assert_allclose(np.array([2., 2.]), con.dual_value, atol=1e-4)
     check_kkt(p, places=3)
 
 
@@ -227,21 +211,21 @@ def _abs(v, solver, use_quad_obj=False):
     prob = Problem(Minimize(sum_squares(u)), [abs(u[1] - u[0]) <= 100])
     assert prob.is_qp()
     result = _solve(prob, solver, use_quad_obj)
-    assert_almost_equal(result, 0)
+    np.testing.assert_allclose(result, 0, atol=1e-5)
 
 
 def _power(v, solver, use_quad_obj=False):
     p = Problem(Minimize(sum(power(v.x, 2))), [])
     _solve(p, solver, use_quad_obj)
     for var in p.variables():
-        assert_items_almost_equal([0., 0.], var.value, places=4)
+        np.testing.assert_allclose([0., 0.], var.value, atol=1e-4)
 
 
 def _power_matrix(v, solver, use_quad_obj=False):
     p = Problem(Minimize(sum(power(v.A - 3., 2))), [])
     _solve(p, solver, use_quad_obj)
     for var in p.variables():
-        assert_items_almost_equal([3., 3., 3., 3.], var.value, places=4)
+        np.testing.assert_allclose(var.value, np.full((2, 2), 3.), atol=1e-4)
 
 
 def _square_affine(v, solver, use_quad_obj=False):
@@ -250,8 +234,8 @@ def _square_affine(v, solver, use_quad_obj=False):
     p = Problem(Minimize(sum_squares(A @ v.x - b)))
     _solve(p, solver, use_quad_obj)
     for var in p.variables():
-        assert_items_almost_equal(
-            lstsq(A, b)[0].flatten(order='F'), var.value, places=1
+        np.testing.assert_allclose(
+            lstsq(A, b)[0].flatten(order='F'), var.value, atol=1e-1
         )
 
 
@@ -264,7 +248,7 @@ def _quad_form(v, solver, use_quad_obj=False):
     p = Problem(Minimize(QuadForm(v.w, P) + q.T @ v.w))
     _solve(p, solver, use_quad_obj)
     for var in p.variables():
-        assert_items_almost_equal(z, var.value, places=4)
+        np.testing.assert_allclose(z, var.value, atol=1e-4)
 
 
 def _rep_quad_form(v, solver, use_quad_obj=False):
@@ -278,7 +262,7 @@ def _rep_quad_form(v, solver, use_quad_obj=False):
     p = Problem(Minimize(0.5 * qf + 0.5 * qf + q.T @ v.w))
     _solve(p, solver, use_quad_obj)
     for var in p.variables():
-        assert_items_almost_equal(z, var.value, places=4)
+        np.testing.assert_allclose(z, var.value, atol=1e-4)
 
 
 def _affine_problem(v, solver, use_quad_obj=False):
@@ -288,7 +272,7 @@ def _affine_problem(v, solver, use_quad_obj=False):
     p = Problem(Minimize(sum(v.x)), [v.x >= 0, A @ v.x <= b])
     _solve(p, solver, use_quad_obj)
     for var in p.variables():
-        assert_items_almost_equal([0., 0.], var.value, places=3)
+        np.testing.assert_allclose([0., 0.], var.value, atol=1e-3)
     check_kkt(p, places=3)
 
 
@@ -299,7 +283,7 @@ def _maximize_problem(v, solver, use_quad_obj=False):
     p = Problem(Maximize(-sum(v.x)), [v.x >= 0, A @ v.x <= b])
     _solve(p, solver, use_quad_obj)
     for var in p.variables():
-        assert_items_almost_equal([0., 0.], var.value, places=3)
+        np.testing.assert_allclose([0., 0.], var.value, atol=1e-3)
     check_kkt(p, places=3)
 
 
@@ -312,18 +296,18 @@ def _quad_form_coeff(v, solver, use_quad_obj=False):
     p = Problem(Minimize(QuadForm(v.w, P) + q.T @ v.w))
     _solve(p, solver, use_quad_obj)
     for var in p.variables():
-        assert_items_almost_equal(z, var.value, places=4)
+        np.testing.assert_allclose(z, var.value, atol=1e-4)
 
 
 def _quad_form_bound(v, solver, use_quad_obj=False):
     P = np.array([[13, 12, -2], [12, 17, 6], [-2, 6, 12]])
     q = np.array([[-22], [-14.5], [13]])
-    y_star = np.array([[1], [0.5], [-1]])
+    y_star = np.array([1., 0.5, -1.])
     p = Problem(Minimize(0.5 * QuadForm(v.y, P) + q.T @ v.y + 1),
                 [v.y >= -1, v.y <= 1])
     _solve(p, solver, use_quad_obj)
     for var in p.variables():
-        assert_items_almost_equal(y_star, var.value, places=4)
+        np.testing.assert_allclose(var.value, y_star, atol=1e-4)
     check_kkt(p)
 
 
@@ -342,7 +326,7 @@ def _regression_1(v, solver, use_quad_obj=False):
     fit_error = sum_squares(line.T - y_data)
     p = Problem(Minimize(fit_error), [])
     _solve(p, solver, use_quad_obj)
-    assert_almost_equal(1171.60037715, p.value, places=4)
+    np.testing.assert_allclose(1171.60037715, p.value, atol=1e-4)
 
 
 def _regression_2(v, solver, use_quad_obj=False):
@@ -358,7 +342,7 @@ def _regression_2(v, solver, use_quad_obj=False):
     fit_error = sum_squares(quadratic.T - y_data)
     p = Problem(Minimize(fit_error), [])
     _solve(p, solver, use_quad_obj)
-    assert_almost_equal(139.225660756, p.value, places=4)
+    np.testing.assert_allclose(139.225660756, p.value, atol=1e-4)
 
 
 def _control(v, solver, use_quad_obj=False):
@@ -380,7 +364,7 @@ def _control(v, solver, use_quad_obj=False):
     constraints += [v.velocity[:, -1] == 0]
     p = Problem(Minimize(.01 * sum_squares(v.force)), constraints)
     _solve(p, solver, use_quad_obj)
-    assert_almost_equal(1059.616, p.value, places=1)
+    np.testing.assert_allclose(1059.616, p.value, atol=1e-1)
     # KKT check skipped: check_stationary_lagrangian fails for 2D matrix
     # variables due to inconsistent gradient ordering (sum_squares uses
     # C order, constraint terms use F order). TODO fix this
@@ -393,7 +377,7 @@ def _sparse_system(v, solver, use_quad_obj=False):
     b = np.random.randn(m)
     p = Problem(Minimize(sum_squares(A @ v.xs - b)), [v.xs == 0])
     _solve(p, solver, use_quad_obj)
-    assert_almost_equal(b.T.dot(b), p.value, places=4)
+    np.testing.assert_allclose(b.T.dot(b), p.value, atol=1e-4)
 
 
 def _smooth_ridge(v, solver, use_quad_obj=False):
@@ -405,7 +389,7 @@ def _smooth_ridge(v, solver, use_quad_obj=False):
     obj = sum_squares(A @ v.xsr - b) + sum_squares(v.xsr[:-1] - v.xsr[1:])
     p = Problem(Minimize(obj), [])
     _solve(p, solver, use_quad_obj)
-    assert_almost_equal(0, p.value, places=4)
+    np.testing.assert_allclose(0, p.value, atol=1e-4)
 
 
 def _huber_small(v, solver, use_quad_obj=False, places=4):
@@ -413,8 +397,9 @@ def _huber_small(v, solver, use_quad_obj=False, places=4):
     objective = sum(huber(x))
     p = Problem(Minimize(objective), [x[2] >= 3])
     _solve(p, solver, use_quad_obj)
-    assert_almost_equal(3, x.value[2], places=places)
-    assert_almost_equal(5, objective.value, places=places)
+    atol = 10 ** (-places)
+    np.testing.assert_allclose(3, x.value[2], atol=atol)
+    np.testing.assert_allclose(5, objective.value, atol=atol)
     check_kkt(p, places=places)
 
 
@@ -433,9 +418,9 @@ def _huber(v, solver, use_quad_obj=False):
     objective = sum(huber(A @ x - b))
     p = Problem(Minimize(objective))
     _solve(p, solver, use_quad_obj)
-    assert_almost_equal(1.452797819667, objective.value, places=3)
-    assert_items_almost_equal(
-        x.value, [1.20524645, -0.85271489, -0.50838494], places=3
+    np.testing.assert_allclose(1.452797819667, objective.value, atol=1e-3)
+    np.testing.assert_allclose(
+        x.value, [1.20524645, -0.85271489, -0.50838494], atol=1e-3
     )
 
 
@@ -453,7 +438,7 @@ def _equivalent_forms_1(v, solver, use_quad_obj=False):
     A, b, G, h = _equivalent_forms_setup()
     p = Problem(Minimize(.1 * sum((A @ v.xef - b) ** 2)), [G @ v.xef == h])
     _solve(p, solver, use_quad_obj)
-    assert_almost_equal(p.value, 68.1119420108, places=4)
+    np.testing.assert_allclose(p.value, 68.1119420108, atol=1e-4)
     check_kkt(p, places=4)
 
 
@@ -466,7 +451,7 @@ def _equivalent_forms_2(v, solver, use_quad_obj=False):
     obj = .1 * (QuadForm(v.xef, P) + q.T @ v.xef + r)
     p = Problem(Minimize(obj), [G @ v.xef == h])
     _solve(p, solver, use_quad_obj)
-    assert_almost_equal(p.value, 68.1119420108, places=4)
+    np.testing.assert_allclose(p.value, 68.1119420108, atol=1e-4)
     check_kkt(p, places=4)
 
 
@@ -479,7 +464,7 @@ def _equivalent_forms_3(v, solver, use_quad_obj=False):
     obj = .1 * (matrix_frac(v.xef, Pinv) + q.T @ v.xef + r)
     p = Problem(Minimize(obj), [G @ v.xef == h])
     _solve(p, solver, use_quad_obj)
-    assert_almost_equal(p.value, 68.1119420108, places=4)
+    np.testing.assert_allclose(p.value, 68.1119420108, atol=1e-4)
     check_kkt(p, places=4)
 
 
@@ -580,8 +565,8 @@ def test_parametric(solver):
         obj_param.append(prob.value)
 
     for i in range(len(b_vec)):
-        assert_items_almost_equal(x_full[i], x_param[i], places=3)
-        assert_almost_equal(obj_full[i], obj_param[i])
+        np.testing.assert_allclose(x_full[i], x_param[i], atol=1e-3)
+        np.testing.assert_allclose(obj_full[i], obj_param[i], atol=1e-5)
 
 
 # --- Solver-specific tests --- #
@@ -597,11 +582,11 @@ def test_warm_start():
     b.value = np.random.randn(m)
     result = prob.solve(solver="OSQP", warm_start=False)
     result2 = prob.solve(solver="OSQP", warm_start=True)
-    assert_almost_equal(result, result2)
+    np.testing.assert_allclose(result, result2, atol=1e-5)
     b.value = np.random.randn(m)
     result = prob.solve(solver="OSQP", warm_start=True)
     result2 = prob.solve(solver="OSQP", warm_start=False)
-    assert_almost_equal(result, result2)
+    np.testing.assert_allclose(result, result2, atol=1e-5)
 
 
 @pytest.mark.skipif(cp.QPALM not in INSTALLED_SOLVERS, reason="QPALM is not installed")
@@ -616,11 +601,11 @@ def test_qpalm_warmstart():
     b.value = np.random.randn(m)
     result = prob.solve(solver=cp.QPALM, warm_start=False)
     result2 = prob.solve(solver=cp.QPALM, warm_start=True)
-    assert_almost_equal(result, result2)
+    np.testing.assert_allclose(result, result2, atol=1e-5)
     b.value = np.random.randn(m)
     result = prob.solve(solver=cp.QPALM, warm_start=True)
     result2 = prob.solve(solver=cp.QPALM, warm_start=False)
-    assert_almost_equal(result, result2)
+    np.testing.assert_allclose(result, result2, atol=1e-5)
 
 
 @pytest.mark.skipif(cp.GUROBI not in INSTALLED_SOLVERS, reason="GUROBI is not installed")
@@ -658,7 +643,7 @@ def test_xpress_warmstart():
     b.value = np.random.randn(m)
     result = prob.solve(solver=cp.XPRESS, warm_start=False)
     result2 = prob.solve(solver=cp.XPRESS, warm_start=True)
-    assert_almost_equal(result, result2)
+    np.testing.assert_allclose(result, result2, atol=1e-5)
     x.value = x.value.astype(np.int64)
 
     xprime = Variable(n, integer=True)
@@ -666,7 +651,7 @@ def test_xpress_warmstart():
     xprime.value = x.value
     result = prob.solve(solver=cp.XPRESS, warm_start=True)
     result2 = prob.solve(solver=cp.XPRESS, warm_start=False)
-    assert_almost_equal(result, result2)
+    np.testing.assert_allclose(result, result2, atol=1e-5)
 
 
 @pytest.mark.skipif(cp.HIGHS not in INSTALLED_SOLVERS, reason="HIGHS is not installed")
@@ -681,11 +666,11 @@ def test_highs_warmstart():
     b.value = np.random.randn(m)
     result = prob.solve(solver=cp.HIGHS, warm_start=False)
     result2 = prob.solve(solver=cp.HIGHS, warm_start=True)
-    assert_almost_equal(result, result2)
+    np.testing.assert_allclose(result, result2, atol=1e-5)
     b.value = np.random.randn(m)
     result = prob.solve(solver=cp.HIGHS, warm_start=True)
     result2 = prob.solve(solver=cp.HIGHS, warm_start=False)
-    assert_almost_equal(result, result2)
+    np.testing.assert_allclose(result, result2, atol=1e-5)
 
 
 @pytest.mark.skipif(cp.HIGHS not in INSTALLED_SOLVERS, reason="HIGHS is not installed")
@@ -716,11 +701,11 @@ def test_piqp_warmstart():
     b.value = np.random.randn(m)
     result = prob.solve(solver=cp.PIQP, warm_start=False)
     result2 = prob.solve(solver=cp.PIQP, warm_start=True)
-    assert_almost_equal(result, result2)
+    np.testing.assert_allclose(result, result2, atol=1e-5)
     b.value = np.random.randn(m)
     result = prob.solve(solver=cp.PIQP, warm_start=True)
     result2 = prob.solve(solver=cp.PIQP, warm_start=False)
-    assert_almost_equal(result, result2)
+    np.testing.assert_allclose(result, result2, atol=1e-5)
 
 
 @pytest.mark.skipif(cp.COPT not in INSTALLED_SOLVERS, reason="COPT is not installed")
@@ -735,11 +720,11 @@ def test_copt_warmstart():
     b.value = np.random.randn(m)
     result = prob.solve(solver=cp.COPT, warm_start=False)
     result2 = prob.solve(solver=cp.COPT, warm_start=True)
-    assert_almost_equal(result, result2)
+    np.testing.assert_allclose(result, result2, atol=1e-5)
     b.value = np.random.randn(m)
     result = prob.solve(solver=cp.COPT, warm_start=True)
     result2 = prob.solve(solver=cp.COPT, warm_start=False)
-    assert_almost_equal(result, result2)
+    np.testing.assert_allclose(result, result2, atol=1e-5)
 
 
 def test_square_param():
@@ -748,7 +733,7 @@ def test_square_param():
     b = Variable()
     prob = Problem(Minimize(b ** 2 + abs(a)))
     prob.solve(solver="SCS")
-    assert_almost_equal(prob.value, 1.0)
+    np.testing.assert_allclose(prob.value, 1.0, atol=1e-5)
 
 
 def test_gurobi_time_limit_no_solution(qp_vars):
@@ -916,8 +901,8 @@ def test_mpax_warmstart():
         cp.Minimize(-4 * x[0] - 5 * x[1]),
         [2 * x[0] + x[1] <= 3, x[0] + 2 * x[1] <= 3, x[0] >= 0, x[1] >= 0],
     )
-    assert_almost_equal(prob.solve(solver='MPAX', warm_start=False), -9, places=4)
-    assert_almost_equal(prob.solve(solver='MPAX', warm_start=True), -9, places=4)
+    np.testing.assert_allclose(prob.solve(solver='MPAX', warm_start=False), -9, atol=1e-4)
+    np.testing.assert_allclose(prob.solve(solver='MPAX', warm_start=True), -9, atol=1e-4)
 
 
 @mpax_skip

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -14,9 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import os
-from types import SimpleNamespace
-
 import numpy as np
 import pytest
 import scipy.sparse as sp
@@ -56,37 +53,12 @@ from cvxpy.tests.solver_test_helpers import (
     StandardTestLPs,
     StandardTestQPs,
 )
+from cvxpy.tests.test_conic_solvers import is_knitro_available, is_mosek_available
 
 # --- License checks --- #
 
-def is_mosek_available():
-    """Check if MOSEK is installed and a license is available."""
-    if 'MOSEK' not in INSTALLED_SOLVERS:
-        return False
-    try:
-        x = cp.Variable()
-        cp.Problem(cp.Minimize(x), [x >= 0]).solve(solver=cp.MOSEK)
-        return True
-    except Exception:
-        return False
-
-
-def is_knitro_available():
-    """Check if KNITRO is installed and a license is available.
-
-    Detection is intentionally based on environment variables rather than
-    importing ``knitro``: importing it loads the native KNITRO runtime (and
-    a bundled OpenMP library on macOS) into the test process, which can
-    crash other solvers -- e.g. an IPOPT solve segfaults on macOS once
-    knitro has been imported.
-    """
-    if 'KNITRO' not in INSTALLED_SOLVERS:
-        return False
-    return bool(
-        os.environ.get('ARTELYS_LICENSE')
-        or os.environ.get('ARTELYS_LICENSE_NETWORK_ADDR')
-    )
-
+# is_mosek_available / is_knitro_available are imported from test_conic_solvers
+# so the canonical, KNITRO-OpenMP-safe implementations live in one place.
 
 def is_xpress_available():
     """Check if XPRESS is installed and a license is available."""
@@ -165,48 +137,18 @@ def _solve(problem, solver, use_quad_obj=False):
     return problem.solve(solver=solver, verbose=False, **kwargs)
 
 
-# --- Fixture --- #
-
-@pytest.fixture
-def qp_vars():
-    """Fresh per-test bag of Variables (replaces ``QPTestBase.setUp``)."""
-    T = 30
-    return SimpleNamespace(
-        a=Variable(name='a'),
-        b=Variable(name='b'),
-        c=Variable(name='c'),
-        x=Variable(2, name='x'),
-        y=Variable(3, name='y'),
-        z=Variable(2, name='z'),
-        w=Variable(5, name='w'),
-        A=Variable((2, 2), name='A'),
-        B=Variable((2, 2), name='B'),
-        C=Variable((3, 2), name='C'),
-        slope=Variable(1, name='slope'),
-        offset=Variable(1, name='offset'),
-        quadratic_coeff=Variable(1, name='quadratic_coeff'),
-        position=Variable((2, T), name='position'),
-        velocity=Variable((2, T), name='velocity'),
-        force=Variable((2, T - 1), name='force'),
-        xs=Variable(80, name='xs'),
-        xsr=Variable(50, name='xsr'),
-        xef=Variable(80, name='xef'),
-    )
-
-
 # --- QP correctness helpers (one per problem shape) --- #
 
-def _quad_over_lin(v, solver, use_quad_obj=False):
-    p = Problem(Minimize(0.5 * quad_over_lin(abs(v.x - 1), 1)), [v.x <= -1])
+def _quad_over_lin(solver, use_quad_obj=False):
+    x = Variable(2)
+    p = Problem(Minimize(0.5 * quad_over_lin(abs(x - 1), 1)), [x <= -1])
     _solve(p, solver, use_quad_obj)
-    for var in p.variables():
-        np.testing.assert_allclose(np.array([-1., -1.]), var.value, atol=1e-4)
-    for con in p.constraints:
-        np.testing.assert_allclose(np.array([2., 2.]), con.dual_value, atol=1e-4)
+    np.testing.assert_allclose(x.value, [-1., -1.], atol=1e-4)
+    np.testing.assert_allclose(p.constraints[0].dual_value, [2., 2.], atol=1e-4)
     check_kkt(p, places=3)
 
 
-def _abs(v, solver, use_quad_obj=False):
+def _abs(solver, use_quad_obj=False):
     u = Variable(2)
     prob = Problem(Minimize(sum_squares(u)), [abs(u[1] - u[0]) <= 100])
     assert prob.is_qp()
@@ -214,104 +156,90 @@ def _abs(v, solver, use_quad_obj=False):
     np.testing.assert_allclose(result, 0, atol=1e-5)
 
 
-def _power(v, solver, use_quad_obj=False):
-    p = Problem(Minimize(sum(power(v.x, 2))), [])
+def _power(solver, use_quad_obj=False):
+    x = Variable(2)
+    p = Problem(Minimize(sum(power(x, 2))), [])
     _solve(p, solver, use_quad_obj)
-    for var in p.variables():
-        np.testing.assert_allclose([0., 0.], var.value, atol=1e-4)
+    np.testing.assert_allclose(x.value, [0., 0.], atol=1e-4)
 
 
-def _power_matrix(v, solver, use_quad_obj=False):
-    p = Problem(Minimize(sum(power(v.A - 3., 2))), [])
+def _power_matrix(solver, use_quad_obj=False):
+    X = Variable((2, 2))
+    p = Problem(Minimize(sum(power(X - 3., 2))), [])
     _solve(p, solver, use_quad_obj)
-    for var in p.variables():
-        np.testing.assert_allclose(var.value, np.full((2, 2), 3.), atol=1e-4)
+    np.testing.assert_allclose(X.value, np.full((2, 2), 3.), atol=1e-4)
 
 
-def _square_affine(v, solver, use_quad_obj=False):
+def _square_affine(solver, use_quad_obj=False):
+    x = Variable(2)
     A = np.random.randn(10, 2)
     b = np.random.randn(10)
-    p = Problem(Minimize(sum_squares(A @ v.x - b)))
+    p = Problem(Minimize(sum_squares(A @ x - b)))
     _solve(p, solver, use_quad_obj)
-    for var in p.variables():
-        np.testing.assert_allclose(
-            lstsq(A, b)[0].flatten(order='F'), var.value, atol=1e-1
-        )
+    np.testing.assert_allclose(x.value, lstsq(A, b)[0], atol=1e-1)
 
 
-def _quad_form(v, solver, use_quad_obj=False):
+def _quad_form(solver, use_quad_obj=False):
     np.random.seed(0)
     A = np.random.randn(5, 5)
     z = np.random.randn(5)
-    P = A.T.dot(A)
-    q = -2 * P.dot(z)
-    p = Problem(Minimize(QuadForm(v.w, P) + q.T @ v.w))
+    P = A.T @ A
+    q = -2 * P @ z
+    w = Variable(5)
+    p = Problem(Minimize(QuadForm(w, P) + q.T @ w))
     _solve(p, solver, use_quad_obj)
-    for var in p.variables():
-        np.testing.assert_allclose(z, var.value, atol=1e-4)
+    np.testing.assert_allclose(w.value, z, atol=1e-4)
 
 
-def _rep_quad_form(v, solver, use_quad_obj=False):
+def _rep_quad_form(solver, use_quad_obj=False):
     """A problem where the quad_form term is used multiple times."""
     np.random.seed(0)
     A = np.random.randn(5, 5)
     z = np.random.randn(5)
-    P = A.T.dot(A)
-    q = -2 * P.dot(z)
-    qf = QuadForm(v.w, P)
-    p = Problem(Minimize(0.5 * qf + 0.5 * qf + q.T @ v.w))
+    P = A.T @ A
+    q = -2 * P @ z
+    w = Variable(5)
+    qf = QuadForm(w, P)
+    p = Problem(Minimize(0.5 * qf + 0.5 * qf + q.T @ w))
     _solve(p, solver, use_quad_obj)
-    for var in p.variables():
-        np.testing.assert_allclose(z, var.value, atol=1e-4)
+    np.testing.assert_allclose(w.value, z, atol=1e-4)
 
 
-def _affine_problem(v, solver, use_quad_obj=False):
+def _affine_problem(solver, use_quad_obj=False):
     np.random.seed(0)
     A = np.maximum(np.random.randn(5, 2), 0)
     b = np.maximum(np.random.randn(5), 0)
-    p = Problem(Minimize(sum(v.x)), [v.x >= 0, A @ v.x <= b])
+    x = Variable(2)
+    p = Problem(Minimize(sum(x)), [x >= 0, A @ x <= b])
     _solve(p, solver, use_quad_obj)
-    for var in p.variables():
-        np.testing.assert_allclose([0., 0.], var.value, atol=1e-3)
+    np.testing.assert_allclose(x.value, [0., 0.], atol=1e-3)
     check_kkt(p, places=3)
 
 
-def _maximize_problem(v, solver, use_quad_obj=False):
+def _maximize_problem(solver, use_quad_obj=False):
     np.random.seed(0)
     A = np.maximum(np.random.randn(5, 2), 0)
     b = np.maximum(np.random.randn(5), 0)
-    p = Problem(Maximize(-sum(v.x)), [v.x >= 0, A @ v.x <= b])
+    x = Variable(2)
+    p = Problem(Maximize(-sum(x)), [x >= 0, A @ x <= b])
     _solve(p, solver, use_quad_obj)
-    for var in p.variables():
-        np.testing.assert_allclose([0., 0.], var.value, atol=1e-3)
+    np.testing.assert_allclose(x.value, [0., 0.], atol=1e-3)
     check_kkt(p, places=3)
 
 
-def _quad_form_coeff(v, solver, use_quad_obj=False):
-    np.random.seed(0)
-    A = np.random.randn(5, 5)
-    z = np.random.randn(5)
-    P = A.T.dot(A)
-    q = -2 * P.dot(z)
-    p = Problem(Minimize(QuadForm(v.w, P) + q.T @ v.w))
-    _solve(p, solver, use_quad_obj)
-    for var in p.variables():
-        np.testing.assert_allclose(z, var.value, atol=1e-4)
-
-
-def _quad_form_bound(v, solver, use_quad_obj=False):
+def _quad_form_bound(solver, use_quad_obj=False):
     P = np.array([[13, 12, -2], [12, 17, 6], [-2, 6, 12]])
     q = np.array([[-22], [-14.5], [13]])
     y_star = np.array([1., 0.5, -1.])
-    p = Problem(Minimize(0.5 * QuadForm(v.y, P) + q.T @ v.y + 1),
-                [v.y >= -1, v.y <= 1])
+    y = Variable(3)
+    p = Problem(Minimize(0.5 * QuadForm(y, P) + q.T @ y + 1),
+                [y >= -1, y <= 1])
     _solve(p, solver, use_quad_obj)
-    for var in p.variables():
-        np.testing.assert_allclose(var.value, y_star, atol=1e-4)
+    np.testing.assert_allclose(y.value, y_star, atol=1e-4)
     check_kkt(p)
 
 
-def _regression_1(v, solver, use_quad_obj=False):
+def _regression_1(solver, use_quad_obj=False):
     np.random.seed(1)
     n = 100
     true_coeffs = np.array([[2, -2, 0.5]]).T
@@ -322,47 +250,49 @@ def _regression_1(v, solver, use_quad_obj=False):
     y_data = np.atleast_2d(
         x_data_expanded.T.dot(true_coeffs) + 0.5 * np.random.rand(n, 1)
     )
-    line = v.offset + x_data * v.slope
-    fit_error = sum_squares(line.T - y_data)
-    p = Problem(Minimize(fit_error), [])
+    slope = Variable(1)
+    offset = Variable(1)
+    line = offset + x_data * slope
+    p = Problem(Minimize(sum_squares(line.T - y_data)))
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(1171.60037715, p.value, atol=1e-4)
 
 
-def _regression_2(v, solver, use_quad_obj=False):
+def _regression_2(solver, use_quad_obj=False):
     np.random.seed(1)
     n = 100
     true_coeffs = np.array([2, -2, 0.5])
     x_data = np.random.rand(n) * 5
     x_data_expanded = np.vstack([np.power(x_data, i) for i in range(1, 4)])
     y_data = x_data_expanded.T.dot(true_coeffs) + 0.5 * np.random.rand(n)
-    quadratic = (
-        v.offset + x_data * v.slope + v.quadratic_coeff * np.power(x_data, 2)
-    )
-    fit_error = sum_squares(quadratic.T - y_data)
-    p = Problem(Minimize(fit_error), [])
+    slope = Variable(1)
+    offset = Variable(1)
+    quadratic_coeff = Variable(1)
+    quadratic = offset + x_data * slope + quadratic_coeff * np.power(x_data, 2)
+    p = Problem(Minimize(sum_squares(quadratic.T - y_data)))
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(139.225660756, p.value, atol=1e-4)
 
 
-def _control(v, solver, use_quad_obj=False):
-    initial_velocity = np.array([-20, 100])
-    final_position = np.array([100, 100])
+def _control(solver, use_quad_obj=False):
     T = 30
     h = 0.1
     mass = 1
     drag = 0.1
     g = np.array([0, -9.8])
+    position = Variable((2, T))
+    velocity = Variable((2, T))
+    force = Variable((2, T - 1))
     constraints = []
     for i in range(T - 1):
-        constraints += [v.position[:, i + 1] == v.position[:, i] + h * v.velocity[:, i]]
-        acceleration = v.force[:, i] / mass + g - drag * v.velocity[:, i]
-        constraints += [v.velocity[:, i + 1] == v.velocity[:, i] + h * acceleration]
-    constraints += [v.position[:, 0] == 0]
-    constraints += [v.position[:, -1] == final_position]
-    constraints += [v.velocity[:, 0] == initial_velocity]
-    constraints += [v.velocity[:, -1] == 0]
-    p = Problem(Minimize(.01 * sum_squares(v.force)), constraints)
+        constraints += [position[:, i + 1] == position[:, i] + h * velocity[:, i]]
+        acceleration = force[:, i] / mass + g - drag * velocity[:, i]
+        constraints += [velocity[:, i + 1] == velocity[:, i] + h * acceleration]
+    constraints += [position[:, 0] == 0]
+    constraints += [position[:, -1] == np.array([100, 100])]
+    constraints += [velocity[:, 0] == np.array([-20, 100])]
+    constraints += [velocity[:, -1] == 0]
+    p = Problem(Minimize(.01 * sum_squares(force)), constraints)
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(1059.616, p.value, atol=1e-1)
     # KKT check skipped: check_stationary_lagrangian fails for 2D matrix
@@ -370,29 +300,31 @@ def _control(v, solver, use_quad_obj=False):
     # C order, constraint terms use F order). TODO fix this
 
 
-def _sparse_system(v, solver, use_quad_obj=False):
+def _sparse_system(solver, use_quad_obj=False):
     m, n = 100, 80
     np.random.seed(1)
     A = sp.random_array((m, n), density=0.4)
     b = np.random.randn(m)
-    p = Problem(Minimize(sum_squares(A @ v.xs - b)), [v.xs == 0])
+    xs = Variable(n)
+    p = Problem(Minimize(sum_squares(A @ xs - b)), [xs == 0])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(b.T.dot(b), p.value, atol=1e-4)
 
 
-def _smooth_ridge(v, solver, use_quad_obj=False):
+def _smooth_ridge(solver, use_quad_obj=False):
     np.random.seed(1)
     n = 50
     k = 20
     A = np.ones((k, n))
     b = np.ones(k)
-    obj = sum_squares(A @ v.xsr - b) + sum_squares(v.xsr[:-1] - v.xsr[1:])
+    xsr = Variable(n)
+    obj = sum_squares(A @ xsr - b) + sum_squares(xsr[:-1] - xsr[1:])
     p = Problem(Minimize(obj), [])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(0, p.value, atol=1e-4)
 
 
-def _huber_small(v, solver, use_quad_obj=False, places=4):
+def _huber_small(solver, use_quad_obj=False, places=4):
     x = Variable(3)
     objective = sum(huber(x))
     p = Problem(Minimize(objective), [x[2] >= 3])
@@ -403,7 +335,7 @@ def _huber_small(v, solver, use_quad_obj=False, places=4):
     check_kkt(p, places=places)
 
 
-def _huber(v, solver, use_quad_obj=False):
+def _huber(solver, use_quad_obj=False):
     n, m = 3, 5
     data = [0.89, 0.39, 0.96, 0.34, 0.68, 0.18,
             0.63, 0.42, 0.51, 0.66, 0.43, 0.77]
@@ -434,35 +366,39 @@ def _equivalent_forms_setup(seed=1):
     return A, b, G, h
 
 
-def _equivalent_forms_1(v, solver, use_quad_obj=False):
+def _equivalent_forms_1(solver, use_quad_obj=False):
     A, b, G, h = _equivalent_forms_setup()
-    p = Problem(Minimize(.1 * sum((A @ v.xef - b) ** 2)), [G @ v.xef == h])
+    n = A.shape[1]
+    xef = Variable(n)
+    p = Problem(Minimize(.1 * sum((A @ xef - b) ** 2)), [G @ xef == h])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(p.value, 68.1119420108, atol=1e-4)
     check_kkt(p, places=4)
 
 
-def _equivalent_forms_2(v, solver, use_quad_obj=False):
+def _equivalent_forms_2(solver, use_quad_obj=False):
     A, b, G, h = _equivalent_forms_setup()
     # ||Ax-b||^2 = x^T (A^T A) x - 2(A^T b)^T x + ||b||^2
     P = A.T @ A
     q = -2 * A.T @ b
     r = b.T @ b
-    obj = .1 * (QuadForm(v.xef, P) + q.T @ v.xef + r)
-    p = Problem(Minimize(obj), [G @ v.xef == h])
+    xef = Variable(A.shape[1])
+    obj = .1 * (QuadForm(xef, P) + q.T @ xef + r)
+    p = Problem(Minimize(obj), [G @ xef == h])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(p.value, 68.1119420108, atol=1e-4)
     check_kkt(p, places=4)
 
 
-def _equivalent_forms_3(v, solver, use_quad_obj=False):
+def _equivalent_forms_3(solver, use_quad_obj=False):
     A, b, G, h = _equivalent_forms_setup()
     P = A.T @ A
     q = -2 * A.T @ b
     r = b.T @ b
     Pinv = np.linalg.inv(P)
-    obj = .1 * (matrix_frac(v.xef, Pinv) + q.T @ v.xef + r)
-    p = Problem(Minimize(obj), [G @ v.xef == h])
+    xef = Variable(A.shape[1])
+    obj = .1 * (matrix_frac(xef, Pinv) + q.T @ xef + r)
+    p = Problem(Minimize(obj), [G @ xef == h])
     _solve(p, solver, use_quad_obj)
     np.testing.assert_allclose(p.value, 68.1119420108, atol=1e-4)
     check_kkt(p, places=4)
@@ -471,66 +407,63 @@ def _equivalent_forms_3(v, solver, use_quad_obj=False):
 # --- Per-solver tests --- #
 
 @pytest.mark.parametrize("solver", QP_SOLVER_PARAMS)
-def test_qp_correctness(qp_vars, solver):
+def test_qp_correctness(solver):
     """Run all QP correctness helpers against one native QP solver."""
-    _quad_over_lin(qp_vars, solver)
-    _power(qp_vars, solver)
-    _power_matrix(qp_vars, solver)
-    _square_affine(qp_vars, solver)
-    _quad_form(qp_vars, solver)
-    _affine_problem(qp_vars, solver)
-    _maximize_problem(qp_vars, solver)
-    _abs(qp_vars, solver)
-    _quad_form_coeff(qp_vars, solver)
-    _quad_form_bound(qp_vars, solver)
-    _regression_1(qp_vars, solver)
-    _regression_2(qp_vars, solver)
-    _rep_quad_form(qp_vars, solver)
-    _control(qp_vars, solver)
-    _sparse_system(qp_vars, solver)
-    _smooth_ridge(qp_vars, solver)
-    _huber_small(qp_vars, solver)
-    _huber(qp_vars, solver)
-    _equivalent_forms_1(qp_vars, solver)
-    _equivalent_forms_2(qp_vars, solver)
+    _quad_over_lin(solver)
+    _power(solver)
+    _power_matrix(solver)
+    _square_affine(solver)
+    _quad_form(solver)
+    _affine_problem(solver)
+    _maximize_problem(solver)
+    _abs(solver)
+    _quad_form_bound(solver)
+    _regression_1(solver)
+    _regression_2(solver)
+    _rep_quad_form(solver)
+    _control(solver)
+    _sparse_system(solver)
+    _smooth_ridge(solver)
+    _huber_small(solver)
+    _huber(solver)
+    _equivalent_forms_1(solver)
+    _equivalent_forms_2(solver)
     if solver != cp.KNITRO:
         # KNITRO does not support matrix_frac.
-        _equivalent_forms_3(qp_vars, solver)
+        _equivalent_forms_3(solver)
 
 
 @pytest.mark.parametrize("solver", CONIC_QUAD_OBJ_PARAMS)
-def test_qp_conic_quad_obj(qp_vars, solver):
+def test_qp_conic_quad_obj(solver):
     """Run QP correctness helpers via conic solvers with use_quad_obj=True.
 
     Solvers with ``REQUIRES_CONSTR=True`` skip helpers whose problems are
     unconstrained -- those canonicalize to m=0 and are rejected.
     """
     requires_constr = SOLVER_MAP_CONIC[solver].REQUIRES_CONSTR
-    _quad_over_lin(qp_vars, solver, use_quad_obj=True)
+    _quad_over_lin(solver, use_quad_obj=True)
     if not requires_constr:
-        _power(qp_vars, solver, use_quad_obj=True)
-    _power_matrix(qp_vars, solver, use_quad_obj=True)
-    _square_affine(qp_vars, solver, use_quad_obj=True)
+        _power(solver, use_quad_obj=True)
+    _power_matrix(solver, use_quad_obj=True)
+    _square_affine(solver, use_quad_obj=True)
     if not requires_constr:
-        _quad_form(qp_vars, solver, use_quad_obj=True)
-    _affine_problem(qp_vars, solver, use_quad_obj=True)
-    _maximize_problem(qp_vars, solver, use_quad_obj=True)
-    _abs(qp_vars, solver, use_quad_obj=True)
+        _quad_form(solver, use_quad_obj=True)
+    _affine_problem(solver, use_quad_obj=True)
+    _maximize_problem(solver, use_quad_obj=True)
+    _abs(solver, use_quad_obj=True)
+    _quad_form_bound(solver, use_quad_obj=True)
+    _regression_1(solver, use_quad_obj=True)
+    _regression_2(solver, use_quad_obj=True)
     if not requires_constr:
-        _quad_form_coeff(qp_vars, solver, use_quad_obj=True)
-    _quad_form_bound(qp_vars, solver, use_quad_obj=True)
-    _regression_1(qp_vars, solver, use_quad_obj=True)
-    _regression_2(qp_vars, solver, use_quad_obj=True)
-    if not requires_constr:
-        _rep_quad_form(qp_vars, solver, use_quad_obj=True)
-    _control(qp_vars, solver, use_quad_obj=True)
-    _sparse_system(qp_vars, solver, use_quad_obj=True)
-    _smooth_ridge(qp_vars, solver, use_quad_obj=True)
-    _huber_small(qp_vars, solver, use_quad_obj=True, places=3)
-    _huber(qp_vars, solver, use_quad_obj=True)
-    _equivalent_forms_1(qp_vars, solver, use_quad_obj=True)
-    _equivalent_forms_2(qp_vars, solver, use_quad_obj=True)
-    _equivalent_forms_3(qp_vars, solver, use_quad_obj=True)
+        _rep_quad_form(solver, use_quad_obj=True)
+    _control(solver, use_quad_obj=True)
+    _sparse_system(solver, use_quad_obj=True)
+    _smooth_ridge(solver, use_quad_obj=True)
+    _huber_small(solver, use_quad_obj=True, places=3)
+    _huber(solver, use_quad_obj=True)
+    _equivalent_forms_1(solver, use_quad_obj=True)
+    _equivalent_forms_2(solver, use_quad_obj=True)
+    _equivalent_forms_3(solver, use_quad_obj=True)
 
 
 @pytest.mark.parametrize("solver", QP_SOLVER_PARAMS)
@@ -736,13 +669,14 @@ def test_square_param():
     np.testing.assert_allclose(prob.value, 1.0, atol=1e-5)
 
 
-def test_gurobi_time_limit_no_solution(qp_vars):
+def test_gurobi_time_limit_no_solution():
     """If Gurobi hits its time limit before finding a solution, the solve
     must return cleanly and expose solver stats.
     """
     if cp.GUROBI in INSTALLED_SOLVERS:
         import gurobipy
-        prob = Problem(Minimize(qp_vars.x[0]), [qp_vars.x[0] >= 1])
+        x = Variable(2)
+        prob = Problem(Minimize(x[0]), [x[0] >= 1])
         try:
             prob.solve(solver=cp.GUROBI, TimeLimit=0.0)
         except Exception as e:
@@ -760,13 +694,14 @@ def test_gurobi_time_limit_no_solution(qp_vars):
                 "the test is not relevant anymore."
             )
     else:
-        prob = Problem(Minimize(norm(qp_vars.x, 1)), [qp_vars.x == 0])
+        x = Variable(2)
+        prob = Problem(Minimize(norm(x, 1)), [x == 0])
         with pytest.raises(Exception) as exc_info:
             prob.solve(solver=cp.GUROBI, TimeLimit=0)
         assert str(exc_info.value) == f"The solver {cp.GUROBI} is not installed."
 
 
-def test_gurobi_environment(qp_vars):
+def test_gurobi_environment():
     """Gurobi environments (with licensing/model parameter data) can be passed
     through to the underlying Model.
     """
@@ -788,7 +723,8 @@ def test_gurobi_environment(qp_vars):
             _, _, p_val, _, _, _ = model.getParamInfo(k)
             assert v == p_val
     else:
-        prob = Problem(Minimize(norm(qp_vars.x, 1)), [qp_vars.x == 0])
+        x = Variable(2)
+        prob = Problem(Minimize(norm(x, 1)), [x == 0])
         with pytest.raises(Exception) as exc_info:
             prob.solve(solver=cp.GUROBI, TimeLimit=0)
         assert str(exc_info.value) == f"The solver {cp.GUROBI} is not installed."

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -57,9 +57,7 @@ from cvxpy.tests.solver_test_helpers import (
     StandardTestQPs,
 )
 
-# --------------------------------------------------------------------------- #
-# License helpers
-# --------------------------------------------------------------------------- #
+# --- License checks --- #
 
 def is_mosek_available():
     """Check if MOSEK is installed and a license is available."""
@@ -103,18 +101,10 @@ def is_xpress_available():
         return False
 
 
-# --------------------------------------------------------------------------- #
-# Solver parametrization
-# --------------------------------------------------------------------------- #
+# --- Solver parametrization --- #
 
 def _solver_param(solver):
-    """Build a ``pytest.param`` for ``solver`` with the right skip/knitro marks.
-
-    Licenses are checked eagerly at module import time. Variants with a
-    missing license get an unconditional ``pytest.mark.skip``; KNITRO variants
-    additionally get ``pytest.mark.knitro`` so the CI workflow can run them
-    in their own process.
-    """
+    """``pytest.param`` for ``solver`` with license-skip and knitro marks."""
     marks = []
     if solver == cp.MOSEK and not is_mosek_available():
         marks.append(pytest.mark.skip(reason='MOSEK license not available'))
@@ -127,9 +117,7 @@ def _solver_param(solver):
     return pytest.param(solver, marks=marks, id=solver)
 
 
-QP_SOLVER_PARAMS = [
-    _solver_param(s) for s in QP_SOLVERS if s in INSTALLED_SOLVERS
-]
+QP_SOLVER_PARAMS = [_solver_param(s) for s in QP_SOLVERS if s in INSTALLED_SOLVERS]
 
 # Conic solvers that support quadratic objectives. KNITRO is excluded -- its
 # conic interface with ``use_quad_obj=True`` is unstable in CI.
@@ -142,9 +130,7 @@ CONIC_QUAD_OBJ_PARAMS = [
 ]
 
 
-# --------------------------------------------------------------------------- #
-# Assertion helpers (replace BaseTest helpers used widely in this file)
-# --------------------------------------------------------------------------- #
+# --- Assertion + solve helpers --- #
 
 def _mat_to_list(mat):
     if isinstance(mat, (np.matrix, np.ndarray)):
@@ -152,8 +138,8 @@ def _mat_to_list(mat):
     return mat
 
 
-def assert_items_almost_equal(a, b, places: int = 5) -> None:
-    """List-aware almost-equal; matches ``BaseTest.assertItemsAlmostEqual``."""
+def assert_items_almost_equal(a, b, places=5):
+    """List-aware almost-equal (matches the old ``BaseTest`` helper)."""
     a = [a] if np.isscalar(a) else _mat_to_list(a)
     b = [b] if np.isscalar(b) else _mat_to_list(b)
     assert len(a) == len(b), f"length mismatch: {len(a)} vs {len(b)}"
@@ -161,12 +147,12 @@ def assert_items_almost_equal(a, b, places: int = 5) -> None:
         assert round(ai - bi, places) == 0, f"{ai} != {bi} to {places} places"
 
 
-def assert_almost_equal(a, b, places: int = 5) -> None:
-    """Scalar almost-equal; matches ``unittest.TestCase.assertAlmostEqual``."""
+def assert_almost_equal(a, b, places=5):
+    """Scalar almost-equal (matches ``unittest.TestCase.assertAlmostEqual``)."""
     assert round(a - b, places) == 0, f"{a} != {b} to {places} places"
 
 
-def check_kkt(problem, places: int = 4) -> None:
+def check_kkt(problem, places=4):
     """Verify KKT conditions for a solved problem."""
     obj_pair = (problem.objective, None)
     var_pairs = [(v, None) for v in problem.variables()]
@@ -179,13 +165,27 @@ def check_kkt(problem, places: int = 4) -> None:
     sth.check_stationary_lagrangian(places)
 
 
-# --------------------------------------------------------------------------- #
-# Fixtures
-# --------------------------------------------------------------------------- #
+def _solve(problem, solver, use_quad_obj=False):
+    """Solve ``problem``. With ``use_quad_obj=True`` additionally verify that
+    canonicalization introduces no SOC cones -- that's what the QP path
+    through a conic solver is supposed to guarantee.
+    """
+    if use_quad_obj:
+        data, _, _ = problem.get_problem_data(
+            solver, solver_opts={"use_quad_obj": True}
+        )
+        assert data["dims"].soc == [], (
+            f"Problem should have no SOC cones for QP canonicalization with {solver}"
+        )
+    kwargs = {"use_quad_obj": True} if use_quad_obj else {}
+    return problem.solve(solver=solver, verbose=False, **kwargs)
+
+
+# --- Fixture --- #
 
 @pytest.fixture
 def qp_vars():
-    """Fresh per-test bag of Variables used across the QP correctness helpers."""
+    """Fresh per-test bag of Variables (replaces ``QPTestBase.setUp``)."""
     T = 30
     return SimpleNamespace(
         a=Variable(name='a'),
@@ -210,45 +210,11 @@ def qp_vars():
     )
 
 
-# --------------------------------------------------------------------------- #
-# Solve callables
-# --------------------------------------------------------------------------- #
+# --- QP correctness helpers (one per problem shape) --- #
 
-def _native_solve(solver):
-    """Plain ``problem.solve(solver=...)`` driver used for native QP solvers."""
-    def solve(problem):
-        return problem.solve(solver=solver, verbose=False)
-    return solve
-
-
-def _conic_quad_obj_solve(solver):
-    """Driver for conic solvers under ``use_quad_obj=True``.
-
-    Additionally asserts that the canonicalization introduces no SOC cones --
-    that's the whole point of the QP path through a conic solver.
-    """
-    def solve(problem):
-        data, _, _ = problem.get_problem_data(
-            solver, solver_opts={"use_quad_obj": True}
-        )
-        assert data["dims"].soc == [], (
-            f"Problem should have no SOC cones for QP canonicalization with {solver}"
-        )
-        return problem.solve(solver=solver, use_quad_obj=True, verbose=False)
-    return solve
-
-
-# --------------------------------------------------------------------------- #
-# QP correctness helpers (one per problem shape).
-#
-# Each helper takes the ``qp_vars`` fixture and a solve callable. The matrix
-# test (``test_qp_correctness``) parameterizes both the helper and the solver.
-# --------------------------------------------------------------------------- #
-
-def _quad_over_lin(v, solve_qp):
-    p = Problem(Minimize(0.5 * quad_over_lin(abs(v.x - 1), 1)),
-                [v.x <= -1])
-    solve_qp(p)
+def _quad_over_lin(v, solver, use_quad_obj=False):
+    p = Problem(Minimize(0.5 * quad_over_lin(abs(v.x - 1), 1)), [v.x <= -1])
+    _solve(p, solver, use_quad_obj)
     for var in p.variables():
         assert_items_almost_equal(np.array([-1., -1.]), var.value, places=4)
     for con in p.constraints:
@@ -256,53 +222,52 @@ def _quad_over_lin(v, solve_qp):
     check_kkt(p, places=3)
 
 
-def _abs(v, solve_qp):
+def _abs(v, solver, use_quad_obj=False):
     u = Variable(2)
-    constr = [abs(u[1] - u[0]) <= 100]
-    prob = Problem(Minimize(sum_squares(u)), constr)
+    prob = Problem(Minimize(sum_squares(u)), [abs(u[1] - u[0]) <= 100])
     assert prob.is_qp()
-    result = solve_qp(prob)
+    result = _solve(prob, solver, use_quad_obj)
     assert_almost_equal(result, 0)
 
 
-def _power(v, solve_qp):
+def _power(v, solver, use_quad_obj=False):
     p = Problem(Minimize(sum(power(v.x, 2))), [])
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     for var in p.variables():
         assert_items_almost_equal([0., 0.], var.value, places=4)
 
 
-def _power_matrix(v, solve_qp):
+def _power_matrix(v, solver, use_quad_obj=False):
     p = Problem(Minimize(sum(power(v.A - 3., 2))), [])
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     for var in p.variables():
         assert_items_almost_equal([3., 3., 3., 3.], var.value, places=4)
 
 
-def _square_affine(v, solve_qp):
+def _square_affine(v, solver, use_quad_obj=False):
     A = np.random.randn(10, 2)
     b = np.random.randn(10)
     p = Problem(Minimize(sum_squares(A @ v.x - b)))
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     for var in p.variables():
         assert_items_almost_equal(
             lstsq(A, b)[0].flatten(order='F'), var.value, places=1
         )
 
 
-def _quad_form(v, solve_qp):
+def _quad_form(v, solver, use_quad_obj=False):
     np.random.seed(0)
     A = np.random.randn(5, 5)
     z = np.random.randn(5)
     P = A.T.dot(A)
     q = -2 * P.dot(z)
     p = Problem(Minimize(QuadForm(v.w, P) + q.T @ v.w))
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     for var in p.variables():
         assert_items_almost_equal(z, var.value, places=4)
 
 
-def _rep_quad_form(v, solve_qp):
+def _rep_quad_form(v, solver, use_quad_obj=False):
     """A problem where the quad_form term is used multiple times."""
     np.random.seed(0)
     A = np.random.randn(5, 5)
@@ -311,81 +276,76 @@ def _rep_quad_form(v, solve_qp):
     q = -2 * P.dot(z)
     qf = QuadForm(v.w, P)
     p = Problem(Minimize(0.5 * qf + 0.5 * qf + q.T @ v.w))
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     for var in p.variables():
         assert_items_almost_equal(z, var.value, places=4)
 
 
-def _affine_problem(v, solve_qp):
+def _affine_problem(v, solver, use_quad_obj=False):
     np.random.seed(0)
-    A = np.random.randn(5, 2)
-    A = np.maximum(A, 0)
-    b = np.random.randn(5)
-    b = np.maximum(b, 0)
+    A = np.maximum(np.random.randn(5, 2), 0)
+    b = np.maximum(np.random.randn(5), 0)
     p = Problem(Minimize(sum(v.x)), [v.x >= 0, A @ v.x <= b])
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     for var in p.variables():
         assert_items_almost_equal([0., 0.], var.value, places=3)
     check_kkt(p, places=3)
 
 
-def _maximize_problem(v, solve_qp):
+def _maximize_problem(v, solver, use_quad_obj=False):
     np.random.seed(0)
-    A = np.random.randn(5, 2)
-    A = np.maximum(A, 0)
-    b = np.random.randn(5)
-    b = np.maximum(b, 0)
+    A = np.maximum(np.random.randn(5, 2), 0)
+    b = np.maximum(np.random.randn(5), 0)
     p = Problem(Maximize(-sum(v.x)), [v.x >= 0, A @ v.x <= b])
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     for var in p.variables():
         assert_items_almost_equal([0., 0.], var.value, places=3)
     check_kkt(p, places=3)
 
 
-def _quad_form_coeff(v, solve_qp):
+def _quad_form_coeff(v, solver, use_quad_obj=False):
     np.random.seed(0)
     A = np.random.randn(5, 5)
     z = np.random.randn(5)
     P = A.T.dot(A)
     q = -2 * P.dot(z)
     p = Problem(Minimize(QuadForm(v.w, P) + q.T @ v.w))
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     for var in p.variables():
         assert_items_almost_equal(z, var.value, places=4)
 
 
-def _quad_form_bound(v, solve_qp):
+def _quad_form_bound(v, solver, use_quad_obj=False):
     P = np.array([[13, 12, -2], [12, 17, 6], [-2, 6, 12]])
     q = np.array([[-22], [-14.5], [13]])
-    r = 1
     y_star = np.array([[1], [0.5], [-1]])
-    p = Problem(Minimize(0.5 * QuadForm(v.y, P) + q.T @ v.y + r),
+    p = Problem(Minimize(0.5 * QuadForm(v.y, P) + q.T @ v.y + 1),
                 [v.y >= -1, v.y <= 1])
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     for var in p.variables():
         assert_items_almost_equal(y_star, var.value, places=4)
     check_kkt(p)
 
 
-def _regression_1(v, solve_qp):
+def _regression_1(v, solver, use_quad_obj=False):
     np.random.seed(1)
     n = 100
     true_coeffs = np.array([[2, -2, 0.5]]).T
-    x_data = np.random.rand(n) * 5
-    x_data = np.atleast_2d(x_data)
-    x_data_expanded = np.vstack([np.power(x_data, i) for i in range(1, 4)])
-    x_data_expanded = np.atleast_2d(x_data_expanded)
-    y_data = x_data_expanded.T.dot(true_coeffs) + 0.5 * np.random.rand(n, 1)
-    y_data = np.atleast_2d(y_data)
+    x_data = np.atleast_2d(np.random.rand(n) * 5)
+    x_data_expanded = np.atleast_2d(
+        np.vstack([np.power(x_data, i) for i in range(1, 4)])
+    )
+    y_data = np.atleast_2d(
+        x_data_expanded.T.dot(true_coeffs) + 0.5 * np.random.rand(n, 1)
+    )
     line = v.offset + x_data * v.slope
-    residuals = line.T - y_data
-    fit_error = sum_squares(residuals)
+    fit_error = sum_squares(line.T - y_data)
     p = Problem(Minimize(fit_error), [])
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     assert_almost_equal(1171.60037715, p.value, places=4)
 
 
-def _regression_2(v, solve_qp):
+def _regression_2(v, solver, use_quad_obj=False):
     np.random.seed(1)
     n = 100
     true_coeffs = np.array([2, -2, 0.5])
@@ -395,14 +355,13 @@ def _regression_2(v, solve_qp):
     quadratic = (
         v.offset + x_data * v.slope + v.quadratic_coeff * np.power(x_data, 2)
     )
-    residuals = quadratic.T - y_data
-    fit_error = sum_squares(residuals)
+    fit_error = sum_squares(quadratic.T - y_data)
     p = Problem(Minimize(fit_error), [])
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     assert_almost_equal(139.225660756, p.value, places=4)
 
 
-def _control(v, solve_qp):
+def _control(v, solver, use_quad_obj=False):
     initial_velocity = np.array([-20, 100])
     final_position = np.array([100, 100])
     T = 30
@@ -412,61 +371,55 @@ def _control(v, solve_qp):
     g = np.array([0, -9.8])
     constraints = []
     for i in range(T - 1):
-        constraints += [
-            v.position[:, i + 1] == v.position[:, i] + h * v.velocity[:, i]
-        ]
+        constraints += [v.position[:, i + 1] == v.position[:, i] + h * v.velocity[:, i]]
         acceleration = v.force[:, i] / mass + g - drag * v.velocity[:, i]
-        constraints += [
-            v.velocity[:, i + 1] == v.velocity[:, i] + h * acceleration
-        ]
+        constraints += [v.velocity[:, i + 1] == v.velocity[:, i] + h * acceleration]
     constraints += [v.position[:, 0] == 0]
     constraints += [v.position[:, -1] == final_position]
     constraints += [v.velocity[:, 0] == initial_velocity]
     constraints += [v.velocity[:, -1] == 0]
     p = Problem(Minimize(.01 * sum_squares(v.force)), constraints)
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     assert_almost_equal(1059.616, p.value, places=1)
     # KKT check skipped: check_stationary_lagrangian fails for 2D matrix
     # variables due to inconsistent gradient ordering (sum_squares uses
     # C order, constraint terms use F order). TODO fix this
 
 
-def _sparse_system(v, solve_qp):
+def _sparse_system(v, solver, use_quad_obj=False):
     m, n = 100, 80
     np.random.seed(1)
     A = sp.random_array((m, n), density=0.4)
     b = np.random.randn(m)
     p = Problem(Minimize(sum_squares(A @ v.xs - b)), [v.xs == 0])
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     assert_almost_equal(b.T.dot(b), p.value, places=4)
 
 
-def _smooth_ridge(v, solve_qp):
+def _smooth_ridge(v, solver, use_quad_obj=False):
     np.random.seed(1)
     n = 50
     k = 20
-    eta = 1
     A = np.ones((k, n))
     b = np.ones(k)
-    obj = sum_squares(A @ v.xsr - b) + eta * sum_squares(v.xsr[:-1] - v.xsr[1:])
+    obj = sum_squares(A @ v.xsr - b) + sum_squares(v.xsr[:-1] - v.xsr[1:])
     p = Problem(Minimize(obj), [])
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     assert_almost_equal(0, p.value, places=4)
 
 
-def _huber_small(v, solve_qp, places: int = 4):
+def _huber_small(v, solver, use_quad_obj=False, places=4):
     x = Variable(3)
     objective = sum(huber(x))
     p = Problem(Minimize(objective), [x[2] >= 3])
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     assert_almost_equal(3, x.value[2], places=places)
     assert_almost_equal(5, objective.value, places=places)
     check_kkt(p, places=places)
 
 
-def _huber(v, solve_qp):
-    n = 3
-    m = 5
+def _huber(v, solver, use_quad_obj=False):
+    n, m = 3, 5
     data = [0.89, 0.39, 0.96, 0.34, 0.68, 0.18,
             0.63, 0.42, 0.51, 0.66, 0.43, 0.77]
     indices = [0, 1, 2, 3, 4, 2, 3, 0, 1, 2, 3, 4]
@@ -479,131 +432,120 @@ def _huber(v, solve_qp):
     x = Variable(n)
     objective = sum(huber(A @ x - b))
     p = Problem(Minimize(objective))
-    solve_qp(p)
+    _solve(p, solver, use_quad_obj)
     assert_almost_equal(1.452797819667, objective.value, places=3)
     assert_items_almost_equal(
         x.value, [1.20524645, -0.85271489, -0.50838494], places=3
     )
 
 
-def _equivalent_forms_1(v, solve_qp):
+def _equivalent_forms_setup(seed=1):
+    np.random.seed(seed)
     m, n, r = 100, 80, 70
-    np.random.seed(1)
     A = np.random.randn(m, n)
     b = np.random.randn(m)
     G = np.random.randn(r, n)
     h = np.random.randn(r)
-    obj1 = .1 * sum((A @ v.xef - b) ** 2)
-    cons = [G @ v.xef == h]
-    p1 = Problem(Minimize(obj1), cons)
-    solve_qp(p1)
-    assert_almost_equal(p1.value, 68.1119420108, places=4)
-    check_kkt(p1, places=4)
+    return A, b, G, h
 
 
-def _equivalent_forms_2(v, solve_qp):
-    m, n, r = 100, 80, 70
-    np.random.seed(1)
-    A = np.random.randn(m, n)
-    b = np.random.randn(m)
-    G = np.random.randn(r, n)
-    h = np.random.randn(r)
+def _equivalent_forms_1(v, solver, use_quad_obj=False):
+    A, b, G, h = _equivalent_forms_setup()
+    p = Problem(Minimize(.1 * sum((A @ v.xef - b) ** 2)), [G @ v.xef == h])
+    _solve(p, solver, use_quad_obj)
+    assert_almost_equal(p.value, 68.1119420108, places=4)
+    check_kkt(p, places=4)
+
+
+def _equivalent_forms_2(v, solver, use_quad_obj=False):
+    A, b, G, h = _equivalent_forms_setup()
     # ||Ax-b||^2 = x^T (A^T A) x - 2(A^T b)^T x + ||b||^2
-    P = np.dot(A.T, A)
-    q = -2 * np.dot(A.T, b)
-    r_val = np.dot(b.T, b)
-    obj2 = .1 * (QuadForm(v.xef, P) + q.T @ v.xef + r_val)
-    cons = [G @ v.xef == h]
-    p2 = Problem(Minimize(obj2), cons)
-    solve_qp(p2)
-    assert_almost_equal(p2.value, 68.1119420108, places=4)
-    check_kkt(p2, places=4)
+    P = A.T @ A
+    q = -2 * A.T @ b
+    r = b.T @ b
+    obj = .1 * (QuadForm(v.xef, P) + q.T @ v.xef + r)
+    p = Problem(Minimize(obj), [G @ v.xef == h])
+    _solve(p, solver, use_quad_obj)
+    assert_almost_equal(p.value, 68.1119420108, places=4)
+    check_kkt(p, places=4)
 
 
-def _equivalent_forms_3(v, solve_qp):
-    m, n, r = 100, 80, 70
-    np.random.seed(1)
-    A = np.random.randn(m, n)
-    b = np.random.randn(m)
-    G = np.random.randn(r, n)
-    h = np.random.randn(r)
-    # ||Ax-b||^2 = x^T (A^T A) x - 2(A^T b)^T x + ||b||^2
-    P = np.dot(A.T, A)
-    q = -2 * np.dot(A.T, b)
-    r_val = np.dot(b.T, b)
+def _equivalent_forms_3(v, solver, use_quad_obj=False):
+    A, b, G, h = _equivalent_forms_setup()
+    P = A.T @ A
+    q = -2 * A.T @ b
+    r = b.T @ b
     Pinv = np.linalg.inv(P)
-    obj3 = .1 * (matrix_frac(v.xef, Pinv) + q.T @ v.xef + r_val)
-    cons = [G @ v.xef == h]
-    p3 = Problem(Minimize(obj3), cons)
-    solve_qp(p3)
-    assert_almost_equal(p3.value, 68.1119420108, places=4)
-    check_kkt(p3, places=4)
+    obj = .1 * (matrix_frac(v.xef, Pinv) + q.T @ v.xef + r)
+    p = Problem(Minimize(obj), [G @ v.xef == h])
+    _solve(p, solver, use_quad_obj)
+    assert_almost_equal(p.value, 68.1119420108, places=4)
+    check_kkt(p, places=4)
 
 
-# --------------------------------------------------------------------------- #
-# Matrix tests: (helper) x (solver).
-# --------------------------------------------------------------------------- #
+# --- Per-solver tests --- #
 
-QP_HELPERS = [
-    ("quad_over_lin", _quad_over_lin),
-    ("power", _power),
-    ("power_matrix", _power_matrix),
-    ("square_affine", _square_affine),
-    ("quad_form", _quad_form),
-    ("affine_problem", _affine_problem),
-    ("maximize_problem", _maximize_problem),
-    ("abs", _abs),
-    ("quad_form_coeff", _quad_form_coeff),
-    ("quad_form_bound", _quad_form_bound),
-    ("regression_1", _regression_1),
-    ("regression_2", _regression_2),
-    ("rep_quad_form", _rep_quad_form),
-    ("control", _control),
-    ("sparse_system", _sparse_system),
-    ("smooth_ridge", _smooth_ridge),
-    ("huber_small", _huber_small),
-    ("huber", _huber),
-    ("equivalent_forms_1", _equivalent_forms_1),
-    ("equivalent_forms_2", _equivalent_forms_2),
-    ("equivalent_forms_3", _equivalent_forms_3),
-]
-
-_HELPER_IDS = [name for name, _ in QP_HELPERS]
-
-# Conic + use_quad_obj canonicalization yields m=0 for unconstrained problems,
-# which solvers with REQUIRES_CONSTR=True reject. Skip those helpers for those
-# solvers.
-_REQUIRES_CONSTR_INCOMPATIBLE = {
-    "power", "quad_form", "quad_form_coeff", "rep_quad_form",
-}
-
-
-@pytest.mark.parametrize("name,helper", QP_HELPERS, ids=_HELPER_IDS)
 @pytest.mark.parametrize("solver", QP_SOLVER_PARAMS)
-def test_qp_correctness(qp_vars, solver, name, helper):
-    """Run each QP correctness helper against each installed native QP solver."""
-    # KNITRO does not support matrix_frac, which equivalent_forms_3 uses.
-    if solver == cp.KNITRO and name == "equivalent_forms_3":
-        pytest.skip("KNITRO does not support matrix_frac")
-    helper(qp_vars, _native_solve(solver))
+def test_qp_correctness(qp_vars, solver):
+    """Run all QP correctness helpers against one native QP solver."""
+    _quad_over_lin(qp_vars, solver)
+    _power(qp_vars, solver)
+    _power_matrix(qp_vars, solver)
+    _square_affine(qp_vars, solver)
+    _quad_form(qp_vars, solver)
+    _affine_problem(qp_vars, solver)
+    _maximize_problem(qp_vars, solver)
+    _abs(qp_vars, solver)
+    _quad_form_coeff(qp_vars, solver)
+    _quad_form_bound(qp_vars, solver)
+    _regression_1(qp_vars, solver)
+    _regression_2(qp_vars, solver)
+    _rep_quad_form(qp_vars, solver)
+    _control(qp_vars, solver)
+    _sparse_system(qp_vars, solver)
+    _smooth_ridge(qp_vars, solver)
+    _huber_small(qp_vars, solver)
+    _huber(qp_vars, solver)
+    _equivalent_forms_1(qp_vars, solver)
+    _equivalent_forms_2(qp_vars, solver)
+    if solver != cp.KNITRO:
+        # KNITRO does not support matrix_frac.
+        _equivalent_forms_3(qp_vars, solver)
 
 
-@pytest.mark.parametrize("name,helper", QP_HELPERS, ids=_HELPER_IDS)
 @pytest.mark.parametrize("solver", CONIC_QUAD_OBJ_PARAMS)
-def test_conic_quad_obj_correctness(qp_vars, solver, name, helper):
-    """Run QP correctness helpers against conic solvers with use_quad_obj=True."""
-    if (
-        SOLVER_MAP_CONIC[solver].REQUIRES_CONSTR
-        and name in _REQUIRES_CONSTR_INCOMPATIBLE
-    ):
-        pytest.skip(
-            f"{solver} requires constraints; {name} is unconstrained"
-        )
-    if name == "huber_small":
-        # Conic + use_quad_obj has slightly looser precision.
-        helper(qp_vars, _conic_quad_obj_solve(solver), places=3)
-    else:
-        helper(qp_vars, _conic_quad_obj_solve(solver))
+def test_qp_conic_quad_obj(qp_vars, solver):
+    """Run QP correctness helpers via conic solvers with use_quad_obj=True.
+
+    Solvers with ``REQUIRES_CONSTR=True`` skip helpers whose problems are
+    unconstrained -- those canonicalize to m=0 and are rejected.
+    """
+    requires_constr = SOLVER_MAP_CONIC[solver].REQUIRES_CONSTR
+    _quad_over_lin(qp_vars, solver, use_quad_obj=True)
+    if not requires_constr:
+        _power(qp_vars, solver, use_quad_obj=True)
+    _power_matrix(qp_vars, solver, use_quad_obj=True)
+    _square_affine(qp_vars, solver, use_quad_obj=True)
+    if not requires_constr:
+        _quad_form(qp_vars, solver, use_quad_obj=True)
+    _affine_problem(qp_vars, solver, use_quad_obj=True)
+    _maximize_problem(qp_vars, solver, use_quad_obj=True)
+    _abs(qp_vars, solver, use_quad_obj=True)
+    if not requires_constr:
+        _quad_form_coeff(qp_vars, solver, use_quad_obj=True)
+    _quad_form_bound(qp_vars, solver, use_quad_obj=True)
+    _regression_1(qp_vars, solver, use_quad_obj=True)
+    _regression_2(qp_vars, solver, use_quad_obj=True)
+    if not requires_constr:
+        _rep_quad_form(qp_vars, solver, use_quad_obj=True)
+    _control(qp_vars, solver, use_quad_obj=True)
+    _sparse_system(qp_vars, solver, use_quad_obj=True)
+    _smooth_ridge(qp_vars, solver, use_quad_obj=True)
+    _huber_small(qp_vars, solver, use_quad_obj=True, places=3)
+    _huber(qp_vars, solver, use_quad_obj=True)
+    _equivalent_forms_1(qp_vars, solver, use_quad_obj=True)
+    _equivalent_forms_2(qp_vars, solver, use_quad_obj=True)
+    _equivalent_forms_3(qp_vars, solver, use_quad_obj=True)
 
 
 @pytest.mark.parametrize("solver", QP_SOLVER_PARAMS)
@@ -623,18 +565,14 @@ def test_parametric(solver):
 
     x_full, obj_full = [], []
     for b in b_vec:
-        obj = Minimize(a * (x ** 2) + b * x)
-        constraints = [0 <= x, x <= 1]
-        prob = Problem(obj, constraints)
+        prob = Problem(Minimize(a * (x ** 2) + b * x), [0 <= x, x <= 1])
         prob.solve(solver=solver)
         x_full.append(x.value)
         obj_full.append(prob.value)
 
     x_param, obj_param = [], []
     b = Parameter()
-    obj = Minimize(a * (x ** 2) + b * x)
-    constraints = [0 <= x, x <= 1]
-    prob = Problem(obj, constraints)
+    prob = Problem(Minimize(a * (x ** 2) + b * x), [0 <= x, x <= 1])
     for b_value in b_vec:
         b.value = b_value
         prob.solve(solver=solver)
@@ -646,9 +584,7 @@ def test_parametric(solver):
         assert_almost_equal(obj_full[i], obj_param[i])
 
 
-# --------------------------------------------------------------------------- #
-# Solver-specific tests
-# --------------------------------------------------------------------------- #
+# --- Solver-specific tests --- #
 
 def test_warm_start():
     m, n = 200, 100
@@ -755,8 +691,7 @@ def test_highs_warmstart():
 @pytest.mark.skipif(cp.HIGHS not in INSTALLED_SOLVERS, reason="HIGHS is not installed")
 def test_highs_cvar():
     """CVaR constraint regression for https://github.com/cvxpy/cvxpy/issues/2836."""
-    num_stocks = 5
-    num_samples = 25
+    num_stocks, num_samples = 5, 25
     np.random.seed(1)
     pnl_samples = np.random.uniform(low=0.0, high=1.0, size=(num_samples, num_stocks))
     pnl_expected = pnl_samples.mean(axis=0)
@@ -764,11 +699,7 @@ def test_highs_cvar():
     quantile = 0.05
     w = cp.Variable(num_stocks, nonneg=True)
     cvar = cp.cvar(pnl_samples @ w, 1 - quantile)
-    pnl = w @ pnl_expected
-
-    objective = cp.Maximize(pnl)
-    constraints = [cvar <= 0.5]
-    problem = cp.Problem(objective, constraints)
+    problem = cp.Problem(cp.Maximize(w @ pnl_expected), [cvar <= 0.5])
     problem.solve(solver=cp.HIGHS)
     assert problem.status == cp.OPTIMAL
 
@@ -815,69 +746,52 @@ def test_square_param():
     """Issue arising with square plus parameter."""
     a = Parameter(value=1)
     b = Variable()
-    obj = Minimize(b ** 2 + abs(a))
-    prob = Problem(obj)
+    prob = Problem(Minimize(b ** 2 + abs(a)))
     prob.solve(solver="SCS")
-    assert_almost_equal(obj.value, 1.0)
+    assert_almost_equal(prob.value, 1.0)
 
 
 def test_gurobi_time_limit_no_solution(qp_vars):
     """If Gurobi hits its time limit before finding a solution, the solve
     must return cleanly and expose solver stats.
-
-    The test is skipped if Gurobi terminates for a different reason or
-    actually finds a solution despite ``TimeLimit=0``.
     """
-    from cvxpy import GUROBI
-    if GUROBI in INSTALLED_SOLVERS:
+    if cp.GUROBI in INSTALLED_SOLVERS:
         import gurobipy
-        objective = Minimize(qp_vars.x[0])
-        constraints = [qp_vars.x[0] >= 1]
-        prob = Problem(objective, constraints)
+        prob = Problem(Minimize(qp_vars.x[0]), [qp_vars.x[0] >= 1])
         try:
-            prob.solve(solver=GUROBI, TimeLimit=0.0)
+            prob.solve(solver=cp.GUROBI, TimeLimit=0.0)
         except Exception as e:
-            pytest.fail(
-                f"An exception {e} is raised instead of returning a result."
-            )
+            pytest.fail(f"An exception {e} is raised instead of returning a result.")
 
-        extra_stats = None
-        solver_stats = getattr(prob, "solver_stats", None)
-        if solver_stats:
-            extra_stats = getattr(solver_stats, "extra_stats", None)
+        extra_stats = getattr(getattr(prob, "solver_stats", None), "extra_stats", None)
         assert extra_stats, "Solver stats have not been returned."
 
-        nb_solutions = getattr(extra_stats, "SolCount", None)
-        if nb_solutions:
-            pytest.skip(
-                "Gurobi has found a solution, the test is not relevant anymore."
-            )
+        if getattr(extra_stats, "SolCount", None):
+            pytest.skip("Gurobi has found a solution, the test is not relevant anymore.")
 
-        solver_status = getattr(extra_stats, "Status", None)
-        if solver_status != gurobipy.GRB.TIME_LIMIT:
+        if getattr(extra_stats, "Status", None) != gurobipy.GRB.TIME_LIMIT:
             pytest.skip(
-                "Gurobi terminated for a different reason than reaching time "
-                "limit, the test is not relevant anymore."
+                "Gurobi terminated for a different reason than reaching time limit, "
+                "the test is not relevant anymore."
             )
     else:
+        prob = Problem(Minimize(norm(qp_vars.x, 1)), [qp_vars.x == 0])
         with pytest.raises(Exception) as exc_info:
-            prob = Problem(Minimize(norm(qp_vars.x, 1)), [qp_vars.x == 0])
-            prob.solve(solver=GUROBI, TimeLimit=0)
-        assert str(exc_info.value) == f"The solver {GUROBI} is not installed."
+            prob.solve(solver=cp.GUROBI, TimeLimit=0)
+        assert str(exc_info.value) == f"The solver {cp.GUROBI} is not installed."
 
 
 def test_gurobi_environment(qp_vars):
     """Gurobi environments (with licensing/model parameter data) can be passed
     through to the underlying Model.
     """
-    from cvxpy import GUROBI
-    if GUROBI in INSTALLED_SOLVERS:
+    if cp.GUROBI in INSTALLED_SOLVERS:
         import gurobipy
 
         params = {
-            'MIPGap': np.random.random(),       # range {0, INFINITY}
-            'AggFill': np.random.randint(10),   # range {-1, MAXINT}
-            'PerturbValue': np.random.random(), # range: {0, INFINITY}
+            'MIPGap': np.random.random(),
+            'AggFill': np.random.randint(10),
+            'PerturbValue': np.random.random(),
         }
         custom_env = gurobipy.Env()
         for k, v in params.items():
@@ -886,14 +800,13 @@ def test_gurobi_environment(qp_vars):
         sth = StandardTestLPs.test_lp_0(solver='GUROBI', env=custom_env)
         model = sth.prob.solver_stats.extra_stats
         for k, v in params.items():
-            # https://www.gurobi.com/documentation/9.1/refman/py_model_getparaminfo.html
             _, _, p_val, _, _, _ = model.getParamInfo(k)
             assert v == p_val
     else:
+        prob = Problem(Minimize(norm(qp_vars.x, 1)), [qp_vars.x == 0])
         with pytest.raises(Exception) as exc_info:
-            prob = Problem(Minimize(norm(qp_vars.x, 1)), [qp_vars.x == 0])
-            prob.solve(solver=GUROBI, TimeLimit=0)
-        assert str(exc_info.value) == f"The solver {GUROBI} is not installed."
+            prob.solve(solver=cp.GUROBI, TimeLimit=0)
+        assert str(exc_info.value) == f"The solver {cp.GUROBI} is not installed."
 
 
 def test_osqp_infeasible_lp_ineq_constraints():
@@ -925,7 +838,6 @@ def test_highs_dense_quad_form():
     rng = np.random.default_rng(42)
     n_vars, n_nodes = 60, 20
 
-    # Sparse mapping from decision variables to a smaller space.
     rows, cols, vals = [], [], []
     for i in range(n_vars):
         j, k = rng.choice(n_nodes, size=2, replace=False)
@@ -934,27 +846,22 @@ def test_highs_dense_quad_form():
         vals += [1.0, -1.0]
     M = sp.csr_matrix((vals, (rows, cols)), shape=(n_vars, n_nodes))
 
-    # Dense PSD matrix via eigenvalue clamping (typical in practice).
     A = rng.standard_normal((n_nodes, n_nodes))
     raw = A @ A.T + rng.standard_normal((n_nodes, n_nodes)) * 0.01
     sym = 0.5 * (raw + raw.T)
     eigvals, eigvecs = np.linalg.eigh(sym)
-    eigvals = np.maximum(eigvals, 0.0)
-    Sigma = eigvecs @ np.diag(eigvals) @ eigvecs.T
+    Sigma = eigvecs @ np.diag(np.maximum(eigvals, 0.0)) @ eigvecs.T
 
     x = cp.Variable(n_vars, nonneg=True)
-    y = x @ M
     prob = cp.Problem(
-        cp.Maximize(cp.sum(x) - 0.1 * cp.quad_form(y, Sigma)),
+        cp.Maximize(cp.sum(x) - 0.1 * cp.quad_form(x @ M, Sigma)),
         [x <= 10],
     )
     prob.solve(solver=cp.HIGHS)
     assert prob.status == cp.OPTIMAL
 
 
-# --------------------------------------------------------------------------- #
-# MPAX tests
-# --------------------------------------------------------------------------- #
+# --- MPAX tests --- #
 
 mpax_skip = pytest.mark.skipif(
     'MPAX' not in INSTALLED_SOLVERS, reason='MPAX is not installed.'
@@ -1005,18 +912,12 @@ def test_mpax_lp_6():
 @mpax_skip
 def test_mpax_warmstart():
     x = cp.Variable(shape=(2,), name='x')
-    objective = cp.Minimize(-4 * x[0] - 5 * x[1])
-    constraints = [
-        2 * x[0] + x[1] <= 3,
-        x[0] + 2 * x[1] <= 3,
-        x[0] >= 0,
-        x[1] >= 0,
-    ]
-    prob = cp.Problem(objective, constraints)
-    result1 = prob.solve(solver='MPAX', warm_start=False)
-    assert_almost_equal(result1, -9, places=4)
-    result2 = prob.solve(solver='MPAX', warm_start=True)
-    assert_almost_equal(result2, -9, places=4)
+    prob = cp.Problem(
+        cp.Minimize(-4 * x[0] - 5 * x[1]),
+        [2 * x[0] + x[1] <= 3, x[0] + 2 * x[1] <= 3, x[0] >= 0, x[1] >= 0],
+    )
+    assert_almost_equal(prob.solve(solver='MPAX', warm_start=False), -9, places=4)
+    assert_almost_equal(prob.solve(solver='MPAX', warm_start=True), -9, places=4)
 
 
 @mpax_skip
@@ -1024,9 +925,7 @@ def test_mpax_qp_0():
     StandardTestQPs.test_qp_0(solver='MPAX')
 
 
-# --------------------------------------------------------------------------- #
-# QP solver cone-type validation
-# --------------------------------------------------------------------------- #
+# --- QP solver cone-type validation --- #
 
 def _apply_reductions(problem):
     """Apply the full reduction chain to get a ParamConeProg."""
@@ -1044,25 +943,22 @@ def test_qp_solver_rejects_exponential_cones():
     """QP solver rejects problems with exponential cones."""
     x = cp.Variable()
     prob = cp.Problem(cp.Maximize(cp.log(x)), [x <= 1])
-    param_cone_prog = _apply_reductions(prob)
     osqp_solver = OSQP()
-    assert not osqp_solver.accepts(param_cone_prog)
+    assert not osqp_solver.accepts(_apply_reductions(prob))
     with pytest.raises(SolverError) as exc_info:
-        osqp_solver.apply(param_cone_prog)
-    msg = str(exc_info.value)
-    assert "exponential cones" in msg
-    assert "OSQP" in msg
+        osqp_solver.apply(_apply_reductions(prob))
+    assert "exponential cones" in str(exc_info.value)
+    assert "OSQP" in str(exc_info.value)
 
 
 def test_qp_solver_rejects_psd_cones():
     """QP solver rejects problems with PSD cones."""
     X = cp.Variable((2, 2), symmetric=True)
     prob = cp.Problem(cp.Minimize(cp.trace(X)), [X >> 0, X[0, 0] >= 1])
-    param_cone_prog = _apply_reductions(prob)
     osqp_solver = OSQP()
-    assert not osqp_solver.accepts(param_cone_prog)
+    assert not osqp_solver.accepts(_apply_reductions(prob))
     with pytest.raises(SolverError) as exc_info:
-        osqp_solver.apply(param_cone_prog)
+        osqp_solver.apply(_apply_reductions(prob))
     assert "PSD cones" in str(exc_info.value)
 
 
@@ -1070,9 +966,8 @@ def test_qp_solver_rejects_soc_cones():
     """QP solver rejects problems with second-order cones."""
     x = cp.Variable(3)
     prob = cp.Problem(cp.Minimize(cp.norm(x)), [cp.sum(x) == 1])
-    param_cone_prog = _apply_reductions(prob)
     osqp_solver = OSQP()
-    assert not osqp_solver.accepts(param_cone_prog)
+    assert not osqp_solver.accepts(_apply_reductions(prob))
     with pytest.raises(SolverError) as exc_info:
-        osqp_solver.apply(param_cone_prog)
+        osqp_solver.apply(_apply_reductions(prob))
     assert "second-order cones" in str(exc_info.value)


### PR DESCRIPTION
## Description

`test_qp_solvers.py` had three issues that were already fixed in `test_conic_solvers.py` (#3332, #3341) but never propagated. This PR mirrors those fixes and rewrites the file as plain pytest while it's open.

### Bugfixes

1. **`is_mosek_available()`** used `env.getlicense()`. In MOSEK 11 that method returns a license token, not a rescode, so the comparison spuriously failed and MOSEK QP tests were silently skipped. Now uses a trivial solve, matching `is_mosek_available()` in `test_conic_solvers.py`. To avoid duplication, `is_mosek_available` and `is_knitro_available` are imported from `test_conic_solvers`.

2. **`is_knitro_available()`** eagerly imported `knitro` and called `KN_new`. On macOS that loads the native KNITRO runtime and its bundled LLVM `libomp.dylib` into the test process at collection time — the exact problem #3341 fixed for the conic suite. Detection now reads `ARTELYS_LICENSE` / `ARTELYS_LICENSE_NETWORK_ADDR`.

3. **KNITRO QP tests** were not marked `@pytest.mark.knitro` and not run in a separate pytest invocation. Now `@pytest.mark.knitro` lives on every KNITRO-bearing `pytest.param`, and `test_optional_solvers.yml` runs `test_qp_solvers.py` in two passes (`-m "not knitro"` then `-m knitro`), matching the existing split for `test_conic_solvers.py`.

### Rewrite

The file drops `unittest` entirely. Old structure: `BaseTest` subclasses (`QPTestBase` / `TestQp` / `TestConicQuadObj`) with ~20 helper methods called from two giant `test_all_solvers` loops. New structure:

- Each QP correctness check is its own pytest test (e.g. `test_quad_form`), parametrized over a single `QP_PARAMS` list of `(solver, use_quad_obj)` pairs.
- `QP_PARAMS` covers every native QP solver with `use_quad_obj=False` plus every conic solver that supports quadratic objectives with `use_quad_obj=True`. KNITRO is excluded from the conic-side because its conic + `use_quad_obj=True` path is unstable in CI.
- License-driven skips (MOSEK, XPRESS) and the `knitro` mark are attached per-`pytest.param`. No more class-level decorators or runtime `filter_licensed_solvers` calls.
- Five identical warm-start tests collapse to one parametrized `test_warm_start`. The four infeasibility tests collapse to two. (XPRESS and Gurobi warm-start tests stay separate — they exercise genuinely different code paths.)
- Custom `assertItemsAlmostEqual` / `assertAlmostEqual` helpers are gone; tests use `np.testing.assert_allclose` directly.

A `test_quad_form` failure for CLARABEL in the conic + `use_quad_obj` path now shows up as `test_quad_form[CLARABEL-quadobj]` instead of being buried inside a `test_all_solvers` loop.

Issue link (if applicable): N/A — follow-up cleanup noted on the 1.9.1 backport before tagging.

## Type of change

- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)

- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

Locally (no MOSEK/KNITRO licenses available):

```
$ uv run pytest -rs -m "not knitro" cvxpy/tests/test_qp_solvers.py
======================== 94 passed, 15 skipped in 1.59s ========================
```