### PR TITLE
Add manual coverage workflow

### DIFF
--- a/.github/workflows/manual_coverage.yml
+++ b/.github/workflows/manual_coverage.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       require_licensed_solvers:
-        description: "Fail if licensed optional solvers such as COPT and MOSEK are unavailable"
+        description: "Fail if licensed commercial solvers are unavailable"
         required: true
         default: true
         type: boolean
@@ -23,6 +23,8 @@ jobs:
       KNITRO_LICENSE: ${{ secrets.KNITRO_LICENSE }}
       FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
       MOREAU_LICENSE_KEY: ${{ secrets.MOREAU_KEY }}
+      COVERAGE_SOURCE_INCLUDE: "cvxpy/*"
+      COVERAGE_SOURCE_OMIT: "cvxpy/tests/*,cvxpy/cvxcore/*,cvxpy/utilities/einsum_utilities.py"
 
     steps:
       - uses: actions/checkout@v5
@@ -45,7 +47,29 @@ jobs:
       - name: Install COSMO
         run: julia -e 'using Pkg; Pkg.add("COSMO")'
 
-      - name: Set up solver licenses
+      - name: Install cvxpy dependencies and open-source optional solvers
+        run: |
+          uv sync --all-extras --no-extra uno --no-extra knitro --no-extra mosek --no-extra copt --no-extra gurobi --no-extra xpress --dev
+          uv pip install coverage pytest-cov
+
+      - name: Print installed solvers
+        run: uv run python -c "import cvxpy; print(cvxpy.installed_solvers())"
+
+      - name: Run core tests with coverage
+        id: core_tests
+        continue-on-error: true
+        run: |
+          uv run pytest -rs \
+            --cov=cvxpy --cov-append --cov-context=test --cov-report= \
+            -m "not knitro" \
+            --ignore=cvxpy/tests/test_copt_write.py \
+            --ignore=cvxpy/tests/test_conic_solvers.py \
+            --ignore=cvxpy/tests/test_qp_solvers.py \
+            --ignore=cvxpy/tests/nlp_tests \
+            cvxpy/tests
+
+      - name: Set up commercial solver licenses
+        if: always()
         run: |
           if [ -n "$MOSEK_CI_BASE64" ]; then
             echo "$MOSEK_CI_BASE64" | base64 -d > mosek.lic
@@ -57,54 +81,54 @@ jobs:
             echo "ARTELYS_LICENSE=$HOME" >> "$GITHUB_ENV"
           fi
 
-      - name: Install cvxpy dependencies and optional solvers
+      - name: Install commercial solvers
+        if: always()
         run: |
-          uv sync --all-extras --no-extra uno --dev
-          uv pip install -e ".[UNO]"
-          uv pip install cyipopt coverage pytest-cov
+          uv pip install -e ".[COPT,GUROBI,MOSEK,XPRESS,KNITRO]"
+          uv pip install cplex naginterfaces
+          if [ -n "$FURY_TOKEN" ]; then
+            uv pip install moreau --extra-index-url https://${FURY_TOKEN}:@pypi.fury.io/optimalintellect/
+          fi
 
-      - name: Install Moreau
-        if: env.FURY_TOKEN != ''
-        run: uv pip install moreau --extra-index-url https://${FURY_TOKEN}:@pypi.fury.io/optimalintellect/
-
-      - name: Print installed solvers
-        run: uv run python -c "import cvxpy; print(cvxpy.installed_solvers())"
-
-      - name: Verify licensed optional solvers
-        if: inputs.require_licensed_solvers
+      - name: Verify commercial solvers
+        id: commercial_solver_check
+        continue-on-error: true
+        if: always() && inputs.require_licensed_solvers
         run: |
           uv run python - <<'PY'
           import cvxpy as cp
 
-          required = {"COPT", "MOSEK"}
+          required = {
+              "MOSEK",
+              "MOREAU",
+              "GUROBI",
+              "CPLEX",
+              "COPT",
+              "XPRESS",
+              "NAG",
+              "KNITRO",
+          }
           installed = set(cp.installed_solvers())
           missing = sorted(required - installed)
           if missing:
               raise SystemExit(
-                  f"Required optional solvers missing: {missing}; "
+                  f"Required commercial solvers missing: {missing}; "
                   f"installed={sorted(installed)}"
               )
 
           x = cp.Variable()
-          cp.Problem(cp.Minimize(x), [x >= 0]).solve(solver=cp.COPT)
-          cp.Problem(cp.Minimize(x), [x >= 0]).solve(solver=cp.MOSEK)
+          for solver in sorted(required):
+              cp.Problem(cp.Minimize(x), [x >= 0]).solve(solver=solver)
           PY
 
-      - name: Run core tests with coverage
-        id: core_tests
-        continue-on-error: true
-        run: |
-          uv run pytest -rs \
-            --cov=cvxpy --cov-append --cov-context=test --cov-report= \
-            -m "not knitro" \
-            --ignore=cvxpy/tests/test_conic_solvers.py \
-            --ignore=cvxpy/tests/test_qp_solvers.py \
-            --ignore=cvxpy/tests/nlp_tests \
-            cvxpy/tests
+      - name: Print installed solvers after commercial setup
+        if: always()
+        run: uv run python -c "import cvxpy; print(cvxpy.installed_solvers())" | tee installed_solvers.txt
 
       - name: Run conic solver tests with coverage
         id: conic_tests
         continue-on-error: true
+        if: always()
         run: |
           uv run pytest -rs \
             --cov=cvxpy --cov-append --cov-context=test --cov-report= \
@@ -114,10 +138,17 @@ jobs:
       - name: Run QP solver tests with coverage
         id: qp_tests
         continue-on-error: true
+        if: always()
         run: |
           uv run pytest -rs \
             --cov=cvxpy --cov-append --cov-context=test --cov-report= \
             cvxpy/tests/test_qp_solvers.py
+
+      - name: Install NLP solvers
+        if: always()
+        run: |
+          uv pip install -e ".[UNO]"
+          uv pip install cyipopt
 
       - name: Run NLP tests with coverage
         id: nlp_tests
@@ -131,6 +162,7 @@ jobs:
       - name: Run KNITRO conic solver tests with coverage
         id: knitro_conic_tests
         continue-on-error: true
+        if: always()
         run: |
           uv run pytest -rs \
             --cov=cvxpy --cov-append --cov-context=test --cov-report= \
@@ -140,6 +172,7 @@ jobs:
       - name: Run KNITRO NLP tests with coverage
         id: knitro_nlp_tests
         continue-on-error: true
+        if: always()
         run: |
           uv run pytest -v \
             --cov=cvxpy --cov-append --cov-context=test --cov-report= \
@@ -150,19 +183,47 @@ jobs:
         if: always()
         run: |
           uv run coverage report > coverage.txt
-          uv run coverage html --show-contexts -d htmlcov
-          uv run coverage xml -o coverage.xml
-          uv run coverage json --show-contexts -o coverage.json
-          uv run coverage lcov -o coverage.lcov
+          uv run coverage report --include="$COVERAGE_SOURCE_INCLUDE" --omit="$COVERAGE_SOURCE_OMIT" > source_coverage.txt
+          awk 'NR > 2 && $1 ~ /^cvxpy\// && $1 != "TOTAL" { pct=$4; gsub("%", "", pct); if (pct + 0 < 80) print }' source_coverage.txt > low_coverage_sources.txt
+          awk 'NR > 2 && $1 ~ /^cvxpy\// && $1 != "TOTAL" { pct=$4; gsub("%", "", pct); if (pct + 0 == 0) print }' source_coverage.txt > zero_coverage_sources.txt
+          uv run coverage html --show-contexts --include="$COVERAGE_SOURCE_INCLUDE" --omit="$COVERAGE_SOURCE_OMIT" -d htmlcov
+          uv run coverage xml --include="$COVERAGE_SOURCE_INCLUDE" --omit="$COVERAGE_SOURCE_OMIT" -o coverage.xml
+          uv run coverage json --include="$COVERAGE_SOURCE_INCLUDE" --omit="$COVERAGE_SOURCE_OMIT" -o coverage.json
+          uv run coverage lcov --include="$COVERAGE_SOURCE_INCLUDE" --omit="$COVERAGE_SOURCE_OMIT" -o coverage.lcov
 
       - name: Write coverage summary
         if: always()
         run: |
           {
-            echo "## Coverage summary"
+            echo "## Source coverage summary"
+            echo
+            echo '```text'
+            cat source_coverage.txt
+            echo '```'
+            echo
+            echo "## Low source coverage (<80%)"
+            echo
+            echo '```text'
+            cat low_coverage_sources.txt
+            echo '```'
+            echo
+            echo "## Zero-covered source files"
+            echo
+            echo '```text'
+            cat zero_coverage_sources.txt
+            echo '```'
+            echo
+            echo "## Full coverage summary"
             echo
             echo '```text'
             cat coverage.txt
+            echo '```'
+            echo
+            echo "## Commercial solver target"
+            echo
+            echo '```text'
+            echo "Required when require_licensed_solvers=true: MOSEK, MOREAU, GUROBI, CPLEX, COPT, XPRESS, NAG, KNITRO"
+            cat installed_solvers.txt
             echo '```'
             echo
             echo "## Test step outcomes"
@@ -170,6 +231,7 @@ jobs:
             echo "| Step | Outcome |"
             echo "| --- | --- |"
             echo "| Core tests | ${{ steps.core_tests.outcome }} |"
+            echo "| Commercial solver check | ${{ steps.commercial_solver_check.outcome }} |"
             echo "| Conic solver tests | ${{ steps.conic_tests.outcome }} |"
             echo "| QP solver tests | ${{ steps.qp_tests.outcome }} |"
             echo "| NLP tests | ${{ steps.nlp_tests.outcome }} |"
@@ -184,15 +246,20 @@ jobs:
           name: coverage-reports
           path: |
             coverage.txt
+            source_coverage.txt
+            low_coverage_sources.txt
+            zero_coverage_sources.txt
             coverage.xml
             coverage.json
             coverage.lcov
+            installed_solvers.txt
             htmlcov
 
       - name: Fail if any test step failed
         if: >-
           ${{
             steps.core_tests.outcome != 'success' ||
+            (inputs.require_licensed_solvers && steps.commercial_solver_check.outcome != 'success') ||
             steps.conic_tests.outcome != 'success' ||
             steps.qp_tests.outcome != 'success' ||
             steps.nlp_tests.outcome != 'success' ||

--- a/.github/workflows/manual_coverage.yml
+++ b/.github/workflows/manual_coverage.yml
@@ -17,7 +17,6 @@ jobs:
         shell: bash -l {0}
 
     env:
-      RUNNER_OS: ubuntu-22.04
       PYTHON_VERSION: "3.12"
       MOSEK_CI_BASE64: ${{ secrets.MOSEK_CI_BASE64 }}
       KNITRO_LICENSE: ${{ secrets.KNITRO_LICENSE }}

--- a/.github/workflows/manual_coverage.yml
+++ b/.github/workflows/manual_coverage.yml
@@ -1,0 +1,202 @@
+name: manual_coverage
+
+on:
+  workflow_dispatch:
+    inputs:
+      require_licensed_solvers:
+        description: "Fail if licensed optional solvers such as COPT and MOSEK are unavailable"
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  coverage:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    env:
+      RUNNER_OS: ubuntu-22.04
+      PYTHON_VERSION: "3.12"
+      MOSEK_CI_BASE64: ${{ secrets.MOSEK_CI_BASE64 }}
+      KNITRO_LICENSE: ${{ secrets.KNITRO_LICENSE }}
+      FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
+      MOREAU_LICENSE_KEY: ${{ secrets.MOREAU_KEY }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
+
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v3
+        with:
+          version: 'lts'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y coinor-libipopt-dev liblapack-dev libblas-dev
+
+      - name: Install COSMO
+        run: julia -e 'using Pkg; Pkg.add("COSMO")'
+
+      - name: Set up solver licenses
+        run: |
+          if [ -n "$MOSEK_CI_BASE64" ]; then
+            echo "$MOSEK_CI_BASE64" | base64 -d > mosek.lic
+            echo "MOSEKLM_LICENSE_FILE=$(realpath mosek.lic)" >> "$GITHUB_ENV"
+          fi
+
+          if [ -n "$KNITRO_LICENSE" ]; then
+            echo "$KNITRO_LICENSE" > "$HOME/artelys_lic.txt"
+            echo "ARTELYS_LICENSE=$HOME" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install cvxpy dependencies and optional solvers
+        run: |
+          uv sync --all-extras --no-extra uno --dev
+          uv pip install -e ".[UNO]"
+          uv pip install cyipopt coverage pytest-cov
+
+      - name: Install Moreau
+        if: env.FURY_TOKEN != ''
+        run: uv pip install moreau --extra-index-url https://${FURY_TOKEN}:@pypi.fury.io/optimalintellect/
+
+      - name: Print installed solvers
+        run: uv run python -c "import cvxpy; print(cvxpy.installed_solvers())"
+
+      - name: Verify licensed optional solvers
+        if: inputs.require_licensed_solvers
+        run: |
+          uv run python - <<'PY'
+          import cvxpy as cp
+
+          required = {"COPT", "MOSEK"}
+          installed = set(cp.installed_solvers())
+          missing = sorted(required - installed)
+          if missing:
+              raise SystemExit(
+                  f"Required optional solvers missing: {missing}; "
+                  f"installed={sorted(installed)}"
+              )
+
+          x = cp.Variable()
+          cp.Problem(cp.Minimize(x), [x >= 0]).solve(solver=cp.COPT)
+          cp.Problem(cp.Minimize(x), [x >= 0]).solve(solver=cp.MOSEK)
+          PY
+
+      - name: Run core tests with coverage
+        id: core_tests
+        continue-on-error: true
+        run: |
+          uv run pytest -rs \
+            --cov=cvxpy --cov-append --cov-context=test --cov-report= \
+            -m "not knitro" \
+            --ignore=cvxpy/tests/test_conic_solvers.py \
+            --ignore=cvxpy/tests/test_qp_solvers.py \
+            --ignore=cvxpy/tests/nlp_tests \
+            cvxpy/tests
+
+      - name: Run conic solver tests with coverage
+        id: conic_tests
+        continue-on-error: true
+        run: |
+          uv run pytest -rs \
+            --cov=cvxpy --cov-append --cov-context=test --cov-report= \
+            -m "not knitro" \
+            cvxpy/tests/test_conic_solvers.py
+
+      - name: Run QP solver tests with coverage
+        id: qp_tests
+        continue-on-error: true
+        run: |
+          uv run pytest -rs \
+            --cov=cvxpy --cov-append --cov-context=test --cov-report= \
+            cvxpy/tests/test_qp_solvers.py
+
+      - name: Run NLP tests with coverage
+        id: nlp_tests
+        continue-on-error: true
+        run: |
+          uv run pytest -v \
+            --cov=cvxpy --cov-append --cov-context=test --cov-report= \
+            -m "not knitro" \
+            cvxpy/tests/nlp_tests/
+
+      - name: Run KNITRO conic solver tests with coverage
+        id: knitro_conic_tests
+        continue-on-error: true
+        run: |
+          uv run pytest -rs \
+            --cov=cvxpy --cov-append --cov-context=test --cov-report= \
+            -m knitro \
+            cvxpy/tests/test_conic_solvers.py
+
+      - name: Run KNITRO NLP tests with coverage
+        id: knitro_nlp_tests
+        continue-on-error: true
+        run: |
+          uv run pytest -v \
+            --cov=cvxpy --cov-append --cov-context=test --cov-report= \
+            -m knitro \
+            cvxpy/tests/nlp_tests/
+
+      - name: Generate coverage reports
+        if: always()
+        run: |
+          uv run coverage report > coverage.txt
+          uv run coverage html --show-contexts -d htmlcov
+          uv run coverage xml -o coverage.xml
+          uv run coverage json --show-contexts -o coverage.json
+          uv run coverage lcov -o coverage.lcov
+
+      - name: Write coverage summary
+        if: always()
+        run: |
+          {
+            echo "## Coverage summary"
+            echo
+            echo '```text'
+            cat coverage.txt
+            echo '```'
+            echo
+            echo "## Test step outcomes"
+            echo
+            echo "| Step | Outcome |"
+            echo "| --- | --- |"
+            echo "| Core tests | ${{ steps.core_tests.outcome }} |"
+            echo "| Conic solver tests | ${{ steps.conic_tests.outcome }} |"
+            echo "| QP solver tests | ${{ steps.qp_tests.outcome }} |"
+            echo "| NLP tests | ${{ steps.nlp_tests.outcome }} |"
+            echo "| KNITRO conic solver tests | ${{ steps.knitro_conic_tests.outcome }} |"
+            echo "| KNITRO NLP tests | ${{ steps.knitro_nlp_tests.outcome }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-reports
+          path: |
+            coverage.txt
+            coverage.xml
+            coverage.json
+            coverage.lcov
+            htmlcov
+
+      - name: Fail if any test step failed
+        if: >-
+          ${{
+            steps.core_tests.outcome != 'success' ||
+            steps.conic_tests.outcome != 'success' ||
+            steps.qp_tests.outcome != 'success' ||
+            steps.nlp_tests.outcome != 'success' ||
+            steps.knitro_conic_tests.outcome != 'success' ||
+            steps.knitro_nlp_tests.outcome != 'success'
+          }}
+        run: exit 1


### PR DESCRIPTION
## Description
Adds a manually triggered coverage workflow for on-demand inspection of Python line coverage across the main test suite, optional solver tests, and NLP solver tests. The workflow installs broad optional dependencies, configures solver licenses from available secrets, optionally verifies COPT and MOSEK availability, and uploads text, XML, JSON, LCOV, and HTML coverage reports with test contexts.

Issue link (if applicable): N/A

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.