### PR TITLE
Require highspy >= 1.14.0 and tighten HIGHS QP test

### DIFF
--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -878,13 +878,17 @@ class TestQp(QPTestBase):
         StandardTestInfeasibleProblems.test_lp_eq_constraints(solver=cp.HIGHS)
 
     def test_highs_dense_quad_form(self) -> None:
-        """Regression test for https://github.com/cvxpy/cvxpy/issues/3301.
+        """Regression test for https://github.com/cvxpy/cvxpy/issues/3301
+        and a related silent wrong-answer bug on highspy < 1.14.0.
 
         A dense quad_form applied to a linear expression (not a raw Variable)
         produces a Hessian whose upper and lower triangles may differ by
-        floating-point epsilon after canonicalization. Passing such a Hessian
-        in square format to HiGHS >= 1.14.0 triggers an asymmetry error
-        and native heap corruption. Using triangular format avoids this.
+        floating-point epsilon after canonicalization. We pass it to HiGHS
+        in triangular format. HiGHS < 1.14.0 only honors the lower triangle
+        in that format and silently returns wrong solutions when given the
+        upper triangle, hence the `highspy >= 1.14.0` minimum in
+        pyproject.toml. Cross-check the objective against CLARABEL because
+        status alone (`kOptimal`) does not detect a wrong-QP solve.
         """
         if cp.HIGHS not in INSTALLED_SOLVERS:
             return
@@ -919,6 +923,11 @@ class TestQp(QPTestBase):
         )
         prob.solve(solver=cp.HIGHS)
         self.assertEqual(prob.status, cp.OPTIMAL)
+        highs_value = prob.value
+
+        prob.solve(solver=cp.CLARABEL)
+        self.assertEqual(prob.status, cp.OPTIMAL)
+        self.assertAlmostEqual(highs_value, prob.value, places=4)
 
 
 class TestConicQuadObj(QPTestBase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,10 @@ dependencies = [
     "scs >= 3.2.4.post1",
     "numpy >= 2.0.0",
     "scipy >= 1.13.0",
-    "highspy >= 1.11.0",
+    # HiGHS < 1.14.0 only honors the lower triangle in `kTriangular` Hessian
+    # format and silently returns wrong solutions when given the upper
+    # triangle (which highs_qpif.py passes). See test_highs_dense_quad_form.
+    "highspy >= 1.14.0",
     "qdldl >= 0.1.7.post0",
     "sparsediffpy >= 0.3.0, < 0.4.0",
 ]


### PR DESCRIPTION
## Description

Bump minimum `highspy` to `1.14.0` and add a CLARABEL cross-check to `test_highs_dense_quad_form`. On `highspy < 1.14.0`, `kTriangular` Hessians only honor the lower triangle and `highs_qpif.py` (#3302) passes the upper triangle, so QPs with off-diagonal `P` silently return wrong solutions; HiGHS still reports `kOptimal`, so the existing test missed it.

Issue link (if applicable): conda-forge/cvxpy-feedstock#127, #3302.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.