### PR TITLE
Add commercial solver default setting

### DIFF
--- a/cvxpy/problems/problem_form.py
+++ b/cvxpy/problems/problem_form.py
@@ -336,8 +336,8 @@ _QP_CONES = frozenset([NonNeg, Zero])
 def pick_default_solver(problem_form: ProblemForm) -> Solver | None:
     """Pick the default solver for a problem based on its structure.
 
-    Checks premium solvers first (MOSEK, MOREAU, GUROBI), then falls back
-    to open-source defaults based on problem type.
+    Checks commercial solvers first when configured to do so, then falls
+    back to open-source defaults based on problem type.
 
     Parameters
     ----------
@@ -353,10 +353,11 @@ def pick_default_solver(problem_form: ProblemForm) -> Solver | None:
         inst = solver_map.get(name)
         return inst if inst is not None and inst.is_installed() else None
 
-    for solver_name in slv_def.COMMERCIAL_SOLVERS:
-        solver = _get(slv_def.SOLVER_MAP_CONIC, solver_name)
-        if solver is not None and solver.can_solve(problem_form):
-            return solver
+    if s.DEFAULT_TO_COMMERCIAL_SOLVERS:
+        for solver_name in slv_def.COMMERCIAL_SOLVERS:
+            solver = _get(slv_def.SOLVER_MAP_CONIC, solver_name)
+            if solver is not None and solver.can_solve(problem_form):
+                return solver
 
     # Mixed-integer: LP → HIGHS, non-LP → SCIP.
     if problem_form.is_mixed_integer():

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import logging
+import os
 import sys
 
 LOGGER = logging.getLogger("__cvxpy__")
@@ -109,6 +110,17 @@ SOLVERS = [CLARABEL, ECOS, CVXOPT, GLOP, GLPK, GLPK_MI,
            MOSEK, MOREAU, CBC, COPT, XPRESS, PIQP, PROXQP, QOCO, QPALM,
            NAG, PDLP, SCIP, SCIPY, DAQP, HIGHS, MPAX,
            CUCLARABEL, CUOPT, KNITRO, COSMO, PDCS, IPOPT, UNO]
+
+
+def _env_var_to_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+# Internal-only feature flag. This may be removed in a future version without warning.
+DEFAULT_TO_COMMERCIAL_SOLVERS = _env_var_to_bool(
+    "CVXPY_DEFAULT_TO_COMMERCIAL_SOLVERS", True)
 
 # Xpress-specific items
 XPRESS_IIS = "XPRESS_IIS"

--- a/cvxpy/tests/test_problem_form.py
+++ b/cvxpy/tests/test_problem_form.py
@@ -16,6 +16,7 @@ limitations under the License.
 from unittest.mock import patch
 
 import cvxpy as cp
+import cvxpy.settings as s
 from cvxpy.constraints import PSD, SOC, ExpCone, NonNeg, PowCone3D, Zero
 from cvxpy.error import SolverError
 from cvxpy.problems.problem_form import ProblemForm, pick_default_solver
@@ -167,8 +168,49 @@ class TestProblemForm(BaseTest):
 class TestPickDefaultSolver(BaseTest):
     """Tests for pick_default_solver()."""
 
+    class _FakeSolver:
+        def __init__(self, name: str) -> None:
+            self._name = name
+
+        def name(self) -> str:
+            return self._name
+
+        def is_installed(self) -> bool:
+            return True
+
+        def can_solve(self, problem_form) -> bool:
+            return True
+
     def _is_commercial(self, solver) -> bool:
         return solver is not None and solver.name() in slv_def.COMMERCIAL_SOLVERS
+
+    def test_default_to_commercial_solvers_setting(self) -> None:
+        x = cp.Variable(2)
+        prob = cp.Problem(cp.Minimize(cp.sum(x)), [x >= 1])
+        commercial = self._FakeSolver("FAKE_COMMERCIAL")
+        clarabel = self._FakeSolver(s.CLARABEL)
+        solver_map = {
+            commercial.name(): commercial,
+            clarabel.name(): clarabel,
+        }
+
+        with patch.object(s, "DEFAULT_TO_COMMERCIAL_SOLVERS", True), \
+                patch.object(slv_def, "COMMERCIAL_SOLVERS", [commercial.name()]), \
+                patch.object(slv_def, "SOLVER_MAP_CONIC", solver_map):
+            self.assertIs(pick_default_solver(ProblemForm(prob)), commercial)
+
+        with patch.object(s, "DEFAULT_TO_COMMERCIAL_SOLVERS", False), \
+                patch.object(slv_def, "COMMERCIAL_SOLVERS", [commercial.name()]), \
+                patch.object(slv_def, "SOLVER_MAP_CONIC", solver_map):
+            self.assertIs(pick_default_solver(ProblemForm(prob)), clarabel)
+
+    def test_default_to_commercial_solvers_env_var(self) -> None:
+        with patch.dict("os.environ", {"CVXPY_DEFAULT_TO_COMMERCIAL_SOLVERS": "0"}):
+            self.assertFalse(s._env_var_to_bool(
+                "CVXPY_DEFAULT_TO_COMMERCIAL_SOLVERS", True))
+        with patch.dict("os.environ", {"CVXPY_DEFAULT_TO_COMMERCIAL_SOLVERS": "1"}):
+            self.assertTrue(s._env_var_to_bool(
+                "CVXPY_DEFAULT_TO_COMMERCIAL_SOLVERS", False))
 
     def test_lp_gets_clarabel(self) -> None:
         x = cp.Variable(2)


### PR DESCRIPTION
## Description
Adds an internal env-backed setting to skip commercial solvers when choosing defaults. This is useful for local development when testing multiple solver interfaces.
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.