### PR TITLE
Fix XPRESS QP test gating to run under the Community license

### DIFF
--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -50,14 +50,21 @@ from cvxpy.tests.test_conic_solvers import is_knitro_available, is_mosek_availab
 # canonical, KNITRO-OpenMP-safe implementations live in one place.
 
 def is_xpress_available():
-    """Check if XPRESS is installed and a license is available."""
+    """Check if XPRESS is installed and a usable license can be acquired.
+
+    The Community license bundled with the ``xpress`` package is sufficient for
+    the small problems in this suite, so we only confirm that a problem object
+    can be created -- that is where XPRESS acquires its license. The previous
+    ``xpress.env().getlicense()`` API was removed in modern xpress, so the check
+    raised ``AttributeError`` and always returned False, silently skipping every
+    license-gated XPRESS QP test.
+    """
     if 'XPRESS' not in INSTALLED_SOLVERS:
         return False
     try:
         import xpress  # type: ignore
-        env = xpress.env()
-        status = env.getlicense()
-        return status == 0
+        xpress.problem()
+        return True
     except Exception:
         return False
 
@@ -116,7 +123,23 @@ def _solve(problem, solver, use_quad_obj):
             f"Problem should have no SOC cones for QP canonicalization with {solver}"
         )
     kwargs = {"use_quad_obj": True} if use_quad_obj else {}
-    return problem.solve(solver=solver, verbose=False, **kwargs)
+    try:
+        return problem.solve(solver=solver, verbose=False, **kwargs)
+    except Exception as exc:
+        _skip_if_xpress_community_limit(solver, exc)
+        raise
+
+
+def _skip_if_xpress_community_limit(solver, exc):
+    """Skip when a problem exceeds the XPRESS Community license size limit.
+
+    The Community license bundled with the ``xpress`` package caps problems at
+    200 rows+columns; larger problems raise a size-limit ``SolverError``. Skip
+    those rather than fail -- they run fully under a full XPRESS license, and
+    the smaller problems still exercise the QP interface.
+    """
+    if solver == cp.XPRESS and "too many rows and columns" in str(exc):
+        pytest.skip("XPRESS Community license problem-size limit (200 rows+cols)")
 
 
 def check_kkt(problem, places=4):


### PR DESCRIPTION
## Description
`is_xpress_available()` in `test_qp_solvers.py` gated every license-sensitive XPRESS QP test, but it checked the license via `xpress.env().getlicense()`. `xpress.env` was **removed in modern xpress (9.x)**, so the call raised `AttributeError`, which the bare `except Exception: return False` swallowed. The helper therefore *always* returned False, and pytest silently skipped every XPRESS-parametrized QP correctness test.

The practical consequence: the inequality-row and constraint-dual code paths in `xpress_qpif.py` were never exercised (the only XPRESS QP test that ran was the unconstrained-MIP warm-start test), leaving the interface at 74.5% coverage despite XPRESS being installed and licensed in CI.

This PR detects availability by creating a `problem()` object — that is where XPRESS acquires its license — which works under the Community license bundled with the `xpress` package, mirroring how the MOSEK/KNITRO helpers construct an env/context.

The Community license caps problems at 200 rows+columns. Five standard QP correctness tests exceed that limit, so `_solve()` now catches XPRESS's specific size-limit `SolverError` and skips those tests with a clear reason — a full XPRESS license still runs all of them.

Verified locally with `xpress==9.9.0` (Community license):
- XPRESS QP tests: 18 passed, 5 skipped (oversized), 0 failed
- Full `test_qp_solvers.py`: 244 passed, 20 skipped, 0 failed (no change for other solvers)
- `xpress_qpif.py` coverage: 74.5% → 87%, with the inequality-row and constraint-dual paths now covered

Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)