### PR TITLE
Return COPT dual Farkas infeasibility certificates (conic interface)

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -334,16 +334,17 @@ class COPT(ConicSolver):
                 model.loadExpCone(nexpcone, None,
                                   range(A.shape[1] - nexpconedim, A.shape[1]))
 
+        # Request a dual Farkas ray so an infeasibility certificate is available
+        # for infeasible problems (not the dualized PSD path, and not MIPs). Set
+        # it before the user-settings loop so an explicit value in solver_opts wins.
+        if not dims[s.PSD_DIM] and not (data[s.BOOL_IDX] or data[s.INT_IDX]):
+            model.setParam(copt.COPT.Param.ReqFarkasRay, 1)
+
         # Set parameters
         for key, value in solver_opts.items():
             # Ignore arguments unique to the CVXPY interface.
             if key not in self.INTERFACE_ARGS:
                 model.setParam(key, value)
-
-        # Request a dual Farkas ray so an infeasibility certificate is available
-        # for infeasible problems (not the dualized PSD path, and not MIPs).
-        if not dims[s.PSD_DIM] and not (data[s.BOOL_IDX] or data[s.INT_IDX]):
-            model.setParam(copt.COPT.Param.ReqFarkasRay, 1)
 
         if 'save_file' in solver_opts:
             model.write(solver_opts['save_file'])

--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -138,6 +138,29 @@ class COPT(ConicSolver):
 
         return data, inv_data
 
+    def _dual_vars(self, solution, inverse_data):
+        """Map the stacked ``[eq; ineq]`` dual vector to a CVXPY dual dict.
+
+        Shared by the optimal duals and the infeasibility (Farkas) certificate,
+        which use the same row layout.
+        """
+        eq_dual = utilities.get_dual_values(
+            solution[s.EQ_DUAL],
+            utilities.extract_dual_value,
+            inverse_data[COPT.EQ_CONSTR])
+        leq_dual = utilities.get_dual_values(
+            solution[s.INEQ_DUAL],
+            utilities.extract_dual_value,
+            inverse_data[COPT.NEQ_CONSTR])
+        for con in inverse_data[self.NEQ_CONSTR]:
+            if isinstance(con, ExpCone):
+                cid = con.id
+                n_cones = con.num_cones()
+                perm = utilities.expcone_permutor(n_cones, COPT.EXP_CONE_ORDER)
+                leq_dual[cid] = leq_dual[cid][perm]
+        eq_dual.update(leq_dual)
+        return eq_dual
+
     def invert(self, solution, inverse_data):
         """
         Returns the solution to the original problem given the inverse_data.
@@ -147,31 +170,18 @@ class COPT(ConicSolver):
                 s.NUM_ITERS: solution[s.NUM_ITERS],
                 s.EXTRA_STATS: solution['model']}
 
-        primal_vars = None
+        # EQ_DUAL/INEQ_DUAL hold the constraint duals when a solution is present
+        # and the dual Farkas infeasibility certificate otherwise.
         dual_vars = None
+        if s.EQ_DUAL in solution and not inverse_data['is_mip']:
+            dual_vars = self._dual_vars(solution, inverse_data)
+
         if status in s.SOLUTION_PRESENT:
             opt_val = solution[s.VALUE] + inverse_data[s.OFFSET]
             primal_vars = {inverse_data[COPT.VAR_ID]: solution[s.PRIMAL]}
-            if not inverse_data['is_mip']:
-                eq_dual = utilities.get_dual_values(
-                    solution[s.EQ_DUAL],
-                    utilities.extract_dual_value,
-                    inverse_data[COPT.EQ_CONSTR])
-                leq_dual = utilities.get_dual_values(
-                    solution[s.INEQ_DUAL],
-                    utilities.extract_dual_value,
-                    inverse_data[COPT.NEQ_CONSTR])
-                for con in inverse_data[self.NEQ_CONSTR]:
-                    if isinstance(con, ExpCone):
-                        cid = con.id
-                        n_cones = con.num_cones()
-                        perm = utilities.expcone_permutor(n_cones, COPT.EXP_CONE_ORDER)
-                        leq_dual[cid] = leq_dual[cid][perm]
-                eq_dual.update(leq_dual)
-                dual_vars = eq_dual
             return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            return failure_solution(status, attr)
+            return failure_solution(status, attr, dual_vars)
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
         """
@@ -330,6 +340,11 @@ class COPT(ConicSolver):
             if key not in self.INTERFACE_ARGS:
                 model.setParam(key, value)
 
+        # Request a dual Farkas ray so an infeasibility certificate is available
+        # for infeasible problems (not the dualized PSD path, and not MIPs).
+        if not dims[s.PSD_DIM] and not (data[s.BOOL_IDX] or data[s.INT_IDX]):
+            model.setParam(copt.COPT.Param.ReqFarkasRay, 1)
+
         if 'save_file' in solver_opts:
             model.write(solver_opts['save_file'])
 
@@ -390,6 +405,17 @@ class COPT(ConicSolver):
             solution[s.STATUS] = s.OPTIMAL_INACCURATE
         if solution[s.STATUS] == s.USER_LIMIT and not model.hasmipsol:
             solution[s.STATUS] = s.INFEASIBLE_INACCURATE
+
+        # On infeasibility, return the dual Farkas ray as the certificate,
+        # negated to match CVXPY's sign convention (as done for optimal duals).
+        # Split [eq; ineq] at EQ_DIM, mirroring the optimal-dual extraction.
+        if (not dims[s.PSD_DIM]
+                and solution[s.STATUS] in (s.INFEASIBLE, s.INFEASIBLE_INACCURATE)
+                and not (data[s.BOOL_IDX] or data[s.INT_IDX])
+                and model.hasdualfarkas):
+            y = -np.array(model.getInfo(copt.COPT.Info.DualFarkas, model.getConstrs()))
+            solution[s.EQ_DUAL] = y[0:dims[s.EQ_DIM]]
+            solution[s.INEQ_DUAL] = y[dims[s.EQ_DIM]:]
 
         solution['model'] = model
 

--- a/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
@@ -51,27 +51,6 @@ class COPT(QpSolver):
         """
         import coptpy  # noqa F401
 
-    def _dual_vars(self, y, inverse_data):
-        """Map a stacked ``[eq_constrs; ineq_constrs]`` dual vector to a CVXPY
-        dual dict keyed by constraint id.
-
-        Shared by the optimal duals and the infeasibility (Farkas) certificate,
-        which use the same row layout.
-        """
-        n_eq = inverse_data[self.DIMS].zero
-        eq_dual = utilities.get_dual_values(
-            y[:n_eq],
-            utilities.extract_dual_value,
-            inverse_data[self.EQ_CONSTR])
-        ineq_dual = utilities.get_dual_values(
-            y[n_eq:],
-            utilities.extract_dual_value,
-            inverse_data[self.NEQ_CONSTR])
-        dual_vars = {}
-        dual_vars.update(eq_dual)
-        dual_vars.update(ineq_dual)
-        return dual_vars
-
     def invert(self, solution, inverse_data):
         """
         Returns the solution to the original problem given the inverse_data.
@@ -81,18 +60,30 @@ class COPT(QpSolver):
                 s.NUM_ITERS: solution[s.NUM_ITERS],
                 s.EXTRA_STATS: solution['model']}
 
-        # 'y' holds the constraint duals when a solution is present and the
-        # dual Farkas infeasibility certificate otherwise (continuous only).
+        primal_vars = None
         dual_vars = None
-        if 'y' in solution and not inverse_data[COPT.IS_MIP]:
-            dual_vars = self._dual_vars(solution['y'], inverse_data)
-
         if status in s.SOLUTION_PRESENT:
             opt_val = solution[s.VALUE] + inverse_data[s.OFFSET]
             primal_vars = {inverse_data[COPT.VAR_ID]: solution[s.PRIMAL]}
+            if not inverse_data[COPT.IS_MIP]:
+                # Build dual vars dict keyed by constraint IDs
+                # COPT returns duals for [eq_constrs; ineq_constrs]
+                y = solution['y']
+                n_eq = inverse_data[self.DIMS].zero
+                eq_dual = utilities.get_dual_values(
+                    y[:n_eq],
+                    utilities.extract_dual_value,
+                    inverse_data[self.EQ_CONSTR])
+                ineq_dual = utilities.get_dual_values(
+                    y[n_eq:],
+                    utilities.extract_dual_value,
+                    inverse_data[self.NEQ_CONSTR])
+                dual_vars = {}
+                dual_vars.update(eq_dual)
+                dual_vars.update(ineq_dual)
             return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            return failure_solution(status, attr, dual_vars)
+            return failure_solution(status, attr)
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
         """
@@ -189,12 +180,6 @@ class COPT(QpSolver):
             P = sp.coo_matrix(P)
             model.loadQ(0.5*P)
 
-        # Request a dual Farkas ray so an infeasibility certificate is available
-        # for infeasible problems (continuous only; MIPs have none). Set it
-        # before the user-settings loop so an explicit value in solver_opts wins.
-        if vtype is None:
-            model.setParam(copt.COPT.Param.ReqFarkasRay, 1)
-
         # Set parameters
         for key, value in solver_opts.items():
             # Ignore arguments unique to the CVXPY interface.
@@ -236,13 +221,6 @@ class COPT(QpSolver):
             solution[s.STATUS] = s.OPTIMAL_INACCURATE
         if solution[s.STATUS] == s.USER_LIMIT and not model.hasmipsol:
             solution[s.STATUS] = s.INFEASIBLE_INACCURATE
-
-        # On infeasibility, return the dual Farkas ray as the certificate,
-        # negated to match CVXPY's sign convention (as done for optimal duals).
-        if (solution[s.STATUS] in (s.INFEASIBLE, s.INFEASIBLE_INACCURATE)
-                and vtype is None and model.hasdualfarkas):
-            solution['y'] = -np.array(
-                model.getInfo(copt.COPT.Info.DualFarkas, model.getConstrs()))
 
         solution['model'] = model
         if solver_cache is not None:

--- a/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
@@ -51,6 +51,27 @@ class COPT(QpSolver):
         """
         import coptpy  # noqa F401
 
+    def _dual_vars(self, y, inverse_data):
+        """Map a stacked ``[eq_constrs; ineq_constrs]`` dual vector to a CVXPY
+        dual dict keyed by constraint id.
+
+        Shared by the optimal duals and the infeasibility (Farkas) certificate,
+        which use the same row layout.
+        """
+        n_eq = inverse_data[self.DIMS].zero
+        eq_dual = utilities.get_dual_values(
+            y[:n_eq],
+            utilities.extract_dual_value,
+            inverse_data[self.EQ_CONSTR])
+        ineq_dual = utilities.get_dual_values(
+            y[n_eq:],
+            utilities.extract_dual_value,
+            inverse_data[self.NEQ_CONSTR])
+        dual_vars = {}
+        dual_vars.update(eq_dual)
+        dual_vars.update(ineq_dual)
+        return dual_vars
+
     def invert(self, solution, inverse_data):
         """
         Returns the solution to the original problem given the inverse_data.
@@ -60,30 +81,18 @@ class COPT(QpSolver):
                 s.NUM_ITERS: solution[s.NUM_ITERS],
                 s.EXTRA_STATS: solution['model']}
 
-        primal_vars = None
+        # 'y' holds the constraint duals when a solution is present and the
+        # dual Farkas infeasibility certificate otherwise (continuous only).
         dual_vars = None
+        if 'y' in solution and not inverse_data[COPT.IS_MIP]:
+            dual_vars = self._dual_vars(solution['y'], inverse_data)
+
         if status in s.SOLUTION_PRESENT:
             opt_val = solution[s.VALUE] + inverse_data[s.OFFSET]
             primal_vars = {inverse_data[COPT.VAR_ID]: solution[s.PRIMAL]}
-            if not inverse_data[COPT.IS_MIP]:
-                # Build dual vars dict keyed by constraint IDs
-                # COPT returns duals for [eq_constrs; ineq_constrs]
-                y = solution['y']
-                n_eq = inverse_data[self.DIMS].zero
-                eq_dual = utilities.get_dual_values(
-                    y[:n_eq],
-                    utilities.extract_dual_value,
-                    inverse_data[self.EQ_CONSTR])
-                ineq_dual = utilities.get_dual_values(
-                    y[n_eq:],
-                    utilities.extract_dual_value,
-                    inverse_data[self.NEQ_CONSTR])
-                dual_vars = {}
-                dual_vars.update(eq_dual)
-                dual_vars.update(ineq_dual)
             return Solution(status, opt_val, primal_vars, dual_vars, attr)
         else:
-            return failure_solution(status, attr)
+            return failure_solution(status, attr, dual_vars)
 
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
         """
@@ -186,6 +195,11 @@ class COPT(QpSolver):
             if key not in self.INTERFACE_ARGS:
                 model.setParam(key, value)
 
+        # Request a dual Farkas ray so an infeasibility certificate is
+        # available for infeasible problems (continuous only; MIPs have none).
+        if vtype is None:
+            model.setParam(copt.COPT.Param.ReqFarkasRay, 1)
+
         if warm_start and solver_cache is not None and self.name() in solver_cache:
             old_model, _, old_solution = solver_cache[self.name()]
             if old_solution[s.STATUS] in s.SOLUTION_PRESENT:
@@ -221,6 +235,13 @@ class COPT(QpSolver):
             solution[s.STATUS] = s.OPTIMAL_INACCURATE
         if solution[s.STATUS] == s.USER_LIMIT and not model.hasmipsol:
             solution[s.STATUS] = s.INFEASIBLE_INACCURATE
+
+        # On infeasibility, return the dual Farkas ray as the certificate,
+        # negated to match CVXPY's sign convention (as done for optimal duals).
+        if (solution[s.STATUS] in (s.INFEASIBLE, s.INFEASIBLE_INACCURATE)
+                and vtype is None and model.hasdualfarkas):
+            solution['y'] = -np.array(
+                model.getInfo(copt.COPT.Info.DualFarkas, model.getConstrs()))
 
         solution['model'] = model
         if solver_cache is not None:

--- a/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
@@ -189,16 +189,17 @@ class COPT(QpSolver):
             P = sp.coo_matrix(P)
             model.loadQ(0.5*P)
 
+        # Request a dual Farkas ray so an infeasibility certificate is available
+        # for infeasible problems (continuous only; MIPs have none). Set it
+        # before the user-settings loop so an explicit value in solver_opts wins.
+        if vtype is None:
+            model.setParam(copt.COPT.Param.ReqFarkasRay, 1)
+
         # Set parameters
         for key, value in solver_opts.items():
             # Ignore arguments unique to the CVXPY interface.
             if key not in self.INTERFACE_ARGS:
                 model.setParam(key, value)
-
-        # Request a dual Farkas ray so an infeasibility certificate is
-        # available for infeasible problems (continuous only; MIPs have none).
-        if vtype is None:
-            model.setParam(copt.COPT.Param.ReqFarkasRay, 1)
 
         if warm_start and solver_cache is not None and self.name() in solver_cache:
             old_model, _, old_solution = solver_cache[self.name()]

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -3087,6 +3087,13 @@ class TestCOPT(unittest.TestCase):
         prob.solve(solver='COPT')
         self.assertAlmostEqual(t.value, 2.0, places=3)
 
+    def test_copt_infeasible_lp_ineq(self) -> None:
+        # Verifies COPT returns a valid dual Farkas infeasibility certificate.
+        StandardTestInfeasibleProblems.test_lp_ineq_constraints(solver='COPT')
+
+    def test_copt_infeasible_lp_eq(self) -> None:
+        StandardTestInfeasibleProblems.test_lp_eq_constraints(solver='COPT')
+
 
 @unittest.skipUnless('COSMO' in INSTALLED_SOLVERS, 'COSMO is not installed.')
 class TestCOSMO(BaseTest):


### PR DESCRIPTION
## Description
COPT silently discarded its dual Farkas ray on infeasible problems, so COPT returned `dual_value = None` on infeasible problems while OSQP/HIGHS/CLARABEL return an infeasibility certificate. Neither COPT interface requested the ray (`ReqFarkasRay`) nor read it (`Info.DualFarkas`); `invert()` called `failure_solution(status, attr)` with no duals.

This PR fixes both COPT interfaces to request the ray, read it on infeasibility, negate it for CVXPY's sign convention, split it `[eq; ineq]` like the optimal duals, and pass it through `failure_solution` — mirroring OSQP. Each interface now shares a `_dual_vars()` helper between the optimal-dual and Farkas paths. The dualized PSD path and MIPs are excluded (no dual ray).

### Conic interface (`copt_conif.py`) — verified ✅
Handles infeasible **LPs**, which COPT detects correctly. COPT now passes the full `StandardTestInfeasibleProblems` LP tests (status, value, *and* a valid Farkas certificate `y >= 0, A^T y = 0, b^T y < 0`). Added `test_copt_infeasible_lp_{ineq,eq}`. No regression — 28 COPT conic tests pass.

### QP interface (`copt_qpif.py`) — latent, pending COPT ⚠️
The same fix is applied, but it can't be exercised yet: for infeasible **QPs**, COPT (`loadMatrix` + `loadQ` build path) fails to detect infeasibility and returns a constraint-violating `optimal` instead of `infeasible`, so the new branch is never reached. Reproduced in raw `coptpy` (no CVXPY): with `loadMatrix` then `loadQ`, an infeasible QP solves to a spurious `optimal`; loading `Q` first detects infeasibility but `loadMatrix` then resets the quadratic term — so it's not reorderable on our side. Being reported to Cardinal. The extraction code is in place and activates once COPT detects QP infeasibility. Feasible COPT QP solves are unaffected (23 COPT QP tests pass).

Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.