### PR TITLE
Fix #3333: Support parsing SCS solver options

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
@@ -193,6 +193,8 @@ class SCS(ConicSolver):
 
     @staticmethod
     def parse_solver_options(solver_opts):
+        scs_params = solver_opts.pop("scs_params", {})
+        solver_opts.update(scs_params)
         import scs
         if Version(scs.__version__) < Version('3.0.0'):
             if "eps_abs" in solver_opts or "eps_rel" in solver_opts:

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -175,6 +175,15 @@ class TestSCS(BaseTest):
         self.assertAlmostEqual(prob.value, 1.0, places=2)
         self.assertItemsAlmostEqual(x.value, [0, 0], places=2)
 
+    def test_scs_custom_params(self):
+        """
+        Test that custom scs_params are successfully passed to the SCS solver.
+        """
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(x), [x >= 1])
+        prob.solve(solver=cp.SCS, scs_params={"max_iters": 1})
+        self.assertLessEqual(prob.solver_stats.num_iters, 1)
+
     def test_log_problem(self) -> None:
         # Log in objective.
         obj = cp.Maximize(cp.sum(cp.log(self.x)))
@@ -604,8 +613,6 @@ class TestClarabel(BaseTest):
 
     def test_infeasible_soc_exp_mixed(self):
         StandardTestInfeasibleProblems.test_soc_exp_mixed(solver="CLARABEL")
-
-
 
 @unittest.skipUnless('CUCLARABEL' in INSTALLED_SOLVERS, 'CLARABEL is not installed.')
 class TestCuClarabel(BaseTest):


### PR DESCRIPTION
## Description

This updates `SCS.parse_solver_options` to pull `scs_params` out of `solver_opts` with `.pop()` and merge those options into the arguments passed to SCS. This makes `scs_params` behave like other solver-specific option dictionaries such as `mosek_params`.

I also added `test_scs_custom_params` to check that a custom SCS option, such as `max_iters`, is passed through and affects the solve.

Issue link: #3333

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.