### PR TITLE
Fix Contributing Guide Link

### DIFF
--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -44,6 +44,7 @@ We'll be happy to provide guidance and advice.
 Small scope projects
  - `State required cone types for atoms <https://github.com/cvxpy/cvxpy/issues/574>`_.
  - Add QDLDL as another option for sparse Cholesky.
+ - Add DNLP examples from the `examples repository <https://github.com/cvxpy/examples>`_ to the `examples library <https://www.cvxpy.org/examples/index.html>`_.
  - Have MOSEK interface choose between solving the primal and the dual [`2107 <https://github.com/cvxpy/cvxpy/issues/2107>`_, `1403 <https://github.com/cvxpy/cvxpy/issues/1403>`_].
  - `Add cp.RSOC (Rotated Second-Order Cone) <https://github.com/cvxpy/cvxpy/issues/2874>`_.
  - `Huber function with concomitant scale estimation <https://github.com/cvxpy/cvxpy/issues/1377>`_.

--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -16,7 +16,7 @@ optimization to help out. Here are simple ways to start contributing immediately
 
 * Browse the `issue tracker <https://github.com/cvxpy/cvxpy/issues>`_, and work on unassigned bugs or feature requests
 
-* Polish the `example library <https://github.com/cvxpy/cvxpy/tree/master/examples>`_
+* Polish the `example library <https://www.cvxpy.org/examples/index.html>`_
 
 If you'd like to add a new example to our library, or implement a new feature,
 please get in touch with us first by opening a GitHub issue to make sure that your

--- a/doc/source/examples/index.rst
+++ b/doc/source/examples/index.rst
@@ -24,6 +24,7 @@ Most of these examples are implemented as `Jupyter notebooks
 <https://github.com/jupyter/notebook>`_, while some are implemented as
 interactive `marimo notebooks <https://github.com/marimo-team/marimo>`_.
 
+Additional examples are in the `examples repository <https://github.com/cvxpy/examples>`_.
 
 .. _basic:
 


### PR DESCRIPTION
## Description
Please include a short summary of the change.
Issue link (if applicable): N/A

In [this](https://www.cvxpy.org/contributing/) page, the link under "Polish the [example library]" leads to a 404 error.

There are already two existing link references to an "example library", but they are different. `CONTRIBUTING.md` uses [this](https://www.cvxpy.org/examples/index.html), which is the current PR fix, but `README.md` points to [this](https://github.com/cvxpy/examples), which `CONTRIBUTING.md` refers to as the "examples repository", so there is a slight discrepancy.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.