### PR TITLE
Draft: Post-solver feasibility design note

### DIFF
--- a/scratch/benchmark_feasibility_check.py
+++ b/scratch/benchmark_feasibility_check.py
@@ -1,0 +1,70 @@
+import time
+
+import numpy as np
+
+import cvxpy as cp
+
+
+def max_constraint_violation(prob):
+    """Compute max violation over all original constraints."""
+    max_violation = 0.0
+
+    for constraint in prob.constraints:
+        violation = constraint.violation()
+        max_violation = max(
+            max_violation,
+            float(np.max(np.asarray(violation))),
+        )
+
+    return max_violation
+
+
+def benchmark_vectorized(n):
+    """One constraint object: x >= 0."""
+    x = cp.Variable(n)
+    prob = cp.Problem(cp.Minimize(cp.sum_squares(x)), [x >= 0])
+
+    prob.solve(solver=cp.CLARABEL)
+
+    start = time.perf_counter()
+    violation = max_constraint_violation(prob)
+    elapsed = time.perf_counter() - start
+
+    return elapsed, violation, len(prob.constraints)
+
+
+def benchmark_many_scalar(n):
+    """Many constraint objects: x[i] >= 0 for each i."""
+    x = cp.Variable(n)
+    constraints = [x[i] >= 0 for i in range(n)]
+    prob = cp.Problem(cp.Minimize(cp.sum_squares(x)), constraints)
+
+    prob.solve(solver=cp.CLARABEL)
+
+    start = time.perf_counter()
+    violation = max_constraint_violation(prob)
+    elapsed = time.perf_counter() - start
+
+    return elapsed, violation, len(prob.constraints)
+
+
+if __name__ == "__main__":
+    sizes = [100, 1_000]
+
+    for n in sizes:
+        print(f"\n=== n = {n} ===")
+
+        vec_time, vec_viol, vec_num_constraints = benchmark_vectorized(n)
+        print("Vectorized:")
+        print(f"  constraints: {vec_num_constraints}")
+        print(f"  check time:  {vec_time:.6f} seconds")
+        print(f"  violation:   {vec_viol:.2e}")
+
+        scalar_time, scalar_viol, scalar_num_constraints = benchmark_many_scalar(n)
+        print("Many scalar:")
+        print(f"  constraints: {scalar_num_constraints}")
+        print(f"  check time:  {scalar_time:.6f} seconds")
+        print(f"  violation:   {scalar_viol:.2e}")
+
+        print("Ratio:")
+        print(f"  scalar/vectorized time: {scalar_time / vec_time:.1f}x")

--- a/scratch/post_solver_feasibility_design.md
+++ b/scratch/post_solver_feasibility_design.md
@@ -175,7 +175,7 @@ The absolute times are small in this toy benchmark, but the scaling difference s
 
 A first PR could stay small:
 
-* Internal helper to normalize each constraint violation to a scalar and compute the max original-constraint violation.
+* Internal helper to normalize each primal constraint violation to a scalar and compute the max original-constraint violation.
 * Tests for a solved feasible problem.
 * Tests for manually corrupted variable values.
 * Tests covering scalar normalization behavior across core constraint classes.
@@ -192,3 +192,15 @@ Possible follow-up work could add warning behavior through a solve flag:
 ```python
 prob.solve(check_feasibility=True, feasibility_tol=...)
 ```
+
+## Future scope
+
+The first version of this design focuses on primal constraint violation only.
+
+However, the API should be documented carefully because the meaning of `prob.violation()` may expand in the future if related checks can be defined consistently. Possible follow-up directions include:
+
+* **Dual feasibility:** checking whether unpacked constraint dual values satisfy the expected dual-domain conditions.
+* **Complementarity:** checking primal-dual complementarity where it can be evaluated cleanly for a constraint type.
+* **Duality gap / stationarity:** investigating whether these can be computed reliably in the original problem space.
+
+These are left out of the first version because they require more care than a primal-side violation check, especially for reductions, functional convex problems, subgradients, and solver-specific dual information.

--- a/scratch/post_solver_feasibility_design.md
+++ b/scratch/post_solver_feasibility_design.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Explore a small post-solver feasibility-check layer for CVXPY. The first API direction considered here is a raw scalar primal-side constraint violation value, which could later support tolerance-based warnings or feasibility reporting.
+Explore a small post-solver validation layer for CVXPY. The first API direction considered here is a raw scalar violation value computed from checks on the original problem after solution values are unpacked. The first pass should cover primal constraint violation, and audit whether dual feasibility and complementarity can be included cleanly.
 
 ## Main design question
 
@@ -82,18 +82,18 @@ Reason:
 * Lowest risk.
 * No default overhead.
 * No new default warnings.
-* Avoids mixing raw violation reporting with tolerance-based feasibility decisions.
+* Separates raw post-solver validation values from tolerance-based feasibility decisions.
 * Easier to extend later into warning behavior or a solve flag.
 
 ## Minimal first API
 
-For the first public API, prefer exposing only a scalar violation value rather than a full feasibility report:
+For the first public API, prefer exposing a scalar violation value rather than a full feasibility report:
 
 ```python
 violation = prob.violation()
 ```
 
-This should be interpreted as a CVXPY-side primal constraint violation check on the original constraints after solution values are unpacked. It should not be framed as an infeasibility certificate.
+This should be interpreted as a CVXPY-side post-solver validation value computed from the original problem after solution values are unpacked. The initial implementation should define exactly which checks are included. It should not be framed as an infeasibility certificate.
 
 Tolerance-based behavior, warnings, or an `is_feasible` boolean can be considered later once the raw violation definition is clear.
 
@@ -109,7 +109,7 @@ all original problem constraints after solution values are unpacked.
 
 Initial audit: `Constraint.violation()` is documented as the distance from the current expression value to the constraint domain. Before building a problem-level API, the main open question is whether each individual constraint violation should first be normalized to a scalar with a clearly documented norm/distance convention. Once each constraint reports a scalar consistently, `prob.violation()` can aggregate those scalar values directly.
 
-This API should only report primal-side violation of returned values against the original constraints. It should not be presented as an infeasibility certificate or as a substitute for solver certificates such as a Farkas ray.
+This API should report post-solver validation against the original problem data. It should not be presented as an infeasibility certificate or as a substitute for solver certificates such as a Farkas ray.
 
 Constraint types to check:
 
@@ -176,12 +176,14 @@ The absolute times are small in this toy benchmark, but the scaling difference s
 A first PR could stay small:
 
 * Internal helper to normalize each primal constraint violation to a scalar and compute the max original-constraint violation.
+* Audit whether dual feasibility can be checked from unpacked `constraint.dual_value` values.
+* Audit whether complementarity can be evaluated cleanly for the main constraint classes.
 * Tests for a solved feasible problem.
 * Tests for manually corrupted variable values.
 * Tests covering scalar normalization behavior across core constraint classes.
 * No public API until the violation definition and API direction are agreed on.
 
-Once the violation definition and API direction are agreed on, expose:
+Once the violation definition and API direction are agreed on, expose something like:
 
 ```python
 prob.violation()
@@ -193,14 +195,16 @@ Possible follow-up work could add warning behavior through a solve flag:
 prob.solve(check_feasibility=True, feasibility_tol=...)
 ```
 
-## Future scope
+## First-pass scope
 
-The first version of this design focuses on primal constraint violation only.
+Based on the design discussion, the first pass should audit and, where clean, include the checks that can be evaluated directly from unpacked primal and dual values in the original problem space:
 
-However, the API should be documented carefully because the meaning of `prob.violation()` may expand in the future if related checks can be defined consistently. Possible follow-up directions include:
+* **Primal constraint violation:** Evaluate the original high-level `Constraint` objects using the unpacked primal values.
+* **Dual feasibility:** Check whether the unpacked `constraint.dual_value` satisfies the expected dual-domain conditions for each constraint type.
+* **Complementarity:** Check primal-dual complementarity where it can be evaluated cleanly for a given constraint type.
 
-* **Dual feasibility:** checking whether unpacked constraint dual values satisfy the expected dual-domain conditions.
-* **Complementarity:** checking primal-dual complementarity where it can be evaluated cleanly for a constraint type.
-* **Duality gap / stationarity:** investigating whether these can be computed reliably in the original problem space.
+The next step is to audit the main constraint classes, including equality, inequality, PSD, SOC, exponential cone, power cone, and quantum/quadrature constraints, to see which of these checks can consistently return scalar values.
 
-These are left out of the first version because they require more care than a primal-side violation check, especially for reductions, functional convex problems, subgradients, and solver-specific dual information.
+## Deferred scope: duality gap and stationarity
+
+Duality gap and stationarity should stay out of the first pass. They require more care in the original problem space, especially for reductions, functional convex problems, subgradients, and solver-specific dual information.

--- a/scratch/post_solver_feasibility_design.md
+++ b/scratch/post_solver_feasibility_design.md
@@ -120,7 +120,7 @@ Constraint types to check:
 - Exponential/power constraints.
 - How vector-valued residuals and scalar norm violations should be aggregated into one report value.
 
-## Benchmark plan
+## Benchmark plan and initial result
 
 Benchmark feasibility-check overhead in two cases.
 
@@ -149,6 +149,24 @@ Measure:
 - Feasibility check time.
 - Scaling with `n`.
 - Whether eager checking would be too expensive for poorly vectorized problems.
+
+### Initial local result
+
+A small local benchmark showed the many-scalar-constraint case is much slower than the vectorized case.
+
+For `n = 100`:
+
+- Vectorized constraint check time: `0.000033s`
+- Many scalar constraints check time: `0.000574s`
+- Scalar/vectorized ratio: `17.5x`
+
+For `n = 1000`:
+
+- Vectorized constraint check time: `0.000027s`
+- Many scalar constraints check time: `0.005542s`
+- Scalar/vectorized ratio: `203.7x`
+
+The absolute times are small in this toy benchmark, but the scaling difference supports making the first public API lazy or explicitly opt-in rather than eager by default.
 
 ## Proposed first PR
 

--- a/scratch/post_solver_feasibility_design.md
+++ b/scratch/post_solver_feasibility_design.md
@@ -2,37 +2,35 @@
 
 ## Goal
 
-Explore a small feasibility-check layer for CVXPY that reports whether the original problem constraints are satisfied after solution values are unpacked.
-
-The current local spike uses the existing `constraint.violation()` path after `Problem.unpack()` and computes the maximum violation over the original constraints.
+Explore a small post-solver feasibility-check layer for CVXPY. The first API direction considered here is a raw scalar primal-side constraint violation value, which could later support tolerance-based warnings or feasibility reporting.
 
 ## Main design question
 
 The main question is the API surface:
 
-- Should users call an explicit method after solve?
-- Should users enable it through a solve flag?
-- Should the report be stored somewhere after solve?
-- Should the check be lazy or eager?
+* Should users call an explicit method after solve?
+* Should users enable it through a solve flag?
+* Should the violation value be stored somewhere after solve?
+* Should the check be lazy or eager?
 
 ## Option A: explicit lazy method
 
 ```python
 prob.solve()
-report = prob.feasibility_report(tol=1e-6)
+violation = prob.violation()
 ```
 
 Pros:
 
-- No overhead unless requested.
-- Clear user intent.
-- Avoids changing default `solve()` behavior.
-- Avoids warning users unless they explicitly ask.
+* No overhead unless requested.
+* Clear user intent.
+* Avoids changing default `solve()` behavior.
+* Keeps the first API focused on reporting a raw violation value.
 
 Cons:
 
-- Users need to know the method exists.
-- Report may become stale if variable values are manually changed after solve.
+* Users need to know the method exists.
+* The value may become stale if variable values are manually changed after solve.
 
 ## Option B: optional solve flag
 
@@ -42,83 +40,88 @@ prob.solve(check_feasibility=True, feasibility_tol=1e-6)
 
 Pros:
 
-- Convenient.
-- Runs immediately after values are unpacked.
-- Could warn when violation exceeds tolerance.
+* Convenient.
+* Runs immediately after values are unpacked.
+* Could warn when violation exceeds tolerance.
 
 Cons:
 
-- Adds solve-time overhead.
-- Needs careful behavior for inaccurate/infeasible statuses.
-- Warning behavior needs design.
+* Adds solve-time overhead.
+* Needs careful behavior for inaccurate/infeasible statuses.
+* Warning behavior needs design.
 
-## Option C: stored report
+## Option C: stored violation value
 
 ```python
 prob.solve()
-prob.feasibility_report
+prob.violation_value  # stored value, name TBD
 ```
 
 Pros:
 
-- Easy to inspect after solve.
-- Keeps the report attached to the problem.
+* Easy to inspect after solve.
+* Keeps the value attached to the problem.
 
 Cons:
 
-- If eager, it adds overhead to every solve.
-- If lazy, it needs cache/staleness rules.
-- Could be confused with `solver_stats`, even though this is CVXPY-side validation rather than solver-returned metadata.
+* If eager, it adds overhead to every solve.
+* If lazy, it needs cache/staleness rules.
+* Could be confused with `solver_stats`, even though this is CVXPY-side validation rather than solver-returned metadata.
 
 ## Current preference
 
-Start with a lazy explicit method:
+Start with a lazy explicit method returning a raw scalar violation value:
 
 ```python
 prob.solve()
-report = prob.feasibility_report(tol=1e-6)
+violation = prob.violation()
 ```
 
 Reason:
 
-- Lowest risk.
-- No default overhead.
-- No new default warnings.
-- Easier to benchmark.
-- Easier to extend later into a solve flag.
+* Lowest risk.
+* No default overhead.
+* No new default warnings.
+* Avoids mixing raw violation reporting with tolerance-based feasibility decisions.
+* Easier to extend later into warning behavior or a solve flag.
 
-## Minimal report
+## Minimal first API
+
+For the first public API, prefer exposing only a scalar violation value rather than a full feasibility report:
 
 ```python
-@dataclass
-class FeasibilityReport:
-    is_feasible: bool
-    max_violation: float
+violation = prob.violation()
 ```
 
-For the first version, I would avoid adding solver metadata because `SolverStats` already covers solver-returned information. This report should focus only on CVXPY-side validation of the original constraints.
+This should be interpreted as a CVXPY-side primal constraint violation check on the original constraints after solution values are unpacked. It should not be framed as an infeasibility certificate.
+
+Tolerance-based behavior, warnings, or an `is_feasible` boolean can be considered later once the raw violation definition is clear.
 
 ## Definition of violation
 
-Initial definition:
+Working definition:
 
 ```text
-max_violation is the maximum value returned by constraint.violation()
-across all original problem constraints after solution values are unpacked.
+Assuming each constraint violation is first normalized to a scalar,
+prob.violation() would return the maximum scalar violation across
+all original problem constraints after solution values are unpacked.
 ```
 
-Initial audit: `Constraint.violation()` is documented as the distance from the current expression value to the constraint domain. Existing tests cover violation behavior for equality, PSD, power cone, boolean/inequality-style, and linear cone cases. One open question is aggregation: some constraints return vector residuals, while others return scalar norms, so the feasibility report needs a clear rule for reducing all constraint violations to one `max_violation` value.
+Initial audit: `Constraint.violation()` is documented as the distance from the current expression value to the constraint domain. Before building a problem-level API, the main open question is whether each individual constraint violation should first be normalized to a scalar with a clearly documented norm/distance convention. Once each constraint reports a scalar consistently, `prob.violation()` can aggregate those scalar values directly.
 
-Before proposing a public API, the next step is to check the existing coverage report and tests for `constraint.violation()` across the main constraint classes, especially equality, inequality, PSD, SOC, exponential, and power constraints.
+This API should only report primal-side violation of returned values against the original constraints. It should not be presented as an infeasibility certificate or as a substitute for solver certificates such as a Farkas ray.
 
 Constraint types to check:
 
-- Equality constraints.
-- Inequality constraints.
-- PSD constraints.
-- SOC constraints.
-- Exponential/power constraints.
-- How vector-valued residuals and scalar norm violations should be aggregated into one report value.
+* Equality constraints.
+* Inequality constraints.
+* PSD constraints.
+* SOC constraints.
+* Exponential cone constraints.
+* Power cone constraints.
+* Quantum constraints using quadrature approximation.
+* Whether each `constraint.violation()` implementation can return a scalar consistently.
+* What norm/distance convention each scalar violation uses.
 
 ## Benchmark plan and initial result
 
@@ -130,7 +133,7 @@ Benchmark feasibility-check overhead in two cases.
 x = cp.Variable(n)
 prob = cp.Problem(cp.Minimize(cp.sum_squares(x)), [x >= 0])
 prob.solve()
-report = prob.feasibility_report()
+violation = prob.violation()
 ```
 
 ### Case 2: poorly vectorized many-scalar-constraint problem
@@ -140,15 +143,15 @@ x = cp.Variable(n)
 constraints = [x[i] >= 0 for i in range(n)]
 prob = cp.Problem(cp.Minimize(cp.sum_squares(x)), constraints)
 prob.solve()
-report = prob.feasibility_report()
+violation = prob.violation()
 ```
 
 Measure:
 
-- Solve time.
-- Feasibility check time.
-- Scaling with `n`.
-- Whether eager checking would be too expensive for poorly vectorized problems.
+* Solve time.
+* Feasibility check time.
+* Scaling with `n`.
+* Whether eager checking would be too expensive for poorly vectorized problems.
 
 ### Initial local result
 
@@ -156,15 +159,15 @@ A small local benchmark showed the many-scalar-constraint case is much slower th
 
 For `n = 100`:
 
-- Vectorized constraint check time: `0.000033s`
-- Many scalar constraints check time: `0.000574s`
-- Scalar/vectorized ratio: `17.5x`
+* Vectorized constraint check time: `0.000033s`
+* Many scalar constraints check time: `0.000574s`
+* Scalar/vectorized ratio: `17.5x`
 
 For `n = 1000`:
 
-- Vectorized constraint check time: `0.000027s`
-- Many scalar constraints check time: `0.005542s`
-- Scalar/vectorized ratio: `203.7x`
+* Vectorized constraint check time: `0.000027s`
+* Many scalar constraints check time: `0.005542s`
+* Scalar/vectorized ratio: `203.7x`
 
 The absolute times are small in this toy benchmark, but the scaling difference supports making the first public API lazy or explicitly opt-in rather than eager by default.
 
@@ -172,19 +175,19 @@ The absolute times are small in this toy benchmark, but the scaling difference s
 
 A first PR could stay small:
 
-- Internal helper to compute max original-constraint violation.
-- Minimal `FeasibilityReport`.
-- Tests for a solved feasible problem.
-- Tests for manually corrupted variable values.
-- No public API until the design direction is agreed on.
+* Internal helper to normalize each constraint violation to a scalar and compute the max original-constraint violation.
+* Tests for a solved feasible problem.
+* Tests for manually corrupted variable values.
+* Tests covering scalar normalization behavior across core constraint classes.
+* No public API until the violation definition and API direction are agreed on.
 
-After that, expose either:
+Once the violation definition and API direction are agreed on, expose:
 
 ```python
-prob.feasibility_report(tol=...)
+prob.violation()
 ```
 
-or:
+Possible follow-up work could add warning behavior through a solve flag:
 
 ```python
 prob.solve(check_feasibility=True, feasibility_tol=...)

--- a/scratch/post_solver_feasibility_design.md
+++ b/scratch/post_solver_feasibility_design.md
@@ -1,0 +1,173 @@
+# Post-solver feasibility checks design note
+
+## Goal
+
+Explore a small feasibility-check layer for CVXPY that reports whether the original problem constraints are satisfied after solution values are unpacked.
+
+The current local spike uses the existing `constraint.violation()` path after `Problem.unpack()` and computes the maximum violation over the original constraints.
+
+## Main design question
+
+The main question is the API surface:
+
+- Should users call an explicit method after solve?
+- Should users enable it through a solve flag?
+- Should the report be stored somewhere after solve?
+- Should the check be lazy or eager?
+
+## Option A: explicit lazy method
+
+```python
+prob.solve()
+report = prob.feasibility_report(tol=1e-6)
+```
+
+Pros:
+
+- No overhead unless requested.
+- Clear user intent.
+- Avoids changing default `solve()` behavior.
+- Avoids warning users unless they explicitly ask.
+
+Cons:
+
+- Users need to know the method exists.
+- Report may become stale if variable values are manually changed after solve.
+
+## Option B: optional solve flag
+
+```python
+prob.solve(check_feasibility=True, feasibility_tol=1e-6)
+```
+
+Pros:
+
+- Convenient.
+- Runs immediately after values are unpacked.
+- Could warn when violation exceeds tolerance.
+
+Cons:
+
+- Adds solve-time overhead.
+- Needs careful behavior for inaccurate/infeasible statuses.
+- Warning behavior needs design.
+
+## Option C: stored report
+
+```python
+prob.solve()
+prob.feasibility_report
+```
+
+Pros:
+
+- Easy to inspect after solve.
+- Keeps the report attached to the problem.
+
+Cons:
+
+- If eager, it adds overhead to every solve.
+- If lazy, it needs cache/staleness rules.
+- Could be confused with `solver_stats`, even though this is CVXPY-side validation rather than solver-returned metadata.
+
+## Current preference
+
+Start with a lazy explicit method:
+
+```python
+prob.solve()
+report = prob.feasibility_report(tol=1e-6)
+```
+
+Reason:
+
+- Lowest risk.
+- No default overhead.
+- No new default warnings.
+- Easier to benchmark.
+- Easier to extend later into a solve flag.
+
+## Minimal report
+
+```python
+@dataclass
+class FeasibilityReport:
+    is_feasible: bool
+    max_violation: float
+```
+
+For the first version, I would avoid adding solver metadata because `SolverStats` already covers solver-returned information. This report should focus only on CVXPY-side validation of the original constraints.
+
+## Definition of violation
+
+Initial definition:
+
+```text
+max_violation is the maximum value returned by constraint.violation()
+across all original problem constraints after solution values are unpacked.
+```
+
+Initial audit: `Constraint.violation()` is documented as the distance from the current expression value to the constraint domain. Existing tests cover violation behavior for equality, PSD, power cone, boolean/inequality-style, and linear cone cases. One open question is aggregation: some constraints return vector residuals, while others return scalar norms, so the feasibility report needs a clear rule for reducing all constraint violations to one `max_violation` value.
+
+Before proposing a public API, the next step is to check the existing coverage report and tests for `constraint.violation()` across the main constraint classes, especially equality, inequality, PSD, SOC, exponential, and power constraints.
+
+Constraint types to check:
+
+- Equality constraints.
+- Inequality constraints.
+- PSD constraints.
+- SOC constraints.
+- Exponential/power constraints.
+- How vector-valued residuals and scalar norm violations should be aggregated into one report value.
+
+## Benchmark plan
+
+Benchmark feasibility-check overhead in two cases.
+
+### Case 1: vectorized constraint
+
+```python
+x = cp.Variable(n)
+prob = cp.Problem(cp.Minimize(cp.sum_squares(x)), [x >= 0])
+prob.solve()
+report = prob.feasibility_report()
+```
+
+### Case 2: poorly vectorized many-scalar-constraint problem
+
+```python
+x = cp.Variable(n)
+constraints = [x[i] >= 0 for i in range(n)]
+prob = cp.Problem(cp.Minimize(cp.sum_squares(x)), constraints)
+prob.solve()
+report = prob.feasibility_report()
+```
+
+Measure:
+
+- Solve time.
+- Feasibility check time.
+- Scaling with `n`.
+- Whether eager checking would be too expensive for poorly vectorized problems.
+
+## Proposed first PR
+
+A first PR could stay small:
+
+- Internal helper to compute max original-constraint violation.
+- Minimal `FeasibilityReport`.
+- Tests for a solved feasible problem.
+- Tests for manually corrupted variable values.
+- No public API until the design direction is agreed on.
+
+After that, expose either:
+
+```python
+prob.feasibility_report(tol=...)
+```
+
+or:
+
+```python
+prob.solve(check_feasibility=True, feasibility_tol=...)
+```


### PR DESCRIPTION
## Description

This is a draft design note for the post-solver feasibility check direction listed on the CVXPY GSoC project ideas page.

The full design note is in `scratch/post_solver_feasibility_design.md`.

It focuses on:

- possible API surfaces;
- lazy vs eager feasibility checking;
- how `constraint.violation()` values should be aggregated;
- a small local benchmark comparing one vectorized constraint against many scalar constraints.

This is not intended as a ready-to-merge implementation yet. I’m opening it as a draft to collect design feedback before turning the spike into a cleaner implementation PR.

## Type of change

- [x] Other (design discussion / spike)

AI assistance was used for brainstorming the design-note structure and reviewing wording.