### PR TITLE
Deduplicate Xpress column names to allow duplicate Variable.name()

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/xpress_conif.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from collections.abc import Iterable
+
 import numpy as np
 
 import cvxpy.settings as s
@@ -36,6 +38,41 @@ def makeMstart(A, n, ifCol: int = 1):
                              np.array([0] * (n - len(mstart)), dtype=np.int64)))
     mstart = np.cumsum(mstart)
     return mstart
+
+
+def make_unique_names(names: Iterable[str]) -> list[str]:
+    """Disambiguate duplicate Xpress column names with a "__dup<n>" suffix.
+
+    Avoids a "Duplicate column names are not allowed" error on Xpress >= 9.5
+    when any Variables share the same .name().
+
+    Only repeated entries are altered (the first occurrence of each name is kept
+    unchanged), and every generated suffix is checked against the names already
+    emitted, so a pre-existing "foo__dup1" cannot collide with the
+    disambiguated form of a duplicated "foo".
+    """
+    seen = set()
+    dup_counts = {}
+    unique_names = []
+    for name in names:
+        if name not in seen:
+            seen.add(name)
+            unique_names.append(name)
+            continue
+        count = dup_counts.get(name, 0)
+        while True:
+            # unlikely to iterate more than once
+            # for each outer name, unless the model
+            # variables themselves use the __dup<n>
+            # name pattern
+            count += 1
+            candidate = f"{name}__dup{count}"
+            if candidate not in seen:
+                break
+        dup_counts[name] = count
+        seen.add(candidate)
+        unique_names.append(candidate)
+    return unique_names
 
 
 class XPRESS(ConicSolver):
@@ -112,13 +149,13 @@ class XPRESS(ConicSolver):
         data["initial_mip_values"] = values[mipidxs] if mipidxs.size > 0 else []
         data["initial_mip_idxs"] = mipidxs
 
-        # Setup names
-        data["variable_names"] = np.concatenate([
-            np.ravel([
-                f"{var.name()}_x_{i:09d}" for i in range(var.size)
-            ], order="F")
-            for var in variables
-        ]).tolist()
+        # Setup names. Variable names are derived from user-supplied
+        # Variable.name() values, which need not be unique; de-duplicate so
+        # Xpress >= 9.5 does not reject the problem (?1030).
+        data["variable_names"] = make_unique_names(
+            f"{var.name()}_x_{i:09d}"
+            for var in variables for i in range(var.size)
+        )
         if problem.constraints:
             data["constraint_names"] = np.concatenate([
                 np.ravel([

--- a/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/xpress_qpif.py
@@ -7,6 +7,7 @@ from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.conic_solvers.xpress_conif import (
     get_status_map,
+    make_unique_names,
     makeMstart,
 )
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
@@ -60,13 +61,13 @@ class XPRESS(QpSolver):
         data["initial_mip_values"] = values[mipidxs] if mipidxs.size > 0 else []
         data["initial_mip_idxs"] = mipidxs
 
-        # Setup names
-        data["variable_names"] = np.concatenate([
-            np.ravel([
-                f"{var.name()}_x_{i:09d}" for i in range(var.size)
-            ], order="F")
-            for var in variables
-        ]).tolist()
+        # Setup names. Variable names are derived from user-supplied
+        # Variable.name() values, which need not be unique; de-duplicate so
+        # Xpress >= 9.5 does not reject the problem (?1030).
+        data["variable_names"] = make_unique_names(
+            f"{var.name()}_x_{i:09d}"
+            for var in variables for i in range(var.size)
+        )
         if problem.constraints:
             data["constraint_names"] = np.concatenate([
                 np.ravel([

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2163,6 +2163,47 @@ class TestGUROBI(BaseTest):
         StandardTestSOCPs.test_mi_socp_2(solver='GUROBI')
 
 
+def test_xpress_make_unique_names() -> None:
+    """Unit test for the Xpress column-name de-duplication helper.
+
+    Runs without an Xpress installation since it exercises pure-Python logic.
+    """
+    from cvxpy.reductions.solvers.conic_solvers.xpress_conif import (
+        make_unique_names,
+    )
+
+    # Duplicates (e.g. two variables sharing a name()) are disambiguated, while
+    # the first occurrence of each name is kept unchanged.
+    assert make_unique_names(["g_x_0", "g_x_1", "g_x_0", "g_x_1"]) == [
+        "g_x_0", "g_x_1", "g_x_0__dup1", "g_x_1__dup1",
+    ]
+
+    # A pre-existing ``__dupN`` name cannot collide with a generated suffix: the
+    # duplicated "foo" takes "foo__dup1", so the literal "foo__dup1" already in
+    # the input is itself bumped to "foo__dup1__dup1".
+    assert make_unique_names(["foo", "foo", "foo__dup1"]) == [
+        "foo", "foo__dup1", "foo__dup1__dup1",
+    ]
+
+    # Triple duplicates all become unique with an incrementing suffix.
+    assert make_unique_names(["v", "v", "v"]) == ["v", "v__dup1", "v__dup2"]
+
+    # Pre-existing ``__dup1``/``__dup2`` ahead of the duplicate force the inner
+    # suffix-search loop through multiple iterations: resolving the final "a"
+    # probes "a__dup1" (taken) and "a__dup2" (taken) before settling on
+    # "a__dup3". A second duplicate must resume from the cached counter rather
+    # than rescan from 1, landing on "a__dup4".
+    assert make_unique_names(["a", "a__dup1", "a__dup2", "a"]) == [
+        "a", "a__dup1", "a__dup2", "a__dup3",
+    ]
+    assert make_unique_names(["a", "a__dup1", "a__dup2", "a", "a"]) == [
+        "a", "a__dup1", "a__dup2", "a__dup3", "a__dup4",
+    ]
+
+    # Collision-free input is returned unchanged.
+    assert make_unique_names(["a", "b", "c"]) == ["a", "b", "c"]
+
+
 @unittest.skipUnless('XPRESS' in INSTALLED_SOLVERS, 'XPRESS is not installed.')
 class TestXPRESS(BaseTest):
 
@@ -2178,6 +2219,25 @@ class TestXPRESS(BaseTest):
         self.A = cp.Variable((2, 2), name='A')
         self.B = cp.Variable((2, 2), name='B')
         self.C = cp.Variable((3, 2), name='C')
+
+    def test_xpress_duplicate_variable_names(self) -> None:
+        """Two variables that share a name() must not crash the conic interface.
+
+        cvxpy derives Xpress column names from ``Variable.name()``, so two
+        variables created with the same name previously produced duplicate
+        columns, which Xpress >= 9.5 rejects with ``?1030``. The SOC constraints
+        force the problem through the conic interface.
+        """
+        x = cp.Variable(2, name='dup')
+        y = cp.Variable(2, name='dup')
+        prob = cp.Problem(
+            cp.Minimize(cp.sum(x) + cp.sum(y)),
+            [x >= 1, y >= 2, cp.norm(x, 2) <= 10, cp.norm(y, 2) <= 10],
+        )
+        prob.solve(solver=cp.XPRESS)
+        assert prob.status in (cp.OPTIMAL, cp.OPTIMAL_INACCURATE)
+        self.assertItemsAlmostEqual(x.value, [1, 1], places=3)
+        self.assertItemsAlmostEqual(y.value, [2, 2], places=3)
 
     def test_xpress_warm_start(self) -> None:
         """Make sure that warm starting Xpress behaves as expected

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -577,6 +577,24 @@ def test_xpress_warmstart():
     np.testing.assert_allclose(result, result2, atol=1e-5)
 
 
+@pytest.mark.skipif(not is_xpress_available(), reason="XPRESS license not available")
+def test_xpress_duplicate_variable_names_qp():
+    """Two variables sharing a name() must not crash the QP interface.
+
+    cvxpy derives Xpress column names from ``Variable.name()``, so two variables
+    created with the same name previously produced duplicate columns, which
+    Xpress >= 9.5 rejects with ``?1030 Duplicate column names are not allowed``.
+    The quadratic objective routes the problem through ``xpress_qpif``.
+    """
+    x = cp.Variable(3, name="dup")
+    y = cp.Variable(3, name="dup")
+    prob = cp.Problem(cp.Minimize(cp.sum_squares(x - 1) + cp.sum_squares(y - 2)))
+    prob.solve(solver=cp.XPRESS)
+    assert prob.status in (cp.OPTIMAL, cp.OPTIMAL_INACCURATE)
+    np.testing.assert_allclose(x.value, 1, atol=1e-4)
+    np.testing.assert_allclose(y.value, 2, atol=1e-4)
+
+
 @pytest.mark.skipif(cp.HIGHS not in INSTALLED_SOLVERS, reason="HIGHS is not installed")
 def test_highs_cvar():
     """CVaR constraint regression for https://github.com/cvxpy/cvxpy/issues/2836."""


### PR DESCRIPTION
## Description
Resolves https://github.com/cvxpy/cvxpy/issues/3361 where the column name generation added to the xpress interfaces was resulting in an xpress error for models with duplicate variables names. Adds a function to deduplicate names with a `__dup<n>` suffix.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.