### PR TITLE
Fix cone head lb

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/cuopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cuopt_conif.py
@@ -383,8 +383,15 @@ class CUOPT(ConicSolver):
 
         if n_soc > 0:
             C = np.concatenate([C, np.zeros(n_soc, dtype=np.float64)])
+            # cuOpt Lorentz QCs require a non-negative lower bound on the cone
+            # head (aux index 0 of each SOC block). Tail aux vars stay free.
+            soc_lower_bounds = np.full(n_soc, -np.inf, dtype=np.float64)
+            aux_offset = 0
+            for constr_len in soc_dims:
+                soc_lower_bounds[aux_offset] = 0.0
+                aux_offset += constr_len
             variable_lower_bounds = np.concatenate(
-                [variable_lower_bounds, np.full(n_soc, -np.inf, dtype=np.float64)]
+                [variable_lower_bounds, soc_lower_bounds]
             )
             variable_upper_bounds = np.concatenate(
                 [variable_upper_bounds, np.full(n_soc, np.inf, dtype=np.float64)]

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -3512,8 +3512,12 @@ class TestCUOPT(unittest.TestCase):
         )
 
     def test_cuopt_socp_lorentz_min_x0(self) -> None:
-        """Matches cuOpt barrier Lorentz QCMATRIX smoke test (min x0, x1=1, SOC)."""
-        x0 = cp.Variable(nonneg=True)
+        """Matches cuOpt barrier Lorentz QCMATRIX smoke test (min x0, x1=1, SOC).
+
+        x0 is unconstrained below; cuOpt still requires a non-negative lower
+        bound on the lifted SOC head auxiliary variable.
+        """
+        x0 = cp.Variable()
         x1 = cp.Variable(nonneg=True)
         x2 = cp.Variable()
         prob = cp.Problem(cp.Minimize(x0), [x1 == 1, cp.norm(cp.hstack([x1, x2])) <= x0])


### PR DESCRIPTION
## Description
Cuopt updated/enforced validation checks that now fails with error message `Quadratic constraint must have a non-negative lower bound for the constraint to be convex`.  This fixes the issue by enforcing lower-bound 0.0 on cone heads.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.