### PR TITLE
Probe AVX-512 executability in optional solver workflow

### DIFF
--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -20,26 +20,58 @@ jobs:
         os: [ ubuntu-22.04, macos-14 ]  # Windows excluded - cylp/CBC cannot be built
     steps:
       - uses: actions/checkout@v5
-      # Diagnostics for CPU-feature problems (e.g. illegal-instruction crashes
-      # in native solver binaries). Runs before the install steps so the info
-      # is available even when an install itself crashes.
-      - name: Print CPU features
-        run: |
-          set -e
-          uname -a
-          python3 - <<'PY'
-          import platform
-
-          print(f"machine={platform.machine()}")
-          print(f"processor={platform.processor()}")
-          print(f"platform={platform.platform()}")
-          PY
-      - name: Print CPU features (Linux)
+      # Diagnostics for the COPT illegal-instruction crash. GitHub's Azure pool
+      # mixes EPYC 7763 "Milan" (no AVX-512, COPT succeeds) and EPYC 9V74 "Genoa"
+      # (AVX-512, COPT crashes). Runs before the install steps so the verdict is
+      # captured even if COPT crashes during install/import. Reports whether CPUID
+      # advertises AVX-512, whether the OS enabled the AVX-512 XSAVE state (XCR0),
+      # and whether a real AVX-512 instruction actually executes or #UDs.
+      - name: CPU / AVX-512 diagnostics
         if: runner.os == 'Linux'
-        run: lscpu
-      - name: Print CPU features (macOS)
-        if: runner.os == 'macOS'
-        run: sysctl machdep.cpu hw.machine hw.model hw.optional
+        run: |
+          uname -a
+          cat > /tmp/avx_probe.c <<'PROBE'
+          #include <stdio.h>
+          #include <signal.h>
+          #include <setjmp.h>
+          #include <cpuid.h>
+          static sigjmp_buf jb;
+          static void on_sigill(int s){(void)s; siglongjmp(jb,1);}
+          static int run_insn(void(*fn)(void)){
+          signal(SIGILL,on_sigill);
+          if(sigsetjmp(jb,1)==0){fn(); return 1;}
+          return 0;
+          }
+          static void avx2_insn(void){__asm__ __volatile__("vpxor %%ymm0,%%ymm0,%%ymm0":::"ymm0");}
+          /* vpxorq %zmm0,%zmm0,%zmm0 -- a genuine AVX-512 instruction */
+          static void avx512_insn(void){__asm__ __volatile__(".byte 0x62,0xf1,0xfd,0x48,0xef,0xc0");}
+          int main(void){
+          unsigned a,b,c,d;
+          __get_cpuid(1,&a,&b,&c,&d);
+          int osxsave=(c>>27)&1, avx=(c>>28)&1;
+          __cpuid_count(7,0,a,b,c,d);
+          int avx2=(b>>5)&1, avx512f=(b>>16)&1;
+          unsigned long long xcr0=0;
+          if(osxsave){unsigned lo,hi; __asm__ __volatile__("xgetbv":"=a"(lo),"=d"(hi):"c"(0)); xcr0=((unsigned long long)hi<<32)|lo;}
+          int op=(xcr0>>5)&1, zh=(xcr0>>6)&1, hi16=(xcr0>>7)&1;
+          int state_ok=op&&zh&&hi16;
+          int r2=run_insn(avx2_insn), r5=run_insn(avx512_insn);
+          printf("CPUID  AVX=%d AVX2=%d AVX512F=%d OSXSAVE=%d\n",avx,avx2,avx512f,osxsave);
+          printf("XCR0   0x%llx  opmask(5)=%d ZMM_Hi256(6)=%d Hi16_ZMM(7)=%d  AVX512_state_ok=%d\n",xcr0,op,zh,hi16,state_ok);
+          printf("EXEC   AVX2=%s  AVX-512=%s\n", r2?"ok":"SIGILL", r5?"ok":"SIGILL");
+          if(avx512f&&!r5) printf("VERDICT: BUG-SHAPED -- CPUID claims AVX-512 but it faults (OS/XCR0 state not enabled)\n");
+          else if(avx512f&&r5) printf("VERDICT: AVX-512 present and usable\n");
+          else printf("VERDICT: no AVX-512 on this runner\n");
+          return 0;
+          }
+          PROBE
+          gcc -O2 -o /tmp/avx_probe /tmp/avx_probe.c
+          {
+            echo "### $(grep -m1 'model name' /proc/cpuinfo | cut -d: -f2- | sed 's/^ //')"
+            echo '```'
+            /tmp/avx_probe
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
       - name: Set Additional Envs
         run: |
           echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
@@ -91,6 +123,9 @@ jobs:
 
     env:
       PYTHON_VERSION: 3.12
+      # Dump a Python traceback if COPT crashes the interpreter (SIGILL on an
+      # AVX-512 runner) so the failing coptpy call is visible in the test logs.
+      PYTHONFAULTHANDLER: "1"
       MOSEK_CI_BASE64: ${{ secrets.MOSEK_CI_BASE64 }}
       KNITRO_LICENSE: ${{ secrets.KNITRO_LICENSE }}
       FURY_TOKEN: ${{ secrets.FURY_TOKEN }}

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -152,32 +152,31 @@ jobs:
         if: always()
         run: uv run pytest -rs -m knitro cvxpy/tests/test_qp_solvers.py
 
-      # Capture the faulting instruction directly: re-run the COPT tests under gdb.
-      # gdb stops the process at the #UD *before* any signal handler runs, so
-      # faulthandler can't mangle it (unlike the dmesg and core-dump routes, which
-      # saw the re-raise site instead). On a runner that crashes, $pc is exactly
-      # the illegal instruction; x/4i and x/16xb give the mnemonic and raw bytes.
-      # No-op on runners that don't crash. continue-on-error so it never gates the
-      # job; always() so it runs even after the plain test steps fail.
-      - name: Decode illegal instruction (gdb live)
+      # Decode the faulting instruction from the core dump the crashing test step
+      # left in /tmp/cores. We do NOT re-run the COPT tests under gdb: the crash
+      # is nondeterministic (COPT's multi-threaded barrier solver dispatches the
+      # AVX-512 path only some of the time), so a gdb re-run usually passes and
+      # captures nothing. Decoding the real crash core instead always works.
+      # decode_sigill_core.py walks past faulthandler's re-raise frame to the
+      # SIGTRAMP frame and disassembles the instruction that actually #UD'd.
+      # continue-on-error + always() so it never gates the job and runs even
+      # after the plain test steps fail; a no-op when this runner didn't crash.
+      - name: Decode illegal instruction (core dump)
         if: always() && runner.os == 'Linux'
         continue-on-error: true
         run: |
+          shopt -s nullglob
+          cores=(/tmp/cores/core.*)
+          if [ ${#cores[@]} -eq 0 ]; then
+            echo "no core dump in /tmp/cores -- this runner did not crash"
+            exit 0
+          fi
           sudo apt-get update -qq && sudo apt-get install -y -qq gdb
-          echo "== running COPT tests under gdb (stops at the #UD iff this runner crashes) =="
-          gdb -batch -nx \
-            -ex 'set pagination off' -ex 'set confirm off' \
-            -ex 'handle SIGILL stop print nopass' \
-            -ex 'run' \
-            -ex 'echo \n===== FAULTING INSTRUCTION =====\n' \
-            -ex 'x/4i $pc' \
-            -ex 'x/16xb $pc' \
-            -ex 'info registers rip' \
-            -ex 'info symbol $pc' \
-            -ex 'echo \n===== BACKTRACE =====\n' \
-            -ex 'bt' \
-            --args .venv/bin/python -m pytest -x -p no:cacheprovider -k copt \
-              cvxpy/tests/test_conic_solvers.py cvxpy/tests/test_qp_solvers.py 2>&1 | tail -80
+          for core in "${cores[@]}"; do
+            echo "================ decoding core: $core ================"
+            gdb -batch -nx .venv/bin/python "$core" \
+              -ex 'source tools/decode_sigill_core.py' 2>&1 | tail -120
+          done
 
     env:
       PYTHON_VERSION: 3.12

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -115,6 +115,23 @@ jobs:
         run: uv pip install moreau --extra-index-url https://${FURY_TOKEN}:@pypi.fury.io/optimalintellect/
       - name: Print installed solvers
         run: uv run python -c "import cvxpy; print(cvxpy.installed_solvers())"
+      # COPT support says verbose=True reports which instruction set COPT dispatches
+      # to. Run one verbose COPT solve so that banner -- and the AVX-512 selection on
+      # a Genoa runner -- lands in the log. Line-buffered (stdbuf) so the banner
+      # survives a crash; continue-on-error so a SIGILL here doesn't disrupt the job.
+      - name: COPT verbose instruction-set banner
+        if: runner.os == 'Linux'
+        continue-on-error: true
+        run: |
+          ulimit -c unlimited
+          stdbuf -oL -eL uv run python -u -c "
+          import numpy as np, cvxpy as cp
+          rng = np.random.default_rng(0)
+          A = rng.standard_normal((8, 5)); b = rng.standard_normal(8)
+          x = cp.Variable(5)
+          cp.Problem(cp.Minimize(cp.sum_squares(A @ x - b))).solve(solver=cp.COPT, verbose=True)
+          print('COPT verbose solve completed')
+          "
       # KNITRO bundles LLVM libomp; CVXOPT bundles GNU libgomp via its
       # OpenBLAS dependency. Loading both in one process can crash inside
       # KNITRO's KN_solve on macOS, so run KNITRO tests in a separate

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -121,6 +121,39 @@ jobs:
         if: always()
         run: uv run pytest -rs -m knitro cvxpy/tests/test_qp_solvers.py
 
+      # The probe above shows baseline AVX-512 executes fine on the Genoa runner
+      # where COPT crashes, so the faulting opcode is a narrower extension Genoa
+      # (Zen 4) lacks. Identify it: on a #UD the kernel logs
+      # "trap invalid opcode ip:<addr> ... in <module>[<base>+<size>]". Turn
+      # ip-base into a file offset and objdump that spot to read the actual
+      # instruction. Runs always so it fires on the crashing run; prints
+      # "(no trap)" harmlessly when nothing crashed.
+      - name: Decode illegal instruction
+        if: always() && runner.os == 'Linux'
+        run: |
+          echo "== kernel traps =="
+          sudo dmesg | grep -iE 'trap|invalid opcode|segfault|protection' | tail -20 || true
+          line=$(sudo dmesg | grep -iE 'invalid opcode' | tail -1 || true)
+          if [ -z "$line" ]; then echo "(no invalid-opcode trap recorded in dmesg)"; exit 0; fi
+          echo; echo "== faulting trap =="; echo "$line"
+          ip=$(grep -oP 'ip:\K[0-9a-f]+' <<<"$line")
+          mod=$(grep -oP ' in \K[^[]+' <<<"$line")
+          base=$(grep -oP ' in [^[]+\[\K[0-9a-f]+' <<<"$line")
+          off=$(printf '%x' $((0x$ip - 0x$base)))
+          echo "ip=0x$ip base=0x$base module=$mod -> file offset 0x$off"
+          case "$mod" in
+            /*) path="$mod" ;;
+            *)  path=$(find / -name "$mod" 2>/dev/null | head -1)
+                [ -z "$path" ] && path=$(find / -name "${mod%%.*}*" 2>/dev/null | head -1) ;;
+          esac
+          echo "module path: ${path:-<not found>}"
+          if [ -n "$path" ]; then
+            s=$((0x$off - 0x40)); e=$((0x$off + 0x20))
+            echo "== objdump around fault =="
+            objdump -d --start-address=$s --stop-address=$e "$path" 2>/dev/null \
+              | gawk -v o=$((0x$off)) '/^[[:space:]]*[0-9a-f]+:/{a=$1; sub(":","",a); if (strtonum("0x"a)==o){print $0"   <=== ILLEGAL INSTRUCTION"; next}} {print}'
+          fi
+
     env:
       PYTHON_VERSION: 3.12
       # Dump a Python traceback if COPT crashes the interpreter (SIGILL on an

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -20,6 +20,26 @@ jobs:
         os: [ ubuntu-22.04, macos-14 ]  # Windows excluded - cylp/CBC cannot be built
     steps:
       - uses: actions/checkout@v5
+      # Diagnostics for CPU-feature problems (e.g. illegal-instruction crashes
+      # in native solver binaries). Runs before the install steps so the info
+      # is available even when an install itself crashes.
+      - name: Print CPU features
+        run: |
+          set -e
+          uname -a
+          python3 - <<'PY'
+          import platform
+
+          print(f"machine={platform.machine()}")
+          print(f"processor={platform.processor()}")
+          print(f"platform={platform.platform()}")
+          PY
+      - name: Print CPU features (Linux)
+        if: runner.os == 'Linux'
+        run: lscpu
+      - name: Print CPU features (macOS)
+        if: runner.os == 'macOS'
+        run: sysctl machdep.cpu hw.machine hw.model hw.optional
       - name: Set Additional Envs
         run: |
           echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
@@ -51,29 +71,6 @@ jobs:
       - name: Install Moreau
         if: runner.os == 'Linux' && env.FURY_TOKEN != ''
         run: uv pip install moreau --extra-index-url https://${FURY_TOKEN}:@pypi.fury.io/optimalintellect/
-      - name: Print CPU features
-        run: |
-          uname -a
-          python - <<'PY'
-          import platform
-
-          print(f"machine={platform.machine()}")
-          print(f"processor={platform.processor()}")
-          print(f"platform={platform.platform()}")
-          PY
-
-          if command -v lscpu >/dev/null 2>&1; then
-            lscpu
-          fi
-
-          if [ -r /proc/cpuinfo ]; then
-            grep -m1 -E '^(model name|Processor|cpu model)' /proc/cpuinfo || true
-            grep -m1 -E '^(flags|Features)' /proc/cpuinfo || true
-          fi
-
-          if [ "$RUNNER_OS" = "macOS" ]; then
-            sysctl -a | grep -E '^(machdep.cpu|hw.machine|hw.model|hw.optional)' || true
-          fi
       - name: Print installed solvers
         run: uv run python -c "import cvxpy; print(cvxpy.installed_solvers())"
       # KNITRO bundles LLVM libomp; CVXOPT bundles GNU libgomp via its
@@ -93,7 +90,6 @@ jobs:
         run: uv run pytest -rs -m knitro cvxpy/tests/test_qp_solvers.py
 
     env:
-      RUNNER_OS: ${{ matrix.os }}
       PYTHON_VERSION: 3.12
       MOSEK_CI_BASE64: ${{ secrets.MOSEK_CI_BASE64 }}
       KNITRO_LICENSE: ${{ secrets.KNITRO_LICENSE }}

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -152,33 +152,32 @@ jobs:
         if: always()
         run: uv run pytest -rs -m knitro cvxpy/tests/test_qp_solvers.py
 
-      # COPT #UDs on AVX-512 Genoa runners. PYTHONFAULTHANDLER catches SIGILL, so
-      # the kernel logs no "invalid opcode" trap (it only logs unhandled signals)
-      # -- dmesg is empty. Instead use the core dump faulthandler leaves behind
-      # (it re-raises to the default action after printing the traceback) and
-      # disassemble at the crash PC with gdb to read the exact faulting
-      # instruction. Runs always; no-ops when nothing crashed.
-      - name: Decode illegal instruction
+      # Capture the faulting instruction directly: re-run the COPT tests under gdb.
+      # gdb stops the process at the #UD *before* any signal handler runs, so
+      # faulthandler can't mangle it (unlike the dmesg and core-dump routes, which
+      # saw the re-raise site instead). On a runner that crashes, $pc is exactly
+      # the illegal instruction; x/4i and x/16xb give the mnemonic and raw bytes.
+      # No-op on runners that don't crash. continue-on-error so it never gates the
+      # job; always() so it runs even after the plain test steps fail.
+      - name: Decode illegal instruction (gdb live)
         if: always() && runner.os == 'Linux'
+        continue-on-error: true
         run: |
-          shopt -s nullglob
-          cores=(/tmp/cores/core.*)
-          echo "cores: ${cores[*]:-none}"
-          if [ ${#cores[@]} -eq 0 ]; then
-            echo "(no core dumped -- nothing crashed, or core dumps unavailable)"
-            sudo dmesg | grep -iE 'invalid opcode|trap.*ip:' | tail -5 || true
-            exit 0
-          fi
           sudo apt-get update -qq && sudo apt-get install -y -qq gdb
-          for core in "${cores[@]}"; do
-            echo "==================== $core ===================="
-            gdb -batch -nx -q \
-              -ex 'set pagination off' \
-              -ex 'x/4i $pc' \
-              -ex 'info registers rip' \
-              -ex 'bt' \
-              .venv/bin/python "$core" 2>&1 | head -40
-          done
+          echo "== running COPT tests under gdb (stops at the #UD iff this runner crashes) =="
+          gdb -batch -nx \
+            -ex 'set pagination off' -ex 'set confirm off' \
+            -ex 'handle SIGILL stop print nopass' \
+            -ex 'run' \
+            -ex 'echo \n===== FAULTING INSTRUCTION =====\n' \
+            -ex 'x/4i $pc' \
+            -ex 'x/16xb $pc' \
+            -ex 'info registers rip' \
+            -ex 'info symbol $pc' \
+            -ex 'echo \n===== BACKTRACE =====\n' \
+            -ex 'bt' \
+            --args .venv/bin/python -m pytest -x -p no:cacheprovider -k copt \
+              cvxpy/tests/test_conic_solvers.py cvxpy/tests/test_qp_solvers.py 2>&1 | tail -80
 
     env:
       PYTHON_VERSION: 3.12

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -72,6 +72,16 @@ jobs:
             /tmp/avx_probe
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"
+      # Capture a core dump if COPT crashes. PYTHONFAULTHANDLER catches SIGILL
+      # (so the kernel logs no "invalid opcode" trap), but faulthandler re-raises
+      # to the default action afterward, which dumps core -- which we later
+      # disassemble to read the faulting instruction.
+      - name: Enable core dumps
+        if: runner.os == 'Linux'
+        run: |
+          sudo mkdir -p /tmp/cores && sudo chmod 1777 /tmp/cores
+          sudo sysctl -w kernel.core_pattern='/tmp/cores/core.%e.%p'
+          cat /proc/sys/kernel/core_pattern
       - name: Set Additional Envs
         run: |
           echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
@@ -110,49 +120,48 @@ jobs:
       # KNITRO's KN_solve on macOS, so run KNITRO tests in a separate
       # process (mirrors test_nlp_solvers.yml).
       - name: Run test_conic_solvers
-        run: uv run pytest -rs -m "not knitro" cvxpy/tests/test_conic_solvers.py
+        run: |
+          ulimit -c unlimited
+          uv run pytest -rs -m "not knitro" cvxpy/tests/test_conic_solvers.py
       - name: Run test_conic_solvers (KNITRO)
         if: always()
         run: uv run pytest -rs -m knitro cvxpy/tests/test_conic_solvers.py
       - name: Run test_qp_solvers
         if: always()
-        run: uv run pytest -rs -m "not knitro" cvxpy/tests/test_qp_solvers.py
+        run: |
+          ulimit -c unlimited
+          uv run pytest -rs -m "not knitro" cvxpy/tests/test_qp_solvers.py
       - name: Run test_qp_solvers (KNITRO)
         if: always()
         run: uv run pytest -rs -m knitro cvxpy/tests/test_qp_solvers.py
 
-      # The probe above shows baseline AVX-512 executes fine on the Genoa runner
-      # where COPT crashes, so the faulting opcode is a narrower extension Genoa
-      # (Zen 4) lacks. Identify it: on a #UD the kernel logs
-      # "trap invalid opcode ip:<addr> ... in <module>[<base>+<size>]". Turn
-      # ip-base into a file offset and objdump that spot to read the actual
-      # instruction. Runs always so it fires on the crashing run; prints
-      # "(no trap)" harmlessly when nothing crashed.
+      # COPT #UDs on AVX-512 Genoa runners. PYTHONFAULTHANDLER catches SIGILL, so
+      # the kernel logs no "invalid opcode" trap (it only logs unhandled signals)
+      # -- dmesg is empty. Instead use the core dump faulthandler leaves behind
+      # (it re-raises to the default action after printing the traceback) and
+      # disassemble at the crash PC with gdb to read the exact faulting
+      # instruction. Runs always; no-ops when nothing crashed.
       - name: Decode illegal instruction
         if: always() && runner.os == 'Linux'
         run: |
-          echo "== kernel traps =="
-          sudo dmesg | grep -iE 'trap|invalid opcode|segfault|protection' | tail -20 || true
-          line=$(sudo dmesg | grep -iE 'invalid opcode' | tail -1 || true)
-          if [ -z "$line" ]; then echo "(no invalid-opcode trap recorded in dmesg)"; exit 0; fi
-          echo; echo "== faulting trap =="; echo "$line"
-          ip=$(grep -oP 'ip:\K[0-9a-f]+' <<<"$line")
-          mod=$(grep -oP ' in \K[^[]+' <<<"$line")
-          base=$(grep -oP ' in [^[]+\[\K[0-9a-f]+' <<<"$line")
-          off=$(printf '%x' $((0x$ip - 0x$base)))
-          echo "ip=0x$ip base=0x$base module=$mod -> file offset 0x$off"
-          case "$mod" in
-            /*) path="$mod" ;;
-            *)  path=$(find / -name "$mod" 2>/dev/null | head -1)
-                [ -z "$path" ] && path=$(find / -name "${mod%%.*}*" 2>/dev/null | head -1) ;;
-          esac
-          echo "module path: ${path:-<not found>}"
-          if [ -n "$path" ]; then
-            s=$((0x$off - 0x40)); e=$((0x$off + 0x20))
-            echo "== objdump around fault =="
-            objdump -d --start-address=$s --stop-address=$e "$path" 2>/dev/null \
-              | gawk -v o=$((0x$off)) '/^[[:space:]]*[0-9a-f]+:/{a=$1; sub(":","",a); if (strtonum("0x"a)==o){print $0"   <=== ILLEGAL INSTRUCTION"; next}} {print}'
+          shopt -s nullglob
+          cores=(/tmp/cores/core.*)
+          echo "cores: ${cores[*]:-none}"
+          if [ ${#cores[@]} -eq 0 ]; then
+            echo "(no core dumped -- nothing crashed, or core dumps unavailable)"
+            sudo dmesg | grep -iE 'invalid opcode|trap.*ip:' | tail -5 || true
+            exit 0
           fi
+          sudo apt-get update -qq && sudo apt-get install -y -qq gdb
+          for core in "${cores[@]}"; do
+            echo "==================== $core ===================="
+            gdb -batch -nx -q \
+              -ex 'set pagination off' \
+              -ex 'x/4i $pc' \
+              -ex 'info registers rip' \
+              -ex 'bt' \
+              .venv/bin/python "$core" 2>&1 | head -40
+          done
 
     env:
       PYTHON_VERSION: 3.12

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -51,6 +51,29 @@ jobs:
       - name: Install Moreau
         if: runner.os == 'Linux' && env.FURY_TOKEN != ''
         run: uv pip install moreau --extra-index-url https://${FURY_TOKEN}:@pypi.fury.io/optimalintellect/
+      - name: Print CPU features
+        run: |
+          uname -a
+          python - <<'PY'
+          import platform
+
+          print(f"machine={platform.machine()}")
+          print(f"processor={platform.processor()}")
+          print(f"platform={platform.platform()}")
+          PY
+
+          if command -v lscpu >/dev/null 2>&1; then
+            lscpu
+          fi
+
+          if [ -r /proc/cpuinfo ]; then
+            grep -m1 -E '^(model name|Processor|cpu model)' /proc/cpuinfo || true
+            grep -m1 -E '^(flags|Features)' /proc/cpuinfo || true
+          fi
+
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            sysctl -a | grep -E '^(machdep.cpu|hw.machine|hw.model|hw.optional)' || true
+          fi
       - name: Print installed solvers
         run: uv run python -c "import cvxpy; print(cvxpy.installed_solvers())"
       # KNITRO bundles LLVM libomp; CVXOPT bundles GNU libgomp via its

--- a/tools/decode_sigill_core.py
+++ b/tools/decode_sigill_core.py
@@ -1,0 +1,75 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+# gdb-python script: recover the exact faulting instruction from a SIGILL core.
+#
+# PYTHONFAULTHANDLER catches the SIGILL, prints a traceback, then re-raises via
+# raise(), so the crashing thread's innermost frame is __pthread_kill -- not the
+# illegal instruction. The original #UD is still on that thread's stack as a
+# "<signal handler called>" (SIGTRAMP) frame; the frame just *older* than it is
+# the instruction that actually faulted. This script finds that frame on every
+# thread and disassembles it, so the mnemonic and raw bytes of the offending
+# opcode land in the log. If no SIGTRAMP frame exists (faulthandler disabled --
+# the core is taken directly at the #UD), it disassembles each thread's $pc.
+#
+# Run as:  gdb -batch python <core> -ex 'source tools/decode_sigill_core.py'
+import gdb
+
+
+def _disasm(pc, label):
+    print("\n===== %s =====" % label)
+    print("RIP = 0x%x" % pc)
+    gdb.execute("info symbol 0x%x" % pc)
+    gdb.execute("x/4i 0x%x" % pc)
+    gdb.execute("x/16xb 0x%x" % pc)
+
+
+gdb.execute("set pagination off")
+inferior = gdb.selected_inferior()
+found_sigtramp = False
+for thread in inferior.threads():
+    thread.switch()
+    try:
+        frame = gdb.newest_frame()
+    except gdb.error:
+        continue
+    while frame is not None:
+        try:
+            is_sigtramp = frame.type() == gdb.SIGTRAMP_FRAME
+        except gdb.error:
+            is_sigtramp = False
+        if is_sigtramp:
+            faulting = frame.older()
+            if faulting is not None:
+                faulting.select()
+                _disasm(faulting.pc(), "FAULTING INSTRUCTION (thread %d)" % thread.num)
+                print("\n===== BACKTRACE OF FAULTING THREAD =====")
+                gdb.execute("bt")
+                found_sigtramp = True
+            break
+        frame = frame.older()
+    if found_sigtramp:
+        break
+
+if not found_sigtramp:
+    print("\nno SIGTRAMP frame found (faulthandler off?); disassembling each $pc:")
+    for thread in inferior.threads():
+        thread.switch()
+        try:
+            _disasm(gdb.newest_frame().pc(), "thread %d $pc" % thread.num)
+        except gdb.error:
+            continue
+    print("\n===== ALL-THREAD BACKTRACE =====")
+    gdb.execute("thread apply all bt")


### PR DESCRIPTION
## Description
Adds a diagnostic step to `test_optional_solvers` that prints CPU architecture and feature information before solver tests run, to help diagnose COPT illegal instruction failures.
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.