### PR TITLE
Type Canonicalization.canonicalize_tree/expr with Canonical

### DIFF
--- a/cvxpy/reductions/canonicalization.py
+++ b/cvxpy/reductions/canonicalization.py
@@ -14,12 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from typing import overload
+
 from cvxpy import problems
+from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
 from cvxpy.expressions.expression import Expression
+from cvxpy.problems.objective import Objective
 from cvxpy.reductions.inverse_data import InverseData
 from cvxpy.reductions.reduction import Reduction
 from cvxpy.reductions.solution import Solution
+from cvxpy.utilities.canonical import Canonical
 
 
 class Canonicalization(Reduction):
@@ -87,8 +92,27 @@ class Canonicalization(Reduction):
         return Solution(solution.status, solution.opt_val, pvars, dvars,
                         solution.attr)
 
-    def canonicalize_tree(self, expr, canonicalize_params: bool = True):
+    @overload
+    def canonicalize_tree(
+        self, expr: Expression, canonicalize_params: bool = True
+    ) -> tuple[Expression, list[Constraint]]: ...
+    @overload
+    def canonicalize_tree(
+        self, expr: Constraint, canonicalize_params: bool = True
+    ) -> tuple[Constraint, list[Constraint]]: ...
+    @overload
+    def canonicalize_tree(
+        self, expr: Objective, canonicalize_params: bool = True
+    ) -> tuple[Objective, list[Constraint]]: ...
+
+    def canonicalize_tree(
+        self, expr: Canonical, canonicalize_params: bool = True
+    ) -> tuple[Canonical, list[Constraint]]:
         """Recursively canonicalize an Expression.
+
+        Canonicalizing an Expression yields an Expression, a Constraint yields
+        a Constraint, and an Objective yields an Objective; the overloads above
+        preserve that distinction for callers.
 
         Args:
             expr: Expression to canonicalize.
@@ -128,10 +152,10 @@ class Canonicalization(Reduction):
 
     def canonicalize_expr(
             self,
-            expr: Expression,
-            args: list,
+            expr: Canonical,
+            args: list[Expression],
             canonicalize_params: bool = True
-        ):
+        ) -> tuple[Canonical, list[Constraint]]:
         """Canonicalize an expression, w.r.t. canonicalized arguments.
 
         Args:


### PR DESCRIPTION
## Description

`Canonicalization.canonicalize_tree` and `canonicalize_expr` are the generic recursive canonicalizers that every reduction inherits. They run not just on `Expression`s but also on `Constraint`s and `Objective`s — all three derive from `u.Canonical` — and each returns the same category it was handed (`canonicalize_tree(constraint)` returns a canonicalized `Constraint`, `canonicalize_tree(objective)` returns an `Objective`, etc.).

The base methods previously had no return annotation and typed `expr` as `Expression`, which is too narrow for what actually flows through. This PR types them honestly:

- Both implementations are typed against `Canonical` (the common base). Attribute access inside the bodies is already guarded by `isinstance(expr, Expression)` narrowing, so nothing in the bodies changes.
- `canonicalize_tree` gains three `@overload` signatures so callers recover the precise category:
  - `Expression -> tuple[Expression, list[Constraint]]`
  - `Constraint -> tuple[Constraint, list[Constraint]]`
  - `Objective -> tuple[Objective, list[Constraint]]`

  `Expression`, `Constraint`, and `Objective` are disjoint siblings, so the overloads don't overlap (no `reportOverlappingOverload`). `canonicalize_expr` doesn't need overloads — its result only flows back through `canonicalize_tree`'s implementation — so it simply returns `tuple[Canonical, list[Constraint]]`.

A constrained `TypeVar` was considered and rejected: canonicalization produces `Canonical` internally (via `expr.copy()` and the child recursion over `expr.args`), so a `expr: T -> tuple[T, ...]` promise can't be satisfied without `cast()`s. Overloads decouple the precise public contract from the `Canonical` implementation cleanly.

This is a type-annotation-only change; the method bodies are byte-for-byte unchanged. Verified that overload resolution recovers the right category on real subclasses (`Minimize -> Objective`, `Inequality -> Constraint`).

Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)