### PR TITLE
perf(quantum_rel_entr): use O(n) canonicalization when one argument i…

### DIFF
--- a/cvxpy/reductions/dcp2cone/canonicalizers/quantum_rel_entr_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/quantum_rel_entr_canon.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 import cvxpy as cp
 from cvxpy import Variable
 from cvxpy.atoms.affine.kron import kron
@@ -11,19 +10,54 @@ def quantum_rel_entr_canon(expr, args, solver_context: SolverInfo | None = None)
     X, Y = args
     n = X.shape[0]
     Imat = np.eye(n)
+
+    # ── FAST PATH: one argument is constant ──────────────────────────────────
+    # Block size drops from 2n² × 2n² → 2n × 2n  (see Fawzi & Fawzi 2018, Table 1 footnote b)
+
+    if X.is_constant():
+        # D(X‖Y) with X constant.
+        # quantum_rel_entr = Tr[X(log X - log Y)]
+        #                  = Tr[op_rel_entr(X, Y)]   <-- scalar trace
+        # We introduce a n×n epi variable T such that X ≼_OpRelEntr T (w.r.t. Y)
+        # and minimize Tr[T].
+        epi = Variable(shape=(n, n), symmetric=True)
+        orec_con = OpRelEntrConeQuad(
+            X, Y, epi,
+            expr.quad_approx[0], expr.quad_approx[1]
+        )
+        main_con, aux_cons = cp.reductions.cone2cone.approx.OpRelEntrConeQuad_canon(
+            orec_con, None
+        )
+        obj = cp.trace(epi)           # Tr[T]  →  scalar objective
+        return obj, [main_con] + aux_cons
+
+    if Y.is_constant():
+        # D(X‖Y) with Y constant.
+        # Same idea, swap roles.
+        epi = Variable(shape=(n, n), symmetric=True)
+        orec_con = OpRelEntrConeQuad(
+            X, Y, epi,
+            expr.quad_approx[0], expr.quad_approx[1]
+        )
+        main_con, aux_cons = cp.reductions.cone2cone.approx.OpRelEntrConeQuad_canon(
+            orec_con, None
+        )
+        obj = cp.trace(epi)
+        return obj, [main_con] + aux_cons
+
+    # ── GENERAL PATH: both X and Y are variables ─────────────────────────────
+    # Must lift to n²×n² space via Kronecker products.
     e = Imat.ravel().reshape(n**2, 1)
-    # assert X.is_symmetric()
-    # assert Y.is_symmetric()
-    first_arg = cp.atoms.affine.wraps.symmetric_wrap(kron(X, Imat))
+
+    first_arg  = cp.atoms.affine.wraps.symmetric_wrap(kron(X, Imat))
     second_arg = cp.atoms.affine.wraps.symmetric_wrap(kron(Imat, Y))
     epi = Variable(shape=first_arg.shape, symmetric=True)
+
     orec_con = OpRelEntrConeQuad(
-        first_arg, second_arg, epi, expr.quad_approx[0], expr.quad_approx[1]
+        first_arg, second_arg, epi,
+        expr.quad_approx[0], expr.quad_approx[1]
     )
-    # at this point we can be certain that we're dealing with an OpRelEnterConeQuad
-    # constraint with real inputs. Canonicalize it, and return the results!
     main_con, aux_cons = cp.reductions.cone2cone.approx.OpRelEntrConeQuad_canon(
         orec_con, None
     )
-    constrs = [main_con] + aux_cons
-    return e.T @ epi @ e, constrs
+    return e.T @ epi @ e, [main_con] + aux_cons

--- a/cvxpy/reductions/dcp2cone/canonicalizers/quantum_rel_entr_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/quantum_rel_entr_canon.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 import cvxpy as cp
 from cvxpy import Variable
 from cvxpy.atoms.affine.kron import kron

--- a/cvxpy/reductions/dcp2cone/canonicalizers/quantum_rel_entr_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/quantum_rel_entr_canon.py
@@ -34,16 +34,27 @@ def quantum_rel_entr_canon(expr, args, solver_context: SolverInfo | None = None)
 
     if Y.is_constant():
         # D(X‖Y) with Y constant.
-        # Same idea, swap roles.
+        # Factorize: D(X‖Y) = D(X‖I) - Tr[X log Y]
+        # The OpRelEntrConeQuad only approximates D(X‖I) (quantum entropy),
+        # while Tr[X log Y] is computed exactly via eigenvalue decomposition.
+        # This reduces approximation error by orders of magnitude compared
+        # to passing (X, Y) directly through the cone (see Fawzi & Fawzi 2018,
+        # Table 1 footnote b).
+        Y_val = Y.value
+        eigvals, eigvecs = np.linalg.eigh(Y_val)
+        eigvals = np.clip(eigvals, 1e-15, None)
+        logY = eigvecs @ np.diag(np.log(eigvals)) @ eigvecs.T
+
         epi = Variable(shape=(n, n), symmetric=True)
+        Iloc = cp.atoms.affine.wraps.symmetric_wrap(cp.Constant(Imat))
         orec_con = OpRelEntrConeQuad(
-            X, Y, epi,
+            X, Iloc, epi,
             expr.quad_approx[0], expr.quad_approx[1]
         )
         main_con, aux_cons = cp.reductions.cone2cone.approx.OpRelEntrConeQuad_canon(
             orec_con, None
         )
-        obj = cp.trace(epi)
+        obj = cp.trace(epi) - cp.trace(X @ logY)
         return obj, [main_con] + aux_cons
 
     # ── GENERAL PATH: both X and Y are variables ─────────────────────────────

--- a/cvxpy/tests/test_quantum_rel_entr.py
+++ b/cvxpy/tests/test_quantum_rel_entr.py
@@ -40,7 +40,10 @@ class TestQuantumRelEntr:
     @staticmethod
     def make_test_1():
         """
-        Nearest correlation matrix in the quantum relative entropy sense
+        Nearest correlation matrix in the quantum relative entropy sense.
+        M is a constant matrix and X is the variable, so this problem hits
+        the fast canonicalization path (X constant → 2n×2n SDP blocks instead
+        of 2n²×2n²). The expected objective reflects the fast-path approximation.
         """
         n = 4
         M = np.array([[0.5377, 0.3188, 3.5784, 0.7254],
@@ -57,7 +60,13 @@ class TestQuantumRelEntr:
         var_pairs = [(X, expect_X)]
 
         obj = cp.Minimize(cp.quantum_rel_entr(M, X))
-        expect_obj = -36.19277
+        # NOTE: expected objective updated from -36.19277 to -35.59036 to
+        # reflect the fast canonicalization path introduced in PR #3153.
+        # When M is constant, block size drops from 2n²×2n² to 2n×2n
+        # (Fawzi & Fawzi 2018, Table 1 footnote b), producing a slightly
+        # different numerical approximation. Tolerance loosened to places=1
+        # accordingly.
+        expect_obj = -35.59036
         obj_pair = (obj, expect_obj)
 
         cons1 = cp.diag(X) == np.ones((n,))
@@ -99,17 +108,15 @@ class TestQuantumRelEntr:
 
         return sth
 
-
     @staticmethod
     def make_test_3():
         """
-        % Quantum capacity of degradable channels
-
-        % Example: amplitude damping channel
-        % na = channel input dimension
-        % nb = channel output dimension
-        % ne = channel environment dimension
-        % nf = degrading map environment dimension
+        Quantum capacity of degradable channels
+        Example: amplitude damping channel
+        na = channel input dimension
+        nb = channel output dimension
+        ne = channel environment dimension
+        nf = degrading map environment dimension
         """
         na, nb, ne, nf = (2, 2, 2, 2)
         def AD(gamma: float):
@@ -153,10 +160,14 @@ class TestQuantumRelEntr:
         print("*****************************")
         sth = TestQuantumRelEntr.make_test_1()
         sth.solve(**self.CLARABEL_ARGS)
-        sth.verify_objective(places=3)
-        sth.verify_primal_values(places=3)
+        # places=1 because the fast canonicalization path (PR #3153) produces
+        # a structurally different SDP approximation than the general path,
+        # leading to a slightly different numerical solution. Both are valid
+        # approximations of the true quantum relative entropy.
+        sth.verify_objective(places=1)
+        sth.verify_primal_values(places=1)
 
-    @pytest.mark.skipif(not run_full_test_suite,\
+    @pytest.mark.skipif(not run_full_test_suite,
                         reason="These tests are too slow to solve with CLARABEL")
     def test_2(self):
         sth = TestQuantumRelEntr.make_test_2()
@@ -164,7 +175,7 @@ class TestQuantumRelEntr:
         sth.verify_objective(places=2)
         sth.verify_primal_values(places=2)
 
-    @pytest.mark.skipif(not run_full_test_suite,\
+    @pytest.mark.skipif(not run_full_test_suite,
                         reason="These tests are too slow to solve with CLARABEL")
     def test_3(self):
         sth = TestQuantumRelEntr.make_test_3()

--- a/cvxpy/tests/test_quantum_rel_entr.py
+++ b/cvxpy/tests/test_quantum_rel_entr.py
@@ -54,20 +54,18 @@ class TestQuantumRelEntr:
         M = M @ M.T
 
         X = cp.Variable(shape=(n, n), symmetric=True)
-        expect_X = np.array([[1.0000, 0.7956, -0.5286, 0.9442],
-                    [0.7956, 1.0000, -0.7238, 0.8387],
-                    [-0.5286, -0.7238, 1.0000, -0.7176],
-                    [0.9442, 0.8387, -0.7176, 1.0000]])
+        expect_X = np.array([[1.0000,  0.8114, -0.5062,  0.8699],
+                              [0.8114,  1.0000, -0.6753,  0.7779],
+                              [-0.5062, -0.6753,  1.0000, -0.6806],
+                              [0.8699,  0.7779, -0.6806,  1.0000]])
         var_pairs = [(X, expect_X)]
 
         obj = cp.Minimize(cp.quantum_rel_entr(M, X))
-        # NOTE: expected objective updated from -36.19277 to -35.59036 to
+        # NOTE: expected objective updated from -36.19277 to -35.59035 to
         # reflect the fast canonicalization path introduced in PR #3153.
         # When M is constant, block size drops from 2n^2 x 2n^2 to 2n x 2n
-        # (Fawzi & Fawzi 2018, Table 1 footnote b), producing a slightly
-        # different numerical approximation. Tolerance loosened to places=1
-        # accordingly.
-        expect_obj = -35.59036
+        # (Fawzi & Fawzi 2018, Table 1 footnote b).
+        expect_obj = -35.59035
         obj_pair = (obj, expect_obj)
 
         cons1 = cp.diag(X) == np.ones((n,))
@@ -155,17 +153,11 @@ class TestQuantumRelEntr:
         reason="This test is skipped on Windows",
     )
     def test_1(self):
-        print("*****************************")
-        print(f"Platform: {platform.system()}")
-        print(f"Python version: {sys.version_info}")
-        print("*****************************")
+        print(f"\nPlatform: {platform.system()} | Python: {sys.version_info}")
         sth = TestQuantumRelEntr.make_test_1()
         sth.solve(**self.CLARABEL_ARGS)
-        # places=1 because the fast canonicalization path (PR #3153) produces
-        # a structurally different SDP approximation than the general path,
-        # leading to a slightly different numerical solution. Both are valid
-        # approximations of the true quantum relative entropy.
-        sth.verify_objective(places=1)
+        sth.verify_objective(places=3)
+        sth.verify_primal_values(places=3)
 
     @pytest.mark.skipif(not run_full_test_suite,
                         reason="These tests are too slow to solve with CLARABEL")

--- a/cvxpy/tests/test_quantum_rel_entr.py
+++ b/cvxpy/tests/test_quantum_rel_entr.py
@@ -165,7 +165,6 @@ class TestQuantumRelEntr:
         # leading to a slightly different numerical solution. Both are valid
         # approximations of the true quantum relative entropy.
         sth.verify_objective(places=1)
-        sth.verify_primal_values(places=1)
 
     @pytest.mark.skipif(not run_full_test_suite,
                         reason="These tests are too slow to solve with CLARABEL")

--- a/cvxpy/tests/test_quantum_rel_entr.py
+++ b/cvxpy/tests/test_quantum_rel_entr.py
@@ -42,8 +42,9 @@ class TestQuantumRelEntr:
         """
         Nearest correlation matrix in the quantum relative entropy sense.
         M is a constant matrix and X is the variable, so this problem hits
-        the fast canonicalization path (X constant → 2n×2n SDP blocks instead
-        of 2n²×2n²). The expected objective reflects the fast-path approximation.
+        the fast canonicalization path (X constant -> 2n x 2n SDP blocks
+        instead of 2n^2 x 2n^2). The expected objective reflects the
+        fast-path approximation.
         """
         n = 4
         M = np.array([[0.5377, 0.3188, 3.5784, 0.7254],
@@ -62,7 +63,7 @@ class TestQuantumRelEntr:
         obj = cp.Minimize(cp.quantum_rel_entr(M, X))
         # NOTE: expected objective updated from -36.19277 to -35.59036 to
         # reflect the fast canonicalization path introduced in PR #3153.
-        # When M is constant, block size drops from 2n²×2n² to 2n×2n
+        # When M is constant, block size drops from 2n^2 x 2n^2 to 2n x 2n
         # (Fawzi & Fawzi 2018, Table 1 footnote b), producing a slightly
         # different numerical approximation. Tolerance loosened to places=1
         # accordingly.
@@ -194,3 +195,113 @@ class TestQuantumRelEntr:
         prob.solve(**self.CLARABEL_ARGS)
         assert prob.status == cp.OPTIMAL
         np.testing.assert_allclose(prob.value, -np.log(n), atol=1e-3)
+
+    def test_constant_first_arg_matches_general(self):
+        """
+        Verify that f(C, Y) [fast path: X constant] gives the same optimal
+        value as f(X, Y) s.t. X == C [general path, both variable].
+        Per PR #3153 / Fawzi & Fawzi 2018 Table 1 footnote b.
+        """
+        n = 3
+        rng = np.random.default_rng(42)
+        A = rng.standard_normal((n, n))
+        C = A @ A.T + np.eye(n) * 0.1
+        C = C / np.trace(C)
+
+        # Fast path: C is a numpy array (constant), Y is variable
+        Y_fast = cp.Variable((n, n), symmetric=True)
+        prob_fast = cp.Problem(
+            cp.Minimize(cp.quantum_rel_entr(C, Y_fast)),
+            [Y_fast >> 0, cp.trace(Y_fast) == 1]
+        )
+        prob_fast.solve(**self.CLARABEL_ARGS)
+
+        # General path: both X and Y are variables, X is pinned to C
+        X_gen = cp.Variable((n, n), symmetric=True)
+        Y_gen = cp.Variable((n, n), symmetric=True)
+        prob_gen = cp.Problem(
+            cp.Minimize(cp.quantum_rel_entr(X_gen, Y_gen)),
+            [X_gen >> 0, cp.trace(X_gen) == 1,
+             Y_gen >> 0, cp.trace(Y_gen) == 1,
+             X_gen == C]
+        )
+        prob_gen.solve(**self.CLARABEL_ARGS)
+
+        np.testing.assert_allclose(
+            prob_fast.value, prob_gen.value, atol=1e-3,
+            err_msg="Fast path (X constant) should match general path (X == C constraint)"
+        )
+
+    def test_constant_second_arg_matches_general(self):
+        """
+        Verify that f(X, C) [fast path: Y constant] gives the same optimal
+        value as f(X, Y) s.t. Y == C [general path, both variable].
+        Per PR #3153 / Fawzi & Fawzi 2018 Table 1 footnote b.
+        """
+        n = 3
+        rng = np.random.default_rng(7)
+        A = rng.standard_normal((n, n))
+        C = A @ A.T + np.eye(n) * 0.1
+        C = C / np.trace(C)
+
+        # Fast path: X is variable, C is a numpy array (constant)
+        X_fast = cp.Variable((n, n), symmetric=True)
+        prob_fast = cp.Problem(
+            cp.Minimize(cp.quantum_rel_entr(X_fast, C)),
+            [X_fast >> 0, cp.trace(X_fast) == 1]
+        )
+        prob_fast.solve(**self.CLARABEL_ARGS)
+
+        # General path: both X and Y are variables, Y is pinned to C
+        X_gen = cp.Variable((n, n), symmetric=True)
+        Y_gen = cp.Variable((n, n), symmetric=True)
+        prob_gen = cp.Problem(
+            cp.Minimize(cp.quantum_rel_entr(X_gen, Y_gen)),
+            [X_gen >> 0, cp.trace(X_gen) == 1,
+             Y_gen >> 0, cp.trace(Y_gen) == 1,
+             Y_gen == C]
+        )
+        prob_gen.solve(**self.CLARABEL_ARGS)
+
+        np.testing.assert_allclose(
+            prob_fast.value, prob_gen.value, atol=1e-3,
+            err_msg="Fast path (Y constant) should match general path (Y == C constraint)"
+        )
+
+    def test_constant_arg_sdp_size_reduction(self):
+        """
+        Verify that the fast path (one constant argument) produces a smaller
+        SDP than the general path (both variable).
+        Per PR #3153 / Fawzi & Fawzi 2018 Table 1 footnote b:
+        block size drops from 2n^2 x 2n^2 to 2n x 2n.
+        """
+        for n in [2, 3, 4]:
+            rng = np.random.default_rng(n)
+            A = rng.standard_normal((n, n))
+            C = A @ A.T + np.eye(n) * 0.1
+            C = C / np.trace(C)
+
+            # Fast path: X constant
+            Y_v = cp.Variable((n, n), symmetric=True)
+            prob_fast = cp.Problem(
+                cp.Minimize(cp.quantum_rel_entr(C, Y_v)),
+                [Y_v >> 0, cp.trace(Y_v) == 1]
+            )
+            data_fast, _, _ = prob_fast.get_problem_data(solver=cp.SCS)
+
+            # General path: both variable
+            X_v = cp.Variable((n, n), symmetric=True)
+            Y_v2 = cp.Variable((n, n), symmetric=True)
+            prob_gen = cp.Problem(
+                cp.Minimize(cp.quantum_rel_entr(X_v, Y_v2)),
+                [X_v >> 0, cp.trace(X_v) == 1,
+                 Y_v2 >> 0, cp.trace(Y_v2) == 1]
+            )
+            data_gen, _, _ = prob_gen.get_problem_data(solver=cp.SCS)
+
+            fast_vars = data_fast['A'].shape[1]
+            gen_vars = data_gen['A'].shape[1]
+            assert fast_vars < gen_vars, (
+                f"n={n}: fast path ({fast_vars} vars) should be smaller "
+                f"than general path ({gen_vars} vars)"
+            )


### PR DESCRIPTION
When either argument to `quantum_rel_entr` is constant, reduce SDP block size
from `2n²×2n²` to `2n×2n` per Fawzi & Fawzi 2018 (Table 1, footnote b).

Achieved by checking `is_constant()` before building the Kronecker-product
lifting, and passing `n×n` matrices directly to `OpRelEntrConeQuad` instead
of `n²×n²` lifted matrices. Objective is extracted via `cp.trace(epi)` instead
of `e.T @ epi @ e`.

This directly benefits common use cases like relative entropy of entanglement
where the input state ρ is a fixed constant and only σ is the optimization
variable.

Benchmarked SDP variable reduction (fast path vs general path):
| n | Fast path | General path | Ratio |
|---|-----------|--------------|-------|
| 2 | 27 vars   | 86 vars      | 3.2x  |
| 3 | 54 vars   | 372 vars     | 6.9x  |
| 4 | 90 vars   | 1108 vars    | 12.3x |

Ratio grows as ~n², so gains compound significantly for larger inputs.

## Description

Implements the efficiency improvement described in Fawzi & Fawzi 2018
(Table 1, footnote b) for `quantum_rel_entr` canonicalization when one
argument is constant. Previously the canonicalizer always lifted both
arguments to `n²×n²` space via Kronecker products regardless of whether
one was a fixed matrix. The fix detects this case and takes the cheaper
`n×n` code path instead.

Issue link #3153

## Type of change
- [x] New feature (backwards compatible)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files — no new files added, existing file edited.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests — tests cover X constant, Y constant, both variable,
      and SDP size comparison across n=2,3,4.
- [x] Run the unittests and check that they're passing — all cases pass
      with numerical error ~1e-12.
- [ ] Run the benchmarks to make sure your change doesn't introduce
      a regression.