### PR TITLE
Pass lower Hessian triangle to HiGHS QP interface

### DIFF
--- a/cvxpy/reductions/solvers/qp_solvers/highs_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/highs_qpif.py
@@ -197,11 +197,14 @@ class HIGHS(QpSolver):
             # entries whose upper and lower triangles may differ by floating-
             # point epsilon after canonicalization, which HiGHS >= 1.14.0
             # rejects as asymmetric.  See https://github.com/cvxpy/cvxpy/issues/3301
-            P_upper = sp.triu(P, format="csc")
+            # HiGHS' triangular Hessian format requires the LOWER triangle:
+            # highspy < 1.14.0 silently drops upper-triangle off-diagonal
+            # entries, while highspy >= 1.14.0 accepts either triangle.
+            P_lower = sp.tril(P, format="csc")
             hessian.format_ = hp.HessianFormat.kTriangular
-            hessian.start_ = P_upper.indptr
-            hessian.index_ = P_upper.indices
-            hessian.value_ = P_upper.data
+            hessian.start_ = P_lower.indptr
+            hessian.index_ = P_lower.indices
+            hessian.value_ = P_lower.data
 
         solver = hp.Highs()
 

--- a/cvxpy/tests/test_qp_solvers.py
+++ b/cvxpy/tests/test_qp_solvers.py
@@ -611,6 +611,22 @@ def test_highs_cvar():
     assert problem.status == cp.OPTIMAL
 
 
+@pytest.mark.skipif(cp.HIGHS not in INSTALLED_SOLVERS, reason="HIGHS is not installed")
+def test_highs_hessian_cross_terms():
+    """HiGHS must receive the lower Hessian triangle.
+
+    highspy < 1.14.0 silently drops upper-triangle off-diagonal entries in the
+    triangular Hessian format, returning "optimal" for the wrong (diagonal-P)
+    problem on any QP with cross terms.
+    """
+    x = cp.Variable(2)
+    P = np.array([[2.0, 1.0], [1.0, 2.0]])
+    problem = cp.Problem(cp.Minimize(cp.quad_form(x, P) - 2 * cp.sum(x)))
+    problem.solve(solver=cp.HIGHS)
+    np.testing.assert_allclose(problem.value, -2 / 3, atol=1e-6)
+    np.testing.assert_allclose(x.value, [1 / 3, 1 / 3], atol=1e-6)
+
+
 def test_square_param():
     """Issue arising with square plus parameter."""
     a = cp.Parameter(value=1)


### PR DESCRIPTION
## Description
The HiGHS QP interface passes `sp.triu(P)` with `HessianFormat.kTriangular`, but HiGHS' triangular Hessian format requires the **lower** triangle. highspy < 1.14.0 silently drops all upper-triangle off-diagonal entries and reports `kOptimal` for the wrong (diagonal-Hessian) problem, so any QP with cross terms in the quadratic returns a silently wrong answer:

```python
x = cp.Variable(2)
P = np.array([[2., 1.], [1., 2.]])
prob = cp.Problem(cp.Minimize(cp.quad_form(x, P) - 2*cp.sum(x)))
prob.solve(solver=cp.HIGHS)
print(prob.value)   # -0.5 before this fix; true optimum -2/3 (CLARABEL/OSQP/SCS agree)
```

highspy >= 1.14.0 accepts either triangle, so passing the lower triangle is correct on all versions. With highspy 1.12 installed, 6 existing tests in `test_qp_solvers.py` fail before this change and pass after. Introduced in #3302.

## Type of change
- [x] Bug fix

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)