### PR TITLE
Fix lambda_sum_largest k-doubling for real arguments in Complex2Real

### DIFF
--- a/cvxpy/reductions/complex2real/canonicalizers/matrix_canon.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/matrix_canon.py
@@ -117,10 +117,12 @@ def lambda_sum_largest_canon(expr: lambda_sum_largest,
                              imag_args: list[Expression | None], real2imag):
     """Canonicalize sum of k largest eigenvalues with Hermitian matrix input.
     """
-    # Divide by two because each eigenvalue is repeated twice.
     real, imag = hermitian_canon(expr, real_args, imag_args, real2imag)
-    real.k *= 2
     if imag_args[0] is not None:
+        # The Hermitian dilation repeats each eigenvalue twice, so sum the
+        # 2k largest eigenvalues and divide by two. A real argument is left
+        # untouched by hermitian_canon, so k must not be doubled for it.
+        real.k *= 2
         real /= 2
     return real, imag
 

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -394,6 +394,23 @@ class TestComplex(BaseTest):
             result = prob.solve(solver=cp.SCS, eps=1e-6)
             self.assertAlmostEqual(result, value, places=3)
 
+    def test_lambda_sum_largest_real_arg(self) -> None:
+        """lambda_sum_largest of a real matrix must survive Complex2Real unchanged.
+
+        Complex2Real used to double k for real (symmetric) arguments whenever
+        the problem contained any unrelated complex expression.
+        """
+        X = Variable((3, 3), symmetric=True)
+        constraints = [cp.lambda_sum_largest(X, 2) <= 5, X >> 0, X << 10 * np.eye(3)]
+        objective = cp.Maximize(cp.trace(X))
+        ref = Problem(objective, constraints).solve(solver="CLARABEL")
+        self.assertAlmostEqual(ref, 7.5, places=4)
+
+        z = Variable(complex=True)
+        result = Problem(objective, constraints + [cp.abs(z) <= 1]).solve(solver="CLARABEL")
+        self.assertAlmostEqual(result, ref, places=4)
+        self.assertLessEqual(cp.lambda_sum_largest(X, 2).value, 5 + 1e-4)
+
     def test_quad_form(self) -> None:
         """Test quad_form atom.
         """


### PR DESCRIPTION
## Description
`lambda_sum_largest_canon` in the Complex2Real reduction doubles `k` unconditionally, but the matching `real /= 2` correction (and the 2n×2n Hermitian dilation that makes the doubling correct) only applies when the argument has an imaginary part. Since Complex2Real runs over the whole problem, applying `lambda_sum_largest` to a real symmetric matrix in any problem containing an unrelated complex expression rebuilt the atom with `2k` on the original n×n matrix — silently wrong results, or spurious `unbounded` when `2k > n`:

```python
X = cp.Variable((3,3), symmetric=True)
z = cp.Variable(complex=True)                       # unrelated complex leaf
p = cp.Problem(cp.Maximize(cp.trace(X)),
               [cp.lambda_sum_largest(X, 2) <= 5, X >> 0, X << 10*np.eye(3),
                cp.abs(z) <= 1])
p.solve(solver=cp.CLARABEL)
# before: 30.0 with lambda_sum_largest(X, 2) == 20 (constraint violated)
# after:  7.5, matching the same problem without z
```

The fix moves `real.k *= 2` inside the `imag_args[0] is not None` branch.

## Type of change
- [x] Bug fix

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)