### PR TITLE
Apply ATOM_EVAL_TOL near-integer rounding in floor.numeric

### DIFF
--- a/cvxpy/atoms/elementwise/ceil.py
+++ b/cvxpy/atoms/elementwise/ceil.py
@@ -108,7 +108,8 @@ class floor(Elementwise):
 
     @Elementwise.numpy_numeric
     def numeric(self, values):
-        return np.floor(values[0])
+        decimals = int(np.abs(np.log10(s.ATOM_EVAL_TOL)))
+        return np.floor(np.around(values[0], decimals=decimals))
 
     def sign_from_args(self) -> tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -209,6 +209,15 @@ class TestDqcp(base_test.BaseTest):
         self.assertEqual(problem.objective.value, 11.0)
         self.assertGreater(x.value, 11.7)
 
+    def test_floor_near_integer_tolerance(self) -> None:
+        """floor must round near-integer values within ATOM_EVAL_TOL like ceil
+        does, so solver noise does not shift objective values by 1."""
+        self.assertEqual(cp.floor(cp.Constant(3 - 1e-10)).value, 3.0)
+        self.assertEqual(cp.ceil(cp.Constant(3 + 1e-10)).value, 3.0)
+        self.assertEqual(cp.floor(cp.Constant(-3 - 1e-10)).value, -3.0)
+        self.assertEqual(cp.floor(cp.Constant(2.4)).value, 2.0)
+        self.assertEqual(cp.ceil(cp.Constant(2.4)).value, 3.0)
+
     def test_basic_multiply_nonneg(self) -> None:
         x, y = cp.Variable(2, nonneg=True)
         expr = x * y


### PR DESCRIPTION
## Description
`ceil.numeric` rounds near-integer inputs within `ATOM_EVAL_TOL` before applying `np.ceil` (added in #1300), but `floor.numeric` never received the same treatment:

```python
cp.ceil(cp.Constant(3 + 1e-10)).value    # 3.0 (tolerant)
cp.floor(cp.Constant(3 - 1e-10)).value   # 2.0 before this fix
```

Since solvers return solutions with ~1e-9 noise, DQCP objective values containing `floor` were off by one whenever the optimum sat at an integer. This applies the identical rounding used by `ceil`.

## Type of change
- [x] Bug fix

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)