### PR TITLE
Fix IndexError in Elementwise.is_symmetric for scalar and 1-D atoms

### DIFF
--- a/cvxpy/atoms/elementwise/elementwise.py
+++ b/cvxpy/atoms/elementwise/elementwise.py
@@ -42,8 +42,10 @@ class Elementwise(Atom):
     def is_symmetric(self) -> bool:
         """Is the expression symmetric?
         """
-        symm_args = all(arg.is_symmetric() for arg in self.args)
-        return self.shape[0] == self.shape[1] and symm_args
+        if self.ndim == 2 and self.shape[0] == self.shape[1]:
+            return all(arg.is_symmetric() for arg in self.args)
+        # Fall back to the Expression default (true only for scalars).
+        return super(Elementwise, self).is_symmetric()
 
     @staticmethod
     def elemwise_grad_to_diag(value, rows, cols):

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -952,6 +952,14 @@ class TestAtoms(BaseTest):
         expr = cp.log1p(-0.5)
         self.assertEqual(expr.sign, s.NONPOS)
 
+    def test_elementwise_is_symmetric(self) -> None:
+        """is_symmetric must not crash for scalar or 1-D elementwise atoms."""
+        self.assertTrue(cp.abs(cp.Variable()).is_symmetric())
+        self.assertFalse(cp.abs(cp.Variable(3)).is_symmetric())
+        self.assertTrue(cp.abs(cp.Variable((2, 2), symmetric=True)).is_symmetric())
+        self.assertFalse(cp.abs(cp.Variable((2, 2))).is_symmetric())
+        self.assertFalse(cp.abs(cp.Variable((2, 3))).is_symmetric())
+
     def test_upper_tri(self) -> None:
         with self.assertRaises(Exception) as cm:
             cp.upper_tri(self.C)


### PR DESCRIPTION
## Description
`Elementwise.is_symmetric` indexes `self.shape[0] == self.shape[1]` without an ndim check, so it crashes for every scalar or 1-D elementwise atom:

```python
cp.abs(cp.Variable()).is_symmetric()   # IndexError: tuple index out of range
```

Now square 2-D atoms keep the argument-based check, and everything else falls back to the `Expression` default (`True` only for scalars, matching `cp.Variable().is_symmetric()`).

## Type of change
- [x] Bug fix

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)