### PR TITLE
Fix sign of variables with a partial boolean index list

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -285,8 +285,10 @@ class Leaf(expression.Expression):
 
     def is_nonneg(self) -> bool:
         """Is the expression nonnegative?"""
-        return (self.attributes['nonneg'] or self.attributes['pos'] or
-                self.attributes['boolean'])
+        # The boolean attribute may be an index list constraining only some
+        # entries, in which case the leaf's sign is unknown.
+        return bool(self.attributes['nonneg'] or self.attributes['pos'] or
+                    self.attributes['boolean'] is True)
 
     def is_nonpos(self) -> bool:
         """Is the expression nonpositive?"""

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -642,6 +642,19 @@ class TestExpressions(BaseTest):
         self.assertEqual(A.is_psd(), True)
         self.assertEqual(A.is_nsd(), True)
 
+    def test_partial_boolean_sign(self) -> None:
+        """A variable boolean only at some indices has unknown sign.
+
+        is_nonneg used to return the (truthy) index list itself, so the whole
+        variable was classified NONNEGATIVE, corrupting DCP analysis.
+        """
+        x = cp.Variable(2, boolean=[(0,)])
+        self.assertIs(x.is_nonneg(), False)
+        self.assertEqual(x.sign, s.UNKNOWN)
+        # Fully boolean variables remain nonnegative.
+        y = cp.Variable(2, boolean=True)
+        self.assertIs(y.is_nonneg(), True)
+
     def test_project_boolean_indices(self) -> None:
         idx = (np.array([0, 2]),)
         leaf = cp.Variable((3,), boolean=idx)


### PR DESCRIPTION
## Description
`Leaf.is_nonneg` returns `... or self.attributes['boolean']`, and the boolean attribute may be a list of indices constraining only some entries. The truthy list made the whole variable NONNEGATIVE (and `is_nonneg()` returned the list itself instead of a bool), corrupting DCP analysis:

```python
x = cp.Variable(2, boolean=[(0,)])      # only x[0] boolean; x[1] unconstrained
x.is_nonneg(), x.sign                   # [(0,)], NONNEGATIVE — wrong

f = cp.abs(cp.maximum(x[1], -1.0))      # nonconvex, accepted as DCP via the bogus sign
prob = cp.Problem(cp.Minimize(f), [x[1] <= -3, x[0] == 0])
prob.solve(solver=cp.HIGHS)             # 'infeasible' — truly feasible (x=[0,-3], f=1)
```

A partially-boolean variable now has unknown sign; fully boolean variables (`boolean=True`) remain nonnegative. The `is True` check matches the existing precedent in the variable-bounds path.

## Type of change
- [x] Bug fix

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)