### PR TITLE
Accept Python complex scalars as values of complex leaves

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -464,7 +464,8 @@ class Leaf(expression.Expression):
         elif self.attributes['imag']:
             return np.imag(val)*1j
         elif self.attributes['complex']:
-            return val.astype(complex)
+            # val may be a Python scalar, which has no astype method.
+            return np.asarray(val).astype(complex)
         elif self.attributes['boolean']:
             if hasattr(self, "boolean_idx"):
                 new_val = np.atleast_1d(val.astype(np.float64, copy=True))

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -96,6 +96,19 @@ class TestComplex(BaseTest):
             z.value = np.array([1., 0.])
         self.assertEqual(str(cm.exception), "Parameter value must be imaginary.")
 
+    def test_scalar_complex_value(self) -> None:
+        """Python complex scalars must be accepted as leaf values.
+
+        Leaf.project used to call .astype on the raw value, which built-in
+        complex does not have.
+        """
+        p = Parameter(complex=True)
+        p.value = 2 + 3j
+        self.assertEqual(p.value, 2 + 3j)
+        z = Variable(complex=True)
+        z.value = 2 + 3j
+        self.assertEqual(z.value, 2 + 3j)
+
     def test_constant(self) -> None:
         """Test the parameter class.
         """


### PR DESCRIPTION
## Description
Assigning a Python `complex` scalar to a complex Variable or Parameter crashed:

```python
p = cp.Parameter(complex=True)
p.value = 2 + 3j   # AttributeError: 'complex' object has no attribute 'astype'
```

`intf.convert` leaves Python scalars untouched, and `Leaf.project` called `.astype(complex)` directly on the value. `np.complex128(2+3j)` and `np.array(2+3j)` were accepted, making the most natural spelling the only broken one. Fixed with `np.asarray(val).astype(complex)`.

## Type of change
- [x] Bug fix

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)