### PR TITLE
Register DGP quad_form canonicalizer under the QuadForm class

### DIFF
--- a/cvxpy/reductions/dgp2dcp/canonicalizers/__init__.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/__init__.py
@@ -23,7 +23,7 @@ from cvxpy.atoms.one_minus_pos import one_minus_pos
 from cvxpy.atoms.pf_eigenvalue import pf_eigenvalue
 from cvxpy.atoms.pnorm import Pnorm, PnormApprox
 from cvxpy.atoms.prod import Prod
-from cvxpy.atoms.quad_form import quad_form
+from cvxpy.atoms.quad_form import QuadForm
 from cvxpy.atoms.quad_over_lin import quad_over_lin
 from cvxpy.constraints.finite_set import FiniteSet
 from cvxpy.expressions.constants.constant import Constant
@@ -90,7 +90,7 @@ CANON_METHODS = {
     Power : power_canon,
     PowerApprox : power_canon,
     Prod : prod_canon,
-    quad_form : quad_form_canon,
+    QuadForm : quad_form_canon,
     quad_over_lin : quad_over_lin_canon,
     Trace : trace_canon,
     Sum : sum_canon,

--- a/cvxpy/reductions/dgp2dcp/canonicalizers/quad_form_canon.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/quad_form_canon.py
@@ -1,4 +1,4 @@
-from cvxpy.atoms.affine import hstack
+from cvxpy.atoms.affine.hstack import hstack
 from cvxpy.atoms.log_sum_exp import log_sum_exp
 
 

--- a/cvxpy/tests/test_dgp.py
+++ b/cvxpy/tests/test_dgp.py
@@ -388,3 +388,32 @@ class TestDgp(BaseTest):
             [x <= 2, x >= 0.5],
         )
         self.assertFalse(prob2.is_dgp())
+
+    def test_quad_form(self) -> None:
+        """quad_form's DGP canonicalizer was registered under the quad_form
+        factory function instead of the QuadForm class, so it was unreachable
+        and the atom was copied with log-space args (silent wrong answers)."""
+        P = np.array([[np.exp(4), 1.0], [1.0, np.exp(1)]])
+        x = cvxpy.Variable(2, pos=True)
+        prob = cvxpy.Problem(
+            cvxpy.Minimize(cvxpy.quad_form(x, P)), [x[0] * x[1] >= 1.0]
+        )
+        self.assertTrue(prob.is_dgp())
+        prob.solve(gp=True, solver=cvxpy.CLARABEL)
+
+        # Oracle: the explicit log-space formulation.
+        u = cvxpy.Variable(2)
+        terms = [np.log(P[i, j]) + u[i] + u[j] for i in range(2) for j in range(2)]
+        oracle = cvxpy.Problem(
+            cvxpy.Minimize(cvxpy.log_sum_exp(cvxpy.hstack(terms))), [u[0] + u[1] >= 0]
+        )
+        oracle.solve(solver=cvxpy.CLARABEL)
+        self.assertAlmostEqual(prob.value, np.exp(oracle.value), places=3)
+
+        # This instance used to crash ("Cannot reduce problem to cone program")
+        # because elementwise log(P) is not PSD.
+        P2 = np.array([[1.0, 0.5], [0.5, 1.0]])
+        y = cvxpy.Variable(2, pos=True)
+        prob2 = cvxpy.Problem(cvxpy.Minimize(cvxpy.quad_form(y, P2)), [y >= 1])
+        prob2.solve(gp=True, solver=cvxpy.CLARABEL)
+        self.assertAlmostEqual(prob2.value, 3.0, places=3)


### PR DESCRIPTION
## Description
The DGP `CANON_METHODS` table keyed `quad_form_canon` on the `quad_form` factory **function**, but `Dgp2Dcp.canonicalize_expr` dispatches on `type(expr)`, which is the `QuadForm` **class** — the only non-class key in the table. So the canonicalizer was unreachable: `Dgp2Dcp` accepted the atom (`QuadForm.is_atom_log_log_convex` is True), then fell through to `expr.copy(args)` with log-space arguments, producing `QuadForm(u, log(P))`:

```python
P = np.array([[np.exp(4), 1.0], [1.0, np.exp(1)]])   # log(P) is PSD
x = cp.Variable(2, pos=True)
prob = cp.Problem(cp.Minimize(cp.quad_form(x, P)), [x[0]*x[1] >= 1.0])
prob.solve(gp=True, solver=cp.CLARABEL)
# before: 59.32 (silently wrong) — true GP optimum 26.365
```

When elementwise `log(P)` is not PSD, it instead crashed with `Cannot reduce problem to cone program` despite `is_dgp()` being True.

`quad_form_canon` itself also imported the `hstack` *module* instead of the atom, so it would have crashed on first use — confirming the path was never executed. Both fixed, with the explicit log-space formulation as the test oracle.

## Type of change
- [x] Bug fix

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)