### PR TITLE
Fix factor-2 error in Hermitian PSD constraint dual recovery

### DIFF
--- a/cvxpy/reductions/complex2real/complex2real.py
+++ b/cvxpy/reductions/complex2real/complex2real.py
@@ -340,14 +340,13 @@ class Complex2Real(Reduction):
                         #          [-im(X), re(X)]
                         # and the constraint con_y = Y >> 0.
                         #
-                        # The real part the dual variable for con_x is the upper-left
-                        # block of the dual variable for con_y.
-                        #
-                        # The imaginary part of the dual variable for con_x is the
-                        # upper-right block of the dual variable for con_y.
+                        # If D is the dual variable for con_y, then the dual variable
+                        # for con_x is 2*(D[:n, :n] + 1j*D[n:, :n]). The factor of 2
+                        # accounts for the dilation doubling the inner product:
+                        # <D, Y> = 2*Re(<D[:n, :n] + 1j*D[n:, :n], X>).
                         n = cons.args[0].shape[0]
                         dual = solution.dual_vars[cid]
-                        dvars[cid] = dual[:n, :n] + 1j*dual[n:, :n]
+                        dvars[cid] = 2*(dual[:n, :n] + 1j*dual[n:, :n])
                     elif isinstance(cons, self.UNIMPLEMENTED_COMPLEX_DUALS):
                         # TODO: implement dual variable recovery
                         pass

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -538,6 +538,25 @@ class TestComplex(BaseTest):
         prob.solve(solver="SCS")
         assert prob.status is cp.INFEASIBLE
 
+    def test_hermitian_psd_dual(self) -> None:
+        """Test the dual of a PSD constraint on a Hermitian matrix.
+
+        Regression test: the dual recovered from the real dilation was
+        half its correct value.
+        """
+        C = np.array([[2, 1-1j], [1+1j, 3]])
+        A = np.array([[1, 0.5j], [-0.5j, 1]])
+        X = Variable((2, 2), hermitian=True)
+        con = X >> A
+        prob = Problem(cp.Minimize(cp.real(cp.trace(C @ X))), [con])
+        prob.solve(solver=cp.CLARABEL)
+        self.assertAlmostEqual(prob.value, 4)
+        # KKT conditions give dual variable Y == C exactly.
+        Y = con.dual_value
+        self.assertItemsAlmostEqual(Y, C)
+        # Strong duality: optimal value equals Re(<Y, A>).
+        self.assertAlmostEqual(prob.value, np.real(np.trace(Y.conj().T @ A)))
+
     def test_promote(self) -> None:
         """Test promotion of complex variables.
         """


### PR DESCRIPTION
## Description
A Hermitian PSD constraint X >> 0 is canonicalized to the real
dilation [[Re(X), -Im(X)], [Im(X), Re(X)]] >> 0. The dilation doubles
the inner product: <Y_big, X_big> = 2*Re(<Y, X>) for Y recovered from
the blocks of Y_big. Complex2Real.invert() recovered the complex dual
as dual[:n,:n] + 1j*dual[n:,:n] without compensating, so Hermitian PSD
duals were half their correct value: for
minimize Re(trace(C @ X)) s.t. X >> A the KKT conditions give Y == C,
but con.dual_value returned C/2 and violated strong duality
(Re(<Y, A>) was half the optimal value). The real symmetric analog
already returned the correct dual.

Multiply the recovered dual by 2. Other complex dual recoveries in
complex2real.py (Equality/Zero and purely imaginary constraints) split
into separate real constraints rather than a dilation, so they have no
such factor and are unchanged. No existing tests encoded the halved
value.

The regression test checks the dual equals C and that strong duality
holds; the fix was also verified against finite-difference sensitivity
to Hermitian perturbations of A.

Found by an automated bug-hunting audit of master; each finding was reproduced against an independent oracle before fixing.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
