### PR TITLE
Only merge positive-ratio rows in CVXOPT inequality presolve

### DIFF
--- a/cvxpy/reductions/solvers/compr_matrix.py
+++ b/cvxpy/reductions/solvers/compr_matrix.py
@@ -29,7 +29,8 @@ def get_row_nnz(mat, row):
 def compress_matrix(A, b, equil_eps: float = 1e-10):
     """Compresses A and b by eliminating redundant rows.
 
-    Identifies rows that are multiples of another row.
+    Identifies rows that are positive multiples of another row,
+    i.e. rows that are redundant when (A, b) encodes Ax <= b.
     Reduces A and b to C = PA, d = Pb, where P has one
     nonzero per row.
 
@@ -79,9 +80,11 @@ def compress_matrix(A, b, equil_eps: float = 1e-10):
                 prev_match_ptr = A.indptr[row_match]
                 match_ptr = A.indptr[row_match+1]
                 match_vals = A.data[prev_match_ptr:match_ptr]
-                # Ratio should be constant.
+                # Ratio should be constant and positive. A negative
+                # multiple of an inequality row describes the opposite
+                # half-space, so it is not redundant.
                 ratio = cur_vals/match_vals
-                if np.ptp(ratio) < equil_eps and \
+                if ratio[0] > 0 and np.ptp(ratio) < equil_eps and \
                    abs(ratio[0] - b[row_num]/b[row_match]) < equil_eps:
                     keep_row = False
                     P_V.append(ratio[0])

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -84,6 +84,15 @@ def test_compress_matrix_eliminates_empty_and_duplicate_rows() -> None:
     np.testing.assert_allclose((P @ A_compr).toarray(), [[0.0, 0.0], [1.0, 0.0]])
 
 
+def test_compress_matrix_keeps_negative_multiple_rows() -> None:
+    # x <= 1 and -x <= -1 are opposite half-spaces, so neither row is redundant.
+    A = sp.csr_matrix([[1.0, 0.0], [-1.0, 0.0]])
+    b = np.array([1.0, -1.0])
+    A_compr, b_compr, _ = compress_matrix(A, b)
+    np.testing.assert_allclose(A_compr.toarray(), A.toarray())
+    np.testing.assert_allclose(b_compr, b)
+
+
 @unittest.skipUnless('ECOS' in INSTALLED_SOLVERS, 'ECOS is not installed.')
 class TestECOS(BaseTest):
 
@@ -1329,6 +1338,20 @@ class TestCVXOPT(BaseTest):
 
     def test_cvxopt_sdp_2(self) -> None:
         StandardTestSDPs.test_sdp_2(solver='CVXOPT')
+
+    def test_cvxopt_presolve_opposite_inequalities(self) -> None:
+        """Presolve must not drop a row that is a negative multiple of another.
+
+        The redundant equalities trigger inequality compression, which used
+        to merge z >= 1 (stored as -z <= -1) into z <= 1, making the problem
+        appear unbounded.
+        """
+        x, y, z = cp.Variable(), cp.Variable(), cp.Variable()
+        prob = cp.Problem(cp.Minimize(z),
+                          [x + y == 1, 2 * x + 2 * y == 2, z <= 1, z >= 1, x >= 0, y >= 0])
+        prob.solve(solver='CVXOPT')
+        self.assertEqual(prob.status, cp.OPTIMAL)
+        self.assertAlmostEqual(prob.value, 1.0)
 
 
 @unittest.skipUnless('SDPA' in INSTALLED_SOLVERS, 'SDPA is not installed.')


### PR DESCRIPTION
## Description
compress_matrix, used by the CVXOPT interface to drop redundant
inequality rows when the equality matrix is rank deficient, treated a
row as redundant whenever it was any scalar multiple of a kept row with
a matching right-hand side ratio. For inequalities Gx <= h a negative
multiple describes the opposite half-space (e.g. z >= 1 stored as
-z <= -1 versus z <= 1), so dropping it enlarges the feasible set:
min z s.t. z <= 1, z >= 1 plus duplicated equalities was reported
unbounded instead of optimal at 1.

Require a positive ratio before merging rows. compress_matrix's only
caller compresses the LEQ block of G in cvxopt_conif.py, so no equality
usage relies on merging negative multiples.

Tests: unit test that compress_matrix keeps negative-multiple rows, and
a CVXOPT regression test for the formerly-unbounded problem.

Found by an automated bug-hunting audit of master; each finding was reproduced against an independent oracle before fixing.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
