### PR TITLE
Fix sparse symmetry checks to compare entry positions

### DIFF
--- a/cvxpy/interface/matrix_utilities.py
+++ b/cvxpy/interface/matrix_utilities.py
@@ -332,8 +332,9 @@ def is_sparse_symmetric(m, complex: bool = False) -> bool:
     if m.shape[0] != m.shape[1]:
         raise ValueError('m must be a square matrix')
 
-    if not isinstance(m, sp.coo_array):
-        m = sp.coo_array(m)
+    m = sp.coo_array(m)
+    m.sum_duplicates()
+    m.eliminate_zeros()
 
     r, c, v = m.row, m.col, m.data
     tril_no_diag = r > c
@@ -351,8 +352,13 @@ def is_sparse_symmetric(m, complex: bool = False) -> bool:
 
     sortl = np.lexsort((cl, rl))
     sortu = np.lexsort((ru, cu))
-    vl = vl[sortl]
-    vu = vu[sortu]
+    rl, cl, vl = rl[sortl], cl[sortl], vl[sortl]
+    ru, cu, vu = ru[sortu], cu[sortu], vu[sortu]
+
+    # Entry (i, j) in the lower triangle must mirror entry (j, i)
+    # in the upper triangle.
+    if not (np.array_equal(rl, cu) and np.array_equal(cl, ru)):
+        return False
 
     if complex:
         check = np.allclose(vl, np.conj(vu))
@@ -378,8 +384,9 @@ def is_sparse_skew_symmetric(A) -> bool:
     if A.shape[0] != A.shape[1]:
         raise ValueError('m must be a square matrix')
 
-    if not isinstance(A, sp.coo_array):
-        A = sp.coo_array(A)
+    A = sp.coo_array(A)
+    A.sum_duplicates()
+    A.eliminate_zeros()
 
     r, c, v = A.row, A.col, A.data
     tril = r >= c
@@ -397,8 +404,12 @@ def is_sparse_skew_symmetric(A) -> bool:
 
     sortl = np.lexsort((cl, rl))
     sortu = np.lexsort((ru, cu))
-    vl = vl[sortl]
-    vu = vu[sortu]
+    rl, cl, vl = rl[sortl], cl[sortl], vl[sortl]
+    ru, cu, vu = ru[sortu], cu[sortu], vu[sortu]
+
+    # Entry (i, j) with i >= j must mirror entry (j, i) with j <= i.
+    if not (np.array_equal(rl, cu) and np.array_equal(cl, ru)):
+        return False
 
     check = np.allclose(vl + vu, 0)
     return check

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -332,6 +332,38 @@ class TestExpressions(BaseTest):
         self.assertFalse(C.is_skew_symmetric())
         pass
 
+    def test_sparse_symmetry_checks_positions(self) -> None:
+        """Asymmetric sparse matrices whose triangle values match must not pass."""
+        # A[1, 0] = 5, A[0, 2] = 5: value multisets of the triangles match.
+        A = sp.coo_array(([5.0, 5.0], ((1, 0), (0, 2))), shape=(3, 3))
+        self.assertFalse(intf.is_sparse_symmetric(A))
+        self.assertFalse(Constant(A).is_symmetric())
+        with self.assertRaises(ValueError):
+            cp.quad_form(Variable(3), A)
+
+        H = sp.coo_array(([5 + 1j, 5 - 1j], ((1, 0), (0, 2))), shape=(3, 3))
+        self.assertFalse(Constant(H).is_hermitian())
+
+        B = sp.coo_array(([5.0, -5.0], ((1, 0), (0, 2))), shape=(3, 3))
+        self.assertFalse(intf.is_sparse_skew_symmetric(B))
+        self.assertFalse(Constant(B).is_skew_symmetric())
+
+        # Duplicate COO entries and explicit zeros must not break detection.
+        S = sp.coo_array(([2.0, 3.0, 5.0, 0.0], ((1, 1, 0, 2), (0, 0, 1, 0))), shape=(3, 3))
+        self.assertTrue(intf.is_sparse_symmetric(S))
+        K = sp.coo_array(([5.0, -5.0, 0.0], ((1, 0, 2), (0, 1, 2))), shape=(3, 3))
+        self.assertTrue(intf.is_sparse_skew_symmetric(K))
+
+        # Sparse and dense classification agree on random matrices.
+        rng = np.random.default_rng(0)
+        for trial in range(20):
+            M = sp.random_array((5, 5), density=0.4, rng=rng)
+            if trial % 2 == 0:
+                M = (M + M.T).tocoo()
+            D = M.toarray()
+            self.assertEqual(intf.is_sparse_symmetric(M), np.allclose(D, D.T))
+            self.assertEqual(intf.is_sparse_skew_symmetric(M), np.allclose(D + D.T, 0))
+
     def test_1D_array(self) -> None:
         """Test NumPy 1D arrays as constants.
         """


### PR DESCRIPTION
## Description
is_sparse_symmetric and is_sparse_skew_symmetric in
cvxpy/interface/matrix_utilities.py sorted the strictly-lower and
strictly-upper triangle values independently and compared only the
value arrays, never the positions. Any asymmetric sparse matrix whose
triangle value multisets matched was misclassified as symmetric,
Hermitian, or skew-symmetric, e.g. A with A[1,0]=5, A[0,2]=5 passed
is_sparse_symmetric and quad_form accepted it while the dense path
correctly rejected it.

After the existing lexicographic sort, also require the lower-triangle
coordinates to equal the transposed upper-triangle coordinates before
comparing values. Sum duplicate COO entries and eliminate explicit
zeros first so structurally redundant but genuinely (skew-)symmetric
matrices still classify correctly.

Adds a regression test covering the asymmetric symmetric/Hermitian/
skew repros, duplicate and explicit-zero inputs, and a randomized
sparse-vs-dense agreement battery.

Found by an automated bug-hunting audit of master; each finding was reproduced against an independent oracle before fixing.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
