### PR TITLE
Fix scalar boolean indexing to use NumPy mask semantics

### DIFF
--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -1214,6 +1214,26 @@ class TestExpressions(BaseTest):
         self.assertItemsAlmostEqual(A[np.array([True, True, True]),
                                       np.array([True, False, True, True])], expr.value)
 
+    def test_scalar_bool_indices(self) -> None:
+        """Test indexing with scalar booleans (NumPy mask semantics).
+
+        x[True] prepends a length-1 axis; x[False] a length-0 axis.
+        """
+        A = np.arange(12.).reshape(3, 4)
+        C = Constant(A)
+
+        for key in (True, False, np.True_, (True, 0), (False, 1), (True, slice(1, 3))):
+            expr = C[key]
+            self.assertEqual(expr.shape, A[key].shape)
+            self.assertItemsAlmostEqual(expr.value, A[key])
+
+        # Shape inference, value, and solve must agree.
+        P = Variable((3, 4))
+        prob = Problem(Minimize(cp.sum_squares(P - A)), [P[True, 0] == A[True, 0]])
+        prob.solve(solver=cp.CLARABEL)
+        self.assertEqual(prob.status, cp.OPTIMAL)
+        self.assertItemsAlmostEqual(P[True, 0].value, A[True, 0])
+
     def test_selector_list_indices(self) -> None:
         """Test indexing with lists/ndarrays of indices.
         """

--- a/cvxpy/utilities/key_utils.py
+++ b/cvxpy/utilities/key_utils.py
@@ -225,8 +225,11 @@ def is_special_slice(key) -> bool:
 
 def special_key_to_str(key):
     """Converts a special key to a string representation."""
+    if np.isscalar(key):
+        # Scalar boolean keys are special slices but not iterable.
+        key = (key,)
     key_strs = []
-    for k in to_tuple(key):
+    for k in key:
         if isinstance(k, (np.ndarray, list)):
             key_strs.append(pprint_sequence(k))
         elif isinstance(k, slice):

--- a/cvxpy/utilities/key_utils.py
+++ b/cvxpy/utilities/key_utils.py
@@ -209,10 +209,14 @@ def to_str(key):
 
 
 def is_special_slice(key) -> bool:
-    """Does the key contain a list, ndarray, or logical ndarray?
+    """Does the key contain a list, ndarray, scalar boolean, or logical ndarray?
     """
     # Slices and int-like numbers are fine.
     for elem in to_tuple(key):
+        # Scalar booleans use NumPy mask semantics (new leading axis),
+        # so they must not be treated as integer indices.
+        if isinstance(elem, (bool, np.bool_)):
+            return True
         if not (isinstance(elem, (numbers.Number, slice)) or np.isscalar(elem)):
             return True
 
@@ -222,7 +226,7 @@ def is_special_slice(key) -> bool:
 def special_key_to_str(key):
     """Converts a special key to a string representation."""
     key_strs = []
-    for k in key:
+    for k in to_tuple(key):
         if isinstance(k, (np.ndarray, list)):
             key_strs.append(pprint_sequence(k))
         elif isinstance(k, slice):


### PR DESCRIPTION
## Description
x[True] previously meant three different things: is_special_slice
classified Python/NumPy bool scalars as ordinary numbers (bool passes
both numbers.Number and np.isscalar), so validate_key/format_slice
converted True to integer index 1 for shape inference and the
solve/linop path, while index.numeric applied the original key with
NumPy bool-mask semantics (new leading axis). Shape, .value, and solve
results all disagreed.

Fix: route keys containing scalar booleans to special_index, which
already implements full NumPy semantics self-consistently (it builds
its selection matrix by applying the key with NumPy itself). Now
x[True] == x[None] with shape (1, *shape), x[False] yields a 0-size
leading axis, and bools inside tuple keys work, with shape, value, and
solve all agreeing. Also make special_key_to_str tuple-wrap the key so
name() works for non-iterable keys such as a bare bool.

Adds test_scalar_bool_indices covering True/False/np.True_, tuple keys,
and shape/value/solve agreement via a CLARABEL solve; existing boolean
array-mask and integer/slice indexing tests are unchanged and pass.

Found by an automated bug-hunting audit of master; each finding was reproduced against an independent oracle before fixing.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
