### PR TITLE
Fix cp.moveaxis to handle negative and scalar axes like numpy

### DIFF
--- a/cvxpy/atoms/affine/transpose.py
+++ b/cvxpy/atoms/affine/transpose.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import numpy as np
+from numpy.lib.array_utils import normalize_axis_tuple
 
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
@@ -156,28 +157,30 @@ def swapaxes(expr, axis1: int, axis2: int) -> Expression:
     axes[axis1], axes[axis2] = axes[axis2], axes[axis1]
     return transpose(expr, axes=axes)
 
-def moveaxis(expr, source: list[int], destination: list[int]) -> Expression:
+def moveaxis(expr, source, destination) -> Expression:
     """Move axes of the expression to new positions.
 
     Parameters
     ----------
     expr : AffAtom
         The expression to move axes of.
-    source : list of int
-        The original positions of the axes to move.
-    destination : list of int
-        The new positions for the moved axes.
+    source : int or sequence of int
+        The original positions of the axes to move. Negative values count
+        from the last axis, as in :func:`numpy.moveaxis`.
+    destination : int or sequence of int
+        The new positions for the moved axes. Negative values count from
+        the last axis, as in :func:`numpy.moveaxis`.
 
     Returns
     -------
     AffAtom
         A new transpose atom with the axes moved.
     """
-    if not isinstance(source, list) or not isinstance(destination, list):
-        raise TypeError("Source and destination must be lists of integers.")
-
+    source = normalize_axis_tuple(source, expr.ndim, 'source')
+    destination = normalize_axis_tuple(destination, expr.ndim, 'destination')
     if len(source) != len(destination):
-        raise ValueError("Source and destination must have the same length.")
+        raise ValueError('`source` and `destination` arguments must have '
+                         'the same number of elements')
 
     order = [n for n in range(expr.ndim) if n not in source]
 

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import re
 import warnings
 
 import numpy as np
@@ -1886,6 +1887,34 @@ class TestND_Expressions():
         prob = cp.Problem(self.obj, [expr == y])
         prob.solve(canon_backend=cp.SCIPY_CANON_BACKEND)
         assert np.allclose(expr.value, y)
+
+    @pytest.mark.parametrize("source, destination", [([0], [-1]), ([-1], [0]),
+                                                     ([0, 1], [-1, -2]), (0, -1), ([0], [0])])
+    @pytest.mark.parametrize("shape", [(2, 3, 4), (2, 3, 4, 5)])
+    def test_moveaxis_negative_axes(self, source, destination, shape) -> None:
+        target = np.arange(np.prod(shape)).reshape(shape)
+        expr = cp.moveaxis(cp.Constant(target), source, destination)
+        y = np.moveaxis(target, source, destination)
+        assert expr.shape == y.shape
+        assert np.allclose(expr.value, y)
+
+    def test_moveaxis_negative_axes_solve(self) -> None:
+        target = np.arange(24).reshape((2, 3, 4))
+        var = cp.Variable((2, 3, 4))
+        y = cp.Variable((4, 2, 3))
+        prob = cp.Problem(self.obj, [var == target, y == cp.moveaxis(var, [-1], [0])])
+        prob.solve(solver=cp.CLARABEL, canon_backend=cp.SCIPY_CANON_BACKEND)
+        assert np.allclose(y.value, np.moveaxis(target, [-1], [0]))
+
+    @pytest.mark.parametrize("source, destination", [([3], [0]), ([0], [-4]),
+                                                     ([0, 0], [1, 2]), ([0], [1, 2]),
+                                                     ([0, 1], [0, 0])])
+    def test_moveaxis_invalid_axes(self, source, destination) -> None:
+        target = np.zeros((2, 3, 4))
+        with pytest.raises(ValueError) as np_err:
+            np.moveaxis(target, source, destination)
+        with pytest.raises(ValueError, match=re.escape(str(np_err.value))):
+            cp.moveaxis(cp.Constant(target), source, destination)
 
     @pytest.mark.parametrize("shapes", [((3),(253, 253, 3)),
                                         ((7, 1, 5),(8, 7, 6, 5)),


### PR DESCRIPTION
## Description
cp.moveaxis produced wrong shapes/values for negative axes (e.g.
source=[0], destination=[-1] gave (3,2,4) instead of (3,4,2) for a
(2,3,4) input) and raised an opaque ValueError for negative sources.

Root cause: source/destination were never normalized to non-negative
axes, so `n not in source` failed to exclude negative sources and
`order.insert(dest, src)` with a negative dest inserted at the wrong
position. Scalar axes were also rejected, unlike np.moveaxis.

Fix: normalize both arguments with numpy's public
np.lib.array_utils.normalize_axis_tuple (numpy >= 2.0 is required),
mirroring np.moveaxis exactly, including AxisError for out-of-range
axes, ValueError for duplicates, and acceptance of scalar/tuple axes.

Tests: parametrized regression tests in TestND_Expressions compare
shape and value against np.moveaxis for negative/scalar/identity moves
on 3-D and 4-D constants, assert error messages match numpy for
out-of-range, duplicate, and mismatched-length axes, and check a
CLARABEL solve through a moveaxis constraint.

Found by an automated bug-hunting audit of master; each finding was reproduced against an independent oracle before fixing.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
