### PR TITLE
Fix HuberPerspectiveAtom._grad t-derivative and return sparse matrices

### DIFF
--- a/cvxpy/atoms/elementwise/huber.py
+++ b/cvxpy/atoms/elementwise/huber.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 
 import numpy as np
+import scipy.sparse as sp
 import scipy.special
 
 from cvxpy.atoms.atom import Atom
@@ -282,7 +283,10 @@ class HuberPerspectiveAtom(Atom):
 
         d/dx [t * huber(x/t, M)] = huber'(x/t, M)  (clipped linear in x/t)
         d/dt [t * huber(x/t, M)] = huber(x/t, M) - (x/t) * huber'(x/t, M)
-                                  = -min(x/t, M)^2   (always <= 0)
+                                  = -min(|x/t|, M)^2   (always <= 0)
+
+        Returns:
+            A list of SciPy CSC sparse matrices or None.
         """
         x_val = np.asarray(values[0], dtype=float)
         t_val = float(values[1])
@@ -292,13 +296,14 @@ class HuberPerspectiveAtom(Atom):
         r = x_val / t_val
         M_val = float(self.M.value)
         clipped = np.sign(r) * np.minimum(np.abs(r), M_val)
+        cols = self.size
 
         # gradient w.r.t. x: 2 * clipped (factor of 2 from CVXPY's huber convention)
-        grad_x = 2 * clipped  # shape matches x
+        grad_x = Elementwise.elemwise_grad_to_diag(2 * clipped, self._x.size, cols)
 
-        # gradient w.r.t. t: sum over elements of -2 * min(|r|, M)^2
-        # = sum_i [huber(x_i/t, M) - (x_i/t)*huber'(x_i/t, M)]
-        # = -sum_i min(x_i/t, M)^2   [can be shown by case analysis]
-        grad_t = np.sum(-2 * np.minimum(np.abs(r), M_val) ** 2)  # scalar
+        # gradient w.r.t. t (scalar): each output element j contributes
+        # huber(x_j/t, M) - (x_j/t)*huber'(x_j/t, M) = -min(|x_j/t|, M)^2
+        grad_t_vals = -np.minimum(np.abs(r), M_val) ** 2
+        grad_t = sp.csc_array(np.reshape(np.atleast_1d(grad_t_vals), (1, cols), order="F"))
 
-        return [grad_x, np.atleast_1d(np.array(grad_t))]
+        return [grad_x, grad_t]

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1165,24 +1165,31 @@ class TestAtoms(BaseTest):
         self.assertIn("concave or affine", str(cm.exception))
 
         # -- _grad: gradient w.r.t. x and t --
+        # d/dt [t*huber(x/t, M)] = -min(|x/t|, M)^2, verified by finite differences.
         atom = cp.huber(y, M=1, t=cp.Variable(pos=True))
         g = atom._grad([np.array(0.5), 2.0])
-        self.assertAlmostEqual(float(g[0]), 0.5)
-        self.assertAlmostEqual(g[1].item(), -0.125)
+        self.assertAlmostEqual(g[0].toarray().item(), 0.5)
+        self.assertAlmostEqual(g[1].toarray().item(), -0.0625)
         g = atom._grad([np.array(3.0), 2.0])
-        self.assertAlmostEqual(float(g[0]), 2.0)
-        self.assertAlmostEqual(g[1].item(), -2.0)
+        self.assertAlmostEqual(g[0].toarray().item(), 2.0)
+        self.assertAlmostEqual(g[1].toarray().item(), -1.0)
         g = atom._grad([np.array(-3.0), 2.0])
-        self.assertAlmostEqual(float(g[0]), -2.0)
-        self.assertAlmostEqual(g[1].item(), -2.0)
+        self.assertAlmostEqual(g[0].toarray().item(), -2.0)
+        self.assertAlmostEqual(g[1].toarray().item(), -1.0)
         yv = cp.Variable(3)
         atom_v = cp.huber(yv, M=1, t=cp.Variable(pos=True))
         g = atom_v._grad([np.array([0.5, 3.0, -3.0]), 2.0])
-        self.assertItemsAlmostEqual(g[0], [0.5, 2.0, -2.0])
-        self.assertAlmostEqual(g[1].item(), -4.125)
+        self.assertItemsAlmostEqual(g[0].toarray(), np.diag([0.5, 2.0, -2.0]))
+        self.assertItemsAlmostEqual(g[1].toarray(), [-0.0625, -1.0, -1.0])
         g = atom._grad([np.array(0.5), 0.0])
         self.assertIsNone(g[0])
         self.assertIsNone(g[1])
+        # Chain rule through Atom.grad: d/dt sum_i t*huber(2*x_i/t) at the kink |2x/t| = M.
+        xv, tv = cp.Variable(2), cp.Variable(pos=True)
+        xv.value, tv.value = np.array([1.0, -1.0]), 2.0
+        expr = cp.sum(cp.huber(2 * xv, M=1, t=tv))
+        self.assertItemsAlmostEqual(expr.grad[xv].toarray(), [4.0, -4.0])
+        self.assertAlmostEqual(expr.grad[tv], -2.0)
 
         # -- Copy --
         atom = cp.huber(self.x, M=2, t=3)


### PR DESCRIPTION
## Description
The 3-arg perspective Huber atom f(x, t) = t * huber(x/t, M) had two
bugs in HuberPerspectiveAtom._grad:

1. The t-gradient carried a spurious factor of 2. With CVXPY's
   convention huber(r, M) = 2*scipy.special.huber(M, r), case analysis
   gives d/dt [t*huber(x/t, M)] = huber(r, M) - r*huber'(r, M)
   = -min(|r|, M)^2 (quadratic region: r^2 - r*2r = -r^2; linear
   region: 2M|r| - M^2 - r*2M*sign(r) = -M^2), exactly as the
   derivation comment in the code already stated. The code instead
   returned -2*min(|r|, M)^2. Central finite differences of
   t*2*scipy.special.huber(M, x/t) confirm: at (x=0.5, t=2, M=1) the
   derivative is -0.0625 (code gave -0.125); at (x=3, t=2, M=1) it is
   -1.0 (code gave -2.0).

2. _grad returned plain dense ndarrays (and summed the t-gradient over
   elements), violating the Atom.grad contract that each entry be an
   (arg.size, atom.size) SciPy sparse matrix. Now the x-gradient is a
   sparse diagonal built with Elementwise.elemwise_grad_to_diag (same
   pattern as the 2-arg HuberAtom) and the t-gradient is a (1, size)
   sparse row with per-element entries -min(|x_j/t|, M)^2; the chain
   rule in Atom.grad performs the summation when composed (e.g. under
   cp.sum).

The expected values in test_atoms.py (-0.125, -2.0, -4.125) were
written from the buggy implementation rather than the math; they are
corrected to the finite-difference-verified values (-0.0625, -1.0, and
per-element [-0.0625, -1.0, -1.0]). This is a bug fix to the test's
oracle, not a weakening. A chain-rule check through Atom.grad at the
kink |x/t| = M is added.

Found by an automated bug-hunting audit of master; each finding was reproduced against an independent oracle before fixing.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
