### PR TITLE
Fix log1p bound propagation inherited from log

### DIFF
--- a/cvxpy/atoms/elementwise/log1p.py
+++ b/cvxpy/atoms/elementwise/log1p.py
@@ -19,6 +19,7 @@ import scipy
 
 from cvxpy.atoms.elementwise.log import log
 from cvxpy.constraints.constraint import Constraint
+from cvxpy.utilities import bounds as bounds_utils
 
 
 class log1p(log):
@@ -38,6 +39,11 @@ class log1p(log):
         """The same sign as the argument.
         """
         return (self.args[0].is_nonneg(), self.args[0].is_nonpos())
+
+    def bounds_from_args(self) -> tuple[np.ndarray, np.ndarray]:
+        """Returns bounds for log1p by shifting the argument bounds by 1."""
+        lb, ub = self.args[0].get_bounds()
+        return bounds_utils.log_bounds(lb + 1, ub + 1)
 
     def _grad(self, values):
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.

--- a/cvxpy/tests/test_bounds.py
+++ b/cvxpy/tests/test_bounds.py
@@ -87,6 +87,18 @@ class TestBoundsPropagation:
         assert np.allclose(lb, expected_lb)
         assert np.allclose(ub, expected_ub)
 
+    @pytest.mark.parametrize("bounds,expected_lb,expected_ub", [
+        ([1, 2], np.log(2), np.log(3)),
+        ([-0.5, 0.5], np.log(0.5), np.log(1.5)),
+        ([-1, 0], -np.inf, 0),  # lb on domain boundary x > -1 gives -inf
+    ])
+    def test_log1p_bounds(self, bounds, expected_lb, expected_ub) -> None:
+        """Test log1p bounds are those of log(1 + x), defined on x > -1."""
+        x = cp.Variable(3, bounds=bounds)
+        lb, ub = cp.log1p(x).get_bounds()
+        assert np.allclose(lb, expected_lb)
+        assert np.allclose(ub, expected_ub)
+
     def test_power(self) -> None:
         """Test bounds propagation through power."""
         x = cp.Variable(3, bounds=[1, 2])


### PR DESCRIPTION
## Description
log1p subclasses log and inherited its bounds_from_args, which computes
the interval of log(x) instead of log(1 + x). For an argument bounded
in [1, 2], get_bounds() returned [0, log 2] while the true range is
[log 2, log 3], an interval that does not even contain the function's
range. These bounds feed the NLP solving chain.

Override bounds_from_args in log1p to delegate to the shared
log_bounds utility on the shifted bounds (lb + 1, ub + 1). This also
handles the wider domain x > -1: bounds dipping into (-1, 0] shift to
positive values, and lb <= -1 yields -inf exactly as log_bounds does
for nonpositive lower bounds.

Audited cvxpy/atoms/elementwise/ for other subclasses inheriting
bounds_from_args from a parent with different math: PowerApprox(Power)
is the only other case and approximates the same function, so its
inherited bounds are correct.

Add get_bounds tests for log1p with argument bounds [1, 2],
[-0.5, 0.5], and [-1, 0] in cvxpy/tests/test_bounds.py.

Found by an automated bug-hunting audit of master; each finding was reproduced against an independent oracle before fixing.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
