### PR TITLE
Apply near-integer rounding tolerance in floor.numeric

### DIFF
--- a/cvxpy/atoms/elementwise/ceil.py
+++ b/cvxpy/atoms/elementwise/ceil.py
@@ -108,7 +108,8 @@ class floor(Elementwise):
 
     @Elementwise.numpy_numeric
     def numeric(self, values):
-        return np.floor(values[0])
+        decimals = int(np.abs(np.log10(s.ATOM_EVAL_TOL)))
+        return np.floor(np.around(values[0], decimals=decimals))
 
     def sign_from_args(self) -> tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -209,6 +209,21 @@ class TestDqcp(base_test.BaseTest):
         self.assertEqual(problem.objective.value, 11.0)
         self.assertGreater(x.value, 11.7)
 
+    def test_ceil_floor_near_integer_tolerance(self) -> None:
+        """Values within solver noise of an integer evaluate to that integer."""
+        x = cp.Variable()
+        for noisy in [3 - 1e-10, 3 + 1e-10]:
+            x.value = noisy
+            self.assertEqual(cp.floor(x).value, 3.0)
+            self.assertEqual(cp.ceil(x).value, 3.0)
+        # Exact integers and clearly-non-integer values are unaffected.
+        x.value = 4.0
+        self.assertEqual(cp.floor(x).value, 4.0)
+        self.assertEqual(cp.ceil(x).value, 4.0)
+        x.value = 2.5
+        self.assertEqual(cp.floor(x).value, 2.0)
+        self.assertEqual(cp.ceil(x).value, 3.0)
+
     def test_basic_multiply_nonneg(self) -> None:
         x, y = cp.Variable(2, nonneg=True)
         expr = x * y


### PR DESCRIPTION
## Description
ceil.numeric rounds its input to ATOM_EVAL_TOL decimals before
ceiling (added in #1300 to absorb DQCP solver noise), but
floor.numeric in the same module was never given the same treatment.
As a result cp.floor(x).value at x = 2.9999999999 returned 2.0 while
ceil returned 3.0, so DQCP objective values containing floor were off
by one under ordinary solver noise.

Apply the identical np.around(..., decimals) step in floor.numeric.
ceil and floor are the only numeric() implementations in the
ceil/floor family; no other atom in the module has the omission.

Add a test next to the existing ceil/floor DQCP tests checking that
values within 1e-10 of an integer floor/ceil to that integer while
exact integers and clearly-non-integer values are unchanged.

Found by an automated bug-hunting audit of master; each finding was reproduced against an independent oracle before fixing.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
