### PR TITLE
Map COPT status 4 to the INFEASIBLE_OR_UNBOUNDED status string

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/copt_conif.py
@@ -81,7 +81,7 @@ class COPT(ConicSolver):
                   1: s.OPTIMAL,             # optimal
                   2: s.INFEASIBLE,          # infeasible
                   3: s.UNBOUNDED,           # unbounded
-                  4: s.INF_OR_UNB,          # infeasible or unbounded
+                  4: s.INFEASIBLE_OR_UNBOUNDED,  # infeasible or unbounded
                   5: s.SOLVER_ERROR,        # numerical
                   6: s.USER_LIMIT,          # node limit
                   7: s.OPTIMAL_INACCURATE,  # imprecise

--- a/cvxpy/reductions/solvers/nlp_solvers/copt_nlpif.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/copt_nlpif.py
@@ -31,7 +31,7 @@ class COPT(NLPsolver):
                   1: s.OPTIMAL,             # optimal
                   2: s.INFEASIBLE,          # infeasible
                   3: s.UNBOUNDED,           # unbounded
-                  4: s.INF_OR_UNB,          # infeasible or unbounded
+                  4: s.INFEASIBLE_OR_UNBOUNDED,  # infeasible or unbounded
                   5: s.SOLVER_ERROR,        # numerical
                   6: s.USER_LIMIT,          # node limit
                   7: s.OPTIMAL_INACCURATE,  # imprecise

--- a/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/copt_qpif.py
@@ -27,7 +27,7 @@ class COPT(QpSolver):
                   1: s.OPTIMAL,             # optimal
                   2: s.INFEASIBLE,          # infeasible
                   3: s.UNBOUNDED,           # unbounded
-                  4: s.INF_OR_UNB,          # infeasible or unbounded
+                  4: s.INFEASIBLE_OR_UNBOUNDED,  # infeasible or unbounded
                   5: s.SOLVER_ERROR,        # numerical
                   6: s.USER_LIMIT,          # node limit
                   7: s.OPTIMAL_INACCURATE,  # imprecise

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -3130,6 +3130,15 @@ class TestCOPT(unittest.TestCase):
     def test_copt_mi_lp_5(self) -> None:
         StandardTestLPs.test_mi_lp_5(solver='COPT')
 
+    def test_copt_mi_lp_inf_or_unb(self) -> None:
+        """COPT status 4 must map to the INFEASIBLE_OR_UNBOUNDED status
+        string, not the s.INF_OR_UNB status list (which made unpack raise).
+        """
+        y = cp.Variable(integer=True)
+        prob = cp.Problem(cp.Minimize(y), [y <= 10])
+        prob.solve(solver='COPT')
+        self.assertEqual(prob.status, cp.settings.INFEASIBLE_OR_UNBOUNDED)
+
     def test_copt_mi_socp_1(self) -> None:
         StandardTestSOCPs.test_mi_socp_1(solver='COPT')
 


### PR DESCRIPTION
## Description
The COPT STATUS_MAP entry for status 4 used s.INF_OR_UNB, which is the
list of infeasible/unbounded statuses in cvxpy/settings.py, not the
status string s.INFEASIBLE_OR_UNBOUNDED. When COPT finished with status
4 (e.g. an unbounded MIP), problem.unpack() raised "ValueError: Cannot
unpack invalid solution" instead of reporting the status.

Map status 4 to s.INFEASIBLE_OR_UNBOUNDED. Audited the remaining
STATUS_MAP entries and settings constants used in the file; all others
are status strings (SOLUTION_PRESENT is correctly used as a list).

Add a regression test that an unbounded integer LP reports the
infeasible_or_unbounded status, matching other solvers such as HIGHS.

Found by an automated bug-hunting audit of master; each finding was reproduced against an independent oracle before fixing.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
