### PR TITLE
Include canon_backend in the compilation cache key

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -115,8 +115,8 @@ class Cache:
         self.param_prog = None
         self.inverse_data = None
 
-    def make_key(self, solver, gp, ignore_dpp, use_quad_obj):
-        return (solver, gp, ignore_dpp, use_quad_obj)
+    def make_key(self, solver, gp, ignore_dpp, use_quad_obj, canon_backend):
+        return (solver, gp, ignore_dpp, use_quad_obj, canon_backend)
 
     def gp(self):
         return self.key is not None and self.key[1]
@@ -821,13 +821,13 @@ class Problem(u.Canonical):
         # Convert solver argument to upper case.
         if isinstance(solver, str):
             solver = solver.upper()
-        # Cache includes ignore_dpp and solver_opts['use_quad_obj']
-        # because they alter compilation.
+        # Cache includes ignore_dpp, solver_opts['use_quad_obj'], and
+        # canon_backend because they alter compilation.
         if solver_opts is None:
             use_quad_obj = None
         else:
             use_quad_obj = solver_opts.get('use_quad_obj', None)
-        key = self._cache.make_key(solver, gp, ignore_dpp, use_quad_obj)
+        key = self._cache.make_key(solver, gp, ignore_dpp, use_quad_obj, canon_backend)
         if key != self._cache.key:
             self._cache.invalidate()
             solving_chain = self._construct_chain(

--- a/cvxpy/tests/test_backend_selection.py
+++ b/cvxpy/tests/test_backend_selection.py
@@ -183,6 +183,46 @@ class TestBackendSelectionFallback:
             get_canon_backend(prob, s.CPP_CANON_BACKEND)
 
 
+class TestCanonBackendCacheKey:
+    """Re-solving with a different canon_backend must re-canonicalize."""
+
+    @staticmethod
+    def _problem():
+        p = cp.Parameter(2, value=np.array([1.0, 2.0]))
+        x = cp.Variable(2)
+        return cp.Problem(cp.Minimize(cp.sum_squares(x - p)), [x >= 0])
+
+    @staticmethod
+    def _cached_backend(prob):
+        chain = prob._cache.solving_chain
+        return [r for r in chain.reductions if isinstance(r, ConeMatrixStuffing)][0].canon_backend
+
+    def test_backend_switch_invalidates_cache(self):
+        prob = self._problem()
+        prob.solve(solver=cp.CLARABEL, canon_backend=s.SCIPY_CANON_BACKEND)
+        assert self._cached_backend(prob) == s.SCIPY_CANON_BACKEND
+
+        prob.solve(solver=cp.CLARABEL, canon_backend=s.CPP_CANON_BACKEND)
+        assert self._cached_backend(prob) == s.CPP_CANON_BACKEND
+
+        prob.solve(solver=cp.CLARABEL, canon_backend=s.SCIPY_CANON_BACKEND)
+        assert self._cached_backend(prob) == s.SCIPY_CANON_BACKEND
+
+    def test_same_backend_reuses_cache(self):
+        prob = self._problem()
+        prob.solve(solver=cp.CLARABEL, canon_backend=s.SCIPY_CANON_BACKEND)
+        chain = prob._cache.solving_chain
+        prob.solve(solver=cp.CLARABEL, canon_backend=s.SCIPY_CANON_BACKEND)
+        assert prob._cache.solving_chain is chain
+
+    def test_default_backend_reuses_cache(self):
+        prob = self._problem()
+        prob.solve(solver=cp.CLARABEL)
+        chain = prob._cache.solving_chain
+        prob.solve(solver=cp.CLARABEL)
+        assert prob._cache.solving_chain is chain
+
+
 class TestBackendSelectionSolve:
     """Integration tests that actually solve problems."""
 


### PR DESCRIPTION
## Description
Re-solving a Problem with a different canon_backend silently reused the
previously compiled canonicalization: Cache.make_key only keyed on
(solver, gp, ignore_dpp, use_quad_obj), so get_problem_data treated the
second solve as a cache hit and never constructed a solving chain with
the requested backend.

Fix: add canon_backend to Cache.make_key and its single call site in
get_problem_data. The value is keyed as passed (None for the default),
so the common None -> None re-solve still hits the cache, while None and
an explicit backend are kept distinct (None enables auto-COO selection
for large DPP problems, so they are not equivalent).

Audited the other arguments construct_solving_chain consumes: solver,
gp, ignore_dpp, and solver_opts['use_quad_obj'] were already in the key;
verbose only affects logging; remaining solver_opts are forwarded to the
solver at solve time and do not change canonicalization. enforce_dpp
only gates raising DPPError versus warning for non-DPP problems and
never changes the compiled chain, so it is left out of the key.

Tests: TestCanonBackendCacheKey in test_backend_selection.py asserts a
backend switch re-canonicalizes (via the cached chain's
ConeMatrixStuffing.canon_backend) and that same-backend and default
re-solves still reuse the cached chain object.

Found by an automated bug-hunting audit of master; each finding was reproduced against an independent oracle before fixing.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
