### PR TITLE
Fix N-D parametric matmul in the COO and SCIPY canonicalization backends

### DIFF
--- a/cvxpy/lin_ops/backends/coo_backend.py
+++ b/cvxpy/lin_ops/backends/coo_backend.py
@@ -757,21 +757,22 @@ def _build_interleaved_mul(
 
 
 def _build_interleaved_param_mul(
+    column: CooTensor,
     const_shape: tuple,
     var_shape: tuple,
-    param_size: int,
 ) -> CooTensor:
     """
-    Build the interleaved matrix for a batch-varying direct parameter (P @ X).
+    Build the interleaved matrix for a batch-varying parametric constant (C @ X).
 
-    Parametric analogue of _build_interleaved_mul: P(B,m,k) @ X(B,k,n) where
-    each batch element uses a DIFFERENT (m, k) slice of the parameter P.
-    Values are unknown at canonicalization time, so each entry carries the
-    param_idx of the parameter element P[b, i, r] it corresponds to
-    (column-major: param_idx = b + B*i + B*m*r).
+    Parametric analogue of _build_interleaved_mul: C(B,m,k) @ X(B,k,n) where
+    each batch element uses a DIFFERENT (m, k) slice of C and C depends on
+    Parameters. `column` holds C in column format: an entry with row
+    q = b + B*i + B*m*r (the column-major position of C[b, i, r]), value d and
+    parameter slice s means dC[b, i, r]/dtheta_s = d. For a direct parameter,
+    the column is the identity (d = 1, s = q).
 
     Entries are placed at the interleaved positions (see _build_interleaved_mul):
-        M[b + B*i + B*m*c, b + B*r + B*k*c] = P[b, i, r]  for c in 0..n-1
+        M[b + B*i + B*m*c, b + B*r + B*k*c] = C[b, i, r]  for c in 0..n-1
 
     The result already encodes the batch and output-column structure, so it
     must NOT be expanded again with _kron_nd_structure_mul.
@@ -779,26 +780,26 @@ def _build_interleaved_param_mul(
     B = int(np.prod(const_shape[:-2]))
     m, k = const_shape[-2], const_shape[-1]
     n = var_shape[-1] if len(var_shape) >= 2 else 1
-    assert param_size == B * m * k, "Direct parameter size must match its shape"
+    assert (column.m, column.n) == (B * m * k, 1), "Column data must match the constant shape"
 
-    # bb, ii, rr are grids of indices corresponding to b, i, r in the formula above
-    bb, ii, rr = np.meshgrid(np.arange(B), np.arange(m), np.arange(k), indexing="ij")
-    bb, ii, rr = bb.ravel(), ii.ravel(), rr.ravel()
+    # Decode the column-major position q = b + B*i + B*m*r of each entry
+    bb = column.row % B
+    ii = (column.row // B) % m
+    rr = column.row // (B * m)
 
     base_row = bb + B * ii
     base_col = bb + B * rr
-    param_idx = bb + B * ii + B * m * rr  # column-major index of P[b, i, r]
 
     # Apply I_n: replicate for each output column c in 0..n-1
-    c_offsets = np.repeat(np.arange(n), param_size)
+    c_offsets = np.repeat(np.arange(n), column.nnz)
     return CooTensor(
-        data=np.ones(param_size * n, dtype=np.float64),
+        data=np.tile(column.data, n),
         row=(np.tile(base_row, n) + c_offsets * B * m).astype(np.int64),
         col=(np.tile(base_col, n) + c_offsets * B * k).astype(np.int64),
-        param_idx=np.tile(param_idx, n).astype(np.int64),
+        param_idx=np.tile(column.param_idx, n).astype(np.int64),
         m=B * m * n,
         n=B * k * n,
-        param_size=param_size,
+        param_size=column.param_size,
     )
 
 
@@ -1035,21 +1036,22 @@ def _build_interleaved_rmul(
 
 
 def _build_interleaved_param_rmul(
+    column: CooTensor,
     const_shape: tuple,
     var_shape: tuple,
-    param_size: int,
 ) -> CooTensor:
     """
-    Build the interleaved matrix for a batch-varying direct parameter (X @ P).
+    Build the interleaved matrix for a batch-varying parametric constant (X @ C).
 
-    Parametric analogue of _build_interleaved_rmul: X(B,m,k) @ P(B,k,n) where
-    each batch element uses a DIFFERENT (k, n) slice of the parameter P.
-    Values are unknown at canonicalization time, so each entry carries the
-    param_idx of the parameter element P[b, r, j] it corresponds to
-    (column-major: param_idx = b + B*r + B*k*j).
+    Parametric analogue of _build_interleaved_rmul: X(B,m,k) @ C(B,k,n) where
+    each batch element uses a DIFFERENT (k, n) slice of C and C depends on
+    Parameters. `column` holds C in column format: an entry with row
+    q = b + B*r + B*k*j (the column-major position of C[b, r, j]), value d and
+    parameter slice s means dC[b, r, j]/dtheta_s = d. For a direct parameter,
+    the column is the identity (d = 1, s = q).
 
     Entries are placed at the interleaved positions (see _build_interleaved_rmul):
-        M[b + B*i + B*m*j, b + B*i + B*m*r] = P[b, r, j]  for i in 0..m-1
+        M[b + B*i + B*m*j, b + B*i + B*m*r] = C[b, r, j]  for i in 0..m-1
 
     The result already encodes the batch and row structure, so it must NOT be
     expanded again with _kron_nd_structure_rmul.
@@ -1057,26 +1059,26 @@ def _build_interleaved_param_rmul(
     B = int(np.prod(const_shape[:-2]))
     k, n = const_shape[-2], const_shape[-1]
     m = var_shape[-2] if len(var_shape) >= 2 else 1
-    assert param_size == B * k * n, "Direct parameter size must match its shape"
+    assert (column.m, column.n) == (B * k * n, 1), "Column data must match the constant shape"
 
-    # bb, rr, jj are grids of indices corresponding to b, r, j in the formula above
-    bb, rr, jj = np.meshgrid(np.arange(B), np.arange(k), np.arange(n), indexing="ij")
-    bb, rr, jj = bb.ravel(), rr.ravel(), jj.ravel()
+    # Decode the column-major position q = b + B*r + B*k*j of each entry
+    bb = column.row % B
+    rr = (column.row // B) % k
+    jj = column.row // (B * k)
 
     base_row = bb + B * m * jj
     base_col = bb + B * m * rr
-    param_idx = bb + B * rr + B * k * jj  # column-major index of P[b, r, j]
 
     # Apply I_m: replicate for each row i in 0..m-1
-    i_offsets = np.repeat(np.arange(m), param_size)
+    i_offsets = np.repeat(np.arange(m), column.nnz)
     return CooTensor(
-        data=np.ones(param_size * m, dtype=np.float64),
+        data=np.tile(column.data, m),
         row=(np.tile(base_row, m) + i_offsets * B).astype(np.int64),
         col=(np.tile(base_col, m) + i_offsets * B).astype(np.int64),
-        param_idx=np.tile(param_idx, m).astype(np.int64),
+        param_idx=np.tile(column.param_idx, m).astype(np.int64),
         m=B * m * n,
         n=B * m * k,
-        param_size=param_size,
+        param_size=column.param_size,
     )
 
 
@@ -1950,10 +1952,18 @@ class CooCanonBackend(PythonCanonBackend):
                 # ND parameter with batch dims: each batch element has its own
                 # (m, k) slice of P, so the Kronecker expansion (same matrix
                 # for all batches) does not apply. Build the interleaved
-                # structure directly; it already encodes batch and output
-                # column dims, so apply it without further expansion.
+                # structure directly from the identity column (dP/dP = I);
+                # it already encodes batch and output column dims, so apply
+                # it without further expansion.
+                column = CooTensor(
+                    data=np.ones(param_size, dtype=np.float64),
+                    row=np.arange(param_size, dtype=np.int64),
+                    col=np.zeros(param_size, dtype=np.int64),
+                    param_idx=np.arange(param_size, dtype=np.int64),
+                    m=size, n=1, param_size=param_size
+                )
                 expanded = {param_id: _build_interleaved_param_mul(
-                    const_shape, var_shape, param_size)}
+                    column, const_shape, var_shape)}
                 return self._apply_parametric_matmul(expanded, view)
             # 2D (or trivial batch dims): treat as an (m, k) matrix.
             m, k = const_shape[-2:] if len(const_shape) >= 2 else (1, size)
@@ -1966,6 +1976,23 @@ class CooCanonBackend(PythonCanonBackend):
             )}
             is_param_free = False
         else:
+            if is_batch_varying(const_shape):
+                # Batch-varying constant: keep the column format, which
+                # preserves the batch structure (reshaping to the last two
+                # dims would collapse the per-batch slices of a parametric
+                # constant expression, e.g. 2*P with P(B, m, k)).
+                lhs_data, is_param_free = self.get_constant_data(
+                    const, view, target_shape=None)
+                if not is_param_free:
+                    # Case 1b: Batch-varying parametric LHS
+                    expanded = {
+                        param_id: _build_interleaved_param_mul(
+                            tensor, const_shape, var_shape)
+                        for param_id, tensor in lhs_data.items()
+                    }
+                    return self._apply_parametric_matmul(expanded, view)
+                # Case 2: Batch-varying constant
+                return self._mul_interleaved(lin_op, var_shape, view)
             # Compute 2D target shape (last 2 dims for ND, row vector for 1D)
             target = const_shape[-2:] if len(const_shape) >= 2 else (1, const_shape[0])
             lhs_data, is_param_free = self.get_constant_data(const, view, target_shape=target)
@@ -1973,9 +2000,6 @@ class CooCanonBackend(PythonCanonBackend):
         if not is_param_free:
             # Case 1: Parametric LHS
             return self._mul_parametric_lhs(lhs_data, const_shape, var_shape, view)
-        elif is_batch_varying(const_shape):
-            # Case 2: Batch-varying constant
-            return self._mul_interleaved(lin_op, var_shape, view)
         else:
             # Case 3: 2D constant (or trivial batch dims like (1, m, k))
             return self._mul_kronecker(lhs_data, const_shape, var_shape, view)
@@ -2335,10 +2359,18 @@ class CooCanonBackend(PythonCanonBackend):
                 # ND parameter with batch dims: each batch element has its own
                 # (k, n) slice of P, so the Kronecker expansion (same matrix
                 # for all batches) does not apply. Build the interleaved
-                # structure directly; it already encodes batch and row dims,
-                # so apply it without further expansion.
+                # structure directly from the identity column (dP/dP = I);
+                # it already encodes batch and row dims, so apply it without
+                # further expansion.
+                column = CooTensor(
+                    data=np.ones(param_size, dtype=np.float64),
+                    row=np.arange(param_size, dtype=np.int64),
+                    col=np.zeros(param_size, dtype=np.int64),
+                    param_idx=np.arange(param_size, dtype=np.int64),
+                    m=size, n=1, param_size=param_size
+                )
                 expanded = {param_id: _build_interleaved_param_rmul(
-                    const_shape, var_shape, param_size)}
+                    column, const_shape, var_shape)}
                 return self._apply_parametric_matmul(expanded, view)
             # 2D (or trivial batch dims): treat as a (k, n) matrix.
             k, n = const_shape[-2:] if len(const_shape) >= 2 else (size, 1)
@@ -2351,6 +2383,23 @@ class CooCanonBackend(PythonCanonBackend):
             )}
             is_param_free = False
         else:
+            if is_batch_varying(const_shape):
+                # Batch-varying constant: keep the column format, which
+                # preserves the batch structure (reshaping to the last two
+                # dims would collapse the per-batch slices of a parametric
+                # constant expression, e.g. 2*P with P(B, k, n)).
+                rhs_data, is_param_free = self.get_constant_data(
+                    const, view, target_shape=None)
+                if not is_param_free:
+                    # Case 1b: Batch-varying parametric RHS
+                    expanded = {
+                        param_id: _build_interleaved_param_rmul(
+                            tensor, const_shape, var_shape)
+                        for param_id, tensor in rhs_data.items()
+                    }
+                    return self._apply_parametric_matmul(expanded, view)
+                # Case 2: Batch-varying constant
+                return self._rmul_interleaved(lin_op, var_shape, view)
             # Compute 2D target shape (last 2 dims for ND, column vector for 1D)
             target = const_shape[-2:] if len(const_shape) >= 2 else (const_shape[0], 1)
             rhs_data, is_param_free = self.get_constant_data(const, view, target_shape=target)
@@ -2358,9 +2407,6 @@ class CooCanonBackend(PythonCanonBackend):
         if not is_param_free:
             # Case 1: Parametric RHS
             return self._rmul_parametric_rhs(rhs_data, const_shape, var_shape, view)
-        elif is_batch_varying(const_shape):
-            # Case 2: Batch-varying constant
-            return self._rmul_interleaved(lin_op, var_shape, view)
         else:
             # Case 3: 2D constant (or trivial batch dims like (1, k, n))
             return self._rmul_kronecker(rhs_data, const_shape, var_shape, view)

--- a/cvxpy/lin_ops/backends/coo_backend.py
+++ b/cvxpy/lin_ops/backends/coo_backend.py
@@ -756,6 +756,52 @@ def _build_interleaved_mul(
     )
 
 
+def _build_interleaved_param_mul(
+    const_shape: tuple,
+    var_shape: tuple,
+    param_size: int,
+) -> CooTensor:
+    """
+    Build the interleaved matrix for a batch-varying direct parameter (P @ X).
+
+    Parametric analogue of _build_interleaved_mul: P(B,m,k) @ X(B,k,n) where
+    each batch element uses a DIFFERENT (m, k) slice of the parameter P.
+    Values are unknown at canonicalization time, so each entry carries the
+    param_idx of the parameter element P[b, i, r] it corresponds to
+    (column-major: param_idx = b + B*i + B*m*r).
+
+    Entries are placed at the interleaved positions (see _build_interleaved_mul):
+        M[b + B*i + B*m*c, b + B*r + B*k*c] = P[b, i, r]  for c in 0..n-1
+
+    The result already encodes the batch and output-column structure, so it
+    must NOT be expanded again with _kron_nd_structure_mul.
+    """
+    B = int(np.prod(const_shape[:-2]))
+    m, k = const_shape[-2], const_shape[-1]
+    n = var_shape[-1] if len(var_shape) >= 2 else 1
+    assert param_size == B * m * k, "Direct parameter size must match its shape"
+
+    # bb, ii, rr are grids of indices corresponding to b, i, r in the formula above
+    bb, ii, rr = np.meshgrid(np.arange(B), np.arange(m), np.arange(k), indexing="ij")
+    bb, ii, rr = bb.ravel(), ii.ravel(), rr.ravel()
+
+    base_row = bb + B * ii
+    base_col = bb + B * rr
+    param_idx = bb + B * ii + B * m * rr  # column-major index of P[b, i, r]
+
+    # Apply I_n: replicate for each output column c in 0..n-1
+    c_offsets = np.repeat(np.arange(n), param_size)
+    return CooTensor(
+        data=np.ones(param_size * n, dtype=np.float64),
+        row=(np.tile(base_row, n) + c_offsets * B * m).astype(np.int64),
+        col=(np.tile(base_col, n) + c_offsets * B * k).astype(np.int64),
+        param_idx=np.tile(param_idx, n).astype(np.int64),
+        m=B * m * n,
+        n=B * k * n,
+        param_size=param_size,
+    )
+
+
 def _kron_nd_structure_rmul(tensor: CooTensor, batch_size: int, m: int) -> CooTensor:
     """
     Build the Kronecker structure for ND rmul: C.T tensor I_{B*m}.
@@ -985,6 +1031,52 @@ def _build_interleaved_rmul(
         m=B * m * n,
         n=B * m * k,
         param_size=1
+    )
+
+
+def _build_interleaved_param_rmul(
+    const_shape: tuple,
+    var_shape: tuple,
+    param_size: int,
+) -> CooTensor:
+    """
+    Build the interleaved matrix for a batch-varying direct parameter (X @ P).
+
+    Parametric analogue of _build_interleaved_rmul: X(B,m,k) @ P(B,k,n) where
+    each batch element uses a DIFFERENT (k, n) slice of the parameter P.
+    Values are unknown at canonicalization time, so each entry carries the
+    param_idx of the parameter element P[b, r, j] it corresponds to
+    (column-major: param_idx = b + B*r + B*k*j).
+
+    Entries are placed at the interleaved positions (see _build_interleaved_rmul):
+        M[b + B*i + B*m*j, b + B*i + B*m*r] = P[b, r, j]  for i in 0..m-1
+
+    The result already encodes the batch and row structure, so it must NOT be
+    expanded again with _kron_nd_structure_rmul.
+    """
+    B = int(np.prod(const_shape[:-2]))
+    k, n = const_shape[-2], const_shape[-1]
+    m = var_shape[-2] if len(var_shape) >= 2 else 1
+    assert param_size == B * k * n, "Direct parameter size must match its shape"
+
+    # bb, rr, jj are grids of indices corresponding to b, r, j in the formula above
+    bb, rr, jj = np.meshgrid(np.arange(B), np.arange(k), np.arange(n), indexing="ij")
+    bb, rr, jj = bb.ravel(), rr.ravel(), jj.ravel()
+
+    base_row = bb + B * m * jj
+    base_col = bb + B * m * rr
+    param_idx = bb + B * rr + B * k * jj  # column-major index of P[b, r, j]
+
+    # Apply I_m: replicate for each row i in 0..m-1
+    i_offsets = np.repeat(np.arange(m), param_size)
+    return CooTensor(
+        data=np.ones(param_size * m, dtype=np.float64),
+        row=(np.tile(base_row, m) + i_offsets * B).astype(np.int64),
+        col=(np.tile(base_col, m) + i_offsets * B).astype(np.int64),
+        param_idx=np.tile(param_idx, m).astype(np.int64),
+        m=B * m * n,
+        n=B * m * k,
+        param_size=param_size,
     )
 
 
@@ -1787,18 +1879,17 @@ class CooCanonBackend(PythonCanonBackend):
             param_id: _kron_nd_structure_mul(tensor, batch_size, n)
             for param_id, tensor in lhs_data.items()
         }
+        return self._apply_parametric_matmul(expanded_lhs, view)
 
-        def parametrized_mul(rhs_compact):
-            return {
-                param_id: coo_matmul(lhs_compact, rhs_compact)
-                for param_id, lhs_compact in expanded_lhs.items()
-            }
-
-        # Apply to each variable tensor in-place
+    @staticmethod
+    def _apply_parametric_matmul(expanded: dict, view: CooTensorView) -> CooTensorView:
+        """Left-multiply each variable tensor in the view by per-parameter matrices."""
         for var_id, var_tensor in view.tensor.items():
             const_compact = var_tensor[Constant.ID.value]
-            view.tensor[var_id] = parametrized_mul(const_compact)
-
+            view.tensor[var_id] = {
+                param_id: coo_matmul(matrix, const_compact)
+                for param_id, matrix in expanded.items()
+            }
         view.is_parameter_free = False
         return view
 
@@ -1855,7 +1946,17 @@ class CooCanonBackend(PythonCanonBackend):
             param_id = const.data
             param_size = self.param_to_size[param_id]
             size = int(np.prod(const.shape))
-            m, k = const.shape if len(const.shape) == 2 else (1, size)
+            if is_batch_varying(const_shape):
+                # ND parameter with batch dims: each batch element has its own
+                # (m, k) slice of P, so the Kronecker expansion (same matrix
+                # for all batches) does not apply. Build the interleaved
+                # structure directly; it already encodes batch and output
+                # column dims, so apply it without further expansion.
+                expanded = {param_id: _build_interleaved_param_mul(
+                    const_shape, var_shape, param_size)}
+                return self._apply_parametric_matmul(expanded, view)
+            # 2D (or trivial batch dims): treat as an (m, k) matrix.
+            m, k = const_shape[-2:] if len(const_shape) >= 2 else (1, size)
             lhs_data = {param_id: CooTensor(
                 data=np.ones(param_size, dtype=np.float64),
                 row=np.tile(np.arange(m), k),
@@ -2172,20 +2273,7 @@ class CooCanonBackend(PythonCanonBackend):
             param_id: _kron_nd_structure_rmul(tensor, batch_size, m)
             for param_id, tensor in rhs_data.items()
         }
-
-        def parametrized_rmul(lhs_compact):
-            return {
-                param_id: coo_matmul(rhs_compact, lhs_compact)
-                for param_id, rhs_compact in expanded_rhs.items()
-            }
-
-        # Apply to each variable tensor in-place
-        for var_id, var_tensor in view.tensor.items():
-            const_compact = var_tensor[Constant.ID.value]
-            view.tensor[var_id] = parametrized_rmul(const_compact)
-
-        view.is_parameter_free = False
-        return view
+        return self._apply_parametric_matmul(expanded_rhs, view)
 
     def rmul(self, lin_op, view: CooTensorView) -> CooTensorView:
         """
@@ -2243,7 +2331,17 @@ class CooCanonBackend(PythonCanonBackend):
             param_id = const.data
             param_size = self.param_to_size[param_id]
             size = int(np.prod(const.shape))
-            k, n = const.shape if len(const.shape) == 2 else (size, 1)
+            if is_batch_varying(const_shape):
+                # ND parameter with batch dims: each batch element has its own
+                # (k, n) slice of P, so the Kronecker expansion (same matrix
+                # for all batches) does not apply. Build the interleaved
+                # structure directly; it already encodes batch and row dims,
+                # so apply it without further expansion.
+                expanded = {param_id: _build_interleaved_param_rmul(
+                    const_shape, var_shape, param_size)}
+                return self._apply_parametric_matmul(expanded, view)
+            # 2D (or trivial batch dims): treat as a (k, n) matrix.
+            k, n = const_shape[-2:] if len(const_shape) >= 2 else (size, 1)
             rhs_data = {param_id: CooTensor(
                 data=np.ones(param_size, dtype=np.float64),
                 row=np.tile(np.arange(k), n),

--- a/cvxpy/lin_ops/backends/scipy_backend.py
+++ b/cvxpy/lin_ops/backends/scipy_backend.py
@@ -119,6 +119,48 @@ def _expand_parametric_slices_mul(
         yield _apply_nd_kron_structure_mul(slice_matrix, batch_size, n)
 
 
+def _build_interleaved_param_matrix_mul(
+    column: sp.sparray,
+    param_size: int,
+    const_shape: tuple[int, ...],
+    var_shape: tuple[int, ...],
+) -> sp.csr_array:
+    """
+    Build the stacked interleaved matrix for a batch-varying parametric mul (C @ X).
+
+    For C (B, m, k) @ X (B, k, n) where C depends on Parameters, each batch
+    element uses a DIFFERENT (m, k) slice of C, so the Kronecker expansion
+    (same matrix for all batches) does not apply. `column` is the stacked
+    column format (param_size * B*m*k, 1): the row within parameter slice s is
+    the column-major position q = b + B*i + B*m*r of C[b, i, r] and the value
+    is dC[b, i, r]/dtheta_s. Slice s of the result has entries (cf.
+    _build_interleaved_matrix_mul):
+        M_s[b + B*i + B*m*c, b + B*r + B*k*c] = dC[b, i, r]/dtheta_s
+    for c in 0..n-1. Returns the vertically stacked (param_size * B*m*n, B*k*n)
+    matrix; it already encodes batch and output-column structure, so it must
+    NOT be expanded again with _apply_nd_kron_structure_mul.
+    """
+    B = int(np.prod(const_shape[:-2]))
+    m_dim, k_dim = const_shape[-2], const_shape[-1]
+    n = var_shape[-1] if len(var_shape) >= 2 else 1
+
+    coo = column.tocoo()
+    slice_idx, pos = np.divmod(coo.row, B * m_dim * k_dim)
+    b = pos % B
+    i = (pos // B) % m_dim
+    r = pos // (B * m_dim)
+
+    # Replicate each entry for every output column c in 0..n-1.
+    c = np.repeat(np.arange(n), len(pos))
+    rows = np.tile(slice_idx * (B * m_dim * n) + b + B * i, n) + c * (B * m_dim)
+    cols = np.tile(b + B * r, n) + c * (B * k_dim)
+    data = np.tile(coo.data, n)
+    return sp.csr_array(
+        (data, (rows, cols)),
+        shape=(param_size * B * m_dim * n, B * k_dim * n),
+    )
+
+
 def _build_interleaved_matrix_rmul(
     const_data: np.ndarray,
     const_shape: tuple[int, ...],
@@ -209,6 +251,47 @@ def _expand_parametric_slices_rmul(
     for slice_idx in range(param_size):
         slice_matrix = stacked_matrix[slice_idx * k:(slice_idx + 1) * k, :]
         yield _apply_nd_kron_structure_rmul(slice_matrix, batch_size, m)
+
+
+def _build_interleaved_param_matrix_rmul(
+    column: sp.sparray,
+    param_size: int,
+    const_shape: tuple[int, ...],
+    var_shape: tuple[int, ...],
+) -> sp.csr_array:
+    """
+    Build the stacked interleaved matrix for a batch-varying parametric rmul (X @ C).
+
+    For X (B, m, k) @ C (B, k, n) where C depends on Parameters, each batch
+    element uses a DIFFERENT (k, n) slice of C. `column` is the stacked column
+    format (param_size * B*k*n, 1): the row within parameter slice s is the
+    column-major position q = b + B*r + B*k*j of C[b, r, j] and the value is
+    dC[b, r, j]/dtheta_s. Slice s of the result has entries (cf.
+    _build_interleaved_matrix_rmul):
+        M_s[b + B*i + B*m*j, b + B*i + B*m*r] = dC[b, r, j]/dtheta_s
+    for i in 0..m-1. Returns the vertically stacked (param_size * B*m*n, B*m*k)
+    matrix; it already encodes batch and row structure, so it must NOT be
+    expanded again with _apply_nd_kron_structure_rmul.
+    """
+    B = int(np.prod(const_shape[:-2]))
+    k_dim, n_dim = const_shape[-2], const_shape[-1]
+    m = var_shape[-2] if len(var_shape) >= 2 else 1
+
+    coo = column.tocoo()
+    slice_idx, pos = np.divmod(coo.row, B * k_dim * n_dim)
+    b = pos % B
+    r = (pos // B) % k_dim
+    j = pos // (B * k_dim)
+
+    # Replicate each entry for every row i in 0..m-1.
+    i = np.repeat(np.arange(m), len(pos))
+    rows = np.tile(slice_idx * (B * m * n_dim) + b + B * m * j, m) + i * B
+    cols = np.tile(b + B * m * r, m) + i * B
+    data = np.tile(coo.data, m)
+    return sp.csr_array(
+        (data, (rows, cols)),
+        shape=(param_size * B * m * n_dim, B * m * k_dim),
+    )
 
 
 class SciPyTensorView(DictTensorView):
@@ -548,6 +631,31 @@ class SciPyCanonBackend(PythonCanonBackend):
 
         return view.accumulate_over_variables(parametrized_mul, is_param_free_function=False)
 
+    def _mul_interleaved_parametric_lhs(
+        self,
+        lhs: dict,
+        const_shape: tuple[int, ...],
+        var_shape: tuple[int, ...],
+        view: SciPyTensorView,
+    ) -> SciPyTensorView:
+        """
+        Batch-varying parametric constant @ variable: interleaved matrix structure.
+
+        Each batch element uses a different slice of the parametric constant,
+        so the interleaved matrix is built directly from the column format,
+        which preserves the batch structure.
+        """
+        stacked_lhs = {
+            param_id: _build_interleaved_param_matrix_mul(
+                v, self.param_to_size[param_id], const_shape, var_shape)
+            for param_id, v in lhs.items()
+        }
+
+        def parametrized_mul(x):
+            return {k: v @ x for k, v in stacked_lhs.items()}
+
+        return view.accumulate_over_variables(parametrized_mul, is_param_free_function=False)
+
     def _rmul_kronecker(
         self,
         rhs: sp.sparray,
@@ -626,6 +734,31 @@ class SciPyCanonBackend(PythonCanonBackend):
 
         return view.accumulate_over_variables(parametrized_rmul, is_param_free_function=False)
 
+    def _rmul_interleaved_parametric_rhs(
+        self,
+        rhs: dict,
+        const_shape: tuple[int, ...],
+        var_shape: tuple[int, ...],
+        view: SciPyTensorView,
+    ) -> SciPyTensorView:
+        """
+        Batch-varying variable @ parametric constant: interleaved matrix structure.
+
+        Each batch element uses a different slice of the parametric constant,
+        so the interleaved matrix is built directly from the column format,
+        which preserves the batch structure.
+        """
+        stacked_rhs = {
+            param_id: _build_interleaved_param_matrix_rmul(
+                v, self.param_to_size[param_id], const_shape, var_shape)
+            for param_id, v in rhs.items()
+        }
+
+        def parametrized_rmul(x):
+            return {k: v @ x for k, v in stacked_rhs.items()}
+
+        return view.accumulate_over_variables(parametrized_rmul, is_param_free_function=False)
+
     def mul(self, lin: LinOp, view: SciPyTensorView) -> SciPyTensorView:
         """
         Matrix multiply: C @ X where C is constant/parametric, X is variable.
@@ -639,6 +772,17 @@ class SciPyCanonBackend(PythonCanonBackend):
         var_shape = lin.args[0].shape
         const_shape = const.shape
 
+        if is_batch_varying(const_shape):
+            # Batch-varying constant: keep the column format, which preserves
+            # the batch structure (reshaping to the last two dims would
+            # collapse the per-batch slices of a parametric constant).
+            lhs, is_param_free = self.get_constant_data(const, view, target_shape=None)
+            if is_param_free:
+                # Case 2: Batch-varying constant
+                return self._mul_interleaved(const, var_shape, view)
+            # Case 1b: Batch-varying parametric LHS
+            return self._mul_interleaved_parametric_lhs(lhs, const_shape, var_shape, view)
+
         # Get constant data - this also tells us if it's parametric
         # Compute 2D target shape (last 2 dims for ND, row vector for 1D)
         target = const_shape[-2:] if len(const_shape) >= 2 else (1, const_shape[0])
@@ -647,9 +791,6 @@ class SciPyCanonBackend(PythonCanonBackend):
         if not is_param_free:
             # Case 1: Parametric LHS
             return self._mul_parametric_lhs(lhs, const_shape, var_shape, view)
-        elif is_batch_varying(const_shape):
-            # Case 2: Batch-varying constant
-            return self._mul_interleaved(const, var_shape, view)
         else:
             # Case 3: 2D constant (or trivial batch dims like (1, m, k))
             return self._mul_kronecker(lhs, const_shape, var_shape, view)
@@ -845,6 +986,17 @@ class SciPyCanonBackend(PythonCanonBackend):
         var_shape = lin.args[0].shape
         const_shape = const.shape
 
+        if is_batch_varying(const_shape):
+            # Batch-varying constant: keep the column format, which preserves
+            # the batch structure (reshaping to the last two dims would
+            # collapse the per-batch slices of a parametric constant).
+            rhs, is_param_free = self.get_constant_data(const, view, target_shape=None)
+            if is_param_free:
+                # Case 2: Batch-varying constant
+                return self._rmul_interleaved(const, var_shape, view)
+            # Case 1b: Batch-varying parametric RHS
+            return self._rmul_interleaved_parametric_rhs(rhs, const_shape, var_shape, view)
+
         # Get constant data - this also tells us if it's parametric
         # Compute 2D target shape (last 2 dims for ND, column vector for 1D)
         target = const_shape[-2:] if len(const_shape) >= 2 else (const_shape[0], 1)
@@ -853,9 +1005,6 @@ class SciPyCanonBackend(PythonCanonBackend):
         if not is_param_free:
             # Case 1: Parametric RHS
             return self._rmul_parametric_rhs(rhs, const_shape, var_shape, view)
-        elif is_batch_varying(const_shape):
-            # Case 2: Batch-varying constant
-            return self._rmul_interleaved(const, var_shape, view)
         else:
             # Case 3: 2D constant (or trivial batch dims like (1, k, n))
             return self._rmul_kronecker(rhs, const_shape, var_shape, view)

--- a/cvxpy/tests/test_nd_matmul.py
+++ b/cvxpy/tests/test_nd_matmul.py
@@ -222,6 +222,52 @@ class TestNDMatmulParametric:
         prob.solve(canon_backend=backend)
         np.testing.assert_allclose(P.value @ X.value, target, atol=1e-4)
 
+    @pytest.mark.parametrize("backend", BACKENDS)
+    def test_parametric_expression_batch_varying(self, backend):
+        """Test (2*P) @ X with P (B,m,k): a parametric expression, not a direct Parameter."""
+        B, m, k, n = 3, 2, 2, 2
+        P = cp.Parameter((B, m, k))
+        P.value = np.random.randn(B, m, k)
+        X = cp.Variable((B, k, n))
+
+        X_true = np.random.randn(B, k, n)
+        target = 2 * P.value @ X_true
+        prob = cp.Problem(cp.Minimize(cp.sum_squares((2 * P) @ X - target)))
+        prob.solve(canon_backend=backend)
+
+        assert prob.status == cp.OPTIMAL
+        np.testing.assert_allclose(2 * P.value @ X.value, target, atol=1e-4)
+
+        # Equivalent 2D formulation: each batch slice solved as its own 2D problem.
+        for b in range(B):
+            Xb = cp.Variable((k, n))
+            prob_2d = cp.Problem(cp.Minimize(cp.sum_squares(2 * P.value[b] @ Xb - target[b])))
+            prob_2d.solve(canon_backend=backend)
+            np.testing.assert_allclose(Xb.value, X.value[b], atol=1e-3)
+
+        # Re-solve with a new parameter value (reuses cached canonicalization).
+        P.value = np.random.randn(B, m, k)
+        prob.solve(canon_backend=backend)
+        np.testing.assert_allclose(2 * P.value @ X.value, target, atol=1e-4)
+
+    @pytest.mark.parametrize("backend", BACKENDS)
+    def test_parametric_sum_batch_varying(self, backend):
+        """Test (P + Q) @ X with 3D Parameters P, Q: each batch element has its own slices."""
+        B, m, k, n = 3, 2, 2, 2
+        P = cp.Parameter((B, m, k))
+        Q = cp.Parameter((B, m, k))
+        P.value = np.random.randn(B, m, k)
+        Q.value = np.random.randn(B, m, k)
+        X = cp.Variable((B, k, n))
+
+        C = P.value + Q.value
+        target = C @ np.random.randn(B, k, n)
+        prob = cp.Problem(cp.Minimize(cp.sum_squares((P + Q) @ X - target)))
+        prob.solve(canon_backend=backend)
+
+        assert prob.status == cp.OPTIMAL
+        np.testing.assert_allclose(C @ X.value, target, atol=1e-4)
+
 
 class TestNDMatmulBroadcasting:
     """Test batch dimension broadcasting for ND matmul."""
@@ -569,6 +615,52 @@ class TestNDRmulParametric:
         P.value = np.random.randn(B, k, n)
         prob.solve(canon_backend=backend)
         np.testing.assert_allclose(X.value @ P.value, target, atol=1e-4)
+
+    @pytest.mark.parametrize("backend", BACKENDS)
+    def test_parametric_expression_batch_varying(self, backend):
+        """Test X @ (2*P) with P (B,k,n): a parametric expression, not a direct Parameter."""
+        B, m, k, n = 3, 2, 2, 2
+        X = cp.Variable((B, m, k))
+        P = cp.Parameter((B, k, n))
+        P.value = np.random.randn(B, k, n)
+
+        X_true = np.random.randn(B, m, k)
+        target = X_true @ (2 * P.value)
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(X @ (2 * P) - target)))
+        prob.solve(canon_backend=backend)
+
+        assert prob.status == cp.OPTIMAL
+        np.testing.assert_allclose(X.value @ (2 * P.value), target, atol=1e-4)
+
+        # Equivalent 2D formulation: each batch slice solved as its own 2D problem.
+        for b in range(B):
+            Xb = cp.Variable((m, k))
+            prob_2d = cp.Problem(cp.Minimize(cp.sum_squares(Xb @ (2 * P.value[b]) - target[b])))
+            prob_2d.solve(canon_backend=backend)
+            np.testing.assert_allclose(Xb.value, X.value[b], atol=1e-3)
+
+        # Re-solve with a new parameter value (reuses cached canonicalization).
+        P.value = np.random.randn(B, k, n)
+        prob.solve(canon_backend=backend)
+        np.testing.assert_allclose(X.value @ (2 * P.value), target, atol=1e-4)
+
+    @pytest.mark.parametrize("backend", BACKENDS)
+    def test_parametric_sum_batch_varying(self, backend):
+        """Test X @ (P + Q) with 3D Parameters P, Q: each batch element has its own slices."""
+        B, m, k, n = 3, 2, 2, 2
+        X = cp.Variable((B, m, k))
+        P = cp.Parameter((B, k, n))
+        Q = cp.Parameter((B, k, n))
+        P.value = np.random.randn(B, k, n)
+        Q.value = np.random.randn(B, k, n)
+
+        C = P.value + Q.value
+        target = np.random.randn(B, m, k) @ C
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(X @ (P + Q) - target)))
+        prob.solve(canon_backend=backend)
+
+        assert prob.status == cp.OPTIMAL
+        np.testing.assert_allclose(X.value @ C, target, atol=1e-4)
 
 
 class TestNDRmulBroadcasting:

--- a/cvxpy/tests/test_nd_matmul.py
+++ b/cvxpy/tests/test_nd_matmul.py
@@ -31,6 +31,20 @@ import cvxpy as cp
 
 BACKENDS = [cp.SCIPY_CANON_BACKEND, cp.COO_CANON_BACKEND]
 
+# Backends for batch-varying direct Parameter tests. The SCIPY backend
+# silently drops the batch structure of an ND Parameter (it applies each
+# batch's slice to all batches), so it is expected to fail until fixed.
+BATCH_VARYING_PARAM_BACKENDS = [
+    pytest.param(
+        cp.SCIPY_CANON_BACKEND,
+        marks=pytest.mark.xfail(
+            reason="SCIPY backend mishandles batch-varying Parameters",
+            strict=True,
+        ),
+    ),
+    cp.COO_CANON_BACKEND,
+]
+
 
 @pytest.fixture(autouse=True)
 def seed_rng():
@@ -178,6 +192,43 @@ class TestNDMatmulParametric:
         assert prob.status == cp.OPTIMAL
         # Since target is achievable, optimal value should be near 0
         assert prob.value < 1e-6
+
+    @pytest.mark.parametrize("backend", BACKENDS)
+    def test_parametric_trivial_batch_param(self, backend):
+        """Test P (1,m,k) @ X (1,k,n) with a direct ND Parameter (regression: COO crash)."""
+        m, k, n = 3, 4, 5
+        P = cp.Parameter((1, m, k))
+        P.value = np.random.randn(1, m, k)
+        X = cp.Variable((1, k, n))
+
+        X_true = np.random.randn(1, k, n)
+        target = P.value @ X_true
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(P @ X - target)))
+        prob.solve(canon_backend=backend)
+
+        assert prob.status == cp.OPTIMAL
+        np.testing.assert_allclose(P.value @ X.value, target, atol=1e-4)
+
+    @pytest.mark.parametrize("backend", BATCH_VARYING_PARAM_BACKENDS)
+    def test_parametric_batch_varying_param(self, backend):
+        """Test P (B,m,k) @ X (B,k,n): each batch element has its own slice of P."""
+        B, m, k, n = 3, 2, 2, 2
+        P = cp.Parameter((B, m, k))
+        P.value = np.random.randn(B, m, k)
+        X = cp.Variable((B, k, n))
+
+        X_true = np.random.randn(B, k, n)
+        target = P.value @ X_true
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(P @ X - target)))
+        prob.solve(canon_backend=backend)
+
+        assert prob.status == cp.OPTIMAL
+        np.testing.assert_allclose(P.value @ X.value, target, atol=1e-4)
+
+        # Re-solve with a new parameter value (reuses cached canonicalization).
+        P.value = np.random.randn(B, m, k)
+        prob.solve(canon_backend=backend)
+        np.testing.assert_allclose(P.value @ X.value, target, atol=1e-4)
 
 
 class TestNDMatmulBroadcasting:
@@ -483,6 +534,43 @@ class TestNDRmulParametric:
         assert prob.status == cp.OPTIMAL
         # Since target is achievable, optimal value should be near 0
         assert prob.value < 1e-6
+
+    @pytest.mark.parametrize("backend", BACKENDS)
+    def test_parametric_trivial_batch_param(self, backend):
+        """Test X (1,m,k) @ P (1,k,n) with a direct ND Parameter (regression: COO crash)."""
+        m, k, n = 3, 4, 5
+        X = cp.Variable((1, m, k))
+        P = cp.Parameter((1, k, n))
+        P.value = np.random.randn(1, k, n)
+
+        X_true = np.random.randn(1, m, k)
+        target = X_true @ P.value
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(X @ P - target)))
+        prob.solve(canon_backend=backend)
+
+        assert prob.status == cp.OPTIMAL
+        np.testing.assert_allclose(X.value @ P.value, target, atol=1e-4)
+
+    @pytest.mark.parametrize("backend", BATCH_VARYING_PARAM_BACKENDS)
+    def test_parametric_batch_varying_param(self, backend):
+        """Test X (B,m,k) @ P (B,k,n): each batch element has its own slice of P."""
+        B, m, k, n = 3, 2, 2, 2
+        X = cp.Variable((B, m, k))
+        P = cp.Parameter((B, k, n))
+        P.value = np.random.randn(B, k, n)
+
+        X_true = np.random.randn(B, m, k)
+        target = X_true @ P.value
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(X @ P - target)))
+        prob.solve(canon_backend=backend)
+
+        assert prob.status == cp.OPTIMAL
+        np.testing.assert_allclose(X.value @ P.value, target, atol=1e-4)
+
+        # Re-solve with a new parameter value (reuses cached canonicalization).
+        P.value = np.random.randn(B, k, n)
+        prob.solve(canon_backend=backend)
+        np.testing.assert_allclose(X.value @ P.value, target, atol=1e-4)
 
 
 class TestNDRmulBroadcasting:

--- a/cvxpy/tests/test_nd_matmul.py
+++ b/cvxpy/tests/test_nd_matmul.py
@@ -31,20 +31,6 @@ import cvxpy as cp
 
 BACKENDS = [cp.SCIPY_CANON_BACKEND, cp.COO_CANON_BACKEND]
 
-# Backends for batch-varying direct Parameter tests. The SCIPY backend
-# silently drops the batch structure of an ND Parameter (it applies each
-# batch's slice to all batches), so it is expected to fail until fixed.
-BATCH_VARYING_PARAM_BACKENDS = [
-    pytest.param(
-        cp.SCIPY_CANON_BACKEND,
-        marks=pytest.mark.xfail(
-            reason="SCIPY backend mishandles batch-varying Parameters",
-            strict=True,
-        ),
-    ),
-    cp.COO_CANON_BACKEND,
-]
-
 
 @pytest.fixture(autouse=True)
 def seed_rng():
@@ -209,7 +195,7 @@ class TestNDMatmulParametric:
         assert prob.status == cp.OPTIMAL
         np.testing.assert_allclose(P.value @ X.value, target, atol=1e-4)
 
-    @pytest.mark.parametrize("backend", BATCH_VARYING_PARAM_BACKENDS)
+    @pytest.mark.parametrize("backend", BACKENDS)
     def test_parametric_batch_varying_param(self, backend):
         """Test P (B,m,k) @ X (B,k,n): each batch element has its own slice of P."""
         B, m, k, n = 3, 2, 2, 2
@@ -224,6 +210,12 @@ class TestNDMatmulParametric:
 
         assert prob.status == cp.OPTIMAL
         np.testing.assert_allclose(P.value @ X.value, target, atol=1e-4)
+
+        # Cross-backend consistency: a fresh COO solve gives the same solution.
+        x_backend = X.value.copy()
+        prob_coo = cp.Problem(cp.Minimize(cp.sum_squares(P @ X - target)))
+        prob_coo.solve(canon_backend=cp.COO_CANON_BACKEND)
+        np.testing.assert_allclose(X.value, x_backend, atol=1e-4)
 
         # Re-solve with a new parameter value (reuses cached canonicalization).
         P.value = np.random.randn(B, m, k)
@@ -551,7 +543,7 @@ class TestNDRmulParametric:
         assert prob.status == cp.OPTIMAL
         np.testing.assert_allclose(X.value @ P.value, target, atol=1e-4)
 
-    @pytest.mark.parametrize("backend", BATCH_VARYING_PARAM_BACKENDS)
+    @pytest.mark.parametrize("backend", BACKENDS)
     def test_parametric_batch_varying_param(self, backend):
         """Test X (B,m,k) @ P (B,k,n): each batch element has its own slice of P."""
         B, m, k, n = 3, 2, 2, 2
@@ -566,6 +558,12 @@ class TestNDRmulParametric:
 
         assert prob.status == cp.OPTIMAL
         np.testing.assert_allclose(X.value @ P.value, target, atol=1e-4)
+
+        # Cross-backend consistency: a fresh COO solve gives the same solution.
+        x_backend = X.value.copy()
+        prob_coo = cp.Problem(cp.Minimize(cp.sum_squares(X @ P - target)))
+        prob_coo.solve(canon_backend=cp.COO_CANON_BACKEND)
+        np.testing.assert_allclose(X.value, x_backend, atol=1e-4)
 
         # Re-solve with a new parameter value (reuses cached canonicalization).
         P.value = np.random.randn(B, k, n)

--- a/cvxpy/tests/test_nd_matmul.py
+++ b/cvxpy/tests/test_nd_matmul.py
@@ -196,9 +196,11 @@ class TestNDMatmulParametric:
         np.testing.assert_allclose(P.value @ X.value, target, atol=1e-4)
 
     @pytest.mark.parametrize("backend", BACKENDS)
-    def test_parametric_batch_varying_param(self, backend):
+    # Non-square dims (m != k != n) exercise the interleaved index math;
+    # k >= m keeps the target achievable after the parameter update.
+    @pytest.mark.parametrize("B,m,k,n", [(3, 2, 2, 2), (2, 2, 3, 4)])
+    def test_parametric_batch_varying_param(self, backend, B, m, k, n):
         """Test P (B,m,k) @ X (B,k,n): each batch element has its own slice of P."""
-        B, m, k, n = 3, 2, 2, 2
         P = cp.Parameter((B, m, k))
         P.value = np.random.randn(B, m, k)
         X = cp.Variable((B, k, n))
@@ -590,9 +592,11 @@ class TestNDRmulParametric:
         np.testing.assert_allclose(X.value @ P.value, target, atol=1e-4)
 
     @pytest.mark.parametrize("backend", BACKENDS)
-    def test_parametric_batch_varying_param(self, backend):
+    # Non-square dims (m != k != n) exercise the interleaved index math;
+    # k >= n keeps the target achievable after the parameter update.
+    @pytest.mark.parametrize("B,m,k,n", [(3, 2, 2, 2), (2, 4, 3, 2)])
+    def test_parametric_batch_varying_param(self, backend, B, m, k, n):
         """Test X (B,m,k) @ P (B,k,n): each batch element has its own slice of P."""
-        B, m, k, n = 3, 2, 2, 2
         X = cp.Variable((B, m, k))
         P = cp.Parameter((B, k, n))
         P.value = np.random.randn(B, k, n)


### PR DESCRIPTION
## Description
Three related N-D parametric matmul bugs in the canonicalization backends, one commit each.

**Commit 1 — Fix COO backend IndexError on N-D parametric matmul**
Bug: any matmul with a direct N-D (batched) Parameter, e.g.
P(2,2,2) @ x(2,2,1), crashed the COO canon backend with an IndexError
deep in coo_matmul. The rhs-parameter case (x @ P) crashed the same way.

Root cause: in CooBackend.mul/rmul, a direct-parameter operand was
flattened to a (1, prod(shape)) CooTensor whenever it was not exactly
2-D. _mul_parametric_lhs/_rmul_parametric_rhs then kron-expanded that
tensor using batch dimensions taken from the true 3-D shape, producing
matrices whose dimensions disagreed, so coo_matmul indexed out of
bounds. The Kronecker expansion is also semantically wrong for
batch-varying parameters: it applies the SAME matrix to every batch
element, while a (B,m,k) parameter has a different slice per batch.

Fix: for batch-varying direct parameters, build the interleaved
matrix structure directly (parametric analogues of
_build_interleaved_mul/_build_interleaved_rmul, carrying the
column-major param_idx of each parameter element) and apply it without
further kron expansion. Trivial-batch shapes like (1,m,k) now use the
last two dims in the existing Kronecker path. The shared
_apply_parametric_matmul helper replaces the duplicated closures in
the lhs/rhs parametric paths.

Tests: new lhs/rhs cases in test_nd_matmul.py covering trivial-batch
and batch-varying direct parameters, including a re-solve with new
parameter values to exercise the cached canonicalization. The
batch-varying tests are strict-xfailed on the SCIPY backend, which
silently misapplies one batch slice to all batches (pre-existing,
separate bug). Verified COO results against analytic optima for
square and non-square batched shapes.

**Commit 2 — Fix SCIPY backend batch handling of N-D parametric matmul**
Bug: the SCIPY canon backend silently returned wrong results when a
matmul involved an N-D (batch-varying) parametric operand, e.g.
P = cp.Parameter((B, m, k)); P @ X with X(B, k, n). One slice of the
parameter was applied to all batches instead of each batch using its
own slice. The rhs case (X @ P) was wrong the same way.

Root cause: mul/rmul requested the parametric constant data reshaped to
the last two dims (m, k). _reshape_parametric assumed any extra length
came from broadcast duplication and collapsed it (local_pos //
broadcast_factor plus dedup by param_idx), destroying the batch
structure of a genuinely batch-varying parameter. The slices were then
kron-expanded (I_n x C x I_B), which applies the SAME matrix to every
batch element.

Fix: for batch-varying parametric constants, keep the constant data in
column format, which preserves the batch structure, and build the
interleaved matrix directly from it (parametric analogues of
_build_interleaved_matrix_mul/_build_interleaved_matrix_rmul, with one
stacked block per parameter slice). This mirrors the interleaved
construction the COO backend uses for batch-varying direct parameters.
Param-free batch-varying constants keep the existing interleaved path.

Tests: the strict xfails for the SCIPY backend in test_nd_matmul.py
(TestNDMatmulParametric/TestNDRmulParametric
test_parametric_batch_varying_param) are converted into ordinary
assertions against the analytic optimum, with an added cross-backend
check that a fresh COO solve produces the same solution.
(The strict xfails commit 1 added for these SCIPY cases are converted to ordinary passing assertions.)

**Commit 3 — Fix batch-varying parametric expressions in N-D matmul on COO**
Bug: a parametric EXPRESSION with batch dims used as a matmul operand,
e.g. (2*P) @ X or (P + Q) @ X with P(B, m, k), silently applied one
slice to all batches on the COO backend (and previously also on SCIPY).
The direct-Parameter case was fixed earlier, but expressions take the
get_constant_data path, which had the same flaw.

Root cause: in CooBackend.mul/rmul, the parametric constant data was
reshaped to the last two dims (m, k). reshape_parametric_constant
deduplicates entries by param_idx, assuming extra length comes from
broadcast duplication, which collapses the batch structure of a
genuinely batch-varying parametric expression. The slices were then
kron-expanded, applying the SAME matrix to every batch element.

Fix: for batch-varying parametric constants, keep the constant data in
column format, which preserves the batch structure, and build the
interleaved matrix directly from it. _build_interleaved_param_mul and
_build_interleaved_param_rmul are generalized to take the column-format
CooTensor (entry value d at column-major position q in parameter slice
s means dC[q]/dtheta_s = d); the direct-Parameter case now passes the
identity column, and constant slices of mixed expressions like
P + const flow through unchanged. The SCIPY backend was fixed the same
way in the previous commit, covering this case there as well.

Tests: new test_parametric_expression_batch_varying ((2*P) @ X and
X @ (2*P)) and test_parametric_sum_batch_varying ((P + Q) @ X and
X @ (P + Q)) in test_nd_matmul.py for both backends, checked against
the analytic optimum and an equivalent per-batch 2D formulation,
including a re-solve with new parameter values to exercise the cached
canonicalization.

Found by an automated bug-hunting audit of master; each finding was reproduced against an independent oracle (analytic optima, cross-backend, per-batch 2-D formulations) before fixing, and each commit's tests fail without its fix.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
