### PR TITLE
Fix .grad for affine atoms with ND (ndim > 2) arguments

### DIFF
--- a/cvxpy/atoms/affine/affine_atom.py
+++ b/cvxpy/atoms/affine/affine_atom.py
@@ -19,6 +19,7 @@ import scipy.sparse as sp
 
 import cvxpy.lin_ops.lin_op as lo
 import cvxpy.lin_ops.lin_utils as lu
+import cvxpy.settings as s
 import cvxpy.utilities as u
 from cvxpy.atoms.atom import Atom
 from cvxpy.cvxcore.python import canonInterface
@@ -140,6 +141,14 @@ class AffAtom(Atom):
                                                  self.get_data())
         param_to_size = {lo.CONSTANT_ID: 1}
         param_to_col = {lo.CONSTANT_ID: 0}
+        # The CPP backend does not support expressions with more than
+        # 2 dimensions or atoms without a C++ implementation (e.g.
+        # broadcast_to, concatenate), so use the SCIPY backend for those.
+        if self.ndim > 2 or any(arg.ndim > 2 for arg in self.args) \
+                or not self._supports_cpp():
+            canon_backend = s.SCIPY_CANON_BACKEND
+        else:
+            canon_backend = None
         # Get the matrix representation of the function.
         canon_mat = canonInterface.get_problem_matrix(
             [fake_expr],
@@ -148,6 +157,7 @@ class AffAtom(Atom):
             param_to_size,
             param_to_col,
             self.size,
+            canon_backend,
         )
         # HACK TODO TODO convert tensors back to vectors.
         # COO = (V[lo.CONSTANT_ID][0], (J[lo.CONSTANT_ID][0], I[lo.CONSTANT_ID][0]))

--- a/cvxpy/tests/test_grad.py
+++ b/cvxpy/tests/test_grad.py
@@ -1162,5 +1162,75 @@ class TestBatchedSymmetricGradients:
         assert passed, f"lambda_sum_largest frac nd grad {batch_shape}: {msg}"
 
 
+class TestNDAffineGradients:
+    """Tests for _grad of affine atoms with ND (ndim > 2) arguments."""
+
+    @pytest.mark.parametrize("batch_shape", [(2,), (2, 3)])
+    def test_matmul_nd_var(self, batch_shape):
+        rng = np.random.default_rng(42)
+        A = rng.standard_normal(batch_shape + (3, 4))
+        var_shape = batch_shape + (4, 5)
+        passed, msg = expression_gradcheck(
+            lambda x: cp.Constant(A) @ x, var_shape, rng.standard_normal(var_shape)
+        )
+        assert passed, f"const @ ND-var {batch_shape}: {msg}"
+
+    def test_matmul_nd_const_2d_var(self):
+        rng = np.random.default_rng(42)
+        A = rng.standard_normal((2, 3, 4))
+        passed, msg = expression_gradcheck(
+            lambda x: cp.Constant(A) @ x, (4, 5), rng.standard_normal((4, 5))
+        )
+        assert passed, f"ND-const @ 2D-var: {msg}"
+
+    def test_sum_of_nd_matmul(self):
+        rng = np.random.default_rng(42)
+        A = rng.standard_normal((2, 3, 4))
+        passed, msg = expression_gradcheck(
+            lambda x: cp.sum(cp.Constant(A) @ x), (2, 4, 5),
+            rng.standard_normal((2, 4, 5))
+        )
+        assert passed, f"sum(const @ ND-var): {msg}"
+
+    @pytest.mark.parametrize("expr_factory", [
+        lambda x: cp.transpose(x, axes=(2, 0, 1)),
+        lambda x: cp.reshape(x, (4, 6), order='F'),
+        lambda x: cp.sum(x, axis=1),
+    ], ids=["transpose", "reshape", "sum_axis"])
+    def test_nd_affine_atoms(self, expr_factory):
+        rng = np.random.default_rng(42)
+        passed, msg = expression_gradcheck(
+            expr_factory, (2, 3, 4), rng.standard_normal((2, 3, 4))
+        )
+        assert passed, f"ND affine atom: {msg}"
+
+    def test_matmul_nd_matches_2d(self):
+        # A singleton batch dim does not change the F-order vectorization,
+        # so the ND jacobian must equal the 2-D one.
+        rng = np.random.default_rng(42)
+        A = rng.standard_normal((3, 4))
+        x2 = cp.Variable((4, 5))
+        x3 = cp.Variable((1, 4, 5))
+        x2.value = rng.standard_normal((4, 5))
+        x3.value = x2.value[None]
+        grad2 = (cp.Constant(A) @ x2).grad[x2].toarray()
+        grad3 = (cp.Constant(A[None]) @ x3).grad[x3].toarray()
+        np.testing.assert_allclose(grad3, grad2)
+
+    def test_cpp_unsupported_atom_2d(self):
+        # Atoms without a C++ implementation (broadcast_to, concatenate)
+        # raised from _grad even for ndim <= 2 arguments.
+        rng = np.random.default_rng(42)
+        passed, msg = expression_gradcheck(
+            lambda x: cp.broadcast_to(x, (2, 3)), (3,), rng.standard_normal(3)
+        )
+        assert passed, f"broadcast_to grad: {msg}"
+        passed, msg = expression_gradcheck(
+            lambda x: cp.concatenate([x, 2 * x], axis=0), (2, 2),
+            rng.standard_normal((2, 2))
+        )
+        assert passed, f"concatenate grad: {msg}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description
AffAtom._grad computed the affine jacobian by canonicalizing the atom
through canonInterface.get_problem_matrix without specifying a backend,
so the default CPP backend was used. The CPP backend rejects arrays with
more than 2 dimensions, so e.g. (Constant(A) @ x).grad raised TypeError
(or crashed) for any ND matmul, transpose, reshape, or axis-sum.

Route grads of atoms whose output or arguments have ndim > 2 through
the SCIPY canonicalization backend, mirroring the backend selection
problem canonicalization already performs in get_canon_backend. 1-D and
2-D expressions keep the existing CPP fast path.

Add TestNDAffineGradients to test_grad.py: finite-difference checks for
const @ ND-var (single and multiple batch dims), ND-const @ 2-D var,
chain rule through cp.sum, ND transpose/reshape/axis-sum, and an
equivalence check between the ND and 2-D matmul jacobians.

Note: without the fix, the new tests don't just fail — some ND grad evaluations hard-crash the interpreter via the CPP extension, so this also removes a crash path.

Found by an automated bug-hunting audit of master; each finding was reproduced against an independent oracle before fixing.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
