### PR TITLE
Fix unreachable DGP canonicalizers; add registry key sanity test

### DIFF
--- a/cvxpy/atoms/norm1.py
+++ b/cvxpy/atoms/norm1.py
@@ -55,6 +55,16 @@ class norm1(AxisAtom):
         """
         return False
 
+    def is_atom_log_log_convex(self) -> bool:
+        """Is the atom log-log convex?
+        """
+        return True
+
+    def is_atom_log_log_concave(self) -> bool:
+        """Is the atom log-log concave?
+        """
+        return False
+
     def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """

--- a/cvxpy/reductions/complex2real/canonicalizers/__init__.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/__init__.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 import numpy as np
 
-from cvxpy.atoms import (MatrixFrac, Pnorm, PnormApprox, QuadForm, abs, bmat, conj, conv,
+from cvxpy.atoms import (MatrixFrac, Pnorm, PnormApprox, QuadForm, abs, conj, conv,
                          convolve, cumsum, imag, kron, lambda_max,
                          lambda_sum_largest, log_det, norm1, norm_inf,
                          quad_over_lin, real, reshape, sigma_max, Trace,
@@ -66,7 +66,6 @@ from cvxpy.reductions.complex2real.canonicalizers.variable_canon import (
 
 CANON_METHODS = {
     AddExpression: separable_canon,
-    bmat: separable_canon,
     cumsum: separable_canon,
     diag_mat: separable_canon,
     diag_vec: separable_canon,

--- a/cvxpy/reductions/dgp2dcp/canonicalizers/__init__.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/__init__.py
@@ -23,7 +23,7 @@ from cvxpy.atoms.one_minus_pos import one_minus_pos
 from cvxpy.atoms.pf_eigenvalue import pf_eigenvalue
 from cvxpy.atoms.pnorm import Pnorm, PnormApprox
 from cvxpy.atoms.prod import Prod
-from cvxpy.atoms.quad_form import quad_form
+from cvxpy.atoms.quad_form import QuadForm
 from cvxpy.atoms.quad_over_lin import quad_over_lin
 from cvxpy.constraints.finite_set import FiniteSet
 from cvxpy.expressions.constants.constant import Constant
@@ -90,7 +90,7 @@ CANON_METHODS = {
     Power : power_canon,
     PowerApprox : power_canon,
     Prod : prod_canon,
-    quad_form : quad_form_canon,
+    QuadForm : quad_form_canon,
     quad_over_lin : quad_over_lin_canon,
     Trace : trace_canon,
     Sum : sum_canon,

--- a/cvxpy/reductions/dgp2dcp/canonicalizers/quad_form_canon.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/quad_form_canon.py
@@ -1,4 +1,4 @@
-from cvxpy.atoms.affine import hstack
+from cvxpy.atoms.affine.hstack import hstack
 from cvxpy.atoms.log_sum_exp import log_sum_exp
 
 

--- a/cvxpy/tests/test_canon_methods.py
+++ b/cvxpy/tests/test_canon_methods.py
@@ -1,0 +1,64 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions.expression import Expression
+from cvxpy.reductions.complex2real.canonicalizers import (
+    CANON_METHODS as COMPLEX2REAL_METHODS,
+)
+from cvxpy.reductions.cone2cone.approx import ApproxCone2Cone
+from cvxpy.reductions.cone2cone.exact import ExactCone2Cone
+from cvxpy.reductions.dcp2cone.canonicalizers import CANON_METHODS as DCP2CONE_METHODS
+from cvxpy.reductions.dcp2cone.canonicalizers.quad import (
+    QUAD_CANON_METHODS as QUAD_METHODS,
+)
+from cvxpy.reductions.dgp2dcp.canonicalizers import CANON_METHODS as DGP2DCP_METHODS
+from cvxpy.reductions.discrete2mixedint.valinvec2mixedint import Valinvec2mixedint
+from cvxpy.reductions.dnlp2smooth.canonicalizers import (
+    SMOOTH_CANON_METHODS as DNLP2SMOOTH_METHODS,
+)
+from cvxpy.reductions.eliminate_pwl.canonicalizers import (
+    CANON_METHODS as ELIMINATE_PWL_METHODS,
+)
+
+ALL_REGISTRIES = {
+    "complex2real.CANON_METHODS": COMPLEX2REAL_METHODS,
+    "cone2cone.ApproxCone2Cone.CANON_METHODS": ApproxCone2Cone.CANON_METHODS,
+    "cone2cone.ExactCone2Cone.CANON_METHODS": ExactCone2Cone.CANON_METHODS,
+    "dcp2cone.CANON_METHODS": DCP2CONE_METHODS,
+    "dcp2cone.quad.QUAD_CANON_METHODS": QUAD_METHODS,
+    "dgp2dcp.CANON_METHODS": DGP2DCP_METHODS,
+    "discrete2mixedint.Valinvec2mixedint.CANON_METHODS": Valinvec2mixedint.CANON_METHODS,
+    "dnlp2smooth.SMOOTH_CANON_METHODS": DNLP2SMOOTH_METHODS,
+    "eliminate_pwl.CANON_METHODS": ELIMINATE_PWL_METHODS,
+}
+
+
+def test_canon_method_keys_are_classes() -> None:
+    """Every canonicalizer registry key must be an Expression/Constraint class.
+
+    Canonicalization looks up registries via type(expr), so a key that is a
+    function rather than a class can never match: the atom silently falls
+    through to default handling (e.g. the dgp2dcp registry once keyed the
+    cp.quad_form *function* instead of the QuadForm class, producing wrong
+    DGP results).
+    """
+    for name, registry in ALL_REGISTRIES.items():
+        for key in registry:
+            assert isinstance(key, type), f"{name} key {key!r} is not a class"
+            assert issubclass(key, (Expression, Constraint)), (
+                f"{name} key {key!r} is not an Expression or Constraint subclass"
+            )

--- a/cvxpy/tests/test_dgp.py
+++ b/cvxpy/tests/test_dgp.py
@@ -388,3 +388,26 @@ class TestDgp(BaseTest):
             [x <= 2, x >= 0.5],
         )
         self.assertFalse(prob2.is_dgp())
+
+    def test_norm1_dgp(self) -> None:
+        """Regression test: norm1 is log-log convex (sum of positives)."""
+        x = cvxpy.Variable(2, pos=True)
+        self.assertTrue(cvxpy.norm1(x).is_log_log_convex())
+        # minimize x1 + x2 s.t. x1 * x2 >= 4 has optimum 4 at x = (2, 2).
+        prob = cvxpy.Problem(cvxpy.Minimize(cvxpy.norm(x, 1)), [x[0] * x[1] >= 4])
+        self.assertTrue(prob.is_dgp())
+        prob.solve(gp=True, solver=cvxpy.CLARABEL)
+        self.assertAlmostEqual(prob.value, 4.0, places=4)
+        self.assertItemsAlmostEqual(x.value, [2.0, 2.0], places=4)
+
+    def test_quad_form_dgp(self) -> None:
+        """Regression test: QuadForm must be canonicalized, not copied verbatim."""
+        x = cvxpy.Variable(2, pos=True)
+        P = np.array([[2.0, 1.0], [1.0, 3.0]])
+        prob = cvxpy.Problem(cvxpy.Minimize(cvxpy.quad_form(x, P)), [x[0] * x[1] >= 4])
+        self.assertTrue(prob.is_dgp())
+        prob.solve(gp=True, solver=cvxpy.CLARABEL)
+        # With x2 = 4/x1, the objective is 2*x1^2 + 8 + 48/x1^2,
+        # minimized at x1^2 = sqrt(24) with optimum 8 + 8*sqrt(6).
+        self.assertAlmostEqual(prob.value, 8 + 8 * np.sqrt(6), places=4)
+        self.assertAlmostEqual(x.value @ P @ x.value, prob.value, places=4)


### PR DESCRIPTION
## Description
DGP problems using cp.norm1 (or cp.norm(x, 1)) raised DGPError even
though a norm1 canonicalizer is registered in dgp2dcp: the norm1 atom
never declared is_atom_log_log_convex, so the DGP curvature check
rejected it before canonicalization. For positive arguments, norm1 is
a sum of the entries (a posynomial), hence log-log convex; monotonicity
is already correct via is_incr. Declare is_atom_log_log_convex = True
and is_atom_log_log_concave = False, matching Pnorm and norm_inf.

Auditing the rest of the dgp2dcp registry uncovered a second latent
bug: the quad_form entry was keyed on the quad_form *function* instead
of the QuadForm class, so lookup by type(expr) always missed and the
fallback expr.copy(args) silently built QuadForm(log_x, log_P), giving
a wrong optimal value (e.g. 27.717 instead of 27.596). Registering
QuadForm exposed a third bug in the never-executed quad_form_canon:
it imported the cvxpy.atoms.affine.hstack module instead of the hstack
function. Both are fixed; DGP quad_form now matches the analytic
optimum.

All other registered atoms (norm_inf, Pnorm, sum, max/min, maximum/
minimum, exp, log, xexp, cumprod, geo_mean, prod, trace, power, div,
mul, one_minus_pos, quad_over_lin) were smoke-tested in small DGP
problems and solve correctly.

Adds regression tests for norm1 and quad_form under gp=True with
analytic optima. Test suites test_dgp.py, test_dgp2dcp.py, and
test_curvature.py pass.

Also add a registry-wide sanity test (test_canon_methods.py) asserting every
canonicalizer registry key is an Expression/Constraint class, so function-keyed
entries like this one can never silently reappear. The test immediately caught
one more instance: complex2real's CANON_METHODS keyed the bmat *function*; that
entry was unreachable dead code (bmat() builds Vstack/Hstack expressions, which
have their own entries) and is removed here.

Notes:
- The new `test_canon_methods.py` fails on master on two counts: the dgp2dcp `quad_form` function key fixed here, and the dead complex2real `bmat` function key removed here.
- Import blocks in the two touched `__init__.py` files were re-sorted by the repo's ruff-isort hook (mechanical). #3385 touches the same complex2real import block; the changed lines are disjoint, so the merges should be clean.

Found by an automated bug-hunting audit of master; each finding was reproduced against an independent oracle before fixing, and the new tests fail on master.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
