### PR TITLE
Perturb DQCP bisection query point when the subproblem solver fails

### DIFF
--- a/cvxpy/reductions/solvers/bisection.py
+++ b/cvxpy/reductions/solvers/bisection.py
@@ -106,6 +106,10 @@ def _bisect(problem, solver, t, low, high, tighten_lower, tighten_higher,
 
     verbose_freq = 5
     soln = None
+    # Lower end of the subinterval from which the query point is drawn.
+    # Solver failures move it toward `high`, the feasible end of the
+    # bracket, so a failing query point is never retried verbatim.
+    query_low = low
     for i in range(max_iters):
         assert low <= high
         if soln is not None and (high - low) <= eps:
@@ -114,7 +118,7 @@ def _bisect(problem, solver, t, low, high, tighten_lower, tighten_higher,
             # to the optimal value in the previous iteration (hence the
             # soln is not None check)
             return soln, low, high
-        query_pt = (low + high) / 2.0
+        query_pt = (query_low + high) / 2.0
         if verbose and i % verbose_freq == 0:
             print("(iteration %d) lower bound: %0.6f" % (i, low))
             print("(iteration %d) upper bound: %0.6f" % (i, high))
@@ -127,19 +131,28 @@ def _bisect(problem, solver, t, low, high, tighten_lower, tighten_higher,
             if verbose and i % verbose_freq == 0:
                 print("(iteration %d) query was infeasible.\n" % i)
             low = tighten_lower(query_pt)
+            query_low = low
         elif lowered.status in s.SOLUTION_PRESENT:
             if verbose and i % verbose_freq == 0:
                 print("(iteration %d) query was feasible. %s)\n" %
                       (i, lowered.solution))
             soln = lowered.solution
             high = tighten_higher(query_pt)
+            query_low = low
         else:
+            if query_pt == high:
+                raise error.SolverError(
+                    "Solver failed at every query point between the "
+                    "current bisection bounds; unable to make progress.")
             warnings.warn(
-                "Solver failed at iteration %d, trying next bisection point." % i,
+                "Solver failed at iteration %d, querying a point closer to "
+                "the feasible end of the interval." % i,
                 RuntimeWarning
             )
             if verbose:
-                print("(iteration %d) solver failed, skipping.\n" % i)
+                print("(iteration %d) solver failed, perturbing query "
+                      "point.\n" % i)
+            query_low = query_pt
             continue
     raise error.SolverError("Max iters hit during bisection.")
 

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -247,6 +247,20 @@ class TestDqcp(base_test.BaseTest):
         self.assertAlmostEqual(x.value, -12, places=1)
         self.assertAlmostEqual(y.value, -6, places=1)
 
+    def test_multiply_solver_failure_during_bisection(self) -> None:
+        # Regression test: CLARABEL fails (instead of reporting
+        # infeasibility) at query points near the optimum of this badly
+        # scaled problem; bisection used to re-solve the identical failing
+        # subproblem until it raised "Max iters hit during bisection".
+        x = cp.Variable(nonneg=True)
+        y = cp.Variable(nonneg=True)
+        problem = cp.Problem(cp.Maximize(cp.multiply(x, y)), [x + y <= 1e-4])
+        with pytest.warns(RuntimeWarning):
+            problem.solve(solver=cp.CLARABEL, qcp=True)
+        self.assertIn(problem.status, s.SOLUTION_PRESENT)
+        # optimal value is (5e-5)**2 = 2.5e-9; bisection eps is 1e-6
+        self.assertAlmostEqual(problem.value, 2.5e-9, places=6)
+
     def test_basic_multiply_qcvx(self) -> None:
         x = cp.Variable(nonneg=True)
         y = cp.Variable(nonpos=True)


### PR DESCRIPTION
## Description
Bug: when the sublevel-set feasibility subproblem failed at a query
point t (e.g. CLARABEL returning solver_error near the optimal
boundary of Maximize(multiply(x, y)) with a badly scaled budget
constraint), _bisect re-solved the identical subproblem on every
subsequent iteration -- the retry changed nothing -- and eventually
raised SolverError("Max iters hit during bisection.").

Root cause: the failure branch in _bisect continued the loop without
modifying the bracket, so query_pt = (low + high) / 2 was recomputed
unchanged.

Fix: track the lower end of the query subinterval separately. On a
solver failure, move it to the failed query point so the next query
lands halfway toward `high`, the feasible end of the bracket (the
subproblem only becomes more relaxed toward `high`). Any successful
classification of the perturbed point still tightens the bracket
under the usual bisection invariants, and the subinterval resets to
the full bracket once a query succeeds, so well-behaved problems
bisect exactly as before. If the query point reaches `high` itself
and still fails, raise a descriptive SolverError instead of spinning.

Tests: added test_multiply_solver_failure_during_bisection to
cvxpy/tests/test_dqcp.py; full file passes (52 tests).

Found by an automated bug-hunting audit of master; the regression test fails on master (SolverError: Max iters hit during bisection) and the full DQCP suite passes unchanged with the fix.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
