### PR TITLE
feat: partial_trace and partial_transpose intelligently propagate DCP attributes

### DIFF
--- a/cvxpy/atoms/affine/partial_trace.py
+++ b/cvxpy/atoms/affine/partial_trace.py
@@ -18,6 +18,7 @@ import numpy as np
 import scipy.sparse as sp
 from numpy.lib.array_utils import normalize_axis_index
 
+from cvxpy.atoms.affine.wraps import hermitian_wrap, psd_wrap, symmetric_wrap
 from cvxpy.atoms.atom import Atom
 from cvxpy.expressions.expression import Expression
 
@@ -83,4 +84,11 @@ def partial_trace(expr, dims: tuple[int], axis: int | None = 0) -> Expression:
     if expr.shape[0] != np.prod(dims):
         raise ValueError("Dimension of system doesn't correspond to dimension of subsystems.")
     axis = normalize_axis_index(axis, len(dims))
-    return sum([_term(expr, j, dims, axis) for j in range(dims[axis])])
+    result = sum([_term(expr, j, dims, axis) for j in range(dims[axis])])
+    if expr.is_psd():
+        return psd_wrap(result)
+    if expr.is_symmetric():
+        return symmetric_wrap(result)
+    if expr.is_hermitian():
+        return hermitian_wrap(result)
+    return result

--- a/cvxpy/atoms/affine/partial_trace.py
+++ b/cvxpy/atoms/affine/partial_trace.py
@@ -78,7 +78,7 @@ def partial_trace(expr, dims: tuple[int], axis: int | None = 0) -> Expression:
         The index of the subsystem to be traced out
         from the tensor product that defines expr.
     """
-    expr = Atom.cast_to_const(expr)
+    expr = Atom.cast(expr)
     if expr.ndim < 2 or expr.shape[0] != expr.shape[1]:
         raise ValueError("partial_trace only supports 2-d square arrays.")
     if expr.shape[0] != np.prod(dims):

--- a/cvxpy/atoms/affine/partial_transpose.py
+++ b/cvxpy/atoms/affine/partial_transpose.py
@@ -21,6 +21,7 @@ import numpy as np
 import scipy.sparse as sp
 from numpy.lib.array_utils import normalize_axis_index
 
+from cvxpy.atoms.affine.wraps import hermitian_wrap, symmetric_wrap
 from cvxpy.atoms.atom import Atom
 from cvxpy.expressions.expression import Expression
 
@@ -84,6 +85,11 @@ def partial_transpose(expr, dims: tuple[int, ...], axis: int | None = 0) -> Expr
     if expr.shape[0] != np.prod(dims):
         raise ValueError("Dimension of system doesn't correspond to dimension of subsystems.")
     axis = normalize_axis_index(axis, len(dims))
-    return sum([
+    result = sum([
         _term(expr, i, j, dims, axis) for i in range(dims[axis]) for j in range(dims[axis])
     ])
+    if expr.is_symmetric():
+        return symmetric_wrap(result)
+    if expr.is_hermitian():
+        return hermitian_wrap(result)
+    return result

--- a/cvxpy/atoms/affine/partial_transpose.py
+++ b/cvxpy/atoms/affine/partial_transpose.py
@@ -79,7 +79,7 @@ def partial_transpose(expr, dims: tuple[int, ...], axis: int | None = 0) -> Expr
         The index of the subsystem to be transposed
         from the tensor product that defines expr.
     """
-    expr = Atom.cast_to_const(expr)
+    expr = Atom.cast(expr)
     if expr.ndim < 2 or expr.shape[0] != expr.shape[1]:
         raise ValueError("partial_transpose only supports 2-d square arrays.")
     if expr.shape[0] != np.prod(dims):

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -2402,6 +2402,7 @@ class TestAtoms(BaseTest):
         X_herm = cp.Variable((4, 4), hermitian=True)
         pt_herm = cp.partial_trace(X_herm, (2, 2))
         self.assertTrue(pt_herm.is_hermitian())
+        self.assertFalse(pt_herm.is_symmetric())
 
         # Plain input -> no special attributes
         X_plain = cp.Variable((4, 4))

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -2382,6 +2382,70 @@ class TestAtoms(BaseTest):
         self.assertEqual(str(cm.exception),
                          "Dimension of system doesn't correspond to dimension of subsystems.")
 
+    def test_partial_trace_dcp_attributes(self) -> None:
+        """Test that partial_trace propagates DCP attributes correctly.
+        """
+        # PSD input -> PSD output (partial trace preserves PSD)
+        X_psd = cp.Variable((4, 4), PSD=True)
+        pt_psd = cp.partial_trace(X_psd, (2, 2))
+        self.assertTrue(pt_psd.is_psd())
+        self.assertTrue(pt_psd.is_hermitian())
+        self.assertTrue(pt_psd.is_symmetric())
+
+        # Symmetric input -> Symmetric output
+        X_sym = cp.Variable((4, 4), symmetric=True)
+        pt_sym = cp.partial_trace(X_sym, (2, 2))
+        self.assertTrue(pt_sym.is_symmetric())
+        self.assertTrue(pt_sym.is_hermitian())
+
+        # Hermitian input -> Hermitian output
+        X_herm = cp.Variable((4, 4), hermitian=True)
+        pt_herm = cp.partial_trace(X_herm, (2, 2))
+        self.assertTrue(pt_herm.is_hermitian())
+
+        # Plain input -> no special attributes
+        X_plain = cp.Variable((4, 4))
+        pt_plain = cp.partial_trace(X_plain, (2, 2))
+        self.assertFalse(pt_plain.is_psd())
+        self.assertFalse(pt_plain.is_hermitian())
+
+        # PSD complex input -> PSD output (Hermitian, not necessarily symmetric)
+        X_psd_c = cp.Variable((4, 4), PSD=True, complex=True)
+        pt_psd_c = cp.partial_trace(X_psd_c, (2, 2))
+        self.assertTrue(pt_psd_c.is_psd())
+        self.assertTrue(pt_psd_c.is_hermitian())
+
+    def test_partial_transpose_dcp_attributes(self) -> None:
+        """Test that partial_transpose propagates DCP attributes correctly.
+        """
+        # Symmetric input -> Symmetric output
+        X_sym = cp.Variable((4, 4), symmetric=True)
+        pp_sym = cp.partial_transpose(X_sym, (2, 2))
+        self.assertTrue(pp_sym.is_symmetric())
+        self.assertTrue(pp_sym.is_hermitian())
+
+        # Hermitian input -> Hermitian output
+        X_herm = cp.Variable((4, 4), hermitian=True)
+        pp_herm = cp.partial_transpose(X_herm, (2, 2))
+        self.assertTrue(pp_herm.is_hermitian())
+
+        # PSD input -> NOT PSD output (partial transpose does NOT preserve PSD!)
+        X_psd = cp.Variable((4, 4), PSD=True)
+        pp_psd = cp.partial_transpose(X_psd, (2, 2))
+        self.assertFalse(pp_psd.is_psd())
+        self.assertTrue(pp_psd.is_hermitian())
+
+        # Plain input -> no special attributes
+        X_plain = cp.Variable((4, 4))
+        pp_plain = cp.partial_transpose(X_plain, (2, 2))
+        self.assertFalse(pp_plain.is_hermitian())
+        self.assertFalse(pp_plain.is_symmetric())
+
+        # Complex hermitian input -> Hermitian output
+        X_herm_c = cp.Variable((4, 4), hermitian=True, complex=True)
+        pp_herm_c = cp.partial_transpose(X_herm_c, (2, 2))
+        self.assertTrue(pp_herm_c.is_hermitian())
+
     def test_log_sum_exp(self) -> None:
         """Test log_sum_exp sign.
         """

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -2415,6 +2415,7 @@ class TestAtoms(BaseTest):
         pt_psd_c = cp.partial_trace(X_psd_c, (2, 2))
         self.assertTrue(pt_psd_c.is_psd())
         self.assertTrue(pt_psd_c.is_hermitian())
+        self.assertFalse(pt_psd_c.is_symmetric())
 
     def test_partial_transpose_dcp_attributes(self) -> None:
         """Test that partial_transpose propagates DCP attributes correctly.


### PR DESCRIPTION
Issue opened by @rileyjmurray, @PTNobel 
Issue number #3152 
partial_trace and partial_transpose

partial_trace and partial_transpose are free functions (not Atom subclasses), so they cannot override is_symmetric/is_hermitian/is_psd. Instead, inspect the input's attributes and wrap the result with the appropriate zero-cost wrapper before returning.

Mathematical justification:
- partial_trace preserves symmetry, Hermiticity, AND PSD (congruence transform + sum of PSD is PSD — standard quantum information result)
- partial_transpose preserves symmetry and Hermiticity, but does NOT preserve PSD (Peres-Horodecki criterion: entangled states have non-PSD partial transposes)

Implementation details:
- partial_trace: check PSD→psd_wrap, else symmetric→symmetric_wrap, else Hermitian→hermitian_wrap
- partial_transpose: check symmetric→symmetric_wrap, else Hermitian→hermitian_wrap (no PSD check)
- PSD checked first since psd_wrap simultaneously sets psd, hermitian, and symmetric flags
- Symmetric checked before Hermitian because CVXPY's Leaf class returns is_hermitian()=True for real symmetric variables; checking symmetric first gives the more specific wrapper

## Description
Please include a short summary of the change.
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.