### PR TITLE
Add qoco extra stats

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/qoco_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/qoco_conif.py
@@ -87,8 +87,22 @@ class QOCO(ConicSolver):
 
         attr = {}
         status = self.STATUS_MAP[str(solution.status)]
-        attr[s.SOLVE_TIME] = solution.solve_time_sec + solution.setup_time_sec
+        attr[s.SOLVE_TIME] = solution.solve_time_sec
+        attr[s.SETUP_TIME] = solution.setup_time_sec
         attr[s.NUM_ITERS] = solution.iters
+
+        attr[s.EXTRA_STATS] = {
+                "pres": solution.pres,
+                "dres": solution.dres,
+                "gap": solution.gap,
+                "status": solution.status
+        }
+
+        if hasattr(solution, "ir_iters"):
+            attr[s.EXTRA_STATS]["ir_iters"] = solution.ir_iters
+
+        if hasattr(solution, "analysis_time_sec"):
+            attr[s.EXTRA_STATS]["analysis_time_sec"] = solution.analysis_time_sec
 
         if status in s.SOLUTION_PRESENT:
             primal_val = solution.obj


### PR DESCRIPTION
## Description
Adds extra stats for qoco and breaks total solve time into setup and solve times.

Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.