### PR TITLE
Memoize shared LinOps in Python canonicalization backends

### DIFF
--- a/cvxpy/lin_ops/backends/base.py
+++ b/cvxpy/lin_ops/backends/base.py
@@ -56,6 +56,7 @@ This module contains the abstract base classes used by all backends:
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
@@ -501,6 +502,7 @@ class PythonCanonBackend(CanonBackend):
     ) -> sp.csc_array | sp.csr_array:
         self.id_to_col[-1] = self.var_length
 
+        self._lin_op_counts = self._count_reusable_lin_ops(lin_ops)
         self._lin_op_tensor_cache: dict[int, TensorView] = {}
         try:
             constraint_res = []
@@ -515,9 +517,42 @@ class PythonCanonBackend(CanonBackend):
                 row_offset += lin_op_rows
             tensor_res = self.concatenate_tensors(constraint_res)
         finally:
+            del self._lin_op_counts
             del self._lin_op_tensor_cache
             self.id_to_col.pop(-1)
         return tensor_res.flatten_tensor(self.param_size_plus_one, order=order)
+
+    def _count_reusable_lin_ops(self, lin_ops: list[LinOp]) -> Counter[int]:
+        raw_counts: Counter[int] = Counter()
+        for lin_op in lin_ops:
+            self._count_lin_op_tree(lin_op, raw_counts)
+
+        process_counts: Counter[int] = Counter()
+        seen_cacheable: set[int] = set()
+        for lin_op in lin_ops:
+            self._count_processed_lin_ops(lin_op, raw_counts, process_counts, seen_cacheable)
+        return process_counts
+
+    def _count_lin_op_tree(self, lin_op: LinOp, counts: Counter[int]) -> None:
+        counts[id(lin_op)] += 1
+        for arg in lin_op.args:
+            self._count_lin_op_tree(arg, counts)
+
+    def _count_processed_lin_ops(
+        self,
+        lin_op: LinOp,
+        raw_counts: Counter[int],
+        process_counts: Counter[int],
+        seen_cacheable: set[int],
+    ) -> None:
+        lin_op_id = id(lin_op)
+        process_counts[lin_op_id] += 1
+        if raw_counts[lin_op_id] > 1:
+            if lin_op_id in seen_cacheable:
+                return
+            seen_cacheable.add(lin_op_id)
+        for arg in lin_op.args:
+            self._count_processed_lin_ops(arg, raw_counts, process_counts, seen_cacheable)
 
     def process_constraint(self, lin_op: LinOp, empty_view: TensorView) -> TensorView:
         """
@@ -533,9 +568,11 @@ class PythonCanonBackend(CanonBackend):
         The processed node as a TensorView.
         """
 
+        counts = getattr(self, "_lin_op_counts", None)
+        should_cache = counts is not None and counts[id(lin_op)] > 1
         cache = getattr(self, "_lin_op_tensor_cache", None)
         cache_key = id(lin_op)
-        if cache is not None and cache_key in cache:
+        if should_cache and cache is not None and cache_key in cache:
             return self._copy_tensor_view(cache[cache_key], empty_view)
 
         # Leaf nodes
@@ -571,7 +608,7 @@ class PythonCanonBackend(CanonBackend):
                 assert res is not None
                 result = res
 
-        if cache is not None:
+        if should_cache and cache is not None:
             cache[cache_key] = self._copy_tensor_view(result, empty_view)
         return result
 

--- a/cvxpy/lin_ops/backends/base.py
+++ b/cvxpy/lin_ops/backends/base.py
@@ -501,18 +501,22 @@ class PythonCanonBackend(CanonBackend):
     ) -> sp.csc_array | sp.csr_array:
         self.id_to_col[-1] = self.var_length
 
-        constraint_res = []
-        total_rows = sum(np.prod(lin_op.shape) for lin_op in lin_ops)
-        row_offset = 0
-        for lin_op in lin_ops:
-            lin_op_rows = np.prod(lin_op.shape)
-            empty_view = self.get_empty_view()
-            lin_op_tensor = self.process_constraint(lin_op, empty_view)
-            constraint_res.append(lin_op_tensor.get_tensor_representation(row_offset, total_rows))
-            row_offset += lin_op_rows
-        tensor_res = self.concatenate_tensors(constraint_res)
-
-        self.id_to_col.pop(-1)
+        self._lin_op_tensor_cache: dict[int, TensorView] = {}
+        try:
+            constraint_res = []
+            total_rows = sum(np.prod(lin_op.shape) for lin_op in lin_ops)
+            row_offset = 0
+            for lin_op in lin_ops:
+                lin_op_rows = np.prod(lin_op.shape)
+                empty_view = self.get_empty_view()
+                lin_op_tensor = self.process_constraint(lin_op, empty_view)
+                constraint_res.append(lin_op_tensor.get_tensor_representation(row_offset,
+                                                                               total_rows))
+                row_offset += lin_op_rows
+            tensor_res = self.concatenate_tensors(constraint_res)
+        finally:
+            del self._lin_op_tensor_cache
+            self.id_to_col.pop(-1)
         return tensor_res.flatten_tensor(self.param_size_plus_one, order=order)
 
     def process_constraint(self, lin_op: LinOp, empty_view: TensorView) -> TensorView:
@@ -529,38 +533,74 @@ class PythonCanonBackend(CanonBackend):
         The processed node as a TensorView.
         """
 
+        cache = getattr(self, "_lin_op_tensor_cache", None)
+        cache_key = id(lin_op)
+        if cache is not None and cache_key in cache:
+            return self._copy_tensor_view(cache[cache_key], empty_view)
+
         # Leaf nodes
         if lin_op.type == "variable":
             assert isinstance(lin_op.data, int)
             assert s.ALLOW_ND_EXPR or len(lin_op.shape) in {0, 1, 2}
             variable_tensor = self.get_variable_tensor(lin_op.shape, lin_op.data)
-            return empty_view.create_new_tensor_view({lin_op.data}, variable_tensor,
-                                                     is_parameter_free=True)
+            result = empty_view.create_new_tensor_view({lin_op.data}, variable_tensor,
+                                                       is_parameter_free=True)
         elif lin_op.type in {"scalar_const", "dense_const", "sparse_const"}:
             data_tensor = self.get_data_tensor(lin_op.data)
-            return empty_view.create_new_tensor_view({Constant.ID.value}, data_tensor,
-                                                     is_parameter_free=True)
+            result = empty_view.create_new_tensor_view({Constant.ID.value}, data_tensor,
+                                                       is_parameter_free=True)
         elif lin_op.type == "param":
             param_tensor = self.get_param_tensor(lin_op.shape, lin_op.data)
-            return empty_view.create_new_tensor_view({Constant.ID.value}, param_tensor,
-                                                     is_parameter_free=False)
+            result = empty_view.create_new_tensor_view({Constant.ID.value}, param_tensor,
+                                                       is_parameter_free=False)
 
         # Internal nodes
         else:
             func = self.get_func(lin_op.type)
             if lin_op.type in {"concatenate", "vstack", "hstack"}:
-                return func(lin_op, empty_view)
+                result = func(lin_op, empty_view)
+            else:
+                res = None
+                for arg in lin_op.args:
+                    arg_coeff = self.process_constraint(arg, empty_view)
+                    arg_res = func(lin_op, arg_coeff)
+                    if res is None:
+                        res = arg_res
+                    else:
+                        res += arg_res
+                assert res is not None
+                result = res
 
-            res = None
-            for arg in lin_op.args:
-                arg_coeff = self.process_constraint(arg, empty_view)
-                arg_res = func(lin_op, arg_coeff)
-                if res is None:
-                    res = arg_res
-                else:
-                    res += arg_res
-            assert res is not None
-            return res
+        if cache is not None:
+            cache[cache_key] = self._copy_tensor_view(result, empty_view)
+        return result
+
+    def _copy_tensor_view(self, view: TensorView, empty_view: TensorView) -> TensorView:
+        variable_ids = None if view.variable_ids is None else set(view.variable_ids)
+        return empty_view.create_new_tensor_view(
+            variable_ids,
+            self._copy_tensor_data(view.tensor),
+            view.is_parameter_free,
+        )
+
+    def _copy_tensor_data(self, data: Any) -> Any:
+        if isinstance(data, dict):
+            return {key: self._copy_tensor_data(value) for key, value in data.items()}
+        if data is None:
+            return None
+        if all(hasattr(data, attr) for attr in ("data", "row", "col", "param_idx")):
+            return type(data)(
+                data=data.data.copy(),
+                row=data.row.copy(),
+                col=data.col.copy(),
+                param_idx=data.param_idx.copy(),
+                m=data.m,
+                n=data.n,
+                param_size=data.param_size,
+            )
+        if hasattr(data, "copy"):
+            return data.copy()
+        return data
 
     def get_constant_data(
         self, lin_op: LinOp, view: TensorView, target_shape: tuple[int, ...] | None

--- a/cvxpy/lin_ops/backends/base.py
+++ b/cvxpy/lin_ops/backends/base.py
@@ -535,8 +535,15 @@ class PythonCanonBackend(CanonBackend):
 
     def _count_lin_op_tree(self, lin_op: LinOp, counts: Counter[int]) -> None:
         counts[id(lin_op)] += 1
-        for arg in lin_op.args:
-            self._count_lin_op_tree(arg, counts)
+        for child in self._lin_op_children(lin_op):
+            self._count_lin_op_tree(child, counts)
+
+    @staticmethod
+    def _lin_op_children(lin_op: LinOp) -> list[LinOp]:
+        children = list(lin_op.args)
+        if isinstance(lin_op.data, LinOp):
+            children.append(lin_op.data)
+        return children
 
     def _count_processed_lin_ops(
         self,
@@ -551,8 +558,8 @@ class PythonCanonBackend(CanonBackend):
             if lin_op_id in seen_cacheable:
                 return
             seen_cacheable.add(lin_op_id)
-        for arg in lin_op.args:
-            self._count_processed_lin_ops(arg, raw_counts, process_counts, seen_cacheable)
+        for child in self._lin_op_children(lin_op):
+            self._count_processed_lin_ops(child, raw_counts, process_counts, seen_cacheable)
 
     def process_constraint(self, lin_op: LinOp, empty_view: TensorView) -> TensorView:
         """

--- a/cvxpy/lin_ops/backends/base.py
+++ b/cvxpy/lin_ops/backends/base.py
@@ -625,19 +625,9 @@ class PythonCanonBackend(CanonBackend):
             return {key: self._copy_tensor_data(value) for key, value in data.items()}
         if data is None:
             return None
-        if all(hasattr(data, attr) for attr in ("data", "row", "col", "param_idx")):
-            return type(data)(
-                data=data.data.copy(),
-                row=data.row.copy(),
-                col=data.col.copy(),
-                param_idx=data.param_idx.copy(),
-                m=data.m,
-                n=data.n,
-                param_size=data.param_size,
-            )
         if hasattr(data, "copy"):
             return data.copy()
-        return data
+        raise RuntimeError(f"Tensor type {type(data)} has no copy method")
 
     def get_constant_data(
         self, lin_op: LinOp, view: TensorView, target_shape: tuple[int, ...] | None

--- a/cvxpy/lin_ops/backends/coo_backend.py
+++ b/cvxpy/lin_ops/backends/coo_backend.py
@@ -15,9 +15,10 @@ limitations under the License.
 """
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Self
 
 import numpy as np
 import scipy.sparse as sp
@@ -110,6 +111,9 @@ class CooTensor:
     def stacked_shape(self) -> tuple[int, int]:
         """Shape if this were converted to stacked format."""
         return (self.param_size * self.m, self.n)
+
+    def copy(self) -> Self:
+        return dataclasses.replace(self)
 
     def to_stacked_sparse(self) -> sp.csr_array:
         """Convert to stacked sparse matrix (for compatibility)."""

--- a/cvxpy/tests/test_python_backend_linop_memo.py
+++ b/cvxpy/tests/test_python_backend_linop_memo.py
@@ -61,6 +61,47 @@ def test_shared_linop_lowered_once(monkeypatch, backend, backend_cls) -> None:
     assert matrix.nnz == 2 * 3
 
 
+@pytest.mark.parametrize(("backend", "backend_cls"), PYTHON_BACKENDS)
+def test_single_use_linop_is_not_cached(monkeypatch, backend, backend_cls) -> None:
+    x = lu.create_var((3,), var_id=1)
+    calls = 0
+    original = backend_cls._copy_tensor_view
+
+    def spy_copy_tensor_view(self, view, empty_view):
+        nonlocal calls
+        calls += 1
+        return original(self, view, empty_view)
+
+    monkeypatch.setattr(backend_cls, "_copy_tensor_view", spy_copy_tensor_view)
+
+    matrix = _problem_matrix([x], backend)
+
+    assert calls == 0
+    assert matrix.shape == (3 * (3 + 1), 1)
+    assert matrix.nnz == 3
+
+
+@pytest.mark.parametrize(("backend", "backend_cls"), PYTHON_BACKENDS)
+def test_descendant_of_reused_linop_is_not_cached(monkeypatch, backend, backend_cls) -> None:
+    x = lu.create_var((3,), var_id=1)
+    neg_x = lu.neg_expr(x)
+    calls = 0
+    original = backend_cls._copy_tensor_view
+
+    def spy_copy_tensor_view(self, view, empty_view):
+        nonlocal calls
+        calls += 1
+        return original(self, view, empty_view)
+
+    monkeypatch.setattr(backend_cls, "_copy_tensor_view", spy_copy_tensor_view)
+
+    matrix = _problem_matrix([neg_x, neg_x], backend)
+
+    assert calls == 2
+    assert matrix.shape == (2 * 3 * (3 + 1), 1)
+    assert matrix.nnz == 2 * 3
+
+
 @pytest.mark.parametrize("backend", [backend for backend, _ in PYTHON_BACKENDS])
 def test_shared_linop_cache_hits_do_not_share_mutable_views(backend) -> None:
     x = lu.create_var((3,), var_id=1)

--- a/cvxpy/tests/test_python_backend_linop_memo.py
+++ b/cvxpy/tests/test_python_backend_linop_memo.py
@@ -17,6 +17,7 @@ limitations under the License.
 import numpy as np
 import pytest
 
+import cvxpy as cp
 import cvxpy.settings as s
 from cvxpy.cvxcore.python import canonInterface
 from cvxpy.lin_ops import lin_utils as lu
@@ -29,13 +30,37 @@ PYTHON_BACKENDS = [
 ]
 
 
-def _problem_matrix(lin_ops, backend):
+def _problem_matrix(lin_ops, backend, variables=None, parameters=None):
+    if variables is None:
+        var_length = 3
+        id_to_col = {1: 0}
+    else:
+        var_length = 0
+        id_to_col = {}
+        for variable in variables:
+            id_to_col[variable.id] = var_length
+            var_length += int(np.prod(variable.shape))
+
+    param_to_size = {-1: 1}
+    param_to_col = {-1: 0}
+    if parameters is not None:
+        offset = 0
+        param_to_size = {}
+        param_to_col = {}
+        for parameter in parameters:
+            param_size = int(np.prod(parameter.shape))
+            param_to_size[parameter.id] = param_size
+            param_to_col[parameter.id] = offset
+            offset += param_size
+        param_to_size[-1] = 1
+        param_to_col[-1] = offset
+
     return canonInterface.get_problem_matrix(
         lin_ops,
-        var_length=3,
-        id_to_col={1: 0},
-        param_to_size={-1: 1},
-        param_to_col={-1: 0},
+        var_length=var_length,
+        id_to_col=id_to_col,
+        param_to_size=param_to_size,
+        param_to_col=param_to_col,
         constr_length=sum(np.prod(lin_op.shape) for lin_op in lin_ops),
         canon_backend=backend,
     )
@@ -59,6 +84,36 @@ def test_shared_linop_lowered_once(monkeypatch, backend, backend_cls) -> None:
     assert calls == 1
     assert matrix.shape == (2 * 3 * (3 + 1), 1)
     assert matrix.nnz == 2 * 3
+
+
+@pytest.mark.parametrize(("backend", "backend_cls"), PYTHON_BACKENDS)
+def test_shared_parameter_linop_in_data_is_lowered_once(monkeypatch, backend, backend_cls) -> None:
+    P = cp.Parameter((3, 3), name="P")
+    x = cp.Variable(3, name="x")
+    y = cp.Variable(3, name="y")
+    scaled = 2 * P
+    lin_op_x, _ = (scaled @ x).canonical_form
+    lin_op_y, _ = (scaled @ y).canonical_form
+
+    assert lin_op_x.data is lin_op_y.data
+    assert lin_op_x.data.type == "mul_elem"
+
+    calls = 0
+    original = backend_cls.get_param_tensor
+
+    def spy_get_param_tensor(self, shape, parameter_id):
+        nonlocal calls
+        calls += 1
+        return original(self, shape, parameter_id)
+
+    monkeypatch.setattr(backend_cls, "get_param_tensor", spy_get_param_tensor)
+
+    matrix = _problem_matrix([lin_op_x, lin_op_y], backend, variables=[x, y], parameters=[P])
+
+    assert calls == 1
+    assert matrix.shape == (2 * 3 * (2 * 3 + 1), 3 * 3 + 1)
+    assert matrix.nnz == 2 * 3 * 3
+    np.testing.assert_array_equal(matrix.data, 2 * np.ones(matrix.nnz))
 
 
 @pytest.mark.parametrize(("backend", "backend_cls"), PYTHON_BACKENDS)

--- a/cvxpy/tests/test_python_backend_linop_memo.py
+++ b/cvxpy/tests/test_python_backend_linop_memo.py
@@ -1,0 +1,74 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import numpy as np
+import pytest
+
+import cvxpy.settings as s
+from cvxpy.cvxcore.python import canonInterface
+from cvxpy.lin_ops import lin_utils as lu
+from cvxpy.lin_ops.backends.coo_backend import CooCanonBackend
+from cvxpy.lin_ops.backends.scipy_backend import SciPyCanonBackend
+
+PYTHON_BACKENDS = [
+    (s.SCIPY_CANON_BACKEND, SciPyCanonBackend),
+    (s.COO_CANON_BACKEND, CooCanonBackend),
+]
+
+
+def _problem_matrix(lin_ops, backend):
+    return canonInterface.get_problem_matrix(
+        lin_ops,
+        var_length=3,
+        id_to_col={1: 0},
+        param_to_size={-1: 1},
+        param_to_col={-1: 0},
+        constr_length=sum(np.prod(lin_op.shape) for lin_op in lin_ops),
+        canon_backend=backend,
+    )
+
+
+@pytest.mark.parametrize(("backend", "backend_cls"), PYTHON_BACKENDS)
+def test_shared_linop_lowered_once(monkeypatch, backend, backend_cls) -> None:
+    x = lu.create_var((3,), var_id=1)
+    calls = 0
+    original = backend_cls.get_variable_tensor
+
+    def spy_get_variable_tensor(self, shape, variable_id):
+        nonlocal calls
+        calls += 1
+        return original(self, shape, variable_id)
+
+    monkeypatch.setattr(backend_cls, "get_variable_tensor", spy_get_variable_tensor)
+
+    matrix = _problem_matrix([x, x], backend)
+
+    assert calls == 1
+    assert matrix.shape == (2 * 3 * (3 + 1), 1)
+    assert matrix.nnz == 2 * 3
+
+
+@pytest.mark.parametrize("backend", [backend for backend, _ in PYTHON_BACKENDS])
+def test_shared_linop_cache_hits_do_not_share_mutable_views(backend) -> None:
+    x = lu.create_var((3,), var_id=1)
+    matrix = _problem_matrix([lu.neg_expr(x), x], backend).toarray()
+    matrix = matrix.reshape((6, 4), order="F")
+
+    first_block = matrix[:3, :3]
+    second_block = matrix[3:, :3]
+
+    np.testing.assert_array_equal(first_block, -np.eye(3))
+    np.testing.assert_array_equal(second_block, np.eye(3))


### PR DESCRIPTION
## Description

Adds a per-`build_matrix` memo to the Python canonicalization backend path (`SCIPY` and `COO`) keyed by Python LinOp object identity. When the same LinOp object appears multiple times, the backend now reuses the already-lowered TensorView instead of recursively lowering that LinOp tree again.

Cached TensorViews are cloned when stored and on cache hits, so mutating backend operations such as negation, row selection, and accumulation cannot alter the cached snapshot or another occurrence's view.

In order to control cache size, we first walk the full tree counting duplicates, and then only store objects that are needed later.

Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
