### PR TITLE
DOC: fix grammar issues across cvxpy

### DIFF
--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -461,7 +461,7 @@ class Atom(Expression):
         else:
             arg_values = []
             for arg in self.args:
-                # A argument without a value makes all higher level
+                # An argument without a value makes all higher level
                 # values None.
                 # But if the atom is constant with non-constant
                 # arguments it doesn't depend on its arguments,

--- a/cvxpy/atoms/dotsort.py
+++ b/cvxpy/atoms/dotsort.py
@@ -50,7 +50,7 @@ class dotsort(Atom):
         if not self.args[1].is_constant():
             raise ValueError("The W argument must be constant.")
         if self.args[0].size < self.args[1].size:
-            raise ValueError("The size of of W must be less or equal to the size of X.")
+            raise ValueError("The size of W must be less or equal to the size of X.")
 
         super(dotsort, self).validate_arguments()
 

--- a/cvxpy/constraints/constraint.py
+++ b/cvxpy/constraints/constraint.py
@@ -233,7 +233,7 @@ class Constraint(u.Canonical):
         """
         residual = self.residual
         if residual is None:
-            raise ValueError("Cannot compute the violation of an constraint "
+            raise ValueError("Cannot compute the violation of a constraint "
                              "whose expression is None-valued.")
         return residual
 
@@ -259,7 +259,7 @@ class Constraint(u.Canonical):
         """
         residual = self.residual
         if residual is None:
-            raise ValueError("Cannot compute the value of an constraint "
+            raise ValueError("Cannot compute the value of a constraint "
                              "whose expression is None-valued.")
         return np.all(residual <= tolerance)
 

--- a/cvxpy/constraints/nonpos.py
+++ b/cvxpy/constraints/nonpos.py
@@ -96,7 +96,7 @@ class NonPos(Constraint):
     def violation(self):
         res = self.residual
         if res is None:
-            raise ValueError("Cannot compute the violation of an constraint "
+            raise ValueError("Cannot compute the violation of a constraint "
                              "whose expression is None-valued.")
         viol = np.linalg.norm(res, ord=2)
         return viol
@@ -162,7 +162,7 @@ class NonNeg(Constraint):
     def violation(self):
         res = self.residual
         if res is None:
-            raise ValueError("Cannot compute the violation of an constraint "
+            raise ValueError("Cannot compute the violation of a constraint "
                              "whose expression is None-valued.")
         viol = np.linalg.norm(res, ord=2)
         return viol

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -562,7 +562,7 @@ class Leaf(expression.Expression):
                     'expr.value_sparse = scipy.sparse.coo_array((values, expr)) instead.')
             raise ValueError(
                 'Invalid type for assigning value_sparse.'
-                f'Recieved: {type(val)} Expected scipy.sparse.coo_array.'
+                f'Received: {type(val)} Expected scipy.sparse.coo_array.'
                 f' Instantiate with scipy.sparse.coo_array((value_array, coordinates))'
                 )
         self.save_value(self._validate_value(val, True), True)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -2913,7 +2913,7 @@ class TestDotsort(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.dotsort(self.x, [1, 2, 3, 4, 5, 8])
         self.assertEqual(str(cm.exception),
-                         "The size of of W must be less or equal to the size of X.")
+                         "The size of W must be less or equal to the size of X.")
 
         # two variable expressions
         with self.assertRaises(Exception) as cm:


### PR DESCRIPTION
Fix grammar issues: 'an constraint'->'a constraint' (constraint.py x2, nonpos.py x2), 'A argument'->'An argument' (atom.py), 'Recieved'->'Received' (leaf.py), 'of of'->'of' (dotsort.py).

**Files changed:**
- `cvxpy/constraints/constraint.py`
- `cvxpy/constraints/nonpos.py`
- `cvxpy/atoms/atom.py`
- `cvxpy/expressions/leaf.py`
- `cvxpy/atoms/dotsort.py`
- `cvxpy/tests/test_atoms.py`