### PR TITLE
Replaces cast_to_const with cast internally

### DIFF
--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -156,8 +156,8 @@ class MulExpression(BinaryOperator):
         For A @ B where A has shape (...a, m, k) and B has shape (...b, k, n),
         broadcasts both to have batch shape broadcast(...a, ...b).
         """
-        lh_exp = Expression.cast_to_const(lh_exp)
-        rh_exp = Expression.cast_to_const(rh_exp)
+        lh_exp = Expression.cast(lh_exp)
+        rh_exp = Expression.cast(rh_exp)
 
         lh_shape = lh_exp.shape
         rh_shape = rh_exp.shape
@@ -650,10 +650,10 @@ def outer(x, y) -> Expression:
     expr : Expression
         The outer product of (x,y), linear in x and transposed-linear in y.
     """
-    x = Expression.cast_to_const(x)
+    x = Expression.cast(x)
     if x.ndim > 1:
         raise ValueError("x must be a 1-d array.")
-    y = Expression.cast_to_const(y)
+    y = Expression.cast(y)
     if y.ndim > 1:
         raise ValueError("y must be a 1-d array.")
 

--- a/cvxpy/atoms/affine/diag.py
+++ b/cvxpy/atoms/affine/diag.py
@@ -42,7 +42,7 @@ def diag(expr, k: int = 0) -> "diag_mat" | "diag_vec":
     Expression
         An Expression representing the diagonal vector/matrix.
     """
-    expr = AffAtom.cast_to_const(expr)
+    expr = AffAtom.cast(expr)
     if expr.is_vector():
         return diag_vec(vec(expr, order='F'), k)
     elif expr.ndim == 2 and expr.shape[0] == expr.shape[1]:

--- a/cvxpy/atoms/affine/diff.py
+++ b/cvxpy/atoms/affine/diff.py
@@ -48,7 +48,7 @@ def diff(x, k: int = 1, axis: int = 0) -> Expression:
     Expression
         The kth order differences along the specified axis.
     """
-    x = Expression.cast_to_const(x)
+    x = Expression.cast(x)
 
     # Validate and normalize axis (handles negative indices)
     if x.ndim == 0:

--- a/cvxpy/atoms/affine/hstack.py
+++ b/cvxpy/atoms/affine/hstack.py
@@ -30,7 +30,7 @@ def hstack(arg_list) -> "Hstack":
     arg_list : list of Expression
         The Expressions to concatenate.
     """
-    arg_list = [AffAtom.cast_to_const(arg) for arg in arg_list]
+    arg_list = [AffAtom.cast(arg) for arg in arg_list]
     for idx, arg in enumerate(arg_list):
         if arg.ndim == 0:
             arg_list[idx] = arg.flatten(order='F')

--- a/cvxpy/atoms/affine/index.py
+++ b/cvxpy/atoms/affine/index.py
@@ -139,7 +139,7 @@ class special_index(AffAtom):
     def __init__(self, expr: Expression, key) -> None:
         self.key = key
         # Order the entries of expr and select them using key.
-        expr = index.cast_to_const(expr)
+        expr = index.cast(expr)
         idx_mat = np.arange(expr.size)
         idx_mat = np.reshape(idx_mat, expr.shape, order='F')
         self._select_mat = idx_mat[key]

--- a/cvxpy/atoms/affine/promote.py
+++ b/cvxpy/atoms/affine/promote.py
@@ -40,7 +40,7 @@ def promote(expr: Expression, shape: tuple[int, ...]) -> Expression:
         If ``expr`` is not a scalar.
     """
 
-    expr = Expression.cast_to_const(expr)
+    expr = Expression.cast(expr)
     if expr.shape != shape:
         if not expr.is_scalar():
             raise ValueError('Only 0-d arrays (i.e., scalars) may be promoted.')

--- a/cvxpy/atoms/affine/reshape.py
+++ b/cvxpy/atoms/affine/reshape.py
@@ -171,7 +171,7 @@ def deep_flatten(x):
         else:
             return x.flatten(order='F')
     elif isinstance(x, np.ndarray) or isinstance(x, (int, float)):
-        x = Expression.cast_to_const(x)
+        x = Expression.cast(x)
         return x.flatten(order='F')
     # recursion
     if isinstance(x, list):

--- a/cvxpy/atoms/affine/stack.py
+++ b/cvxpy/atoms/affine/stack.py
@@ -43,7 +43,7 @@ from cvxpy.expressions.expression import Expression
 
 def _as_expression(obj) -> Expression:
     """Cast scalars/arrays to ``Constant`` while leaving Expressions intact."""
-    return obj if isinstance(obj, Expression) else Expression.cast_to_const(obj)
+    return obj if isinstance(obj, Expression) else Expression.cast(obj)
 
 
 def stack(arrays: Sequence[object] | Iterable[object], axis: int = 0) -> Expression:

--- a/cvxpy/atoms/affine/upper_tri.py
+++ b/cvxpy/atoms/affine/upper_tri.py
@@ -116,7 +116,7 @@ def vec_to_upper_tri(expr, strict: bool = False) -> Expression:
     matrix should be returned.
     Inverts cp.upper_tri.
     """
-    expr = Expression.cast_to_const(expr)
+    expr = Expression.cast(expr)
 
     if not expr.is_vector():
         raise ValueError("The input must be a vector.")

--- a/cvxpy/atoms/affine/vec.py
+++ b/cvxpy/atoms/affine/vec.py
@@ -40,5 +40,5 @@ def vec(X, order: Literal["F", "C", None] = None) -> Expression:
         warn(vec_order_warning, FutureWarning)
         order = 'F'
     assert order in ['F', 'C']
-    X = Expression.cast_to_const(X)
+    X = Expression.cast(X)
     return reshape(X, (X.size,), order)

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -48,7 +48,7 @@ class Atom(Expression):
                 "No arguments given to %s." % self.__class__.__name__
             )
         # Convert raw values to Constants.
-        self.args = [Atom.cast_to_const(arg) for arg in args]
+        self.args = [Atom.cast(arg) for arg in args]
         self.validate_arguments()
         self._shape = self.shape_from_args()
         if not s.ALLOW_ND_EXPR and len(self._shape) > 2:

--- a/cvxpy/atoms/elementwise/huber.py
+++ b/cvxpy/atoms/elementwise/huber.py
@@ -88,7 +88,7 @@ class HuberAtom(Elementwise):
     """
 
     def __init__(self, x, M: int = 1) -> None:
-        self.M = self.cast_to_const(M)
+        self.M = self.cast(M)
         super(HuberAtom, self).__init__(x)
 
     def parameters(self):
@@ -189,8 +189,8 @@ class HuberPerspectiveAtom(Atom):
     """
 
     def __init__(self, x, t, M=1) -> None:
-        self.M = self.cast_to_const(M)
-        t = self.cast_to_const(t)
+        self.M = self.cast(M)
+        t = self.cast(t)
         super(HuberPerspectiveAtom, self).__init__(x, t)
 
     @property

--- a/cvxpy/atoms/elementwise/log_normcdf.py
+++ b/cvxpy/atoms/elementwise/log_normcdf.py
@@ -48,7 +48,7 @@ def log_normcdf(x) -> Expression:
     )
     b = np.array([[3.0, 2.0, 1.0, 0.0, -1.0, -2.5, -3.5]]).reshape(-1, 1)
 
-    x = Expression.cast_to_const(x)
+    x = Expression.cast(x)
     flat_x = reshape(x, (1, x.size), order='F')
 
     y = A @ (b @ np.ones(flat_x.shape) - np.ones(b.shape) @ flat_x)

--- a/cvxpy/atoms/elementwise/power.py
+++ b/cvxpy/atoms/elementwise/power.py
@@ -51,8 +51,8 @@ def power(x, p, max_denom: int = 1024, approx: bool = True) -> Expression:
     """
 
     # Cast both to CVXPY expressions for inspection
-    x_expr = Expression.cast_to_const(x)
-    p_expr = Expression.cast_to_const(p)
+    x_expr = Expression.cast(x)
+    p_expr = Expression.cast(p)
 
     # Case: b**x where b is constant and x is variable
     # e.g. cp.power(2, x) — dispatch to exp(x * log(b))
@@ -173,7 +173,7 @@ class Power(Elementwise):
         # NB: It is important that the exponent is an attribute, not
         # an argument. This prevents parametrized exponents from being replaced
         # with their logs in Dgp2Dcp.
-        self.p = cvxtypes.expression().cast_to_const(p)
+        self.p = cvxtypes.expression().cast(p)
         if not (isinstance(self.p, cvxtypes.constant()) or
                 isinstance(self.p, cvxtypes.parameter())):
             raise ValueError("The exponent `p` must be either a Constant or "

--- a/cvxpy/atoms/geo_mean.py
+++ b/cvxpy/atoms/geo_mean.py
@@ -215,9 +215,9 @@ class GeoMean(Atom):
             if isinstance(x, list):
                 x = np.array(x)
             if x.ndim == 0:
-                x = Expression.cast_to_const(promote(x, shape=(1,)))[idxs]
+                x = Expression.cast(promote(x, shape=(1,)))[idxs]
             else:
-                x = Expression.cast_to_const(x)[idxs]
+                x = Expression.cast(x)[idxs]
             p = p[idxs]
         super(GeoMean, self).__init__(x)
 

--- a/cvxpy/atoms/gmatmul.py
+++ b/cvxpy/atoms/gmatmul.py
@@ -49,7 +49,7 @@ class gmatmul(Atom):
         # NB: It is important that the exponent is an attribute, not
         # an argument. This prevents parametrized exponents from being replaced
         # with their logs in Dgp2Dcp.
-        self.A = Atom.cast_to_const(A)
+        self.A = Atom.cast(A)
         super(gmatmul, self).__init__(X)
 
     def numeric(self, values):

--- a/cvxpy/atoms/harmonic_mean.py
+++ b/cvxpy/atoms/harmonic_mean.py
@@ -35,7 +35,7 @@ def harmonic_mean(x) -> Expression:
 
         where :math:`n` is the length of :math:`x`.
     """
-    x = Expression.cast_to_const(x)
+    x = Expression.cast(x)
     # TODO(akshayka): Behavior of the below is incorrect when x has negative
     # entries. Either fail fast or provide a correct expression with
     # unknown curvature.

--- a/cvxpy/atoms/lambda_min.py
+++ b/cvxpy/atoms/lambda_min.py
@@ -21,5 +21,5 @@ from cvxpy.expressions.expression import Expression
 def lambda_min(X) -> Expression:
     """ Minimum eigenvalue; :math:`\\lambda_{\\min}(A)`.
     """
-    X = Expression.cast_to_const(X)
+    X = Expression.cast(X)
     return -lambda_max(-X)

--- a/cvxpy/atoms/lambda_sum_smallest.py
+++ b/cvxpy/atoms/lambda_sum_smallest.py
@@ -21,5 +21,5 @@ from cvxpy.expressions.expression import Expression
 def lambda_sum_smallest(X, k) -> Expression:
     """Sum of the smallest k eigenvalues.
     """
-    X = Expression.cast_to_const(X)
+    X = Expression.cast(X)
     return -lambda_sum_largest(-X, k)

--- a/cvxpy/atoms/mixed_norm.py
+++ b/cvxpy/atoms/mixed_norm.py
@@ -36,7 +36,7 @@ def mixed_norm(X, p: int | str = 2, q: int | str = 1) -> Expression:
     Expression
         An Expression representing the mixed norm.
     """
-    X = Expression.cast_to_const(X)
+    X = Expression.cast(X)
 
     # inner norms
     vecnorms = norm(X, p, axis=1)

--- a/cvxpy/atoms/norm.py
+++ b/cvxpy/atoms/norm.py
@@ -48,7 +48,7 @@ def norm(x, p: int | str = 2, axis=None, keepdims: bool = False) -> Expression:
     Expression
         An Expression representing the norm.
     """
-    x = Expression.cast_to_const(x)
+    x = Expression.cast(x)
     # matrix norms take precedence
     num_nontrivial_idxs = sum([d > 1 for d in x.shape])
     if axis is None and x.ndim == 2:

--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -302,7 +302,7 @@ def quad_form(x, P, assume_PSD: bool = False) -> Expression:
     quadratic objectives, ``quad_form(x, P)`` can participate in a DPP solve,
     so repeated solves can reuse cached compilation data.
     """
-    x, P = map(Expression.cast_to_const, (x, P))
+    x, P = map(Expression.cast, (x, P))
     # Check dimensions.
     if not P.ndim == 2 or P.shape[0] != P.shape[1] or max(x.shape, (1,))[0] != P.shape[0]:
         raise Exception("Invalid dimensions for arguments to quad_form.")

--- a/cvxpy/atoms/sum_smallest.py
+++ b/cvxpy/atoms/sum_smallest.py
@@ -21,5 +21,5 @@ from cvxpy.expressions.expression import Expression
 def sum_smallest(x, k, axis=None, keepdims=False) -> Expression:
     """Sum of the smallest k values, optionally along an axis.
     """
-    x = Expression.cast_to_const(x)
+    x = Expression.cast(x)
     return -sum_largest(-x, k, axis=axis, keepdims=keepdims)

--- a/cvxpy/atoms/suppfunc.py
+++ b/cvxpy/atoms/suppfunc.py
@@ -21,7 +21,7 @@ class SuppFuncAtom(Atom):
             The object containing data for the convex set associated with this atom.
         """
         self.id = lu.get_id()
-        self.args = [Atom.cast_to_const(y)]
+        self.args = [Atom.cast(y)]
         self._parent = parent
         self._eta = None  # store for debugging purposes
         self._shape: tuple[int, ...] = tuple()

--- a/cvxpy/atoms/total_variation.py
+++ b/cvxpy/atoms/total_variation.py
@@ -39,7 +39,7 @@ def tv(value, *args) -> Expression:
     Expression
         An Expression representing the total variation.
     """
-    value = Expression.cast_to_const(value)
+    value = Expression.cast(value)
     if value.ndim == 0:
         raise ValueError("tv cannot take a scalar argument.")
     # L1 norm for vectors.
@@ -48,7 +48,7 @@ def tv(value, *args) -> Expression:
     # L2 norm for matrices.
     elif value.ndim == 2:
         rows, cols = value.shape
-        args = map(Expression.cast_to_const, args)
+        args = map(Expression.cast, args)
         values = [value] + list(args)
         diffs = []
         for mat in values:

--- a/cvxpy/constraints/constraint.py
+++ b/cvxpy/constraints/constraint.py
@@ -41,7 +41,7 @@ class Constraint(u.Canonical):
 
     def __init__(self, args, constr_id=None) -> None:
         # TODO cast constants.
-        # self.args = [cvxtypes.expression().cast_to_const(arg) for arg in args]
+        # self.args = [cvxtypes.expression().cast(arg) for arg in args]
         self.args = args
         self._label = None
         if constr_id is None:

--- a/cvxpy/constraints/finite_set.py
+++ b/cvxpy/constraints/finite_set.py
@@ -59,7 +59,7 @@ class FiniteSet(Constraint):
         Expression = cvxtypes.expression()
         if isinstance(vec, set):
             vec = list(vec)
-        vec = Expression.cast_to_const(vec).flatten(order='F')
+        vec = Expression.cast(vec).flatten(order='F')
         if not expre.is_affine() and not expre.is_log_log_affine():
             msg = """
             Provided Expression must be affine or log-log affine, but had curvature %s.

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -41,13 +41,13 @@ class PowCone3D(Cone):
 
     def __init__(self, x, y, z, alpha, constr_id=None) -> None:
         Expression = cvxtypes.expression()
-        self.x = Expression.cast_to_const(x)
-        self.y = Expression.cast_to_const(y)
-        self.z = Expression.cast_to_const(z)
+        self.x = Expression.cast(x)
+        self.y = Expression.cast(y)
+        self.z = Expression.cast(z)
         for val in [self.x, self.y, self.z]:
             if not (val.is_affine() and val.is_real()):
                 raise ValueError('All arguments must be affine and real.')
-        alpha = Expression.cast_to_const(alpha)
+        alpha = Expression.cast(alpha)
         alpha_promoted_to_vec = False
         if alpha.is_scalar():
             if self.x.shape:
@@ -192,11 +192,11 @@ class PowConeND(Cone):
 
     def __init__(self, W, z, alpha, axis: int = 0, constr_id=None) -> None:
         Expression = cvxtypes.expression()
-        W = Expression.cast_to_const(W)
+        W = Expression.cast(W)
         if not (W.is_real() and W.is_affine()):
             msg = "Invalid first argument; W must be affine and real."
             raise ValueError(msg)
-        z = Expression.cast_to_const(z)
+        z = Expression.cast(z)
         if z.ndim > 1 or not (z.is_real() and z.is_affine()):
             msg = ("Invalid second argument. z must be affine, real, "
                    "and have at most one z.ndim <= 1.")
@@ -211,7 +211,7 @@ class PowConeND(Cone):
         if W.ndim == 2 and W.shape[axis] <= 1:
             msg = "PowConeND requires left-hand-side to have at least two terms."
             raise ValueError(msg)
-        alpha = Expression.cast_to_const(alpha)
+        alpha = Expression.cast(alpha)
         if alpha.shape != W.shape:
             raise ValueError("Argument dimensions %s and %s are not equal."
                              % (W.shape, alpha.shape))

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -717,7 +717,7 @@ class Expression(u.Canonical):
         """
         If expr_like is an Expression, return it. Otherwise, cast expr_like to a Constant.
 
-        This is a wrapper around the misleadingly-named `Expression.cast` function.
+        Deprecated: This is a wrapper around the `Expression.cast` function.
         """
         return Expression.cast(expr_like)
 

--- a/cvxpy/expressions/expression.py
+++ b/cvxpy/expressions/expression.py
@@ -52,7 +52,7 @@ def _cast_other(binary_op):
     def cast_op(self, other):
         """A wrapped binary operator that can handle non-Expression arguments.
         """
-        other = self.cast_to_const(other)
+        other = self.cast(other)
         return binary_op(self, other)
     return cast_op
 
@@ -688,7 +688,7 @@ class Expression(u.Canonical):
         Expression
             The expression raised to ``power``.
         """
-        power_expr = Expression.cast_to_const(power)
+        power_expr = Expression.cast(power)
         if self.is_constant() and not power_expr.is_constant():
             return _pow_const_base(self, power_expr)
         return cvxtypes.power()(self, power)
@@ -709,21 +709,21 @@ class Expression(u.Canonical):
             exp(self * log(base))
         """
 
-        base_expr = cvxtypes.expression().cast_to_const(base)
+        base_expr = cvxtypes.expression().cast(base)
         return _pow_const_base(base_expr, self)
 
     @staticmethod
-    def cast(expr_like) -> "Expression":
+    def cast_to_const(expr_like) -> "Expression":
         """
         If expr_like is an Expression, return it. Otherwise, cast expr_like to a Constant.
 
-        This is a wrapper around the misleadingly-named `Expression.cast_to_const` function.
+        This is a wrapper around the misleadingly-named `Expression.cast` function.
         """
-        return Expression.cast_to_const(expr_like)
+        return Expression.cast(expr_like)
 
     # Arithmetic operators.
     @staticmethod
-    def cast_to_const(expr: "Expression"):
+    def cast(expr: "Expression"):
         """Converts a non-Expression to a Constant.
         """
         if isinstance(expr, list):
@@ -738,8 +738,8 @@ class Expression(u.Canonical):
     @staticmethod
     def broadcast(lh_expr: "Expression", rh_expr: "Expression"):
         """Broadcast the binary operator."""
-        lh_expr = Expression.cast_to_const(lh_expr)
-        rh_expr = Expression.cast_to_const(rh_expr)
+        lh_expr = Expression.cast(lh_expr)
+        rh_expr = Expression.cast(rh_expr)
         # Promote.
         if lh_expr.is_scalar() and not rh_expr.is_scalar():
             lh_expr = cp.promote(lh_expr, rh_expr.shape)

--- a/cvxpy/problems/objective.py
+++ b/cvxpy/problems/objective.py
@@ -39,7 +39,7 @@ class Objective(u.Canonical):
     NAME = "objective"
 
     def __init__(self, expr) -> None:
-        self.args = [Expression.cast_to_const(expr)]
+        self.args = [Expression.cast(expr)]
         # Needed for Canonical._aggregate_metrics.
         self.ndim = 0
         # Validate that the objective resolves to a scalar.

--- a/cvxpy/reductions/cone2cone/approx.py
+++ b/cvxpy/reductions/cone2cone/approx.py
@@ -197,7 +197,7 @@ def pow_3d_canon(con, args):
     x, y, z = args
 
     # alpha is always a CVXPY Expression (PowCone3D.__init__ wraps it
-    # via cast_to_const), so .value always exists.
+    # via cast), so .value always exists.
     alpha_val = alpha.value
 
     # Normalize to a 1-D numpy array so the branches below can

--- a/cvxpy/tests/test_linalg_utils.py
+++ b/cvxpy/tests/test_linalg_utils.py
@@ -57,7 +57,7 @@ class TestSparseCholesky(BaseTest):
         A = sp.csc_array(B @ B.T)
         if use_expression:
             from cvxpy.expressions.expression import Expression
-            A = Expression.cast_to_const(A)
+            A = Expression.cast(A)
             assert isinstance(A, Expression)
         _, L, p = lau.sparse_cholesky(A)
         self.check_factor(L)

--- a/cvxpy/transforms/linearize.py
+++ b/cvxpy/transforms/linearize.py
@@ -41,7 +41,7 @@ def linearize(expr):
     Returns:
         An affine expression or None.
     """
-    expr = Constant.cast_to_const(expr)
+    expr = Constant.cast(expr)
     if expr.is_affine():
         return expr
     else:

--- a/cvxpy/transforms/partial_optimize.py
+++ b/cvxpy/transforms/partial_optimize.py
@@ -261,7 +261,7 @@ class PartialProblem(Expression):
             lagr = self.args[0].objective.args[0]
             for constr in self.args[0].constraints:
                 # TODO: better way to get constraint expressions.
-                lagr_multiplier = self.cast_to_const(sign * constr.dual_value)
+                lagr_multiplier = self.cast(sign * constr.dual_value)
                 prod = lagr_multiplier.T @ constr.expr
                 if prod.is_scalar():
                     lagr += sum(prod)


### PR DESCRIPTION
## Description
Closes #3410.

No deprecation warning or anything on cast_to_const not really sure we need it.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.