### PR TITLE
Make NLP solver tests less verbose in CI

### DIFF
--- a/cvxpy/tests/nlp_tests/test_best_of.py
+++ b/cvxpy/tests/nlp_tests/test_best_of.py
@@ -84,7 +84,7 @@ class TestBestOf():
         y = cp.Variable(bounds=[-3, 3])
         obj = cp.Minimize((x - 1) ** 2 + (y - 2) ** 2)
         prob = cp.Problem(obj)
-        prob.solve(nlp=True, best_of=3)
+        prob.solve(nlp=True, best_of=3, verbose=False)
 
         all_objs = prob.solver_stats.extra_stats['all_objs_from_best_of']
         assert len(all_objs) == 3
@@ -110,7 +110,7 @@ class TestBestOf():
         y.value = 5
         obj = cp.Minimize((x - 1) ** 2 + (y - 2) ** 2)
         prob = cp.Problem(obj)
-        prob.solve(nlp=True, best_of=3)
+        prob.solve(nlp=True, best_of=3, verbose=False)
         all_objs = prob.solver_stats.extra_stats['all_objs_from_best_of']
         assert len(all_objs) == 3
 

--- a/cvxpy/tests/nlp_tests/test_broadcast.py
+++ b/cvxpy/tests/nlp_tests/test_broadcast.py
@@ -38,7 +38,7 @@ class TestBroadcast():
         x.value = None
 
         problem.solve(solver=cp.IPOPT, nlp=True, hessian_approximation='exact',
-                    derivative_test='none', verbose=True)
+                    derivative_test='none', verbose=False)
         assert(problem.status == cp.OPTIMAL)
         assert(np.allclose(x.value, np.mean(A)))
 
@@ -50,7 +50,7 @@ class TestBroadcast():
         problem = cp.Problem(cp.Minimize(obj))
 
         problem.solve(solver=cp.IPOPT, nlp=True, hessian_approximation='exact',
-                    derivative_test='none', verbose=True)
+                    derivative_test='none', verbose=False)
         assert(problem.status == cp.OPTIMAL)
         assert(np.allclose(x.value, np.mean(A, axis=0)))
 
@@ -66,7 +66,7 @@ class TestBroadcast():
         problem = cp.Problem(cp.Minimize(obj))
 
         problem.solve(solver=cp.IPOPT, nlp=True, hessian_approximation='exact',
-                    derivative_test='none', verbose=True)
+                    derivative_test='none', verbose=False)
         assert(problem.status == cp.OPTIMAL)
         assert(np.allclose(x.value.flatten(), np.mean(A, axis=1)))
 

--- a/cvxpy/tests/nlp_tests/test_huber_sum_largest.py
+++ b/cvxpy/tests/nlp_tests/test_huber_sum_largest.py
@@ -100,7 +100,7 @@ class TestNonsmoothNontrivial():
         prob = cp.Problem(cp.Minimize(cost), [cp.sum(x) == 1, x >= 0])
 
         # solve using NLP solver
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         nlp_value = prob.value
 
         # solve using conic solver
@@ -123,7 +123,7 @@ class TestNonsmoothNontrivial():
         prob = cp.Problem(cp.Maximize(cost), [cp.sum(x) == 1, x >= 0])
 
         # solve using NLP solver
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         nlp_value = prob.value
 
         # solve using conic solver

--- a/cvxpy/tests/nlp_tests/test_hyperbolic.py
+++ b/cvxpy/tests/nlp_tests/test_hyperbolic.py
@@ -29,7 +29,7 @@ class TestHyperbolic():
         x = cp.Variable(n)
         prob = cp.Problem(cp.Minimize(cp.sum(cp.nlp.sinh(cp.logistic(x * 2)))),
                            [x >= 0.1, cp.sum(x) == 10])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
 
         checker = DerivativeChecker(prob)
@@ -40,7 +40,7 @@ class TestHyperbolic():
         x = cp.Variable(n)
         prob = cp.Problem(cp.Minimize(cp.sum(cp.nlp.tanh(cp.logistic(x * 2)))),
                            [x >= 0.1, cp.sum(x) == 10])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
 
         checker = DerivativeChecker(prob)
@@ -51,7 +51,7 @@ class TestHyperbolic():
         x = cp.Variable(n)
         prob = cp.Problem(cp.Minimize(cp.sum(cp.nlp.asinh(cp.logistic(x * 3)))),
                            [x >= 0.1, cp.sum(x) == 10])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
 
         checker = DerivativeChecker(prob)
@@ -62,7 +62,7 @@ class TestHyperbolic():
         x = cp.Variable(n)
         prob = cp.Problem(cp.Minimize(cp.sum(cp.nlp.atanh(cp.logistic(x * 0.1)))),
                            [x >= 0.1, cp.sum(x) == 10])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
 
         checker = DerivativeChecker(prob)

--- a/cvxpy/tests/nlp_tests/test_initialization.py
+++ b/cvxpy/tests/nlp_tests/test_initialization.py
@@ -33,7 +33,7 @@ class TestVariableAttributeInit:
         prob = cp.Problem(cp.Maximize(cp.sum(cp.log(cp.exp(D)))))
 
         # Should not crash - tests diag_vec Jacobian and value propagation
-        prob.solve(solver=cp.IPOPT, nlp=True, max_iter=10)
+        prob.solve(solver=cp.IPOPT, nlp=True, max_iter=10, verbose=False)
 
     def test_diag_variable_value_sparse_init(self):
         """Test that diagonal variables with sparse value initialization work.
@@ -58,7 +58,7 @@ class TestVariableAttributeInit:
         )
 
         # Solve with NLP - the sparse initialization should propagate correctly
-        prob.solve(solver=cp.IPOPT, nlp=True)
+        prob.solve(solver=cp.IPOPT, nlp=True, verbose=False)
 
         assert prob.status == cp.OPTIMAL
         # The optimal solution should have sum = 1 (constraint active at minimum)
@@ -99,6 +99,6 @@ class TestVariableAttributeInit:
         B.value = np.random.randn(n, rank)
         C.value = np.random.randn(rank, n)
 
-        problem.solve(solver=cp.IPOPT, nlp=True, max_iter=200)
+        problem.solve(solver=cp.IPOPT, nlp=True, max_iter=200, verbose=False)
 
         assert problem.status == cp.OPTIMAL, "Problem did not solve to optimality"

--- a/cvxpy/tests/nlp_tests/test_interfaces.py
+++ b/cvxpy/tests/nlp_tests/test_interfaces.py
@@ -34,7 +34,7 @@ class TestKNITROInterface:
         """Test that KNITRO can solve a basic NLP problem."""
         x = cp.Variable()
         prob = cp.Problem(cp.Minimize((x - 2) ** 2), [x >= 1])
-        prob.solve(solver=cp.KNITRO, nlp=True)
+        prob.solve(solver=cp.KNITRO, nlp=True, verbose=False)
         assert prob.status == cp.OPTIMAL
         assert np.isclose(x.value, 2.0, atol=1e-5)
 
@@ -184,7 +184,7 @@ class TestKNITROInterface:
         prob = cp.Problem(cp.Minimize(x[0]**2 + x[1]**2), [x[0] + x[1] >= 1])
 
         # Use a reasonable maxit value that allows convergence
-        prob.solve(solver=cp.KNITRO, nlp=True, maxit=100)
+        prob.solve(solver=cp.KNITRO, nlp=True, maxit=100, verbose=False)
         assert prob.status == cp.OPTIMAL
         assert np.allclose(x.value, [0.5, 0.5], atol=1e-4)
 
@@ -198,7 +198,7 @@ class TestKNITROInterface:
         )
 
         # With only 1 iteration, solver should hit the limit
-        prob.solve(solver=cp.KNITRO, nlp=True, maxit=1)
+        prob.solve(solver=cp.KNITRO, nlp=True, maxit=1, verbose=False)
         # Status should be USER_LIMIT (iteration limit reached)
         assert prob.status in [cp.USER_LIMIT, cp.OPTIMAL_INACCURATE, cp.OPTIMAL]
 
@@ -234,7 +234,7 @@ class TestKNITROInterface:
         prob = cp.Problem(cp.Minimize((x - 2) ** 2), [x >= 1])
 
         with pytest.raises(ValueError, match="Unknown KNITRO option"):
-            prob.solve(solver=cp.KNITRO, nlp=True, unknown_option=123)
+            prob.solve(solver=cp.KNITRO, nlp=True, verbose=False, unknown_option=123)
 
     def test_knitro_solver_stats(self):
         """Test that solver stats (num_iters, solve_time) are available."""
@@ -242,7 +242,7 @@ class TestKNITROInterface:
         x.value = np.array([1.0, 1.0])
         prob = cp.Problem(cp.Minimize(x[0]**2 + x[1]**2), [x[0] + x[1] >= 1])
 
-        prob.solve(solver=cp.KNITRO, nlp=True)
+        prob.solve(solver=cp.KNITRO, nlp=True, verbose=False)
 
         assert prob.status == cp.OPTIMAL
         assert prob.solver_stats is not None
@@ -257,7 +257,7 @@ class TestCOPTInterface:
         """Test that COPT can solve a basic NLP problem."""
         x = cp.Variable()
         prob = cp.Problem(cp.Minimize((x - 2) ** 2), [x >= 1])
-        prob.solve(solver=cp.COPT, nlp=True)
+        prob.solve(solver=cp.COPT, nlp=True, verbose=False)
         assert prob.status == cp.OPTIMAL
         assert np.isclose(x.value, 2.0, atol=1e-5)
 
@@ -268,6 +268,6 @@ class TestCOPTInterface:
         prob = cp.Problem(cp.Minimize(x[0]**2 + x[1]**2), [x[0] + x[1] >= 1])
 
         # Use a reasonable maxit value that allows convergence
-        prob.solve(solver=cp.COPT, nlp=True, NLPIterLimit=100)
+        prob.solve(solver=cp.COPT, nlp=True, NLPIterLimit=100, verbose=False)
         assert prob.status == cp.OPTIMAL
         assert np.allclose(x.value, [0.5, 0.5], atol=1e-4)

--- a/cvxpy/tests/nlp_tests/test_matmul.py
+++ b/cvxpy/tests/nlp_tests/test_matmul.py
@@ -71,7 +71,7 @@ class TestMatmul():
         problem = cp.Problem(cp.Minimize(obj))
 
         problem.solve(solver=cp.IPOPT, nlp=True, hessian_approximation='exact',
-                    derivative_test='none', verbose=True)
+                    derivative_test='none', verbose=False)
         assert(problem.status == cp.OPTIMAL)
 
         checker = DerivativeChecker(problem)
@@ -87,7 +87,7 @@ class TestMatmul():
         problem = cp.Problem(cp.Minimize(obj))
 
         problem.solve(solver=cp.IPOPT, nlp=True, hessian_approximation='exact',
-                    derivative_test='none', verbose=True)
+                    derivative_test='none', verbose=False)
         assert(problem.status == cp.OPTIMAL)
 
         checker = DerivativeChecker(problem)
@@ -104,7 +104,7 @@ class TestMatmul():
         problem = cp.Problem(cp.Minimize(obj))
 
         problem.solve(solver=cp.IPOPT, nlp=True, hessian_approximation='exact',
-                    derivative_test='none', verbose=True)
+                    derivative_test='none', verbose=False)
         assert(problem.status == cp.OPTIMAL)
 
         checker = DerivativeChecker(problem)

--- a/cvxpy/tests/nlp_tests/test_nlp_parameters.py
+++ b/cvxpy/tests/nlp_tests/test_nlp_parameters.py
@@ -39,10 +39,10 @@ class TestNlpParameters:
         prob1 = cp.Problem(cp.Minimize(cp.sum_squares(A1 @ x - b1)))
         prob2 = cp.Problem(cp.Minimize(cp.sum_squares(A2 @ x - b2)))
         x.value = None
-        prob1.solve(nlp=True, solver='IPOPT')
+        prob1.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol1 = x.value
         x.value = None
-        prob2.solve(nlp=True, solver='IPOPT')
+        prob2.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol2 = x.value
 
         # Solve with parameters
@@ -50,14 +50,14 @@ class TestNlpParameters:
         b = cp.Parameter(m, value=b1)
         prob = cp.Problem(cp.Minimize(cp.sum_squares(A @ x - b)))
         x.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol1 = x.value
         A.value = A2
         b.value = b2
         x.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol2 = x.value
@@ -81,10 +81,10 @@ class TestNlpParameters:
         prob1 = cp.Problem(cp.Maximize(cp.sum(cp.entr(x))), constraints1)
         prob2 = cp.Problem(cp.Maximize(cp.sum(cp.entr(x))), constraints2)
         x.value = None
-        prob1.solve(nlp=True, solver='IPOPT')
+        prob1.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol1 = x.value
         x.value = None
-        prob2.solve(nlp=True, solver='IPOPT')
+        prob2.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol2 = x.value
 
         # Solve with parameters
@@ -93,14 +93,14 @@ class TestNlpParameters:
         constraints = [A @ x <= b, cp.sum(x) == 1]
         prob = cp.Problem(cp.Maximize(cp.sum(cp.entr(x))), constraints)
         x.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol1 = x.value
         A.value = A2
         b.value = b2
         x.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol2 = x.value
@@ -122,10 +122,10 @@ class TestNlpParameters:
         prob1 = cp.Problem(cp.Minimize(cp.log_sum_exp(A1 @ x + b1)))
         prob2 = cp.Problem(cp.Minimize(cp.log_sum_exp(A2 @ x + b2)))
         x.value = None
-        prob1.solve(nlp=True, solver='IPOPT')
+        prob1.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol1 = x.value
         x.value = None
-        prob2.solve(nlp=True, solver='IPOPT')
+        prob2.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol2 = x.value
 
         # Solve with parameters
@@ -133,14 +133,14 @@ class TestNlpParameters:
         b = cp.Parameter(m, value=b1)
         prob = cp.Problem(cp.Minimize(cp.log_sum_exp(A @ x + b)))
         x.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol1 = x.value
         A.value = A2
         b.value = b2
         x.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol2 = x.value
@@ -162,10 +162,10 @@ class TestNlpParameters:
         prob1 = cp.Problem(cp.Minimize(cp.sum_squares(X @ A1 - B1)))
         prob2 = cp.Problem(cp.Minimize(cp.sum_squares(X @ A2 - B2)))
         X.value = None
-        prob1.solve(nlp=True, solver='IPOPT')
+        prob1.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol1 = X.value
         X.value = None
-        prob2.solve(nlp=True, solver='IPOPT')
+        prob2.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol2 = X.value
 
         # Solve with parameters
@@ -173,14 +173,14 @@ class TestNlpParameters:
         B = cp.Parameter((m, p), value=B1)
         prob = cp.Problem(cp.Minimize(cp.sum_squares(X @ A - B)))
         X.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol1 = X.value
         A.value = A2
         B.value = B2
         X.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol2 = X.value
@@ -204,10 +204,10 @@ class TestNlpParameters:
         prob2 = cp.Problem(cp.Minimize(cp.sum_squares(A2 @ x - b2)),
                            [cp.sum(A2 @ x) == 1])
         x.value = None
-        prob1.solve(nlp=True, solver='IPOPT')
+        prob1.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol1 = x.value
         x.value = None
-        prob2.solve(nlp=True, solver='IPOPT')
+        prob2.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol2 = x.value
 
         # Solve with parameters
@@ -216,14 +216,14 @@ class TestNlpParameters:
         prob = cp.Problem(cp.Minimize(cp.sum_squares(A @ x - b)),
                           [cp.sum(A @ x) == 1])
         x.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol1 = x.value
         A.value = A2
         b.value = b2
         x.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol2 = x.value
@@ -246,10 +246,10 @@ class TestNlpParameters:
         prob2 = cp.Problem(cp.Minimize(cp.sum_squares(
             cp.multiply(cp.promote(cp.Constant(a2), (m,)), x) - b2)))
         x.value = None
-        prob1.solve(nlp=True, solver='IPOPT')
+        prob1.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol1 = x.value
         x.value = None
-        prob2.solve(nlp=True, solver='IPOPT')
+        prob2.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol2 = x.value
 
         # Solve with parameters
@@ -258,14 +258,14 @@ class TestNlpParameters:
         prob = cp.Problem(cp.Minimize(cp.sum_squares(
             cp.multiply(cp.promote(a, (m,)), x) - b)))
         x.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol1 = x.value
         a.value = a2
         b.value = b2
         x.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol2 = x.value
@@ -289,10 +289,10 @@ class TestNlpParameters:
         prob2 = cp.Problem(cp.Minimize(cp.sum_squares(
             cp.multiply(cp.broadcast_to(cp.Constant(a2), (m, n)), X) - B2)))
         X.value = None
-        prob1.solve(nlp=True, solver='IPOPT')
+        prob1.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol1 = X.value
         X.value = None
-        prob2.solve(nlp=True, solver='IPOPT')
+        prob2.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol2 = X.value
 
         # Solve with parameters
@@ -301,14 +301,14 @@ class TestNlpParameters:
         prob = cp.Problem(cp.Minimize(cp.sum_squares(
             cp.multiply(cp.broadcast_to(a, (m, n)), X) - B)))
         X.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol1 = X.value
         a.value = a2
         B.value = B2
         X.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol2 = X.value
@@ -328,23 +328,23 @@ class TestNlpParameters:
         prob1 = cp.Problem(cp.Minimize(-cp.sum(a1 * cp.log(x))), constraints)
         prob2 = cp.Problem(cp.Minimize(-cp.sum(a2 * cp.log(x))), constraints)
         x.value = None
-        prob1.solve(nlp=True, solver='IPOPT')
+        prob1.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol1 = x.value
         x.value = None
-        prob2.solve(nlp=True, solver='IPOPT')
+        prob2.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol2 = x.value
 
         # Solve with parameters
         a = cp.Parameter(value=a1)
         prob = cp.Problem(cp.Minimize(-cp.sum(a * cp.log(x))), constraints)
         x.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol1 = x.value
         a.value = a2
         x.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol2 = x.value
@@ -365,23 +365,23 @@ class TestNlpParameters:
         prob1 = cp.Problem(cp.Minimize(-cp.sum(cp.log(x) * a1)), constraints)
         prob2 = cp.Problem(cp.Minimize(-cp.sum(cp.log(x) * a2)), constraints)
         x.value = None
-        prob1.solve(nlp=True, solver='IPOPT')
+        prob1.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol1 = x.value
         x.value = None
-        prob2.solve(nlp=True, solver='IPOPT')
+        prob2.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol2 = x.value
 
         # Solve with parameters
         a = cp.Parameter(value=a1)
         prob = cp.Problem(cp.Minimize(-cp.sum(cp.log(x) * a)), constraints)
         x.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol1 = x.value
         a.value = a2
         x.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol2 = x.value
@@ -399,22 +399,22 @@ class TestNlpParameters:
         prob1 = cp.Problem(cp.Minimize(cp.sum(A1 @ X)))
         prob2 = cp.Problem(cp.Minimize(cp.sum(A2 @ X)))
         X.value = None
-        prob1.solve(nlp=True, solver='IPOPT')
+        prob1.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol1 = X.value_sparse
         X.value = None
-        prob2.solve(nlp=True, solver='IPOPT')
+        prob2.solve(nlp=True, solver='IPOPT', verbose=False)
         hardcoded_sol2 = X.value_sparse
 
         A = cp.Parameter((n, n), value=A1)
         prob = cp.Problem(cp.Minimize(cp.sum(A @ X)))
         X.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol1 = X.value_sparse
         A.value = A2
         X.value = None
-        prob.solve(nlp=True, solver='IPOPT')
+        prob.solve(nlp=True, solver='IPOPT', verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
         param_sol2 = X.value_sparse

--- a/cvxpy/tests/nlp_tests/test_nlp_solvers.py
+++ b/cvxpy/tests/nlp_tests/test_nlp_solvers.py
@@ -53,7 +53,7 @@ class TestNLPExamples:
             cp.sum(cp.square(x)) == 40,
         ]
         problem = cp.Problem(objective, constraints)
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
         assert problem.status == cp.OPTIMAL
         assert np.allclose(x.value, np.array([0.75450865, 4.63936861, 3.78856881, 1.88513184]))
 
@@ -78,7 +78,7 @@ class TestNLPExamples:
 
         objective = cp.Maximize(log_likelihood)
         problem = cp.Problem(objective, constraints)
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
         assert problem.status == cp.OPTIMAL
         assert np.allclose(sigma.value, 0.77079388)
         assert np.allclose(mu.value, 0.59412321)
@@ -107,7 +107,7 @@ class TestNLPExamples:
                 x >= 0
             ]
         )
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
         assert problem.status == cp.OPTIMAL
         # Second element can be slightly negative due to numerical tolerance
         assert np.allclose(x.value, np.array([4.97045504e+02, 0.0, 5.02954496e+02]), atol=1e-4)
@@ -136,7 +136,7 @@ class TestNLPExamples:
                 x >= 0
             ]
         )
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
         assert problem.status == cp.OPTIMAL
         # Second element can be slightly negative due to numerical tolerance
         assert np.allclose(x.value, np.array([4.97045504e+02, 0.0, 5.02954496e+02]), atol=1e-4)
@@ -150,7 +150,7 @@ class TestNLPExamples:
         x = cp.Variable(2, name='x')
         objective = cp.Minimize((1 - x[0])**2 + 100 * (x[1] - x[0]**2)**2)
         problem = cp.Problem(objective, [])
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
         assert problem.status == cp.OPTIMAL
         assert np.allclose(x.value, np.array([1.0, 1.0]))
         checker = DerivativeChecker(problem)
@@ -169,7 +169,7 @@ class TestNLPExamples:
             x**2 - cp.multiply(y, z) <= 0
         ]
         problem = cp.Problem(objective, constraints)
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
         assert problem.status == cp.OPTIMAL
         assert np.allclose(x.value, np.array([0.32699284]))
         assert np.allclose(y.value, np.array([0.25706586]))
@@ -192,7 +192,7 @@ class TestNLPExamples:
         objective = cp.Minimize(-cp.sum(cp.log(b - A @ x)))
         problem = cp.Problem(objective, [])
         # Solve the problem
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
 
         assert problem.status == cp.OPTIMAL
 
@@ -213,7 +213,7 @@ class TestNLPExamples:
         objective = cp.Minimize(-cp.sum(cp.log(b - A @ x)))
         problem = cp.Problem(objective, [])
         # Solve the problem
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
         assert problem.status == cp.OPTIMAL
 
         checker = DerivativeChecker(problem)
@@ -237,7 +237,7 @@ class TestNLPExamples:
 
         # Create and solve the problem
         problem = cp.Problem(objective, constraints)
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
         assert problem.status == cp.OPTIMAL
         assert np.allclose(objective.value, -13.548638814247532)
         assert np.allclose(x.value, [-3.87462191, -2.12978826, 2.33480343])
@@ -262,7 +262,7 @@ class TestNLPExamples:
                        cp.sum(x) == 1,
                        x >= 0]
         problem = cp.Problem(objective, constraints)
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
         assert problem.status == cp.OPTIMAL
         assert np.allclose(problem.value, -1.93414338e+00)
 
@@ -285,7 +285,7 @@ class TestNLPExamples:
                        cp.sum(x) == 1,
                        x >= 0]
         problem = cp.Problem(objective, constraints)
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
         assert problem.status == cp.OPTIMAL
         assert np.allclose(problem.value, -1.93414338e+00)
 
@@ -304,7 +304,7 @@ class TestNLPExamples:
         constraints = [t == cp.sqrt(cp.sum(cp.square(x - a), axis=1))]
         objective = cp.Minimize(cp.sum_squares(t - rho))
         problem = cp.Problem(objective, constraints)
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
         assert problem.status == cp.OPTIMAL
         assert np.allclose(x.value, x_true)
 
@@ -323,7 +323,7 @@ class TestNLPExamples:
         constraints = [t == cp.sqrt(cp.sum(cp.square(x - a), axis=1))]
         objective = cp.Minimize(cp.sum_squares(t - rho))
         problem = cp.Problem(objective, constraints)
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
         assert problem.status == cp.OPTIMAL
         assert np.allclose(x.value, x_true)
 
@@ -348,7 +348,7 @@ class TestNLPExamples:
         obj = cp.Minimize(t)
         constraints += [cp.max(cp.norm_inf(centers, axis=0) + radius) <= t]
         problem = cp.Problem(obj, constraints)
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
 
         true_sol = np.array([[1.73655994, -1.98685738, 2.57208783],
                              [1.99273311, -1.67415425, -2.57208783]])
@@ -377,7 +377,7 @@ class TestNLPExamples:
         centers.value = rng.uniform(-5.0, 5.0, (2, n))
         obj = cp.Minimize(cp.max(cp.norm_inf(centers, axis=0) + radius))
         prob = cp.Problem(obj, constraints)
-        prob.solve(solver=solver, nlp=True)
+        prob.solve(solver=solver, nlp=True, verbose=False)
 
         assert np.allclose(obj.value, 4.602738956101437)
 
@@ -415,7 +415,7 @@ class TestNLPExamples:
         centers.value = rng.uniform(-5.0, 5.0, (2, n))
         obj = cp.Minimize(cp.max(cp.max(cp.abs(centers), axis=0) + radius))
         prob = cp.Problem(obj, constraints)
-        prob.solve(solver=solver, nlp=True)
+        prob.solve(solver=solver, nlp=True, verbose=False)
 
         # after the chain rule implementation, we find another configuration
         # with a minus sign
@@ -434,7 +434,7 @@ class TestNLPExamples:
         objective = cp.Maximize(geo_mean)
         constraints = [cp.sum(x) == 1]
         problem = cp.Problem(objective, constraints)
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
         assert problem.status == cp.OPTIMAL
         assert np.allclose(x.value, np.array([1/3, 1/3, 1/3]))
 
@@ -447,7 +447,7 @@ class TestNLPExamples:
         p = np.array([.07, .12, .23, .19, .39])
         x = cp.Variable(5, nonneg=True)
         prob = cp.Problem(cp.Maximize(cp.geo_mean(x, p)), [cp.sum(x) <= 1])
-        prob.solve(solver=solver, nlp=True)
+        prob.solve(solver=solver, nlp=True, verbose=False)
         x_true = p/sum(p)
         assert prob.status == cp.OPTIMAL
         assert np.allclose(x.value, x_true)
@@ -457,7 +457,7 @@ class TestNLPExamples:
     def test_div_composition(self, solver):
         x = cp.Variable(nonneg=True, bounds=[1, 5])
         prob = cp.Problem(cp.Maximize(cp.exp(1 / x)))
-        prob.solve(solver=solver, nlp=True)
+        prob.solve(solver=solver, nlp=True, verbose=False)
         x_true = 1.0
         assert prob.status == cp.OPTIMAL
         assert np.allclose(x.value, x_true)
@@ -486,7 +486,7 @@ class TestNLPExamples:
         constraints.append(angle_constraint)
 
         problem = cp.Problem(objective, constraints)
-        problem.solve(solver=solver, nlp=True)
+        problem.solve(solver=solver, nlp=True, verbose=False)
         assert problem.status == cp.OPTIMAL
         assert np.allclose(problem.value, 3.500e+02)
 

--- a/cvxpy/tests/nlp_tests/test_prod.py
+++ b/cvxpy/tests/nlp_tests/test_prod.py
@@ -69,7 +69,7 @@ class TestProdIPOPT:
         obj = cp.Maximize(cp.prod(x))
         constr = [cp.sum(x) <= 3]
         prob = cp.Problem(obj, constr)
-        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0)
+        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0, verbose=False)
 
         # Optimal is x = [1, 1, 1] by AM-GM inequality
         assert np.allclose(x.value, [1.0, 1.0, 1.0], atol=1e-4)
@@ -85,7 +85,7 @@ class TestProdIPOPT:
         obj = cp.Minimize(cp.prod(x)**2)
         constr = [x[0] >= 0.5, x[1] <= -0.5, x[2] >= 1, cp.sum(x) == 2]
         prob = cp.Problem(obj, constr)
-        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0)
+        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0, verbose=False)
 
         # Check constraints are satisfied
         assert x.value[0] >= 0.5 - 1e-4
@@ -106,7 +106,7 @@ class TestProdIPOPT:
         # Constraint per row so AM-GM applies independently to each row
         constr = [cp.sum(X, axis=1) <= 3]
         prob = cp.Problem(obj, constr)
-        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0)
+        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0, verbose=False)
 
         # By AM-GM, each row should be [1, 1, 1] for max prod
         assert np.allclose(X.value, np.ones((2, 3)), atol=1e-4)
@@ -122,7 +122,7 @@ class TestProdIPOPT:
         # Constraint per row so AM-GM applies independently to each row
         constr = [cp.sum(X, axis=1) <= 5]
         prob = cp.Problem(obj, constr)
-        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0)
+        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0, verbose=False)
 
         # By AM-GM, each row should be [1, 1, 1, 1, 1] for max prod
         assert np.allclose(X.value, np.ones((4, 5)), atol=1e-4)
@@ -138,7 +138,7 @@ class TestProdIPOPT:
         obj = cp.Minimize((cp.prod(x) - 1)**2)
         constr = [x[0] >= 0.5, x[2] >= 1, cp.sum(x) == 3]
         prob = cp.Problem(obj, constr)
-        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0)
+        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0, verbose=False)
 
         # Should find a point where prod(x) ≈ 1
         assert np.isclose(np.prod(x.value), 1.0, atol=1e-3)
@@ -153,7 +153,7 @@ class TestProdIPOPT:
         obj = cp.Minimize((cp.prod(x) + 4)**2)  # min (x1*x2 + 4)^2
         constr = [x[0] == 2, x[1] == -2]
         prob = cp.Problem(obj, constr)
-        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0)
+        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0, verbose=False)
 
         # With x = [2, -2], prod = -4, so (prod + 4)^2 = 0
         assert np.isclose(x.value[0], 2.0, atol=1e-3)
@@ -170,7 +170,7 @@ class TestProdIPOPT:
         obj = cp.Minimize(cp.sum(x))
         constr = [cp.prod(x) >= 8]
         prob = cp.Problem(obj, constr)
-        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0)
+        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0, verbose=False)
 
         # By AM-GM, min sum when prod = 8 is at x = [2, 2, 2]
         assert np.allclose(x.value, [2.0, 2.0, 2.0], atol=1e-3)
@@ -188,7 +188,7 @@ class TestProdIPOPT:
         obj1 = cp.Maximize(cp.log(cp.prod(x)))
         constr = [cp.sum(x) <= n]
         prob1 = cp.Problem(obj1, constr)
-        prob1.solve(solver=cp.IPOPT, nlp=True, print_level=0)
+        prob1.solve(solver=cp.IPOPT, nlp=True, print_level=0, verbose=False)
         val1 = prob1.value
         x1 = x.value.copy()
 
@@ -198,7 +198,7 @@ class TestProdIPOPT:
         # Using sum(log(x))
         obj2 = cp.Maximize(cp.sum(cp.log(x)))
         prob2 = cp.Problem(obj2, constr)
-        prob2.solve(solver=cp.IPOPT, nlp=True, print_level=0)
+        prob2.solve(solver=cp.IPOPT, nlp=True, print_level=0, verbose=False)
         val2 = prob2.value
         x2 = x.value.copy()
 
@@ -218,7 +218,7 @@ class TestProdIPOPT:
         obj1 = cp.Maximize(cp.prod(x))
         constr = [cp.sum(x) <= n]
         prob1 = cp.Problem(obj1, constr)
-        prob1.solve(solver=cp.IPOPT, nlp=True, print_level=0)
+        prob1.solve(solver=cp.IPOPT, nlp=True, print_level=0, verbose=False)
         prod_val = prob1.value
         x1 = x.value.copy()
 
@@ -228,7 +228,7 @@ class TestProdIPOPT:
         # Maximize exp(sum(log(x))) which equals prod(x)
         obj2 = cp.Maximize(cp.exp(cp.sum(cp.log(x))))
         prob2 = cp.Problem(obj2, constr)
-        prob2.solve(solver=cp.IPOPT, nlp=True, print_level=0)
+        prob2.solve(solver=cp.IPOPT, nlp=True, print_level=0, verbose=False)
         exp_sum_log_val = prob2.value
         x2 = x.value.copy()
 
@@ -246,7 +246,7 @@ class TestProdIPOPT:
         # Constraint per column so AM-GM applies independently to each column
         constr = [cp.sum(X, axis=0) <= 3]
         prob = cp.Problem(obj, constr)
-        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0)
+        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0, verbose=False)
 
         # By AM-GM, each column should be [1, 1, 1] for max prod
         assert np.allclose(X.value, np.ones((3, 2)), atol=1e-4)
@@ -262,7 +262,7 @@ class TestProdIPOPT:
         # Constraint per column so AM-GM applies independently to each column
         constr = [cp.sum(X, axis=0) <= 5]
         prob = cp.Problem(obj, constr)
-        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0)
+        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0, verbose=False)
 
         # By AM-GM, each column should be [1, 1, 1, 1, 1] for max prod
         assert np.allclose(X.value, np.ones((5, 4)), atol=1e-4)
@@ -277,7 +277,7 @@ class TestProdIPOPT:
         obj = cp.Maximize(cp.prod(x))
         constr = [x <= 5]
         prob = cp.Problem(obj, constr)
-        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0)
+        prob.solve(solver=cp.IPOPT, nlp=True, print_level=0, verbose=False)
 
         assert np.isclose(x.value[0], 5.0, atol=1e-4)
         assert np.isclose(prob.value, 5.0, atol=1e-4)

--- a/cvxpy/tests/nlp_tests/test_quasi_newton.py
+++ b/cvxpy/tests/nlp_tests/test_quasi_newton.py
@@ -38,7 +38,7 @@ class TestQuasiNewton:
         objective = cp.Minimize((1 - x[0])**2 + 100 * (x[1] - x[0]**2)**2)
         problem = cp.Problem(objective, [])
         problem.solve(solver=cp.IPOPT, nlp=True,
-                      hessian_approximation='limited-memory')
+                      hessian_approximation='limited-memory', verbose=False)
         assert problem.status == cp.OPTIMAL
         assert np.allclose(x.value, np.array([1.0, 1.0]), atol=1e-4)
 
@@ -54,7 +54,7 @@ class TestQuasiNewton:
         ]
         problem = cp.Problem(objective, constraints)
         problem.solve(solver=cp.IPOPT, nlp=True,
-                      hessian_approximation='limited-memory')
+                      hessian_approximation='limited-memory', verbose=False)
         assert problem.status == cp.OPTIMAL
         # L-BFGS may converge to a slightly different point, use looser tolerance
         expected = np.array([0.75450865, 4.63936861, 3.78856881, 1.88513184])
@@ -81,7 +81,7 @@ class TestQuasiNewton:
             ]
         )
         problem.solve(solver=cp.IPOPT, nlp=True,
-                      hessian_approximation='limited-memory')
+                      hessian_approximation='limited-memory', verbose=False)
         assert problem.status == cp.OPTIMAL
         expected = np.array([4.97045504e+02, 0.0, 5.02954496e+02])
         assert np.allclose(x.value, expected, atol=1e-3)
@@ -98,7 +98,7 @@ class TestQuasiNewton:
         objective = cp.Minimize(-cp.sum(cp.log(b - A @ x)))
         problem = cp.Problem(objective, [])
         problem.solve(solver=cp.IPOPT, nlp=True,
-                      hessian_approximation='limited-memory')
+                      hessian_approximation='limited-memory', verbose=False)
         assert problem.status == cp.OPTIMAL
 
     def test_exact_vs_lbfgs_solution_quality(self):
@@ -109,7 +109,7 @@ class TestQuasiNewton:
         # Solve with exact Hessian
         problem_exact = cp.Problem(objective, [])
         problem_exact.solve(solver=cp.IPOPT, nlp=True,
-                            hessian_approximation='exact')
+                            hessian_approximation='exact', verbose=False)
         x_exact = x.value.copy()
 
         # Solve with L-BFGS
@@ -144,7 +144,7 @@ class TestQuasiNewton:
         # Solve with L-BFGS
         problem.solve(solver=cp.IPOPT, nlp=True,
                       hessian_approximation='limited-memory',
-                      print_level=0)
+                      print_level=0, verbose=False)
         assert problem.status == cp.OPTIMAL
 
     def test_socp_lbfgs(self):
@@ -161,7 +161,7 @@ class TestQuasiNewton:
 
         problem = cp.Problem(objective, constraints)
         problem.solve(solver=cp.IPOPT, nlp=True,
-                      hessian_approximation='limited-memory')
+                      hessian_approximation='limited-memory', verbose=False)
         assert problem.status == cp.OPTIMAL
         assert np.allclose(objective.value, -13.548638814247532, atol=1e-3)
 
@@ -178,7 +178,7 @@ class TestQuasiNewton:
         problem = cp.Problem(objective, constraints)
 
         problem.solve(solver=cp.IPOPT, nlp=True,
-                      hessian_approximation='limited-memory')
+                      hessian_approximation='limited-memory', verbose=False)
         assert problem.status == cp.OPTIMAL
         # Optimal solution is uniform: x_i = 1/n
         assert np.allclose(x.value, np.ones(n) / n, atol=1e-4)

--- a/cvxpy/tests/nlp_tests/test_scalar_and_matrix_problems.py
+++ b/cvxpy/tests/nlp_tests/test_scalar_and_matrix_problems.py
@@ -28,7 +28,7 @@ class TestScalarProblems():
     def test_exp(self):
         x = cp.Variable()
         prob = cp.Problem(cp.Minimize(cp.exp(x)), [x >= 4])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -36,7 +36,7 @@ class TestScalarProblems():
     def test_entropy(self):
         x = cp.Variable()
         prob = cp.Problem(cp.Maximize(cp.entr(x)), [x >= 0.1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -45,7 +45,7 @@ class TestScalarProblems():
        p = cp.Variable()
        q = cp.Variable()
        prob = cp.Problem(cp.Minimize(cp.kl_div(p, q)), [p >= 0.1, q >= 0.1, p + q == 2])
-       prob.solve(nlp=True, solver=cp.IPOPT)
+       prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
        assert prob.status == cp.OPTIMAL
        checker = DerivativeChecker(prob)
        checker.run_and_assert()
@@ -55,7 +55,7 @@ class TestScalarProblems():
         X = cp.Variable((3, 3))
         prob = cp.Problem(cp.Minimize(cp.sum(cp.kl_div(X, Y))),
                         [X >= 0.1, Y >= 0.1, cp.sum(X) + cp.sum(Y) == 6])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -63,7 +63,7 @@ class TestScalarProblems():
     def test_entropy_matrix(self):
         x = cp.Variable((3, 2))
         prob = cp.Problem(cp.Maximize(cp.sum(cp.entr(x))), [x >= 0.1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -71,7 +71,7 @@ class TestScalarProblems():
     def test_logistic(self):
         x = cp.Variable()
         prob = cp.Problem(cp.Minimize(cp.logistic(x)), [x >= 0.4])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -79,7 +79,7 @@ class TestScalarProblems():
     def test_logistic_matrix(self):
         x = cp.Variable((3, 2))
         prob = cp.Problem(cp.Minimize(cp.sum(cp.logistic(x))), [x >= 0.4])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -87,7 +87,7 @@ class TestScalarProblems():
     def test_power(self):
         x = cp.Variable()
         prob = cp.Problem(cp.Minimize(cp.power(x, 3)), [x >= 2])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -95,7 +95,7 @@ class TestScalarProblems():
     def test_power_matrix(self):
         x = cp.Variable((3, 2))
         prob = cp.Problem(cp.Minimize(cp.sum(cp.power(x, 3))), [x >= 2])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -103,14 +103,14 @@ class TestScalarProblems():
     def test_power_fractional(self):
         x = cp.Variable()
         prob = cp.Problem(cp.Minimize(cp.power(x, 1.5)), [x >= 2])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
 
         x = cp.Variable((3, 2))
         prob = cp.Problem(cp.Minimize(cp.sum(cp.power(x, 0.6))), [x >= 2])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -118,14 +118,14 @@ class TestScalarProblems():
     def test_power_fractional_matrix(self):
         x = cp.Variable((3, 2))
         prob = cp.Problem(cp.Minimize(cp.sum(cp.power(x, 1.5))), [x >= 2])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
 
         x = cp.Variable((3, 2))
         prob = cp.Problem(cp.Minimize(cp.sum(cp.power(x, 0.6))), [x >= 2])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -133,19 +133,19 @@ class TestScalarProblems():
     def test_scalar_trig(self):
         x = cp.Variable()
         prob = cp.Problem(cp.Minimize(cp.nlp.tan(x)), [x >= 0.1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
 
         prob = cp.Problem(cp.Minimize(cp.nlp.sin(x)), [x >= 0.1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
 
         prob = cp.Problem(cp.Minimize(cp.nlp.cos(x)), [x >= 0.1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -153,19 +153,19 @@ class TestScalarProblems():
     def test_matrix_trig(self):
         x = cp.Variable((3, 2))
         prob = cp.Problem(cp.Minimize(cp.sum(cp.nlp.tan(x))), [x >= 0.1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
 
         prob = cp.Problem(cp.Minimize(cp.sum(cp.nlp.sin(x))), [x >= 0.1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
 
         prob = cp.Problem(cp.Minimize(cp.sum(cp.nlp.cos(x))), [x >= 0.1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -173,13 +173,13 @@ class TestScalarProblems():
     def test_matrix_hyperbolic(self):
         x = cp.Variable((3, 2))
         prob = cp.Problem(cp.Minimize(cp.sum(cp.nlp.sinh(x))), [x >= 0.1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
 
         prob = cp.Problem(cp.Minimize(cp.sum(cp.nlp.tanh(x))), [x >= 0.1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -187,13 +187,13 @@ class TestScalarProblems():
     def test_scalar_hyperbolic(self):
         x = cp.Variable()
         prob = cp.Problem(cp.Minimize(cp.nlp.sinh(x)), [x >= 0.1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
 
         prob = cp.Problem(cp.Minimize(cp.nlp.tanh(x)), [x >= 0.1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -201,14 +201,14 @@ class TestScalarProblems():
     def test_xexp(self):
         x = cp.Variable()
         prob = cp.Problem(cp.Minimize(cp.xexp(x)), [x >= 0.1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
 
         x = cp.Variable((3, 2))
         prob = cp.Problem(cp.Minimize(cp.sum(cp.xexp(x))), [x >= 0.1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -217,7 +217,7 @@ class TestScalarProblems():
         x = cp.Variable((1, ))
         P = np.array([[3]])
         prob = cp.Problem(cp.Minimize(cp.quad_form(x, P)), [x >= 1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -226,7 +226,7 @@ class TestScalarProblems():
         x = cp.Variable()
         y = cp.Variable()
         prob = cp.Problem(cp.Minimize(cp.quad_over_lin(x, y)), [x >= 1, y <= 1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -235,14 +235,14 @@ class TestScalarProblems():
         x = cp.Variable((3, 2))
         y = cp.Variable((1, ))
         prob = cp.Problem(cp.Minimize(cp.quad_over_lin(x, y)), [x >= 1, y <= 1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
 
         y = cp.Variable()
         prob = cp.Problem(cp.Minimize(cp.quad_over_lin(x, y)), [x >= 1, y <= 1])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -252,7 +252,7 @@ class TestScalarProblems():
         y = cp.Variable()
         prob = cp.Problem(cp.Minimize(cp.rel_entr(x, y)),
                           [x >= 0.1, y >= 0.1, x <= 2, y <= 2])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -261,7 +261,7 @@ class TestScalarProblems():
         y = cp.Variable((1, ))
         prob = cp.Problem(cp.Minimize(cp.rel_entr(x, y)),
                           [x >= 0.1, y >= 0.1, x <= 2, y <= 2])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -271,7 +271,7 @@ class TestScalarProblems():
         y = cp.Variable()
         prob = cp.Problem(cp.Minimize(cp.sum(cp.rel_entr(x, y))),
                           [x >= 0.1, y >= 0.1, x <= 2, y <= 2])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -281,7 +281,7 @@ class TestScalarProblems():
         y = cp.Variable((3, 2))
         prob = cp.Problem(cp.Minimize(cp.sum(cp.rel_entr(x, y))),
                           [x >= 0.1, y >= 0.1, x <= 2, y <= 2])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -291,7 +291,7 @@ class TestScalarProblems():
         y = cp.Variable((3, 2))
         prob = cp.Problem(cp.Minimize(cp.sum(cp.rel_entr(x, y))),
                           [x >= 0.1, y >= 0.1, x <= 2, y <= 2])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
@@ -301,7 +301,7 @@ class TestScalarProblems():
         y = cp.Variable((3, ))
         prob = cp.Problem(cp.Minimize(cp.sum(cp.rel_entr(x, y))),
                           [x >= 0.1, y >= 0.1, x <= 2, y <= 2])
-        prob.solve(nlp=True, solver=cp.IPOPT)
+        prob.solve(nlp=True, solver=cp.IPOPT, verbose=False)
         assert prob.status == cp.OPTIMAL
         checker = DerivativeChecker(prob)
         checker.run_and_assert()

--- a/cvxpy/tests/nlp_tests/test_sum.py
+++ b/cvxpy/tests/nlp_tests/test_sum.py
@@ -31,7 +31,7 @@ class TestSumIPOPT:
         obj = cp.Minimize((cp.sum(x) - 3)**2)
         constr = [x <= 1]
         prob = cp.Problem(obj, constr)
-        prob.solve(solver=cp.IPOPT, nlp=True)
+        prob.solve(solver=cp.IPOPT, nlp=True, verbose=False)
         assert np.allclose(x.value, [[1.0], [1.0]])
 
         checker = DerivativeChecker(prob)
@@ -44,7 +44,7 @@ class TestSumIPOPT:
         obj = cp.Minimize(cp.sum((cp.sum(X, axis=1) - 4)**2))
         constr = [X >= 0, X <= 1]
         prob = cp.Problem(obj, constr)
-        prob.solve(solver=cp.IPOPT, nlp=True)
+        prob.solve(solver=cp.IPOPT, nlp=True, verbose=False)
         expected = np.full((2, 3), 1)
         assert np.allclose(X.value, expected)
 
@@ -59,7 +59,7 @@ class TestSumIPOPT:
         obj = cp.Minimize(cp.prod(cp.sum(A @ X, axis=1)))
         constr = [X >= 0, X <= 1]
         prob = cp.Problem(obj, constr)
-        prob.solve(solver=cp.IPOPT, nlp=True)
+        prob.solve(solver=cp.IPOPT, nlp=True, verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
 
@@ -69,7 +69,7 @@ class TestSumIPOPT:
         obj = cp.Minimize(cp.sum((cp.sum(X, axis=0) - 4)**2))
         constr = [X >= 0, X <= 1]
         prob = cp.Problem(obj, constr)
-        prob.solve(solver=cp.IPOPT, nlp=True)
+        prob.solve(solver=cp.IPOPT, nlp=True, verbose=False)
         expected = np.full((2, 3), 1)
         assert np.allclose(X.value, expected)
 
@@ -84,7 +84,7 @@ class TestSumIPOPT:
         obj = cp.Minimize(cp.prod(cp.sum(A @ X, axis=0)))
         constr = [X >= 0, X <= 1]
         prob = cp.Problem(obj, constr)
-        prob.solve(solver=cp.IPOPT, nlp=True)
+        prob.solve(solver=cp.IPOPT, nlp=True, verbose=False)
         checker = DerivativeChecker(prob)
         checker.run_and_assert()
 
@@ -96,7 +96,7 @@ class TestSumIPOPT:
         obj = cp.sum(cp.multiply(A, T))
         constraints = [T >= 1, T <= 2]
         problem = cp.Problem(cp.Minimize(obj), constraints)
-        problem.solve(solver=cp.IPOPT, nlp=True, verbose=True, derivative_test='none')
+        problem.solve(solver=cp.IPOPT, nlp=True, verbose=False, derivative_test='none')
         assert(np.allclose(T.value, 1))
         assert problem.status == cp.OPTIMAL
 


### PR DESCRIPTION
Add verbose=False to all .solve() calls in 13 NLP test files to reduce CI log noise. Capfd fixture tests and best_of edge-case tests retain verbose=True.

**Files changed:**
- `cvxpy/tests/nlp_tests/test_best_of.py`
- `cvxpy/tests/nlp_tests/test_broadcast.py`
- `cvxpy/tests/nlp_tests/test_huber_sum_largest.py`
- `cvxpy/tests/nlp_tests/test_hyperbolic.py`
- `cvxpy/tests/nlp_tests/test_initialization.py`
- `cvxpy/tests/nlp_tests/test_interfaces.py`
- `cvxpy/tests/nlp_tests/test_matmul.py`
- `cvxpy/tests/nlp_tests/test_nlp_parameters.py`
- `cvxpy/tests/nlp_tests/test_nlp_solvers.py`
- `cvxpy/tests/nlp_tests/test_prod.py`
- `cvxpy/tests/nlp_tests/test_quasi_newton.py`
- `cvxpy/tests/nlp_tests/test_scalar_and_matrix_problems.py`
- `cvxpy/tests/nlp_tests/test_sum.py`