### PR TITLE
DOC: fix 'overriden' typo in scipy_conif.py

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scipy_conif.py
@@ -109,7 +109,7 @@ class SCIPY(ConicSolver):
     def solve_via_data(self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None):
         from scipy import optimize as opt
 
-        # Set default method which can be overriden by user inputs
+        # Set default method which can be overridden by user inputs
         if (Version(scipy.__version__) < Version('1.6.1')):
             meth = "interior-point"
         else:


### PR DESCRIPTION
Fix 'overriden' -> 'overridden' in comment in scipy_conif.py

**Files changed:**
- `cvxpy/reductions/solvers/conic_solvers/scipy_conif.py`