### PR TITLE
DOC: Fix mismatched docstring parameter names and return types across cvxpy

### DIFF
--- a/cvxpy/atoms/affine/einsum.py
+++ b/cvxpy/atoms/affine/einsum.py
@@ -65,7 +65,7 @@ def einsum(subscripts, *exprs, optimize="greedy") -> Expression:
     ----------
     subscripts : str
         The subscripts for the einsum operation.
-    exprs : Expression
+    *exprs : Expression
         The expressions to contract.
     optimize : {bool, 'greedy', 'optimal'}, optional
         Whether to contract the expressions using the optimal or greedy ordering.

--- a/cvxpy/atoms/inv_prod.py
+++ b/cvxpy/atoms/inv_prod.py
@@ -25,7 +25,7 @@ def inv_prod(value, approx=True) -> Expression:
 
     Parameters
     ----------
-    x : Expression or numeric
+    value : Expression or numeric
         The expression whose reciprocal product is to be computed. Must have
         positive entries.
     approx : bool

--- a/cvxpy/atoms/total_variation.py
+++ b/cvxpy/atoms/total_variation.py
@@ -31,7 +31,7 @@ def tv(value, *args) -> Expression:
     ----------
     value : Expression or numeric constant
         The value to take the total variation of.
-    args : Matrix constants/expressions
+    *args : Matrix constants/expressions
         Additional matrices extending the third dimension of value.
 
     Returns

--- a/cvxpy/interface/matrix_utilities.py
+++ b/cvxpy/interface/matrix_utilities.py
@@ -62,7 +62,7 @@ def sparse2cvxopt(value):
 
     Parameters
     ----------
-    sparse_mat : SciPy sparse matrix
+    value : SciPy sparse matrix
         The matrix to convert.
 
     Returns

--- a/cvxpy/lin_ops/lin_utils.py
+++ b/cvxpy/lin_ops/lin_utils.py
@@ -177,7 +177,7 @@ def neg_expr(operator):
 
     Parameters
     ----------
-    expr : LinOp
+    operator : LinOp
         The operator to be negated.
 
     Returns
@@ -378,10 +378,14 @@ def sum_entries(operator, shape: tuple[int, ...], axis=None, keepdims=None):
 
     Parameters
     ----------
-    expr : LinOp
+    operator : LinOp
         The operator to sum the entries of.
     shape : tuple
         The shape of the sum.
+    axis : int, optional
+        The axis to sum along.
+    keepdims : bool, optional
+        Whether to keep the reduced dimensions.
 
     Returns
     -------
@@ -558,7 +562,7 @@ def hstack(operators, shape: tuple[int, ...]):
 
     Parameters
     ----------
-    operator : list
+    operators : list
         The operators to stack.
     shape : tuple
         The (rows, cols) of the stacked operators.
@@ -576,7 +580,7 @@ def vstack(operators, shape: tuple[int, ...]):
 
     Parameters
     ----------
-    operator : list
+    operators : list
         The operators to stack.
     shape : tuple
         The (rows, cols) of the stacked operators.
@@ -593,7 +597,7 @@ def concatenate(operators, shape: tuple[int, ...], axis: int | None = 0):
 
     Parameters
     ----------
-    operator : list
+    operators : list
         The operators to concatenate.
     shape : tuple
         The (rows, cols) of the concatenated operators.
@@ -622,9 +626,9 @@ def create_eq(lh_op, rh_op=None, constr_id=None):
 
     Parameters
     ----------
-    lh_term : LinOp
+    lh_op : LinOp
         The left-hand operator in the equality constraint.
-    rh_term : LinOp
+    rh_op : LinOp
         The right-hand operator in the equality constraint.
     constr_id : int
         The id of the CVXPY equality constraint creating the constraint.
@@ -644,9 +648,9 @@ def create_leq(lh_op, rh_op=None, constr_id=None):
 
     Parameters
     ----------
-    lh_term : LinOp
+    lh_op : LinOp
         The left-hand operator in the <= constraint.
-    rh_term : LinOp
+    rh_op : LinOp
         The right-hand operator in the <= constraint.
     constr_id : int
         The id of the CVXPY equality constraint creating the constraint.
@@ -666,16 +670,16 @@ def create_geq(lh_op, rh_op=None, constr_id=None):
 
     Parameters
     ----------
-    lh_term : LinOp
+    lh_op : LinOp
         The left-hand operator in the >= constraint.
-    rh_term : LinOp
+    rh_op : LinOp
         The right-hand operator in the >= constraint.
     constr_id : int
         The id of the CVXPY equality constraint creating the constraint.
 
     Returns
     -------
-    LinLeqConstr
+    LinGeqConstr
     """
     if rh_op is not None:
         rh_op = neg_expr(rh_op)

--- a/cvxpy/transforms/partial_optimize.py
+++ b/cvxpy/transforms/partial_optimize.py
@@ -61,7 +61,7 @@ def partial_optimize(
         The variables to not optimize over.
     solver : str, optional
         The default solver to use for value and grad.
-    kwargs : keywords, optional
+    **kwargs : keywords, optional
         Additional solver specific keyword arguments.
 
     Returns


### PR DESCRIPTION
Fix docstring parameter name mismatches: exprs->*exprs, x->value, args->*args, sparse_mat->value, operator->operators, lh_term->lh_op, rh_term->rh_op, expr->operator. Added missing axis/keepdims docs. Fixed LinLeqConstr->LinGeqConstr return type. kwargs->**kwargs.

**Files changed:**
- `cvxpy/atoms/affine/einsum.py`
- `cvxpy/atoms/inv_prod.py`
- `cvxpy/atoms/total_variation.py`
- `cvxpy/interface/matrix_utilities.py`
- `cvxpy/lin_ops/lin_utils.py`
- `cvxpy/transforms/partial_optimize.py`