### PR TITLE
BUG: fix None.value crashes in power, finite_set, and inverse modules

### DIFF
--- a/cvxpy/atoms/elementwise/power.py
+++ b/cvxpy/atoms/elementwise/power.py
@@ -190,12 +190,17 @@ class Power(Elementwise):
 
     @Elementwise.numpy_numeric
     def numeric(self, values):
+        if self.p.value is None:
+            raise ValueError(
+                "Power exponent must have a value set. "
+                "Received a Parameter exponent without a value."
+            )
         return np.power(values[0], float(self.p.value))
 
     def sign_from_args(self) -> tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
-        if self.p.value == 1:
+        if self.p.value is not None and self.p.value == 1:
             # Same as input.
             return (self.args[0].is_nonneg(), self.args[0].is_nonpos())
         else:
@@ -473,4 +478,8 @@ class PowerApprox(Power):
 
         self.p_used = p_val
         self.w = w
-        self.approx_error = float(abs(self.p_used - self.p.value))
+        self.approx_error = (
+            float(abs(self.p_used - self.p.value))
+            if self.p.value is not None
+            else 0.0
+        )

--- a/cvxpy/constraints/finite_set.py
+++ b/cvxpy/constraints/finite_set.py
@@ -128,7 +128,7 @@ class FiniteSet(Constraint):
         -------
         float
         """
-        if self.expre.value is None:
+        if self.expre.value is None or self.vec.value is None:
             return None
         expr_val = np.array(self.expre.value).flatten(order='F')
         vec_val = self.vec.value

--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -59,6 +59,11 @@ class PowCone3D(Cone):
                 alpha_promoted_to_vec = True
                 alpha = cvxtypes.promote()(alpha, (1,))
         self.alpha = alpha
+        if self.alpha.value is None:
+            raise ValueError(
+                "Argument alpha must have a value set. Received "
+                "parameter exponent without a value."
+            )
         if np.any(self.alpha.value <= 0) or np.any(self.alpha.value >= 1):
             msg = "Argument alpha must have entries in the open interval (0, 1)."
             raise ValueError(msg)
@@ -217,6 +222,11 @@ class PowConeND(Cone):
         if alpha.shape != W.shape:
             raise ValueError("Argument dimensions %s and %s are not equal."
                              % (W.shape, alpha.shape))
+        if alpha.value is None:
+            raise ValueError(
+                "Argument alpha must have a value set. Received "
+                "parameter exponent without a value."
+            )
         if np.any(alpha.value <= 0):
             raise ValueError("Argument alpha must be entry-wise positive.")
         if np.any(np.abs(1 - np.sum(alpha.value, axis=axis)) > PowConeND._TOL_):

--- a/cvxpy/reductions/dqcp2dcp/inverse.py
+++ b/cvxpy/reductions/dqcp2dcp/inverse.py
@@ -47,6 +47,11 @@ def inverse(expr):
         return lambda t: atoms.log(atoms.exp(t) - 1) if t.is_nonneg() else -np.inf
     elif isinstance(expr, atoms.Power):  # catches both Power and PowerApprox
         def power_inv(t):
+            if expr.p.value is None:
+                raise ValueError(
+                    "Power exponent must have a value set. "
+                    "Received a Parameter exponent without a value."
+                )
             if expr.p.value is not None and expr.p.value == 1:
                 return t
             if t.is_nonneg():

--- a/cvxpy/reductions/dqcp2dcp/inverse.py
+++ b/cvxpy/reductions/dqcp2dcp/inverse.py
@@ -47,7 +47,7 @@ def inverse(expr):
         return lambda t: atoms.log(atoms.exp(t) - 1) if t.is_nonneg() else -np.inf
     elif isinstance(expr, atoms.Power):  # catches both Power and PowerApprox
         def power_inv(t):
-            if expr.p.value == 1:
+            if expr.p.value is not None and expr.p.value == 1:
                 return t
             if t.is_nonneg():
                 return atoms.power(t, 1/expr.p.value)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -174,6 +174,13 @@ class TestAtoms(BaseTest):
 
         assert cp.power(-1, 2).value == 1
 
+    def test_power_parameter_without_value_raises(self) -> None:
+        exponent = Parameter(nonneg=True)
+        atom = cp.power(Constant(2), exponent)
+
+        with pytest.raises(ValueError, match="Power exponent must have a value set"):
+            _ = atom.value
+
     # Test the xexp class
     def test_xexp(self) -> None:
         # Test for positive x

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -361,6 +361,9 @@ class TestConstraints(BaseTest):
             con = PowCone3D(x, y, z, 1.001)
         with self.assertRaises(ValueError):
             con = PowCone3D(x, y, z, -0.00001)
+        alpha_param = cp.Parameter(nonneg=True)
+        with self.assertRaises(ValueError):
+            PowCone3D(x, y, z, alpha_param)
 
     def test_pow3d_scalar_alpha_constraint(self) -> None:
         """
@@ -393,6 +396,9 @@ class TestConstraints(BaseTest):
             con = PowConeND(reshape_atom(W, (n, 1), order='F'), z,
                             alpha.reshape((n, 1)),
                             axis=1)
+        alpha_param = cp.Parameter(n, nonneg=True)
+        with self.assertRaises(ValueError):
+            PowConeND(W, z, alpha_param)
         # Compute a violation
         con = PowConeND(W, z, alpha)
         W0 = 0.1 + np.random.rand(n)
@@ -636,6 +642,12 @@ class TestConstraints(BaseTest):
         from cvxpy.constraints.finite_set import FiniteSet
         x = cp.Variable()
         constr = FiniteSet(x, [1, 2, 3])
+        self.assertIsNone(constr.residual)
+
+    def test_finite_set_residual_none_when_set_value_missing(self) -> None:
+        vec = cp.Parameter(3)
+        x = cp.Variable(value=2)
+        constr = cp.constraints.FiniteSet(x, vec)
         self.assertIsNone(constr.residual)
 
     def test_dual_cone_no_args(self) -> None:

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -19,6 +19,7 @@ import pytest
 import cvxpy as cp
 import cvxpy.settings as s
 from cvxpy.reductions.dqcp2dcp.dqcp2dcp import Dqcp2Dcp
+from cvxpy.reductions.dqcp2dcp.inverse import inverse as dqcp_inverse
 from cvxpy.reductions.solvers import bisection
 from cvxpy.tests import base_test
 
@@ -765,6 +766,15 @@ class TestDqcp(base_test.BaseTest):
         problem = cp.Problem(cp.Minimize(0), [cp.power(cp.ceil(x), 2) <= -5])
         problem.solve(SOLVER, qcp=True)
         self.assertEqual(problem.status, s.INFEASIBLE)
+
+    def test_dqcp_power_inverse_parameter_without_value_raises(self) -> None:
+        x = cp.Variable(nonneg=True)
+        exponent = cp.Parameter(nonneg=True)
+        expr = cp.power(x, exponent)
+        inv = dqcp_inverse(expr)
+
+        with pytest.raises(ValueError, match="Power exponent must have a value set"):
+            inv(cp.Variable(nonneg=True))
 
     def test_bisection_low_zero(self) -> None:
         """Bisection with low=0 should not infinite-loop."""


### PR DESCRIPTION
Fix 6 potential crashes from .value access on Parameter objects without set values: PowCone3D.__init__, PowConeND.__init__, Power.sign_from_args, Power.numeric, PowerApprox.__init__ (approx_error), FiniteSet.residual, and dqcp2dcp inverse.py power_inv.

**Files changed:**
- `cvxpy/atoms/elementwise/power.py`
- `cvxpy/constraints/finite_set.py`
- `cvxpy/constraints/power.py`
- `cvxpy/reductions/dqcp2dcp/inverse.py`