### PR TITLE
TST: replace assertTrue(x==y) with assertEqual(x,y) for better diagnostics

### DIFF
--- a/cvxpy/tests/test_dgp.py
+++ b/cvxpy/tests/test_dgp.py
@@ -210,15 +210,15 @@ class TestDgp(BaseTest):
         A = cvxpy.Variable((2, 2))
         with self.assertRaises(Exception) as cm:
             cvxpy.gmatmul(A, x)
-        self.assertTrue(str(cm.exception) ==
-                        "gmatmul(A, X) requires that A be constant.")
+        self.assertEqual(str(cm.exception),
+                         "gmatmul(A, X) requires that A be constant.")
 
         x = cvxpy.Variable(2)
         A = np.ones((4, 2))
         with self.assertRaises(Exception) as cm:
             cvxpy.gmatmul(A, x)
-        self.assertTrue(str(cm.exception) ==
-                        "gmatmul(A, X) requires that X be positive.")
+        self.assertEqual(str(cm.exception),
+                         "gmatmul(A, X) requires that X be positive.")
 
         x = cvxpy.Variable(3, pos=True)
         A = np.ones((4, 3))

--- a/cvxpy/tests/test_versioning.py
+++ b/cvxpy/tests/test_versioning.py
@@ -35,12 +35,12 @@ class TestVersioning(unittest.TestCase):
         self.assertFalse(Version('1.0.0') > Version('1.0.0'))
 
     def test_tuple_construction(self):
-        self.assertTrue(Version('0100.2.03') == Version((100, 2, 3)))
-        self.assertTrue(Version('1.2.3') == Version((1, 2, 3, None)))
-        self.assertTrue(Version('1.2.3') == Version((1, 2, 3, 'junk')))
-        self.assertTrue(Version('1.2.3') == Version((1, 2, 3, -1)))
+        self.assertEqual(Version('0100.2.03'), Version((100, 2, 3)))
+        self.assertEqual(Version('1.2.3'), Version((1, 2, 3, None)))
+        self.assertEqual(Version('1.2.3'), Version((1, 2, 3, 'junk')))
+        self.assertEqual(Version('1.2.3'), Version((1, 2, 3, -1)))
 
     def test_local_version_identifiers(self):
-        self.assertTrue(Version('1.0.0') == Version('1.0.0+1'))
-        self.assertTrue(Version('1.0.0') == Version('1.0.0+xxx'))
-        self.assertTrue(Version('1.0.0') == Version('1.0.0+x.y.z'))
+        self.assertEqual(Version('1.0.0'), Version('1.0.0+1'))
+        self.assertEqual(Version('1.0.0'), Version('1.0.0+xxx'))
+        self.assertEqual(Version('1.0.0'), Version('1.0.0+x.y.z'))


### PR DESCRIPTION
Replace assertTrue(x==y) with assertEqual(x,y) in test_versioning.py (7x) and assertTrue(str(cm.exception)==...) with assertEqual(str(...), ...) in test_dgp.py (2x) for better test failure diagnostics.

**Files changed:**
- `cvxpy/tests/test_versioning.py`
- `cvxpy/tests/test_dgp.py`