### PR TITLE
CI: install Moreau from PyPI instead of private Fury index

### DIFF
--- a/.github/workflows/manual_coverage.yml
+++ b/.github/workflows/manual_coverage.yml
@@ -20,7 +20,6 @@ jobs:
       PYTHON_VERSION: "3.12"
       MOSEK_CI_BASE64: ${{ secrets.MOSEK_CI_BASE64 }}
       KNITRO_LICENSE: ${{ secrets.KNITRO_LICENSE }}
-      FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
       MOREAU_LICENSE_KEY: ${{ secrets.MOREAU_KEY }}
       COVERAGE_SOURCE_INCLUDE: "cvxpy/*"
       COVERAGE_SOURCE_OMIT: "cvxpy/tests/*,cvxpy/cvxcore/*,cvxpy/utilities/einsum_utilities.py"
@@ -84,10 +83,7 @@ jobs:
         if: always()
         run: |
           uv pip install -e ".[COPT,GUROBI,MOSEK,XPRESS,KNITRO]"
-          uv pip install cplex naginterfaces
-          if [ -n "$FURY_TOKEN" ]; then
-            uv pip install moreau --extra-index-url https://${FURY_TOKEN}:@pypi.fury.io/optimalintellect/
-          fi
+          uv pip install cplex naginterfaces moreau
 
       - name: Verify commercial solvers
         id: commercial_solver_check

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Install cvxpy dependencies and all optional solvers
         run: uv sync --all-extras --no-extra uno --dev
       - name: Install Moreau
-        if: runner.os == 'Linux' && env.FURY_TOKEN != ''
-        run: uv pip install moreau --extra-index-url https://${FURY_TOKEN}:@pypi.fury.io/optimalintellect/
+        if: runner.os == 'Linux'
+        run: uv pip install moreau
       - name: Print installed solvers
         run: uv run python -c "import cvxpy; print(cvxpy.installed_solvers())"
       # KNITRO bundles LLVM libomp; CVXOPT bundles GNU libgomp via its
@@ -76,5 +76,4 @@ jobs:
       PYTHON_VERSION: 3.12
       MOSEK_CI_BASE64: ${{ secrets.MOSEK_CI_BASE64 }}
       KNITRO_LICENSE: ${{ secrets.KNITRO_LICENSE }}
-      FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
       MOREAU_LICENSE_KEY: ${{ secrets.MOREAU_KEY }}


### PR DESCRIPTION
## Summary
- Moreau is now on public PyPI, so drop the private Fury index URL and `FURY_TOKEN` secret from CI.
- Fixes both `test_optional_solvers.yml` and `manual_coverage.yml`.
- Also removes the `runner.os == 'Linux' && env.FURY_TOKEN != ''` guard so Moreau installs unconditionally on Linux.

## Type of change
- [x] Other (Documentation, CI, ...)

## Test plan
- [ ] Verify `test_optional_solvers` CI job installs and tests Moreau successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)