### PR TITLE
Fix CUOPT crash on time limit with no incumbent solution

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/cuopt_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/cuopt_conif.py
@@ -477,6 +477,20 @@ class CUOPT(ConicSolver):
             iters = extra_stats["nb_iterations"]
 
         primal_full = cuopt_result.get_primal_solution()
+
+        # USER_LIMIT (time/iteration limit, etc.) only means the solve
+        # stopped early -- it does not guarantee an incumbent was found.
+        # When cuOpt has no solution to report, primal_full comes back
+        # empty; treating that as SOLUTION_PRESENT would make invert() try
+        # to reshape a 0-length array into the variables' shape and crash
+        # with a ValueError. Downgrade to INFEASIBLE_INACCURATE instead,
+        # matching how gurobi_conif.py and copt_conif.py handle the same
+        # "USER_LIMIT with no incumbent" case.
+        if sol_status == s.USER_LIMIT and (
+            primal_full is None or len(primal_full) == 0
+        ):
+            sol_status = s.INFEASIBLE_INACCURATE
+
         primal = primal_full[:n_orig] if primal_full is not None else np.array([])
 
         return Solution(

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -3599,6 +3599,33 @@ class TestCUOPT(unittest.TestCase):
         self.assertTrue(pf.is_mixed_integer())
         self.assertFalse(CUOPT().can_solve(pf))
 
+    def test_cuopt_mi_lp_time_limit_no_incumbent(self) -> None:
+        """A MILP that hits the time limit before any incumbent is found.
+
+        cuOpt reports TimeLimit (mapped to USER_LIMIT) with an empty primal
+        solution. Previously invert() tried to reshape that 0-length array
+        into the variables' shape and crashed with a ValueError; the status
+        must instead be downgraded to INFEASIBLE_INACCURATE (matching Gurobi
+        and COPT), so solve() returns cleanly with prob.value None.
+        """
+        rng = np.random.RandomState(0)
+        n = 400
+        w = cp.Variable(n, boolean=True)
+        weight = rng.rand(n)
+        value = rng.rand(n)
+        prob = cp.Problem(
+            cp.Maximize(value @ w),
+            [weight @ w <= weight.sum() * 0.3, cp.sum(w) >= n * 0.25],
+        )
+        # A tiny time limit makes it very unlikely an incumbent is found.
+        prob.solve(solver="CUOPT", time_limit=0.001)
+        self.assertIn(
+            prob.status,
+            [cp.settings.INFEASIBLE_INACCURATE, cp.settings.USER_LIMIT, cp.OPTIMAL],
+        )
+        if prob.status == cp.settings.INFEASIBLE_INACCURATE:
+            self.assertIsNone(w.value)
+
 
 @pytest.mark.parametrize("solver", INSTALLED_SOLVERS)
 def test_offset_in_opt_val(solver):


### PR DESCRIPTION
## Description

When a MILP or LP is solved with the `CUOPT` solver and the solve hits a time/iteration limit (`TimeLimit` → `USER_LIMIT`) **before any feasible incumbent is found**, cuOpt returns an empty primal solution array. The `CUOPT` interface still reported the status as `USER_LIMIT` (which is in `s.SOLUTION_PRESENT`), so `invert()` tried to reshape the 0-length array into the problem's variable shapes and crashed:

```
ValueError: cannot reshape array of size 0 into shape (N,)
```

This fix downgrades the status to `s.INFEASIBLE_INACCURATE` when the primal solution is empty, matching how `gurobi_conif.py` and `copt_conif.py` already handle the identical "USER_LIMIT with no incumbent" case. `solve()` now returns cleanly with `prob.value is None` and the standard "solution may be inaccurate" warning, instead of raising an opaque reshape error.

Issue link (if applicable): reported at NVIDIA-AI-Blueprints/cuFOLIO#53

## Type of change
- [x] Bug fix

## Contribution checklist
- [x] Add our license to new files. (no new files)
- [x] Check that your code adheres to our coding style. (`ruff check` passes)
- [x] Write unittests. (`TestCUOPT.test_cuopt_mi_lp_time_limit_no_incumbent`)
- [x] Run the unittests and check that they're passing. (new test passes; the 5 pre-existing `TestCUOPT` failures reproduce on unmodified `master` in this environment and are unrelated to this change)
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression. (fix is on a solver-failure path only; no hot-path impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)