### PR TITLE
Pin highspy below 1.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,9 @@ dependencies = [
     "scipy >= 1.13.0",
     # HiGHS < 1.14.0 only honors the lower triangle in `kTriangular` Hessian
     # format and silently returns wrong solutions when given the upper
-    # triangle (which highs_qpif.py passes). See test_highs_dense_quad_form.
-    "highspy >= 1.14.0",
+    # triangle (which highs_qpif.py passes). HiGHS 1.15 is ABI-incompatible
+    # with OR-Tools 9.14's bundled GLOP/PDLP libraries.
+    "highspy >= 1.14.0, < 1.15.0",
     "qdldl >= 0.1.7.post0",
     "sparsediffpy >= 0.5.0, < 0.6.0",
 ]
@@ -120,7 +121,7 @@ GLOP = ["ortools>=9.7,<9.15"]
 GLPK = ["cvxopt"]
 GLPK_MI = ["cvxopt"]
 GUROBI = ["gurobipy"]
-HIGHS = ["highspy"]
+HIGHS = ["highspy >= 1.14.0, < 1.15.0"]
 MOSEK = ["Mosek"]
 OSQP = []
 PDLP = ["ortools>=9.7,<9.15"]


### PR DESCRIPTION
## Description
Pin highspy to >=1.14,<1.15. highspy 1.15.1 is ABI-incompatible with OR-Tools 9.14.6206's bundled GLOP/PDLP libraries and reproduces the undefined-symbol import crash from CI.

## Type of change
- [x] Bug fix
- [x] Other (Documentation, CI, ...)

## Contribution checklist
- [x] Run the unittests and check that they're passing.

Validation:
- uv run python -c 'import highspy, ortools; from ortools.linear_solver import pywraplp; from ortools.pdlp.python import pdlp'
- uv run pytest -q cvxpy/tests/test_conic_solvers.py::TestGLOP cvxpy/tests/test_conic_solvers.py::TestPDLP 'cvxpy/tests/test_conic_solvers.py::test_offset_in_opt_val[GLOP]' 'cvxpy/tests/test_conic_solvers.py::test_offset_in_opt_val[PDLP]'
- uv run pytest -q cvxpy/tests/test_qp_solvers.py::test_highs_dense_quad_form
- uv run pytest -q -m 'not knitro' cvxpy/tests/test_conic_solvers.py