### PR TITLE
Kron diffengine converter

### DIFF
--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
@@ -54,6 +54,8 @@ def convert_kron(expr, children):
     variable-free operand's structurally nonzero entries (column-major flat
     indices). A parametric operand gets all blocks since its values change."""
     a, b = expr.args
+    if not (a.is_constant() or b.is_constant()):
+        raise ValueError("kron requires at least one variable-free operand.")
     const_is_left = a.is_constant()
     const_expr = a if const_is_left else b
     const_node = children[0] if const_is_left else children[1]
@@ -72,6 +74,8 @@ def convert_kron(expr, children):
             active = np.unique(coo.row[mask] + coo.col[mask] * n_rows)
             active = active.astype(np.int32)
         else:
+            # No format conversion: read the nonzero pattern straight off the
+            # dense values, same result as the sparse branch above.
             flat = np.asarray(val, dtype=np.float64).flatten(order="F")
             active = np.flatnonzero(flat).astype(np.int32)
 

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
@@ -47,18 +47,37 @@ def convert_conv(expr, children):
 
 
 def convert_kron(expr, children):
-    """Convert cp.kron(A, B). One operand is variable-free (kron requires it);
-    it is the "parameter" side that scales the variable-carrying operand. The
-    native node re-evaluates that operand each solve, so a parametric A or B is
-    supported (not just a constant). ``const_is_left`` tells the engine which
-    operand is the parameter; (p, q) and (r, s) are A's and B's dims."""
+    """Convert cp.kron(A, B); the variable-free operand (kron requires one) is
+    re-evaluated each solve, so it may be parametric.
+
+    The engine materializes output rows only for the ``active`` blocks: the
+    variable-free operand's structurally nonzero entries (column-major flat
+    indices). A parametric operand gets all blocks since its values change."""
     a, b = expr.args
     const_is_left = a.is_constant()
-    param_node = children[0] if const_is_left else children[1]
+    const_expr = a if const_is_left else b
+    const_node = children[0] if const_is_left else children[1]
     var_node = children[1] if const_is_left else children[0]
-    p, q = a.shape
-    r, s = b.shape
-    return _diffengine.make_kron(param_node, var_node, int(const_is_left), p, q, r, s)
+    p, q = normalize_shape(a.shape)
+    r, s = normalize_shape(b.shape)
+    n_rows = p if const_is_left else r
+
+    if const_expr.parameters():
+        active = np.arange(const_expr.size, dtype=np.int32)
+    else:
+        val = const_expr.value
+        if sparse.issparse(val):
+            coo = val.tocoo()
+            mask = coo.data != 0  # drop stored-but-zero entries
+            active = np.unique(coo.row[mask] + coo.col[mask] * n_rows)
+            active = active.astype(np.int32)
+        else:
+            flat = np.asarray(val, dtype=np.float64).flatten(order="F")
+            active = np.flatnonzero(flat).astype(np.int32)
+
+    if const_is_left:
+        return _diffengine.make_left_kron(const_node, var_node, p, q, r, s, active)
+    return _diffengine.make_right_kron(const_node, var_node, p, q, r, s, active)
 
 
 def convert_div(expr, children):

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
@@ -46,6 +46,21 @@ def convert_conv(expr, children):
     return _diffengine.make_convolve(children[0], children[1])
 
 
+def convert_kron(expr, children):
+    """Convert cp.kron(A, B). One operand is variable-free (kron requires it);
+    it is the "parameter" side that scales the variable-carrying operand. The
+    native node re-evaluates that operand each solve, so a parametric A or B is
+    supported (not just a constant). ``const_is_left`` tells the engine which
+    operand is the parameter; (p, q) and (r, s) are A's and B's dims."""
+    a, b = expr.args
+    const_is_left = a.is_constant()
+    param_node = children[0] if const_is_left else children[1]
+    var_node = children[1] if const_is_left else children[0]
+    p, q = a.shape
+    r, s = b.shape
+    return _diffengine.make_kron(param_node, var_node, int(const_is_left), p, q, r, s)
+
+
 def convert_div(expr, children):
     """Convert x / c by multiplying x by the elementwise reciprocal of c.
 
@@ -311,6 +326,8 @@ ATOM_CONVERTERS = {
     # 1D full convolution
     "conv": convert_conv,
     "convolve": convert_conv,
+    # Kronecker product
+    "kron": convert_kron,
     "Trace": convert_trace,
     # Diagonal and triangular
     "diag_vec": convert_diag_vec,

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
@@ -65,19 +65,20 @@ def convert_kron(expr, children):
     n_rows = p if const_is_left else r
 
     if const_expr.parameters():
-        active = np.arange(const_expr.size, dtype=np.int32)
+        active = np.arange(const_expr.size)
     else:
         val = const_expr.value
         if sparse.issparse(val):
             coo = val.tocoo()
             mask = coo.data != 0  # drop stored-but-zero entries
             active = np.unique(coo.row[mask] + coo.col[mask] * n_rows)
-            active = active.astype(np.int32)
         else:
             # No format conversion: read the nonzero pattern straight off the
             # dense values, same result as the sparse branch above.
             flat = np.asarray(val, dtype=np.float64).flatten(order="F")
-            active = np.flatnonzero(flat).astype(np.int32)
+            active = np.flatnonzero(flat)
+
+    active = active.astype(np.int32)
 
     if const_is_left:
         return _diffengine.make_left_kron(const_node, var_node, p, q, r, s, active)

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
@@ -47,12 +47,17 @@ def convert_conv(expr, children):
 
 
 def convert_kron(expr, children):
-    """Convert cp.kron(A, B); the variable-free operand (kron requires one) is
-    re-evaluated each solve, so it may be parametric.
+    """Convert cp.kron(A, B) to the engine's left/right kron binding.
+
+    kron requires one variable-free operand; that operand may be parametric, in
+    which case the engine re-evaluates it each solve.
 
     The engine materializes output rows only for the ``active`` blocks: the
-    variable-free operand's structurally nonzero entries (column-major flat
-    indices). A parametric operand gets all blocks since its values change."""
+    variable-free operand's structurally nonzero entries, as column-major flat
+    indices. A parametric operand gets every block, since its values change
+    between solves. Indices are bounded by the variable-free operand's size (not
+    by the much larger kron output), so the int32 the bindings take is safe here.
+    """
     a, b = expr.args
     if not (a.is_constant() or b.is_constant()):
         raise ValueError("kron requires at least one variable-free operand.")
@@ -60,9 +65,9 @@ def convert_kron(expr, children):
     const_expr = a if const_is_left else b
     const_node = children[0] if const_is_left else children[1]
     var_node = children[1] if const_is_left else children[0]
-    p, q = normalize_shape(a.shape)
-    r, s = normalize_shape(b.shape)
-    n_rows = p if const_is_left else r
+    a_rows, a_cols = normalize_shape(a.shape)
+    b_rows, b_cols = normalize_shape(b.shape)
+    n_rows = a_rows if const_is_left else b_rows
 
     if const_expr.parameters():
         active = np.arange(const_expr.size)
@@ -70,19 +75,14 @@ def convert_kron(expr, children):
         val = const_expr.value
         if sparse.issparse(val):
             coo = val.tocoo()
-            mask = coo.data != 0  # drop stored-but-zero entries
-            active = np.unique(coo.row[mask] + coo.col[mask] * n_rows)
+            nonzero = coo.data != 0  # drop stored-but-zero entries
+            active = np.unique(coo.row[nonzero] + coo.col[nonzero] * n_rows)
         else:
-            # No format conversion: read the nonzero pattern straight off the
-            # dense values, same result as the sparse branch above.
-            flat = np.asarray(val, dtype=np.float64).flatten(order="F")
-            active = np.flatnonzero(flat)
-
+            active = np.flatnonzero(to_dense_float(val).flatten(order="F"))
     active = active.astype(np.int32)
 
-    if const_is_left:
-        return _diffengine.make_left_kron(const_node, var_node, p, q, r, s, active)
-    return _diffengine.make_right_kron(const_node, var_node, p, q, r, s, active)
+    make_kron = _diffengine.make_left_kron if const_is_left else _diffengine.make_right_kron
+    return make_kron(const_node, var_node, a_rows, a_cols, b_rows, b_cols, active)
 
 
 def convert_div(expr, children):

--- a/cvxpy/tests/nlp_tests/test_kron.py
+++ b/cvxpy/tests/nlp_tests/test_kron.py
@@ -155,3 +155,24 @@ class TestKron:
 
         assert np.linalg.norm(param_sol1 - hardcoded_sol1) == 0.0
         assert np.linalg.norm(param_sol2 - hardcoded_sol2) == 0.0
+
+
+class _FakeKron:
+    """Stand-in for a kron expression: convert_kron only reads ``args``."""
+
+    def __init__(self, a, b):
+        self.args = [a, b]
+
+
+class TestKronConverterGuards:
+    """Converter-level validation; no solver required."""
+
+    def _convert(self, a, b):
+        registry = pytest.importorskip(
+            "cvxpy.reductions.solvers.nlp_solvers.diff_engine.registry"
+        )
+        return registry.convert_kron(_FakeKron(a, b), [None, None])
+
+    def test_rejects_two_variable_operands(self):
+        with pytest.raises(ValueError, match="variable-free operand"):
+            self._convert(cp.Variable((2, 2)), cp.Variable((2, 2)))

--- a/cvxpy/tests/nlp_tests/test_kron.py
+++ b/cvxpy/tests/nlp_tests/test_kron.py
@@ -56,3 +56,102 @@ class TestKron:
 
         checker = DerivativeChecker(problem)
         checker.run_and_assert()
+
+    def test_left_kron_parameter(self):
+        """cp.kron(A, f(X)) with a parametric left operand.
+
+        Solve with hardcoded A1, A2, then with a Parameter and mutate
+        A.value; the solutions must match. A2 is nonzero exactly where A1
+        is zero, so a converter that pruned blocks from the initial
+        parameter value would drop every entry of the second solve.
+        """
+        np.random.seed(0)
+        A1 = np.array([[2.0, 0.0, -1.0],
+                       [0.0, 3.0, 0.0]])
+        A2 = np.array([[0.0, 1.5, 0.0],
+                       [2.5, 0.0, -2.0]])
+        X0 = np.random.rand(2, 2)
+
+        # Solve with hardcoded values.
+        X = cp.Variable((2, 2), bounds=[-1, 1], name='X')
+        prob1 = cp.Problem(cp.Minimize(cp.sum(cp.kron(A1, cp.nlp.sin(X)))))
+        prob2 = cp.Problem(cp.Minimize(cp.sum(cp.kron(A2, cp.nlp.sin(X)))))
+        X.value = X0
+        prob1.solve(solver=cp.IPOPT, nlp=True, verbose=False)
+        assert prob1.status == cp.OPTIMAL
+        hardcoded_sol1 = X.value
+        X.value = X0
+        prob2.solve(solver=cp.IPOPT, nlp=True, verbose=False)
+        assert prob2.status == cp.OPTIMAL
+        hardcoded_sol2 = X.value
+
+        # Solve with a parameter, then update its value and re-solve.
+        A = cp.Parameter((2, 3), value=A1)
+        prob = cp.Problem(cp.Minimize(cp.sum(cp.kron(A, cp.nlp.sin(X)))))
+        X.value = X0
+        prob.solve(solver=cp.IPOPT, nlp=True, verbose=False)
+        assert prob.status == cp.OPTIMAL
+        checker = DerivativeChecker(prob)
+        checker.run_and_assert()
+        param_sol1 = X.value
+
+        A.value = A2
+        X.value = X0
+        prob.solve(solver=cp.IPOPT, nlp=True, verbose=False)
+        assert prob.status == cp.OPTIMAL
+        checker = DerivativeChecker(prob)
+        checker.run_and_assert()
+        param_sol2 = X.value
+
+        assert np.linalg.norm(param_sol1 - hardcoded_sol1) == 0.0
+        assert np.linalg.norm(param_sol2 - hardcoded_sol2) == 0.0
+
+    def test_right_kron_parameter(self):
+        """cp.kron(f(X), B) with a parametric right operand.
+
+        Same structure as test_left_kron_parameter: B2's zero pattern is
+        the complement of B1's, exercising the all-blocks-active path for
+        parametric operands.
+        """
+        np.random.seed(0)
+        B1 = np.array([[1.0, 0.0],
+                       [0.0, -2.0],
+                       [0.5, 0.0]])
+        B2 = np.array([[0.0, 2.0],
+                       [-1.5, 0.0],
+                       [0.0, 1.0]])
+        X0 = np.random.rand(2, 3)
+
+        # Solve with hardcoded values.
+        X = cp.Variable((2, 3), bounds=[-1, 1], name='X')
+        prob1 = cp.Problem(cp.Minimize(cp.sum(cp.kron(cp.nlp.sin(X), B1))))
+        prob2 = cp.Problem(cp.Minimize(cp.sum(cp.kron(cp.nlp.sin(X), B2))))
+        X.value = X0
+        prob1.solve(solver=cp.IPOPT, nlp=True, verbose=False)
+        assert prob1.status == cp.OPTIMAL
+        hardcoded_sol1 = X.value
+        X.value = X0
+        prob2.solve(solver=cp.IPOPT, nlp=True, verbose=False)
+        assert prob2.status == cp.OPTIMAL
+        hardcoded_sol2 = X.value
+
+        # Solve with a parameter, then update its value and re-solve.
+        B = cp.Parameter((3, 2), value=B1)
+        prob = cp.Problem(cp.Minimize(cp.sum(cp.kron(cp.nlp.sin(X), B))))
+        X.value = X0
+        prob.solve(solver=cp.IPOPT, nlp=True, verbose=False)
+        assert prob.status == cp.OPTIMAL
+        checker = DerivativeChecker(prob)
+        checker.run_and_assert()
+        param_sol1 = X.value
+
+        B.value = B2
+        X.value = X0
+        prob.solve(solver=cp.IPOPT, nlp=True, verbose=False)
+        assert prob.status == cp.OPTIMAL
+        checker = DerivativeChecker(prob)
+        checker.run_and_assert()
+        param_sol2 = X.value
+
+        assert np.linalg.norm(param_sol1 - hardcoded_sol1) == 0.0
+        assert np.linalg.norm(param_sol2 - hardcoded_sol2) == 0.0

--- a/cvxpy/tests/nlp_tests/test_kron.py
+++ b/cvxpy/tests/nlp_tests/test_kron.py
@@ -1,0 +1,58 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import numpy as np
+import pytest
+
+import cvxpy as cp
+from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS
+from cvxpy.tests.nlp_tests.derivative_checker import DerivativeChecker
+
+
+@pytest.mark.skipif('IPOPT' not in INSTALLED_SOLVERS, reason='IPOPT is not installed.')
+class TestKron:
+
+    def test_left_kron(self):
+        """cp.kron(A, f(X)) with a constant left operand containing zeros."""
+        np.random.seed(0)
+        A = np.array([[2.0, 0.0, -1.0],
+                      [0.0, 3.0, 0.0]])
+        X = cp.Variable((2, 2), bounds=[-1, 1], name='X')
+        X.value = np.random.rand(2, 2)
+        obj = cp.sum(cp.kron(A, cp.nlp.sin(X)))
+        problem = cp.Problem(cp.Minimize(obj))
+
+        problem.solve(solver=cp.IPOPT, nlp=True, verbose=False)
+        assert(problem.status == cp.OPTIMAL)
+
+        checker = DerivativeChecker(problem)
+        checker.run_and_assert()
+
+    def test_right_kron(self):
+        """cp.kron(f(X), B) with a constant right operand containing zeros."""
+        np.random.seed(0)
+        B = np.array([[1.0, 0.0],
+                      [0.0, -2.0],
+                      [0.5, 0.0]])
+        X = cp.Variable((2, 3), bounds=[-1, 1], name='X')
+        X.value = np.random.rand(2, 3)
+        obj = cp.sum(cp.kron(cp.nlp.sin(X), B))
+        problem = cp.Problem(cp.Minimize(obj))
+
+        problem.solve(solver=cp.IPOPT, nlp=True, verbose=False)
+        assert(problem.status == cp.OPTIMAL)
+
+        checker = DerivativeChecker(problem)
+        checker.run_and_assert()

--- a/cvxpy/tests/nlp_tests/test_kron.py
+++ b/cvxpy/tests/nlp_tests/test_kron.py
@@ -15,164 +15,111 @@ limitations under the License.
 """
 import numpy as np
 import pytest
+from scipy import sparse
 
 import cvxpy as cp
 from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS
 from cvxpy.tests.nlp_tests.derivative_checker import DerivativeChecker
 
+# Constant operands with zeros, so the converter prunes inactive blocks. The
+# tests weight the kron output entrywise before summing: a bare sum would be
+# blind to the block layout, since sum(kron(A, S)) == sum(A) * sum(S) whatever
+# the layout.
+A = np.array([[2.0, 0.0, -1.0],
+              [0.0, 3.0, 0.0]])
+B = np.array([[1.0, 0.0],
+              [0.0, -2.0],
+              [0.5, 0.0]])
+
 
 @pytest.mark.skipif('IPOPT' not in INSTALLED_SOLVERS, reason='IPOPT is not installed.')
-class TestKron:
+class TestKron():
 
     def test_left_kron(self):
         """cp.kron(A, f(X)) with a constant left operand containing zeros."""
         np.random.seed(0)
-        A = np.array([[2.0, 0.0, -1.0],
-                      [0.0, 3.0, 0.0]])
         X = cp.Variable((2, 2), bounds=[-1, 1], name='X')
         X.value = np.random.rand(2, 2)
-        obj = cp.sum(cp.kron(A, cp.nlp.sin(X)))
-        problem = cp.Problem(cp.Minimize(obj))
+        W = np.random.rand(4, 6)
+        problem = cp.Problem(cp.Minimize(cp.sum(cp.multiply(W, cp.kron(A, cp.nlp.sin(X))))))
 
         problem.solve(solver=cp.IPOPT, nlp=True, verbose=False)
-        assert(problem.status == cp.OPTIMAL)
+        assert problem.status == cp.OPTIMAL
+        assert problem.value == pytest.approx(np.sum(W * np.kron(A, np.sin(X.value))))
 
-        checker = DerivativeChecker(problem)
-        checker.run_and_assert()
+        DerivativeChecker(problem).run_and_assert()
 
     def test_right_kron(self):
         """cp.kron(f(X), B) with a constant right operand containing zeros."""
         np.random.seed(0)
-        B = np.array([[1.0, 0.0],
-                      [0.0, -2.0],
-                      [0.5, 0.0]])
         X = cp.Variable((2, 3), bounds=[-1, 1], name='X')
         X.value = np.random.rand(2, 3)
-        obj = cp.sum(cp.kron(cp.nlp.sin(X), B))
-        problem = cp.Problem(cp.Minimize(obj))
+        W = np.random.rand(6, 6)
+        problem = cp.Problem(cp.Minimize(cp.sum(cp.multiply(W, cp.kron(cp.nlp.sin(X), B)))))
 
         problem.solve(solver=cp.IPOPT, nlp=True, verbose=False)
-        assert(problem.status == cp.OPTIMAL)
+        assert problem.status == cp.OPTIMAL
+        assert problem.value == pytest.approx(np.sum(W * np.kron(np.sin(X.value), B)))
 
-        checker = DerivativeChecker(problem)
-        checker.run_and_assert()
+        DerivativeChecker(problem).run_and_assert()
 
-    def test_left_kron_parameter(self):
-        """cp.kron(A, f(X)) with a parametric left operand.
-
-        Solve with hardcoded A1, A2, then with a Parameter and mutate
-        A.value; the solutions must match. A2 is nonzero exactly where A1
-        is zero, so a converter that pruned blocks from the initial
-        parameter value would drop every entry of the second solve.
-        """
+    def test_sparse_constant_operand(self):
+        """A sparse constant operand, with an explicitly stored zero."""
         np.random.seed(0)
-        A1 = np.array([[2.0, 0.0, -1.0],
-                       [0.0, 3.0, 0.0]])
-        A2 = np.array([[0.0, 1.5, 0.0],
-                       [2.5, 0.0, -2.0]])
-        X0 = np.random.rand(2, 2)
-
-        # Solve with hardcoded values.
+        A_sparse = sparse.csr_array(A)
+        A_sparse.data[0] = 0.0  # stored but zero: not an active block
         X = cp.Variable((2, 2), bounds=[-1, 1], name='X')
-        prob1 = cp.Problem(cp.Minimize(cp.sum(cp.kron(A1, cp.nlp.sin(X)))))
-        prob2 = cp.Problem(cp.Minimize(cp.sum(cp.kron(A2, cp.nlp.sin(X)))))
-        X.value = X0
-        prob1.solve(solver=cp.IPOPT, nlp=True, verbose=False)
-        assert prob1.status == cp.OPTIMAL
-        hardcoded_sol1 = X.value
-        X.value = X0
-        prob2.solve(solver=cp.IPOPT, nlp=True, verbose=False)
-        assert prob2.status == cp.OPTIMAL
-        hardcoded_sol2 = X.value
+        X.value = np.random.rand(2, 2)
+        W = np.random.rand(4, 6)
+        problem = cp.Problem(cp.Minimize(cp.sum(cp.multiply(W, cp.kron(A_sparse, cp.nlp.sin(X))))))
 
-        # Solve with a parameter, then update its value and re-solve.
-        A = cp.Parameter((2, 3), value=A1)
-        prob = cp.Problem(cp.Minimize(cp.sum(cp.kron(A, cp.nlp.sin(X)))))
-        X.value = X0
-        prob.solve(solver=cp.IPOPT, nlp=True, verbose=False)
-        assert prob.status == cp.OPTIMAL
-        checker = DerivativeChecker(prob)
-        checker.run_and_assert()
-        param_sol1 = X.value
+        problem.solve(solver=cp.IPOPT, nlp=True, verbose=False)
+        assert problem.status == cp.OPTIMAL
+        expected = np.sum(W * np.kron(A_sparse.toarray(), np.sin(X.value)))
+        assert problem.value == pytest.approx(expected)
 
-        A.value = A2
-        X.value = X0
-        prob.solve(solver=cp.IPOPT, nlp=True, verbose=False)
-        assert prob.status == cp.OPTIMAL
-        checker = DerivativeChecker(prob)
-        checker.run_and_assert()
-        param_sol2 = X.value
+        DerivativeChecker(problem).run_and_assert()
 
-        assert np.linalg.norm(param_sol1 - hardcoded_sol1) == 0.0
-        assert np.linalg.norm(param_sol2 - hardcoded_sol2) == 0.0
+    @pytest.mark.parametrize('const_is_left', [True, False])
+    def test_kron_parameter(self, const_is_left):
+        """A parametric operand must give the same answer as a hardcoded one.
 
-    def test_right_kron_parameter(self):
-        """cp.kron(f(X), B) with a parametric right operand.
-
-        Same structure as test_left_kron_parameter: B2's zero pattern is
-        the complement of B1's, exercising the all-blocks-active path for
-        parametric operands.
+        C2 is nonzero exactly where C1 is zero, so a converter that pruned
+        blocks from the initial parameter value would drop every entry of the
+        second solve.
         """
         np.random.seed(0)
-        B1 = np.array([[1.0, 0.0],
-                       [0.0, -2.0],
-                       [0.5, 0.0]])
-        B2 = np.array([[0.0, 2.0],
-                       [-1.5, 0.0],
-                       [0.0, 1.0]])
-        X0 = np.random.rand(2, 3)
+        if const_is_left:
+            C1, C2 = A, np.array([[0.0, 1.5, 0.0],
+                                  [2.5, 0.0, -2.0]])
+            X = cp.Variable((2, 2), bounds=[-1, 1], name='X')
+        else:
+            C1, C2 = B, np.array([[0.0, 2.0],
+                                  [-1.5, 0.0],
+                                  [0.0, 1.0]])
+            X = cp.Variable((2, 3), bounds=[-1, 1], name='X')
+        X0 = np.random.rand(*X.shape)
+
+        def objective(C):
+            f = cp.nlp.sin(X)
+            return cp.Minimize(cp.sum(cp.kron(C, f) if const_is_left else cp.kron(f, C)))
 
         # Solve with hardcoded values.
-        X = cp.Variable((2, 3), bounds=[-1, 1], name='X')
-        prob1 = cp.Problem(cp.Minimize(cp.sum(cp.kron(cp.nlp.sin(X), B1))))
-        prob2 = cp.Problem(cp.Minimize(cp.sum(cp.kron(cp.nlp.sin(X), B2))))
-        X.value = X0
-        prob1.solve(solver=cp.IPOPT, nlp=True, verbose=False)
-        assert prob1.status == cp.OPTIMAL
-        hardcoded_sol1 = X.value
-        X.value = X0
-        prob2.solve(solver=cp.IPOPT, nlp=True, verbose=False)
-        assert prob2.status == cp.OPTIMAL
-        hardcoded_sol2 = X.value
+        hardcoded = []
+        for C in (C1, C2):
+            X.value = X0
+            problem = cp.Problem(objective(C))
+            problem.solve(solver=cp.IPOPT, nlp=True, verbose=False)
+            assert problem.status == cp.OPTIMAL
+            hardcoded.append(X.value)
 
         # Solve with a parameter, then update its value and re-solve.
-        B = cp.Parameter((3, 2), value=B1)
-        prob = cp.Problem(cp.Minimize(cp.sum(cp.kron(cp.nlp.sin(X), B))))
-        X.value = X0
-        prob.solve(solver=cp.IPOPT, nlp=True, verbose=False)
-        assert prob.status == cp.OPTIMAL
-        checker = DerivativeChecker(prob)
-        checker.run_and_assert()
-        param_sol1 = X.value
-
-        B.value = B2
-        X.value = X0
-        prob.solve(solver=cp.IPOPT, nlp=True, verbose=False)
-        assert prob.status == cp.OPTIMAL
-        checker = DerivativeChecker(prob)
-        checker.run_and_assert()
-        param_sol2 = X.value
-
-        assert np.linalg.norm(param_sol1 - hardcoded_sol1) == 0.0
-        assert np.linalg.norm(param_sol2 - hardcoded_sol2) == 0.0
-
-
-class _FakeKron:
-    """Stand-in for a kron expression: convert_kron only reads ``args``."""
-
-    def __init__(self, a, b):
-        self.args = [a, b]
-
-
-class TestKronConverterGuards:
-    """Converter-level validation; no solver required."""
-
-    def _convert(self, a, b):
-        registry = pytest.importorskip(
-            "cvxpy.reductions.solvers.nlp_solvers.diff_engine.registry"
-        )
-        return registry.convert_kron(_FakeKron(a, b), [None, None])
-
-    def test_rejects_two_variable_operands(self):
-        with pytest.raises(ValueError, match="variable-free operand"):
-            self._convert(cp.Variable((2, 2)), cp.Variable((2, 2)))
+        C = cp.Parameter(C1.shape)
+        problem = cp.Problem(objective(C))
+        for value, expected in zip((C1, C2), hardcoded):
+            C.value = value
+            X.value = X0
+            problem.solve(solver=cp.IPOPT, nlp=True, verbose=False)
+            assert problem.status == cp.OPTIMAL
+            DerivativeChecker(problem).run_and_assert()
+            np.testing.assert_allclose(X.value, expected, atol=1e-6)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dependencies = [
     # triangle (which highs_qpif.py passes). See test_highs_dense_quad_form.
     "highspy >= 1.14.0",
     "qdldl >= 0.1.7.post0",
-    "sparsediffpy >= 0.6.0, < 0.7.0",
+    "sparsediffpy >= 0.6.1, < 0.7.0",
 ]
 requires-python = ">=3.11"
 urls = {Homepage = "https://github.com/cvxpy/cvxpy"}


### PR DESCRIPTION
## Description
Adds native Kronecker-product support to the DNLP diff engine. `cp.kron(A, B)` with one variable-free operand (which `kron`'s DCP rules already require; it may be a `Parameter`) converts to the engine's `make_left_kron` / `make_right_kron` bindings introduced in sparsediffpy 0.6.0.

The converter passes the variable-free operand's structurally nonzero entries as **active blocks** (column-major flat indices), so the engine materializes output rows only for nonzero blocks — `O(nnz(result))` instead of dense coefficient matrices. A parametric operand gets all blocks, since its values change between solves.

Also bumps the sparsediffpy requirement to `>= 0.6.0, < 0.7.0` (the release with the kron bindings, now on PyPI).

Issue link (if applicable): n/a

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.
