### PR TITLE
Default ignore_dpp/non-DPP solves to the DIFFENGINE canon backend

### DIFF
--- a/cvxpy/cvxcore/python/canonInterface.py
+++ b/cvxpy/cvxcore/python/canonInterface.py
@@ -290,6 +290,11 @@ def get_problem_matrix(linOps,
 
     # Allow to switch default backends through an environment variable for CI
     default_canon_backend = get_default_canon_backend()
+    # DIFFENGINE is not a tensor backend: it is resolved in
+    # construct_solving_chain and never reaches this helper. Other consumers
+    # (affine _grad, cone2cone transforms) fall back to the standard default.
+    if default_canon_backend == s.DIFFENGINE_CANON_BACKEND:
+        default_canon_backend = s.DEFAULT_CANON_BACKEND
     canon_backend = default_canon_backend if not canon_backend else canon_backend
 
     if canon_backend == s.CPP_CANON_BACKEND:

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -40,7 +40,6 @@ from cvxpy.problems.objective import Maximize, Minimize
 from cvxpy.reductions import InverseData
 from cvxpy.reductions.chain import Chain
 from cvxpy.reductions.dqcp2dcp import dqcp2dcp
-from cvxpy.reductions.eval_params import EvalParams
 from cvxpy.reductions.flip_objective import FlipObjective
 from cvxpy.reductions.solution import INF_OR_UNB_MESSAGE
 from cvxpy.reductions.solvers import bisection
@@ -789,9 +788,13 @@ class Problem(u.Canonical):
             'CPP' (default) | 'SCIPY' | 'COO' | 'DIFFENGINE'
             Specifies which backend to use for canonicalization, which can affect
             compilation time. Defaults to None, i.e., selecting the default
-            backend. The DIFFENGINE backend keeps parameters symbolic and
-            re-evaluates them on each solve; it requires expressions of
-            dimension at most 2.
+            backend. Non-DPP and ignore_dpp=True solves use the DIFFENGINE
+            backend, which keeps parameters symbolic and re-evaluates them
+            on each solve; explicitly passing a different backend there
+            raises ValueError for parametric problems (parameter-free
+            problems use the requested backend). Parametric problems with
+            expressions of dimension greater than 2 instead bake parameters
+            to constants (EvalParams) and use the tensor backends.
         verbose : bool, optional
             If True, print verbose output related to problem compilation.
         solver_opts : dict, optional
@@ -877,11 +880,12 @@ class Problem(u.Canonical):
                          'Compiling problem (target solver=%s).', solver_name)
                 s.LOGGER.info('Reduction chain: %s', reduction_chain_str)
             data, inverse_data = solving_chain.apply(self, verbose)
+            # The parametric program is cached unless the chain embeds
+            # current parameter values (see SolvingChain.uncached_param_prog).
             safe_to_cache = (
                 isinstance(data, dict)
                 and s.PARAM_PROB in data
-                and not any(isinstance(reduction, EvalParams)
-                            for reduction in solving_chain.reductions)
+                and not solving_chain.uncached_param_prog
             )
             self._compilation_time = time.time() - start
             if verbose:
@@ -933,9 +937,13 @@ class Problem(u.Canonical):
             'CPP' (default) | 'SCIPY' | 'COO' | 'DIFFENGINE'
             Specifies which backend to use for canonicalization, which can affect
             compilation time. Defaults to None, i.e., selecting the default
-            backend. The DIFFENGINE backend keeps parameters symbolic and
-            re-evaluates them on each solve; it requires expressions of
-            dimension at most 2.
+            backend. Non-DPP and ignore_dpp=True solves use the DIFFENGINE
+            backend, which keeps parameters symbolic and re-evaluates them
+            on each solve; explicitly passing a different backend there
+            raises ValueError for parametric problems (parameter-free
+            problems use the requested backend). Parametric problems with
+            expressions of dimension greater than 2 instead bake parameters
+            to constants (EvalParams) and use the tensor backends.
         solver_opts: dict, optional
             Additional arguments to pass to the solver.
 
@@ -1005,9 +1013,13 @@ class Problem(u.Canonical):
             'CPP' (default) | 'SCIPY' | 'COO' | 'DIFFENGINE'
             Specifies which backend to use for canonicalization, which can affect
             compilation time. Defaults to None, i.e., selecting the default
-            backend. The DIFFENGINE backend keeps parameters symbolic and
-            re-evaluates them on each solve; it requires expressions of
-            dimension at most 2.
+            backend. Non-DPP and ignore_dpp=True solves use the DIFFENGINE
+            backend, which keeps parameters symbolic and re-evaluates them
+            on each solve; explicitly passing a different backend there
+            raises ValueError for parametric problems (parameter-free
+            problems use the requested backend). Parametric problems with
+            expressions of dimension greater than 2 instead bake parameters
+            to constants (EvalParams) and use the tensor backends.
         kwargs : dict, optional
             A dict of options that will be passed to the specific solver.
             In general, these options will override any default settings

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -786,10 +786,12 @@ class Problem(u.Canonical):
             When True, DPP problems will be treated as non-DPP,
             which may speed up compilation. Defaults to False.
         canon_backend : str, optional
-            'CPP' (default) | 'SCIPY'
+            'CPP' (default) | 'SCIPY' | 'COO' | 'DIFFENGINE'
             Specifies which backend to use for canonicalization, which can affect
             compilation time. Defaults to None, i.e., selecting the default
-            backend.
+            backend. The DIFFENGINE backend keeps parameters symbolic and
+            re-evaluates them on each solve; it requires expressions of
+            dimension at most 2.
         verbose : bool, optional
             If True, print verbose output related to problem compilation.
         solver_opts : dict, optional
@@ -928,10 +930,12 @@ class Problem(u.Canonical):
             When True, DPP problems will be treated as non-DPP,
             which may speed up compilation. Defaults to False.
         canon_backend : str, optional
-            'CPP' (default) | 'SCIPY'
+            'CPP' (default) | 'SCIPY' | 'COO' | 'DIFFENGINE'
             Specifies which backend to use for canonicalization, which can affect
             compilation time. Defaults to None, i.e., selecting the default
-            backend.
+            backend. The DIFFENGINE backend keeps parameters symbolic and
+            re-evaluates them on each solve; it requires expressions of
+            dimension at most 2.
         solver_opts: dict, optional
             Additional arguments to pass to the solver.
 
@@ -998,10 +1002,12 @@ class Problem(u.Canonical):
             When True, DPP problems will be treated as non-DPP,
             which may speed up compilation. Defaults to False.
         canon_backend : str, optional
-            'CPP' (default) | 'SCIPY'
+            'CPP' (default) | 'SCIPY' | 'COO' | 'DIFFENGINE'
             Specifies which backend to use for canonicalization, which can affect
             compilation time. Defaults to None, i.e., selecting the default
-            backend.
+            backend. The DIFFENGINE backend keeps parameters symbolic and
+            re-evaluates them on each solve; it requires expressions of
+            dimension at most 2.
         kwargs : dict, optional
             A dict of options that will be passed to the specific solver.
             In general, these options will override any default settings

--- a/cvxpy/problems/problem_form.py
+++ b/cvxpy/problems/problem_form.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
 
 
 def _objective_cone_atoms(
-    expr: Expression, affine_above: bool = True, eval_params: bool = False,
+    expr: Expression, affine_above: bool = True,
 ) -> list[type]:
     """Collect atom types that need conic canonicalization under quad_obj=True.
 
@@ -68,12 +68,6 @@ def _objective_cone_atoms(
     of the objective that have a quadratic canonicalization are handled by the
     QP path and do NOT produce conic constraints. Atoms below that head, or
     atoms without a quad canon, still need cone canonicalization.
-
-    Parameters
-    ----------
-    eval_params : bool
-        When True, treat parameter-only sub-expressions as constant
-        (they will be evaluated by EvalParams before canonicalization).
     """
     if isinstance(expr, Leaf):
         return []
@@ -83,16 +77,16 @@ def _objective_cone_atoms(
     if isinstance(expr, Constraint):
         result: list[type] = []
         for arg in expr.args:
-            result += _objective_cone_atoms(arg, False, eval_params)
+            result += _objective_cone_atoms(arg, False)
         return result
-    if expr.is_constant() and (eval_params or not expr.parameters()):
+    if expr.is_constant() and not expr.parameters():
         return []
 
     is_affine = type(expr) not in CANON_METHODS
     child_affine_above = is_affine and affine_above
     result: list[type] = []
     for arg in expr.args:
-        result += _objective_cone_atoms(arg, child_affine_above, eval_params)
+        result += _objective_cone_atoms(arg, child_affine_above)
 
     if affine_above and type(expr) in QUAD_CANON_METHODS:
         # Power with non-quadratic exponent falls back to cone canon.
@@ -108,35 +102,6 @@ def _objective_cone_atoms(
     return result
 
 
-def _expr_cone_atoms(expr: Expression, eval_params: bool = False) -> list[type]:
-    """Collect atom types needing conic canonicalization from an expression.
-
-    Unlike ``_objective_cone_atoms``, this does not apply QP-path filtering.
-    Used for constraint expressions and for the objective when the QP path
-    is not active.
-
-    Parameters
-    ----------
-    eval_params : bool
-        When True, treat parameter-only sub-expressions as constant.
-    """
-    if isinstance(expr, Leaf):
-        return []
-    if isinstance(expr, Constraint):
-        result: list[type] = []
-        for arg in expr.args:
-            result += _expr_cone_atoms(arg, eval_params)
-        return result
-    if expr.is_constant() and (eval_params or not expr.parameters()):
-        return []
-    result: list[type] = []
-    for arg in expr.args:
-        result += _expr_cone_atoms(arg, eval_params)
-    if type(expr) in CANON_METHODS:
-        result.append(type(expr))
-    return result
-
-
 class ProblemForm:
     """Analyzes a CVXPY Problem to determine its structural properties.
 
@@ -144,12 +109,9 @@ class ProblemForm:
     and whether the problem has constraints are computed lazily and cached.
     """
 
-    def __init__(
-        self, problem: Problem, gp: bool = False, eval_params: bool = False,
-    ) -> None:
+    def __init__(self, problem: Problem, gp: bool = False) -> None:
         self._problem = problem
         self._gp = gp
-        self._eval_params = eval_params
         self._has_quadratic_objective: bool | None = None
         self._is_mixed_integer: bool | None = None
         self._cones_full: set[type] | None = None
@@ -192,39 +154,22 @@ class ProblemForm:
             return
 
         problem = self._problem
-        eval_params = self._eval_params
 
-        # When eval_params is set, constraints that are entirely
-        # parameter-determined (no variables) will become trivial after
-        # EvalParams runs, so exclude them from cone analysis.
-        if eval_params:
-            relevant_constrs = [c for c in problem.constraints if c.variables()]
-        else:
-            relevant_constrs = problem.constraints
-
-        constr_types = {type(c) for c in relevant_constrs}
+        constr_types = {type(c) for c in problem.constraints}
         cones: set[type] = set()
 
         # Collect atoms from constraints.
         constr_atoms: list[type] = []
-        for constr in relevant_constrs:
-            if eval_params:
-                constr_atoms += _expr_cone_atoms(constr, eval_params=True)
-            else:
-                constr_atoms += constr.atoms()
+        for constr in problem.constraints:
+            constr_atoms += constr.atoms()
 
         # Use QP-filtered objective atoms as the base: when the objective
         # is quadratic, _objective_cone_atoms excludes atoms handled by the
         # QP path (all of which map to SOC).
         if self.has_quadratic_objective():
-            base_obj_atoms = _objective_cone_atoms(
-                problem.objective.expr, eval_params=eval_params)
+            base_obj_atoms = _objective_cone_atoms(problem.objective.expr)
         else:
-            if eval_params:
-                base_obj_atoms = _expr_cone_atoms(
-                    problem.objective.expr, eval_params=True)
-            else:
-                base_obj_atoms = problem.objective.expr.atoms()
+            base_obj_atoms = problem.objective.expr.atoms()
 
         atoms = base_obj_atoms + constr_atoms
 
@@ -240,7 +185,7 @@ class ProblemForm:
                 for arg in expr.args:
                     _collect_suppfunc_info(arg)
             _collect_suppfunc_info(problem.objective.expr)
-            for constr in relevant_constrs:
+            for constr in problem.constraints:
                 _collect_suppfunc_info(constr)
 
         if SOC in constr_types or any(atom in SOC_ATOMS for atom in atoms):
@@ -390,7 +335,7 @@ def pick_default_solver(problem_form: ProblemForm) -> Solver | None:
     return _get(slv_def.SOLVER_MAP_CONIC, s.CLARABEL)
 
 
-def make_problem_form(problem: Problem, gp: bool, ignore_dpp: bool) -> ProblemForm:
+def make_problem_form(problem: Problem, gp: bool) -> ProblemForm:
     """Validate DCP/DGP compliance and build a ProblemForm.
 
     Parameters
@@ -399,8 +344,6 @@ def make_problem_form(problem: Problem, gp: bool, ignore_dpp: bool) -> ProblemFo
         The problem to analyze.
     gp : bool
         If True, validate DGP rules instead of DCP.
-    ignore_dpp : bool
-        When True, treat parameters as constants for cone analysis.
 
     Returns
     -------
@@ -434,5 +377,4 @@ def make_problem_form(problem: Problem, gp: bool, ignore_dpp: bool) -> ProblemFo
                        "Consider calling solve() with `qcp=True`.")
         raise DGPError("Problem does not follow DGP rules." + append)
 
-    eval_params = ignore_dpp and bool(problem.parameters())
-    return ProblemForm(problem, gp=gp, eval_params=eval_params)
+    return ProblemForm(problem, gp=gp)

--- a/cvxpy/reductions/__init__.py
+++ b/cvxpy/reductions/__init__.py
@@ -26,4 +26,5 @@ from cvxpy.reductions.dgp2dcp.dgp2dcp import Dgp2Dcp
 from cvxpy.reductions.dqcp2dcp.dqcp2dcp import Dqcp2Dcp
 from cvxpy.reductions.eval_params import EvalParams
 from cvxpy.reductions.flip_objective import FlipObjective
+from cvxpy.reductions.fold_callback_params import CallbackParamFold
 from cvxpy.reductions.solvers.solving_chain import SolvingChain

--- a/cvxpy/reductions/dcp2cone/canonicalizers/perspective_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/perspective_canon.py
@@ -37,12 +37,8 @@ def perspective_canon(expr, args, solver_context: SolverInfo | None = None):
     chain = aux_prob._construct_chain(solver=solver, solver_opts=solver_opts, ignore_dpp=True)
     chain.reductions = chain.reductions[:-1]  # skip solver reduction
     prob_canon = chain.apply(aux_prob)[0]  # grab problem instance
-    # get cone representation of c, A, and b for some problem.
-
-    q = prob_canon.q.toarray().flatten()[:-1]
-    d = prob_canon.q.toarray().flatten()[-1]
-    Ab = prob_canon.A.toarray().reshape((-1, len(q) + 1), order="F")
-    A, b = Ab[:, :-1], Ab[:, -1]
+    # get cone representation of q, A, and b for the parameter-free aux problem.
+    q, d, A, b = prob_canon.apply_parameters()
 
     # given f in epigraph form, aka epi f = \{(x,t) | f(x) \leq t\}
     # = \{(x,t) | Fx +tg + e \in K} for K a cone, the epigraph of the

--- a/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
+++ b/cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py
@@ -332,6 +332,45 @@ class ParamConeProg(ParamProb):
                 sltn_dict[var_id] = np.reshape(value, var.shape, order='F')
         return sltn_dict
 
+    def apply_restruct_mat(self, restruct_mat, restruct_mat_op):
+        """Apply the cone-restructuring block-diagonal to A; return a new ParamConeProg.
+
+        `restruct_mat` is the per-constraint list (kept for polymorphic call sites that
+        consume it directly); `restruct_mat_op` is the precomputed block-diagonal linear
+        operator and is what we actually use here. Pass `None` for `restruct_mat_op` when
+        there are no constraints to restructure.
+        """
+        if restruct_mat_op is not None:
+            unspecified, _ = np.divmod(self.A.shape[0] * self.A.shape[1],
+                                        restruct_mat_op.shape[1], dtype=np.int64)
+            reshaped_A = self.A.reshape(restruct_mat_op.shape[1],
+                                        unspecified, order='F').tocsr()
+            restructured_A = restruct_mat_op(reshaped_A).tocoo()
+            # scipy < 1.20 can overflow int32 indices during reshape.
+            restructured_A.row = restructured_A.row.astype(np.int64)
+            restructured_A.col = restructured_A.col.astype(np.int64)
+            restructured_A = restructured_A.reshape(
+                np.int64(restruct_mat_op.shape[0]) * (np.int64(self.x.size) + 1),
+                self.A.shape[1], order='F')
+        else:
+            restructured_A = self.A
+        return ParamConeProg(
+            self.q,
+            self.x,
+            restructured_A,
+            self.variables,
+            self.var_id_to_col,
+            self.constraints,
+            self.parameters,
+            self.param_id_to_col,
+            P=self.P,
+            formatted=True,
+            lower_bounds=self.lower_bounds,
+            upper_bounds=self.upper_bounds,
+            lb_tensor=self.lb_tensor,
+            ub_tensor=self.ub_tensor,
+        )
+
     def split_adjoint(self, del_vars=None):
         """Adjoint of split_solution.
         """
@@ -414,13 +453,6 @@ class ConeMatrixStuffing(MatrixStuffing):
                 con = ExpCone(x.flatten(order='F'), y.flatten(order='F'), z.flatten(order='F'),
                               constr_id=con.constr_id)
             cons.append(con)
-        # Need to check that intended canonicalization backend still works.
-        lowered_con_problem = problem.copy([problem.objective, cons])
-        canon_backend = get_canon_backend(lowered_con_problem, self.canon_backend)
-        # Form the constraints
-        extractor = CoeffExtractor(inverse_data, canon_backend)
-        params_to_P, params_to_c, flattened_variable = self.stuffed_objective(
-            problem, extractor)
         # Reorder constraints to Zero, NonNeg, SOC, PSD, EXP, PowCone3D, PowConeND
         constr_map = group_constraints(cons)
         ordered_cons = constr_map[Zero] + constr_map[NonNeg] + \
@@ -429,13 +461,28 @@ class ConeMatrixStuffing(MatrixStuffing):
             constr_map[PowCone3D] + constr_map[PowConeND]
         inverse_data.cons_id_map = {con.id: con.id for con in ordered_cons}
         self._cons_id_map = inverse_data.cons_id_map
-
         inverse_data.constraints = ordered_cons
+        inverse_data.minimize = type(problem.objective) == Minimize
+
+        if self.canon_backend == s.DIFFENGINE_CANON_BACKEND:
+            from cvxpy.reductions.dcp2cone.diffengine_cone_program import (
+                DiffengineConeProgram,
+            )
+            new_prob = DiffengineConeProgram.from_problem(
+                problem, ordered_cons, inverse_data, self.quad_obj)
+            return new_prob, inverse_data
+
+        # Need to check that intended canonicalization backend still works.
+        lowered_con_problem = problem.copy([problem.objective, ordered_cons])
+        canon_backend = get_canon_backend(lowered_con_problem, self.canon_backend)
+        # Form the constraints
+        extractor = CoeffExtractor(inverse_data, canon_backend)
+        params_to_P, params_to_c, flattened_variable = self.stuffed_objective(
+            problem, extractor)
         # Batch expressions together, then split apart.
         expr_list = [arg for c in ordered_cons for arg in c.args]
         params_to_problem_data = extractor.affine(expr_list)
 
-        inverse_data.minimize = type(problem.objective) == Minimize
         variables = problem.variables()
         if _has_parametric_bounds(variables):
             lb_tensor = extract_bounds_tensor(

--- a/cvxpy/reductions/dcp2cone/dcp2cone.py
+++ b/cvxpy/reductions/dcp2cone/dcp2cone.py
@@ -219,9 +219,12 @@ class Dcp2Cone(Canonicalization):
         A tuple of the canonicalized expression and generated constraints.
         """
         # Constant trees are collapsed, but parameter trees are preserved.
-        if isinstance(expr, Expression) and (
-                expr.is_constant() and not expr.parameters()):
-            return expr, []
+        # Canonicalizing parametric constants is sound here: chains where it
+        # would not be fold them to CallbackParam leaves first (see
+        # CallbackParamFold).
+        if isinstance(expr, Expression) and expr.is_constant():
+            if not expr.parameters():
+                return expr, []
 
         if self.quad_obj and affine_above and type(expr) in self.quad_canon_methods:
             # Special case for power.

--- a/cvxpy/reductions/dcp2cone/diffengine_cone_program.py
+++ b/cvxpy/reductions/dcp2cone/diffengine_cone_program.py
@@ -1,0 +1,212 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from __future__ import annotations
+
+import numpy as np
+import scipy.sparse as sp
+
+from cvxpy.expressions.variable import Variable
+from cvxpy.problems.param_prob import ParamProb
+from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeDims
+from cvxpy.reductions.matrix_stuffing import (
+    extract_lower_bounds,
+    extract_mip_idx,
+    extract_upper_bounds,
+)
+from cvxpy.reductions.solvers.nlp_solvers.diff_engine.extractor import DiffEngineExtractor
+from cvxpy.reductions.utilities import group_constraints
+
+
+class DiffengineConeProgram(ParamProb):
+    """A cone program whose matrices are extracted via the C diff engine.
+
+    Sibling of ParamConeProg under the ParamProb interface. Holds a
+    `DiffEngineExtractor` (the non-DPP analog of CoeffExtractor) and re-evaluates the
+    converted expression trees on each solve via apply_parameters().
+
+    minimize   q'x + d + [(1/2)x'Px]
+    subject to cone_constr(A*x + b) in cones
+    """
+
+    def __init__(
+        self,
+        x: Variable,
+        extractor: DiffEngineExtractor,
+        constraints: list,
+        inverse_data,
+        q: np.ndarray,
+        d: float,
+        A: sp.spmatrix,
+        b: np.ndarray,
+        P,
+        formatted: bool = False,
+        lower_bounds=None,
+        upper_bounds=None,
+        parameters=None,
+    ) -> None:
+        self.x = x
+        self.extractor = extractor
+        self.q = q
+        self.d = d
+        self.A = A
+        self.b = b
+        self.P = P
+        self.constraints = constraints
+        self.constr_map = group_constraints(constraints)
+        self.cone_dims = ConeDims(self.constr_map)
+        self.inverse_data = inverse_data
+        self.formatted = formatted
+        self.lower_bounds = lower_bounds
+        self.upper_bounds = upper_bounds
+        self._restruct_mat = None
+        self.parameters = list(parameters) if parameters else []
+
+    @property
+    def variables(self):
+        return [self.inverse_data.id2var[vid]
+                for vid in self.inverse_data.var_offsets]
+
+    # Parameter-layout attributes mirroring ParamConeProg, so introspection
+    # (tests, tooling) works on either ParamProb implementation.
+    @property
+    def param_id_to_size(self):
+        return {p.id: p.size for p in self.parameters}
+
+    @property
+    def param_id_to_col(self):
+        return self.inverse_data.param_id_map
+
+    @property
+    def total_param_size(self):
+        return sum(p.size for p in self.parameters)
+
+    @property
+    def id_to_param(self):
+        return {p.id: p for p in self.parameters}
+
+    @property
+    def var_id_to_col(self):
+        return self.inverse_data.var_offsets
+
+    @property
+    def id_to_var(self):
+        return self.inverse_data.id2var
+
+    def is_mixed_integer(self) -> bool:
+        return self.x.attributes['boolean'] or self.x.attributes['integer']
+
+    def _param_vec(self, id_to_param_value=None):
+        """Flatten and concatenate parameter values (the extractor's encoding)."""
+        values = ((lambda p: id_to_param_value[p.id])
+                  if id_to_param_value is not None else (lambda p: p.value))
+        return np.concatenate([
+            np.asarray(values(p), dtype=np.float64).flatten(order='F')
+            for p in self.parameters])
+
+    def apply_parameters(self, id_to_param_value=None, zero_offset: bool = False,
+                         keep_zeros: bool = False, quad_obj: bool = False):
+        """Return problem matrices, re-evaluating if parameters are present."""
+        if not self.parameters:
+            if quad_obj and self.P is not None:
+                return self.P, self.q, self.d, self.A, self.b
+            return self.q, self.d, self.A, self.b
+
+        theta = self._param_vec(id_to_param_value)
+        self.extractor.update_parameters(theta)
+        q, d, A, b, P = self.extractor.extract(quad_obj)
+        if self._restruct_mat is not None:
+            A = self._restruct_mat @ A
+            b = np.asarray(self._restruct_mat @ b).flatten()
+        self.A, self.b, self.q, self.d, self.P = A, b, q, d, P
+        if quad_obj:
+            return P, q, d, A, b
+        return q, d, A, b
+
+    def apply_restruct_mat(self, restruct_mat, restruct_mat_op=None):
+        """Materialize the cone-restructuring block-diagonal, cache it, apply to A, b.
+
+        `restruct_mat` is the per-constraint list from `ConicSolver.format_constraints`;
+        `restruct_mat_op` is the linear-operator form used by `ParamConeProg` and is
+        ignored here. The materialized CSC matrix is cached so `apply_parameters` can
+        re-apply it on subsequent solves.
+        """
+        R = None
+        if restruct_mat:
+            sparse_mats = []
+            for mat in restruct_mat:
+                if sp.issparse(mat):
+                    sparse_mats.append(sp.csc_matrix(mat))
+                elif callable(mat):
+                    eye = sp.eye_array(mat.shape[1], format='csc')
+                    sparse_mats.append(sp.csc_matrix(mat(eye)))
+                else:
+                    eye = sp.eye_array(mat.shape[1], format='csc')
+                    sparse_mats.append(sp.csc_matrix(mat @ eye))
+            R = sp.block_diag(sparse_mats, format='csc')
+            new_A = R @ self.A
+            new_b = np.asarray(R @ self.b).flatten()
+        else:
+            new_A, new_b = self.A, self.b
+        # The extractor (and its C problem) is shared with the restructured instance.
+        new_prog = DiffengineConeProgram(
+            self.x, self.extractor, self.constraints, self.inverse_data,
+            self.q, self.d, new_A, new_b, self.P,
+            formatted=True,
+            lower_bounds=self.lower_bounds,
+            upper_bounds=self.upper_bounds,
+            parameters=self.parameters,
+        )
+        if R is not None:
+            new_prog._restruct_mat = R
+        return new_prog
+
+    def split_solution(self, sltn, active_vars=None):
+        from cvxpy.reductions import cvx_attr2constr
+        if active_vars is None:
+            active_vars = [v.id for v in self.variables]
+        sltn_dict = {}
+        for var_id, col in self.var_id_to_col.items():
+            if var_id in active_vars:
+                var = self.id_to_var[var_id]
+                value = sltn[col:var.size + col]
+                if var.attributes_were_lowered():
+                    orig_var = var.leaf_of_provenance()
+                    value = cvx_attr2constr.recover_value_for_leaf(
+                        orig_var, value, project=False)
+                    sltn_dict[orig_var.id] = np.reshape(
+                        value, orig_var.shape, order='F')
+                else:
+                    sltn_dict[var_id] = np.reshape(
+                        value, var.shape, order='F')
+        return sltn_dict
+
+    @classmethod
+    def from_problem(cls, problem, ordered_cons, inverse_data, quad_obj):
+        """Build a DiffengineConeProgram by evaluating expressions at x=0."""
+        expr_list = [arg for c in ordered_cons for arg in c.args]
+        params = problem.parameters()
+        extractor = DiffEngineExtractor(inverse_data).build(
+            problem.objective.expr, expr_list, params, quad_obj)
+        q, d, A, b, P = extractor.extract(quad_obj)
+        n_vars = inverse_data.x_length
+        boolean, integer = extract_mip_idx(problem.variables())
+        x = Variable(n_vars, boolean=boolean, integer=integer)
+        lower_bounds = extract_lower_bounds(problem.variables(), n_vars)
+        upper_bounds = extract_upper_bounds(problem.variables(), n_vars)
+        return cls(x, extractor, ordered_cons, inverse_data,
+                   q, d, A, b, P,
+                   lower_bounds=lower_bounds, upper_bounds=upper_bounds,
+                   parameters=params)

--- a/cvxpy/reductions/fold_callback_params.py
+++ b/cvxpy/reductions/fold_callback_params.py
@@ -1,0 +1,81 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from cvxpy import problems
+from cvxpy.expressions.constants.callback_param import CallbackParam
+from cvxpy.reductions.reduction import Reduction
+from cvxpy.utilities import scopes
+
+
+def _fold_expr(expr):
+    """Replace maximal non-affine variable-free parametric subtrees.
+
+    Such a subtree (e.g. ``power(t, 2)``, ``floor(t)``, ``log_det(P)``)
+    becomes a ``CallbackParam`` evaluating it on each access. Parameter-affine
+    subtrees (a bare ``Parameter``, ``2 * p + A``) stay symbolic.
+    """
+    if not expr.parameters():
+        return expr
+    if not expr.variables():
+        with scopes.dpp_scope():
+            if expr.is_affine():
+                return expr
+        return CallbackParam(
+            callback=lambda e=expr: e.value,
+            shape=expr.shape,
+            nonneg=expr.is_nonneg(),
+            nonpos=expr.is_nonpos(),
+        )
+    new_args = [_fold_expr(arg) for arg in expr.args]
+    if all(id(new) == id(old) for new, old in zip(new_args, expr.args)):
+        return expr
+    return expr.copy(new_args)
+
+
+class CallbackParamFold(Reduction):
+    """Fold non-affine parametric-constant subtrees into CallbackParams.
+
+    Runs before canonicalization on chains where parameters stay symbolic
+    across solves: canonicalizing such subtrees would be unsound there
+    (``x <= power(t, 2)`` would epigraph-relax vacuously), and unlike
+    ``EvalParams`` the folded values refresh per solve, so compiled programs
+    stay cacheable.
+    """
+
+    def accepts(self, problem) -> bool:
+        return True
+
+    def apply(self, problem):
+        if len(problem.objective.parameters()) > 0:
+            obj_expr = _fold_expr(problem.objective.expr)
+            objective = type(problem.objective)(obj_expr)
+        else:
+            objective = problem.objective
+
+        constraints = []
+        for c in problem.constraints:
+            args = [_fold_expr(arg) for arg in c.args]
+            if all(id(new) == id(old) for new, old in zip(args, c.args)):
+                constraints.append(c)
+            else:
+                data = c.get_data()
+                if data is not None:
+                    constraints.append(type(c)(*(args + data)))
+                else:
+                    constraints.append(type(c)(*args))
+        return problems.problem.Problem(objective, constraints), []
+
+    def invert(self, solution, inverse_data):
+        return solution

--- a/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
+++ b/cvxpy/reductions/solvers/conic_solvers/conic_solver.py
@@ -19,8 +19,8 @@ import scipy.sparse as sp
 
 import cvxpy.settings as s
 from cvxpy.constraints import PSD, SOC, ExpCone, NonNeg, PowCone3D, PowConeND, SvecPSD, Zero
+from cvxpy.problems.param_prob import ParamProb
 from cvxpy.reductions.cvx_attr2constr import convex_attributes
-from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ParamConeProg
 from cvxpy.reductions.solution import Solution, failure_solution
 from cvxpy.reductions.solvers import utilities
 from cvxpy.reductions.solvers.solver import Solver
@@ -117,7 +117,7 @@ class ConicSolver(Solver):
     EXP_CONE_ORDER = None
 
     def accepts(self, problem):
-        return (isinstance(problem, ParamConeProg)
+        return (isinstance(problem, ParamProb)
                 and (self.MIP_CAPABLE or not problem.is_mixed_integer())
                 and not convex_attributes([problem.x])
                 and (len(problem.constraints) > 0 or not self.REQUIRES_CONSTR)
@@ -271,45 +271,10 @@ class ConicSolver(Solver):
             else:
                 raise ValueError("Unsupported constraint type.")
 
-        # Form new ParamConeProg
-        if restruct_mat:
-            # TODO(akshayka): profile to see whether using linear operators
-            # or bmat is faster
-            restruct_mat = as_block_diag_linear_operator(restruct_mat)
-            # this is equivalent to but _much_ faster than:
-            #    restruct_mat_rep = sp.block_diag([restruct_mat]*(problem.x.size + 1))
-            #    restruct_A = restruct_mat_rep * problem.A
-            unspecified, _ = np.divmod(problem.A.shape[0] * problem.A.shape[1],
-                                        restruct_mat.shape[1], dtype=np.int64)
-            reshaped_A = problem.A.reshape(restruct_mat.shape[1],
-                                           unspecified, order='F').tocsr()
-            restructured_A = restruct_mat(reshaped_A).tocoo()
-            # Because of a bug in scipy versions <  1.20, `reshape`
-            # can overflow if indices are int32s.
-            restructured_A.row = restructured_A.row.astype(np.int64)
-            restructured_A.col = restructured_A.col.astype(np.int64)
-            restructured_A = restructured_A.reshape(
-                np.int64(restruct_mat.shape[0]) * (np.int64(problem.x.size) + 1),
-                problem.A.shape[1], order='F')
-        else:
-            restructured_A = problem.A
-        new_param_cone_prog = ParamConeProg(
-            problem.q,
-            problem.x,
-            restructured_A,
-            problem.variables,
-            problem.var_id_to_col,
-            problem.constraints,
-            problem.parameters,
-            problem.param_id_to_col,
-            P=problem.P,
-            formatted=True,
-            lower_bounds=problem.lower_bounds,
-            upper_bounds=problem.upper_bounds,
-            lb_tensor=problem.lb_tensor,
-            ub_tensor=problem.ub_tensor,
-        )
-        return new_param_cone_prog
+        # Form new (Param|Diffengine)ConeProg via polymorphic apply_restruct_mat.
+        # TODO(akshayka): profile to see whether using linear operators or bmat is faster
+        restruct_mat_op = as_block_diag_linear_operator(restruct_mat) if restruct_mat else None
+        return problem.apply_restruct_mat(restruct_mat, restruct_mat_op)
 
     def invert(self, solution, inverse_data):
         """Returns the solution to the original problem given the inverse_data.

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/IGNORE_DPP_BEHAVIOR.md
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/IGNORE_DPP_BEHAVIOR.md
@@ -1,0 +1,258 @@
+# `ignore_dpp=True` → DIFFENGINE backend: behavior notes
+
+Developer-facing notes on a subtle semantic change introduced by the diffengine backend
+work. The change is easy to miss because it does not touch any test file, yet it alters
+what `Problem.solve(..., ignore_dpp=True)` does. Read this before changing the
+`ignore_dpp` branch of the solving chain or the DIFFENGINE backend.
+
+## Summary: the old vs. new `ignore_dpp` contract
+
+`ignore_dpp=True` used to prepend the `EvalParams` reduction (baking every `Parameter`
+into a `Constant`). It now instead selects the **DIFFENGINE** canon backend and leaves
+the parameters symbolic — the C diff engine re-evaluates the parametric expression tree
+on every solve, preserving the problem's conic structure.
+
+| | Old (master) | New (this branch) |
+|---|---|---|
+| What `ignore_dpp=True` does | prepend `EvalParams` (params → constants) | set `canon_backend = DIFFENGINE` (re-evaluate params each solve, keep conic structure) |
+| `EvalParams` in the chain? | yes | no |
+| `ConeMatrixStuffing.canon_backend` | `None` (→ CPP) | `'DIFFENGINE'` |
+| Parameter-dependent atoms | folded to constants before canonicalization | canonicalized symbolically (cones preserved) |
+
+### Where this lives in the code
+
+- **The switch** — `cvxpy/reductions/solvers/solving_chain.py:209-212`:
+
+  ```python
+  if ignore_dpp:
+      canon_backend = DIFFENGINE_CANON_BACKEND   # line 210 (new)
+  else:
+      reductions = [EvalParams()] + reductions    # line 212 (old path, now non-DPP only)
+  ```
+
+- **The dispatch** — `cvxpy/reductions/dcp2cone/cone_matrix_stuffing.py:467-471`: when
+  `canon_backend == DIFFENGINE`, stuffing builds a `DiffengineConeProgram` instead of the
+  normal `ParamConeProg`.
+- **The constant** — `cvxpy/settings.py`:
+  `DIFFENGINE_CANON_BACKEND = "DIFFENGINE"`. Auto-activated for `ignore_dpp` / non-DPP
+  solves; since 2026-07 it is also documented as explicitly user-selectable
+  (`canon_backend="DIFFENGINE"`) on the DPP path, where the chain and the
+  `DiffengineConeProgram` are cached across solves (no `EvalParams` in the chain).
+
+## Deep dive: why `log_det(P)` with a parameter `P` is conic, not a constant
+
+This is the most surprising consequence, surfaced by
+`test_dpp.py::test_log_det_with_parameter_ignore_dpp`. Consider:
+
+```python
+P = cp.Parameter((2, 2)); P.value = np.eye(2)
+obj = cp.sum_squares(x + y) - 2 * cp.log_det(P)
+```
+
+Intuitively `P` has a value, so `log_det(P)` "should" just be the constant `0.0`. It is
+not, and here is why.
+
+### A `Parameter` is a symbolic placeholder, not a constant
+
+A `cp.Parameter` deliberately models *a value that varies between solves*. For curvature
+and canonicalization it is treated as **affine, not constant**, so the canonicalization can
+be cached and reused when only `P.value` changes. Setting `P.value` does **not** make the
+canonicalizer fold it away. The only thing that substitutes the value into the tree is the
+`EvalParams` reduction:
+
+- `cvxpy/reductions/eval_params.py:8-16` — `replace_params_with_consts` walks the tree and
+  replaces each `Parameter` leaf with `Constant(expr.value)` (line 16).
+
+### How `log_det(P)` canonicalizes (LDL → PSD + exponential cones)
+
+`cvxpy/reductions/dcp2cone/canonicalizers/log_det_canon.py` reformulates `log_det(A)` via an
+LDL-style factorization:
+
+- introduce an upper-triangular `Z` and its diagonal `D` (lines 69-71),
+- impose the LMI `[[D, Z], [Zᵀ, A]] ⪰ 0` — **one PSD cone** (lines 72-73:
+  `X = bmat([[D, Z], [Z.T, A]])`, `constraints = [PSD(X)]`),
+- bound `tᵢ ≤ log(Dᵢᵢ)` via `log_canon`, which emits **one exponential cone per diagonal
+  entry** (line 75).
+
+For a 2×2 `P` this is exactly **1 PSD cone + 2 exponential cones** — the cones named in the
+`SolverError` that OSQP raises. The parameter `P` enters as the **bottom-right block** of the
+PSD matrix, i.e. `P`'s entries become parameter coefficients of that constraint's affine map.
+Because the constraint is conic, a QP-only solver (OSQP) cannot accept it.
+
+### Why `EvalParams` made it solvable by a QP solver
+
+Under the old path, `EvalParams` runs first and rewrites `log_det(P)` → `log_det(Constant(eye))`.
+Then `Dcp2Cone` short-circuits constant subtrees:
+
+- `cvxpy/reductions/dcp2cone/dcp2cone.py:122-125`:
+  `if expr.is_constant() and not expr.parameters(): return expr, []` — **no cones emitted**.
+
+The atom's `numeric` then folds `slogdet(eye) = 0.0`, the objective collapses to
+`sum_squares(x + y)`, a pure QP that OSQP solves.
+
+### What the DIFFENGINE path does instead
+
+With `ignore_dpp=True` and the DIFFENGINE backend, `P` stays symbolic, so `log_det(P)`
+canonicalizes into the full conic program above. `DiffengineConeProgram.apply_parameters`
+re-extracts the `A`/`b` matrices from the current `P.value` on each solve (that is the whole
+point of the backend — fast parametric re-solves without re-canonicalizing). The conic
+structure is preserved, so a conic solver (CLARABEL/SCS) is required.
+
+## Consistency note: the new behavior matches the *default* DPP path
+
+There is a sibling test, `test_dpp.py::test_log_det_with_parameter` (no `ignore_dpp`), whose
+docstring states that the **default DPP solve must use a conic solver (SCS)** and that *"QP
+solvers cannot handle"* the problem because canonicalization preserves the parameter.
+
+So keeping `log_det(P)` conic under `ignore_dpp` is in fact **more consistent** with the
+default DPP path. The old `EvalParams` behavior was the special case — it only worked by
+folding the parameter away, which contradicts what `ignore_dpp` is otherwise for (fast
+re-solves with changing parameters).
+
+## Resolution: no folding; EvalParams only for N-D (2026-07)
+
+`FoldVariableFreeParams` (which folded variable-free parametric composites like
+`log_det(P)`, `norm(p)` to constants before canonicalization) is **deleted**, and
+`EvalParams` survives in exactly one niche. The non-DPP / `ignore_dpp` branch of
+`solving_chain.py` now:
+
+- **≤2-D + parameters** → `canon_backend = DIFFENGINE`, no reduction prepended. Parameters
+  stay symbolic end to end.
+- **>2-D + parameters** → `EvalParams` + tensor-backend selection (the diff engine is 2-D
+  only; this preserves the pre-DIFFENGINE semantics for backwards compatibility — see
+  `test_einsum.py::test_einsum_ignore_dpp_avoids_diffengine`).
+- **explicit non-DIFFENGINE `canon_backend` + parameters (≤2-D)** → `ValueError` (the
+  opt-out that restored baking semantics is gone). Parameter-free problems honor the
+  requested backend.
+
+### Soundness: parametric constants must not be canonicalized on this path
+
+Removing the fold exposed a correctness constraint, not just a performance one. `Dcp2Cone`
+applies an atom's graph implementation (epigraph substitution) whose direction is only valid
+where DCP-with-params-affine curvature says it is. A parametric-constant composite can sit in
+a position that is DCP-valid *only because parameters count as constants* — e.g.
+`x <= power(t, 2)` with parameter `t`. Epigraph-canonicalizing that (`x <= s, s >= t**2`) is
+**vacuous** — the problem becomes unbounded. DQCP bisection generates exactly these
+subproblems (`ceil`/`floor` lowering), so this is not a corner case.
+
+The fix is a pre-canonicalization rewrite, `CallbackParamFold`
+(`cvxpy/reductions/fold_callback_params.py`), prepended on the non-DPP / `ignore_dpp`
+chain: each maximal variable-free parametric subtree that is NOT parameter-affine
+(`power(t, 2)`, `floor(t)`, raw `log_det(P)`) becomes a `CallbackParam` leaf evaluating
+the subtree on each access. A parameter leaf cannot be mis-canonicalized, and its value
+refreshes between solves. Parameter-affine subtrees
+(a bare `Parameter`, `2 * p + A`) stay symbolic for the backend. The DPP path is
+untouched — DCP analysis with params-affine vets every position there, so its graph
+implementations are sound and the tensor backends get the canonicalized forms they need
+(e.g. DPP `log_det(P)` in an objective is *made* affine-in-parameter by its cone
+reformulation).
+
+### Caching on this path
+
+Not yet. The parametric non-DPP / `ignore_dpp` program is deliberately **rebuilt on
+every solve** (`SolvingChain.uncached_param_prog` marks both the symbolic ≤2-D branch
+and the N-D `EvalParams` fallback; `safe_to_cache` in `cvxpy/problems/problem.py`
+consumes the flag). Everything on this path is *structured* for caching — parameters
+stay symbolic, folds refresh per solve — but enabling it requires a record-at-site
+guard for the one value-consuming canonicalizer (the cone quad_form canon factorizes
+the current `P.value` via `decomp_quad`), which lands in a follow-up PR together with
+the cache-hygiene tests. The explicit-`DIFFENGINE` DPP path (see "Where this lives in
+the code") already caches, as DPP always has.
+
+### QP solvers and the numpy remedy
+
+`log_det(P)` / `norm(p)` are no longer baked to numbers at compile time. Cone analysis
+(`problem_form`) still counts their cones — conservative for composites the fold turns
+into `CallbackParam` leaves, but consistent with the default DPP path — so QP solvers
+raise `SolverError` for such problems under `ignore_dpp`. Users who want a QP compute
+the value themselves:
+
+```python
+log_det_val = np.linalg.slogdet(P.value)[1]   # instead of cp.log_det(P)
+```
+
+See `test_dpp.py::test_log_det_with_parameter_ignore_dpp_qp_solver_raises`.
+
+### No fallback (fail loud)
+
+There is **no fallback** to full parameter baking. If the diff engine cannot convert an atom
+with variables that survives symbolically (e.g. a parametric `kron` was one), the solve
+raises (`NotImplementedError` from `diff_engine/converters.py` / `registry.py`). Non-affine
+variable-free subtrees never raise — they are folded to `CallbackParam` leaves before
+canonicalization and re-evaluated per solve. The new `ValueError` (explicit-backend
+parametric) is the loud edge of the removed opt-out; N-D parametric problems keep the
+`EvalParams` fallback for backwards compatibility.
+
+### Test updates
+
+- **`test_ignore_dpp.py`** (new) pins the explicit-backend `ValueError`, the N-D
+  EvalParams fallback, the epigraph-soundness case (`x <= power(t, 2)`), and the
+  numeric fallback (`floor(p)`); backend mechanics stay in
+  `test_diffengine_backend.py`.
+- `test_dpp.py::test_log_det_with_parameter_ignore_dpp` — CLARABEL solves and refreshes;
+  the OSQP variant asserts `SolverError` + demonstrates the `np.linalg.slogdet` remedy.
+- `test_complex_dpp.py`, `test_parametric_bounds.py`, `test_quad_dpp.py` — assertions on the
+  deleted classes became name-string regression guards.
+- `test_atoms.py::test_convolve` — dropped its explicit CPP backend (now a `ValueError` for
+  non-DPP parametric problems); solves via DIFFENGINE.
+
+## TODOs / follow-ups
+
+Tracked work left after the variable-free-composite-folding change. Grouped by kind. The two
+hard failures (`test_mip_vars::test_miqp_warning`, `test_cone2cone::test_mi_socp_2`) are
+**pre-existing and unrelated** (no mixed-integer solver installed → weak `ECOS_BB` fallback).
+
+### A. Diff-engine converter gaps (the remaining `xfail`ed tests)
+
+Keeping bare parameters symbolic means parametric atoms now reach the diff-engine converter
+instead of being baked away. The remaining features are unimplemented; each `xfail` test is the
+acceptance test — implementing the feature should make it pass (remove the marker).
+
+1. **Parametric divisor** — division by a parameter. ✅ **Implemented.** `convert_div`
+   (`diff_engine/registry.py`) builds a `make_power(d, -1)` reciprocal node, re-evaluated each
+   solve, and routes it through the same scalar/vector `param_mult` dispatch as the constant
+   path. Surfaced by complex division by a `Parameter` (`Complex2Real` rewrites `z / c` into
+   `z·conj(c)/|c|²`, a variable-free composite divisor that reaches the engine because
+   `EvalParams` runs before `Complex2Real`). Tests now passing:
+   `test_complex.py::test_div_complex_divisor`, `test_dpp.py::TestDcp::test_quad_over_lin`.
+
+2. **`kron`** ✅ **Implemented** as a native engine atom (`new_kron` /`make_kron` in
+   SparseDiffEngine, `convert_kron` in `registry.py`). Every kron output entry depends on a single
+   child entry, so the output Jacobian is the child Jacobian's rows gathered (with repetition) and
+   scaled by the variable-free operand — no coefficient matrix, `O(nnz(result))`. Handles
+   `kron(param/const, var)` and `kron(var, param/const)`. Tests now passing:
+   `test_kron_canon.py::TestKronRightVar::test_gen_kronr_param`,
+   `TestKronLeftVar::{test_gen_kronl_param, test_scalar_kronl_param, test_symvar_kronl_param}`.
+
+3. **>2-D expressions** — `einsum` builds a 3-D constant; the converter's `Constant` base case
+   assumes ≤2-D.
+   - Raises: `ValueError: too many values to unpack (expected 2, got 3)`
+     (`diff_engine/converters.py:178`, via `normalize_shape(expr.shape)`).
+   - Needs: >2-D shape handling in the converter (the engine is 2-D today), or an explicit,
+     clearer "diff engine: >2-D not supported" error.
+   - Test: `test_einsum.py::TestEinsum::test_einsum_solve` (xfail).
+
+### B. Code cleanups in this change
+
+4. ✅ **Resolved by deletion (2026-07).** The fold (`FoldVariableFreeParams`) was removed
+   outright; `EvalParams` survives only for the N-D fallback. The uncached-chain coupling
+   is now an explicit `SolvingChain.uncached_param_prog` flag consumed by `safe_to_cache`
+   (see "Resolution: no folding; EvalParams only for N-D" above).
+
+### C. Pre-existing / edge-case correctness
+
+6. ✅ **Resolved (2026-07).** The `problem_form.eval_params` exclusion machinery was deleted
+   along with the fold: cone analysis now always counts parametric subtrees' cones
+   (conservative for atoms the diff engine evaluates numerically, but never under-counting).
+
+### D. Deferred optimization
+
+7. **Reuse Jacobian/Hessian sparsity across per-solve capsule rebuilds.** Because the
+   non-DPP / `ignore_dpp` chain is uncached (`uncached_param_prog`), the DIFFENGINE
+   `C_problem` is rebuilt each solve. Changing parameter values never changes the `A`/`P`
+   sparsity, so the sparsity pattern is invariant and could be reused. This needs a new **sparsediffpy C
+   binding** (`problem_init_jacobian_coo_from` / Hessian equivalent) to initialize a fresh
+   capsule's derivative structures from a cached COO pattern — `_sparsediffengine` currently
+   exposes `problem_init_jacobian_coo` (computes the pattern) and `get_*_sparsity_coo` (reads
+   it) but nothing to *set* a known pattern. Store the pattern on the persistent
+   `ConeMatrixStuffing` instance. Best tackled alongside the gaps in section A.

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/__init__.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/__init__.py
@@ -12,13 +12,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-"""
 
-"""
 CVXPY integration layer for the DNLP diff engine.
 
-This module converts CVXPY expressions to C expression trees
-for automatic differentiation.
+This module converts CVXPY expressions to C expression trees for automatic
+differentiation, shared between the NLP solver path (C_problem) and the DCP
+matrix-stuffing path (DiffengineConeProgram).
 """
 
 from cvxpy.reductions.solvers.nlp_solvers.diff_engine.c_problem import C_problem

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/c_problem.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/c_problem.py
@@ -35,25 +35,51 @@ class C_problem:
             verbose: print solver output
         """
         inverse_data = InverseData(cvxpy_problem)
-        var_dict, n_vars = build_var_dict(inverse_data)
-        param_dict = build_param_dict(cvxpy_problem, inverse_data)
+        self._build_capsule(
+            cvxpy_problem.objective.expr,
+            [c.expr for c in cvxpy_problem.constraints],
+            cvxpy_problem.parameters(),
+            inverse_data,
+            verbose,
+        )
 
-        c_obj = convert_expr(cvxpy_problem.objective.expr,
-                             var_dict, n_vars, param_dict)
-        c_constraints = [convert_expr(c.expr, var_dict, n_vars, param_dict)
-                         for c in cvxpy_problem.constraints]
-        self._capsule = _diffengine.make_problem(
-            c_obj, c_constraints, verbose)
+    @classmethod
+    def from_exprs(cls, objective_expr, constraint_exprs, parameters,
+                   inverse_data, verbose: bool = True):
+        """Build a C_problem from already-lowered objective and constraint expressions.
+
+        Use this when the caller has already lowered/ordered the cvxpy constraints
+        (e.g. flattened multi-arg cones into one expression per arg) and wants to
+        feed the raw expression list directly to the C engine.
+        """
+        self = cls.__new__(cls)
+        self._build_capsule(objective_expr, constraint_exprs, parameters,
+                            inverse_data, verbose)
+        return self
+
+    def _build_capsule(self, objective_expr, constraint_exprs, parameters,
+                       inverse_data, verbose: bool):
+        parameters = list(parameters)
+        var_dict, n_vars = build_var_dict(inverse_data)
+        param_dict = build_param_dict(parameters, inverse_data)
+
+        c_obj = convert_expr(objective_expr, var_dict, n_vars, param_dict)
+        c_constraints = [convert_expr(e, var_dict, n_vars, param_dict)
+                         for e in constraint_exprs]
+        self._capsule = _diffengine.make_problem(c_obj, c_constraints, verbose)
 
         if param_dict:
+            # Keep the node capsules alive alongside the problem capsule: a
+            # registered parameter can appear in no converted expression,
+            # and the engine must be able to update it on every later solve.
+            self._param_capsules = list(param_dict.values())
             _diffengine.problem_register_params(
-                self._capsule, list(param_dict.values()))
-            # Set initial parameter values
+                self._capsule, self._param_capsules)
             theta = np.concatenate([
                 np.asarray(p.value, dtype=np.float64).flatten(order='F')
-                for p in cvxpy_problem.parameters()
+                for p in parameters
             ])
-            _diffengine.problem_update_params(self._capsule, theta)
+            self.update_params(theta)
 
     def update_params(self, theta: np.ndarray) -> None:
         """Update parameter values in the C DAG.
@@ -68,6 +94,15 @@ class C_problem:
         Must be called once before get_jacobian_sparsity_coo() or eval_jacobian_vals().
         """
         _diffengine.problem_init_jacobian_coo(self._capsule)
+
+    def init_hessian(self):
+        """Fill sparsity for the full (symmetric) Lagrangian Hessian CSR.
+
+        Must be called once before eval_hessian_csr(). Cheaper than
+        init_hessian_coo_lower_tri() when only the full CSR is needed (it skips
+        building the lower-triangular COO view).
+        """
+        _diffengine.problem_init_hessian(self._capsule)
 
     def init_hessian_coo_lower_tri(self):
         """Fill sparsity for the Lagrangian Hessian (lower triangle, COO).
@@ -127,3 +162,13 @@ class C_problem:
         Call objective_forward() and constraint_forward() first to set the evaluation point.
         """
         return _diffengine.problem_eval_hessian_vals_coo(self._capsule, obj_factor, lagrange)
+
+    def eval_hessian_csr(self, obj_factor: float, lagrange: np.ndarray):
+        """Evaluate the full (symmetric) Lagrangian Hessian as CSR components.
+
+        Returns ``(data, indices, indptr, (m, n))`` ready for
+        ``scipy.sparse.csr_matrix``. Computes obj_factor * hess_f +
+        sum(lagrange[i] * hess_gi). Call init_hessian() once first, and
+        objective_forward()/constraint_forward() to set the evaluation point.
+        """
+        return _diffengine.problem_hessian(self._capsule, obj_factor, lagrange)

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/converters.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/converters.py
@@ -280,7 +280,8 @@ def convert_expr(expr, var_dict, n_vars, param_dict=None):
         C_expr = ATOM_CONVERTERS[atom_name](expr, children)
     else:
         # Variable-free parametric subtrees with no converter fail loud
-        # rather than baking a stale value.
+        # rather than baking a stale value; the conic ignore_dpp chain folds
+        # them to CallbackParam leaves before they can get here.
         raise NotImplementedError(f"Atom '{atom_name}' not supported")
 
     # check that python dimension is consistent with C dimension

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/converters.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/converters.py
@@ -15,12 +15,20 @@ limitations under the License.
 
 Main entry point for converting CVXPY expressions to C diff engine expressions.
 """
+import operator
+from functools import reduce
+
 import numpy as np
 from scipy import sparse
 from sparsediffpy import _sparsediffengine as _diffengine
 
 import cvxpy as cp
 import cvxpy.settings as s
+from cvxpy.atoms.affine.wraps import Wrap
+from cvxpy.atoms.elementwise.power import Power
+from cvxpy.atoms.quad_form import QuadForm
+from cvxpy.atoms.quad_over_lin import quad_over_lin
+from cvxpy.expressions.constants import Constant
 from cvxpy.reductions.solvers.nlp_solvers.diff_engine.helpers import (
     make_dense_left_matmul,
     make_dense_right_matmul,
@@ -30,6 +38,60 @@ from cvxpy.reductions.solvers.nlp_solvers.diff_engine.helpers import (
     to_dense_float,
 )
 from cvxpy.reductions.solvers.nlp_solvers.diff_engine.registry import ATOM_CONVERTERS
+
+
+def _is_plain_constant(expr):
+    """Variable-free and parameter-free: a value that never changes between solves."""
+    return expr.is_constant() and not expr.parameters()
+
+
+def _is_vector(expr):
+    """1-D, or 2-D with a singleton dimension."""
+    return len(expr.shape) <= 1 or min(expr.shape) == 1
+
+
+def _apply_constant_right(left, c):
+    """Build an expression equivalent to ``left @ c`` for a plain-constant
+    ``c``, pushing ``c`` toward the leaves so constants multiply constants
+    (each engine node's Jacobian has one row per output, so a chain ending in
+    a constant must not drag wide intermediates -- issue #2205):
+
+      constant @ c   -> Constant(value)
+      (A @ B) @ c    -> A @ (B @ c)
+      (-E) @ c       -> -(E @ c)
+      (E1 + E2) @ c  -> E1 @ c + E2 @ c   (vector c only)
+
+    Only parameter-free constants fold, so parametric factors are never frozen.
+    """
+    if _is_plain_constant(left):
+        return Constant(left.value @ c.value)
+    name = type(left).__name__
+    if name == "MulExpression":
+        a, b = left.args
+        if _is_plain_constant(b):
+            return _apply_constant_right(a, Constant(b.value @ c.value))
+        if _is_vector(c):
+            return a @ _apply_constant_right(b, c)
+        if _is_plain_constant(a):
+            # (C1 @ E) @ C2 -> C1 @ (E @ C2): frees the tail to keep folding
+            # when (E @ C2) is normalized on its own visit.
+            return a @ (b @ c)
+        return left @ c
+    if name == "NegExpression":
+        return -_apply_constant_right(left.args[0], c)
+    if (name == "AddExpression" and _is_vector(c)
+            and all(arg.shape == left.shape for arg in left.args)):
+        return reduce(operator.add, [_apply_constant_right(arg, c) for arg in left.args])
+    return left @ c
+
+
+def _normalize_matmul(expr):
+    """Reassociate ``expr`` when a matmul chain ends in a plain-constant
+    factor. General matrix-chain reordering is deliberately not attempted."""
+    left, right = expr.args
+    if _is_plain_constant(right) and not left.is_constant():
+        return _apply_constant_right(left, right)
+    return expr
 
 
 def convert_matmul(expr, children, var_dict, n_vars, param_dict):
@@ -91,6 +153,66 @@ def convert_multiply(expr, children, var_dict, n_vars, param_dict):
         return _diffengine.make_multiply(children[0], children[1])
 
 
+def _lower_symbolic_power(expr):
+    """Lower a power/PowerApprox SymbolicQuadForm to the elementwise square x .* x.
+
+    Rebuild over expr.args[0] (a leaf, per the canonicalizer): the engine's
+    init_jacobian segfaults on a quad form over a compound argument.
+    """
+    return cp.multiply(expr.args[0], expr.args[0])
+
+
+def convert_symbolic_quad_form(expr, var_dict, n_vars, param_dict):
+    """Convert a SymbolicQuadForm (Dcp2Cone quadratic-objective placeholder).
+
+    Scalar x'Px (QuadForm / quad_over_lin / sum_squares) uses the native quad_form
+    binding -- the sparse path for a sparse constant P, the dense path for a dense or
+    parametric P. power/PowerApprox is the elementwise square, lowered to multiply.
+    """
+    if expr.block_indices is not None:
+        raise NotImplementedError(
+            "SymbolicQuadForm with block_indices (axis-reduced quad form) is not "
+            "supported by the diff engine."
+        )
+
+    orig = expr.original_expression
+    if isinstance(orig, (QuadForm, quad_over_lin)):
+        x = expr.args[0]
+        P = expr.args[1]
+        x_c = convert_expr(x, var_dict, n_vars, param_dict)
+        n = x.size
+        if P.parameters():
+            # P is affine in the parameters and independent of x (Hessian still 2P):
+            # feed it as a matrix-valued child evaluated each solve. Peel value-identity
+            # Wrap atoms (e.g. psd_wrap) the converter can't build directly.
+            P_inner = P
+            while isinstance(P_inner, Wrap):
+                P_inner = P_inner.args[0]
+            P_c = convert_expr(P_inner, var_dict, n_vars, param_dict)
+            return _diffengine.make_quad_form(P_c, x_c, "dense", None, n)
+        P_val = P.value
+        if sparse.issparse(P_val):
+            P_csr = P_val.tocsr()
+            return _diffengine.make_quad_form(
+                None, x_c, "sparse",
+                P_csr.data.astype(np.float64),
+                P_csr.indices.astype(np.int32),
+                P_csr.indptr.astype(np.int32),
+                P_csr.shape[0], P_csr.shape[1])
+        P_dense = to_dense_float(P_val)
+        return _diffengine.make_quad_form(
+            None, x_c, "dense", P_dense.flatten(order='F'), n)
+
+    if isinstance(orig, Power):  # PowerApprox subclasses Power; canon only p == 2
+        return convert_expr(
+            _lower_symbolic_power(expr), var_dict, n_vars, param_dict)
+
+    raise NotImplementedError(
+        f"SymbolicQuadForm over '{type(orig).__name__}' is not supported by the "
+        "diff engine."
+    )
+
+
 def convert_expr(expr, var_dict, n_vars, param_dict=None):
     """Convert a CVXPY expression to a C diff engine expression.
 
@@ -114,12 +236,42 @@ def convert_expr(expr, var_dict, n_vars, param_dict=None):
         d1, d2 = normalize_shape(expr.shape)
         return _diffengine.make_parameter(d1, d2, -1, n_vars, c.flatten(order='F'))
 
+    # Fully-constant subtree: evaluate numerically instead of recursing.
+    # Dcp2Cone does not canonicalize constant subtrees, so nonlinear atoms
+    # over plain constants can reach the converter.
+    if not expr.variables() and not expr.parameters():
+        c = to_dense_float(expr.value)
+        d1, d2 = normalize_shape(expr.shape)
+        return _diffengine.make_parameter(d1, d2, -1, n_vars, c.flatten(order='F'))
+
     # Recursive case: atoms
     atom_name = type(expr).__name__
-    children = [convert_expr(arg, var_dict, n_vars, param_dict) for arg in expr.args]
+
+    # Handle SymbolicQuadForm before converting its args: its P arg may
+    # itself be unconvertible (e.g. a parametric divisor).
+    if atom_name == "SymbolicQuadForm":
+        return convert_symbolic_quad_form(expr, var_dict, n_vars, param_dict)
+
+    # Reassociate matmul chains, and skip converting a plain-constant matmul
+    # operand: convert_matmul reads its scipy/numpy value directly, so a dense
+    # make_parameter node for it would be pure waste.
+    skip_child = [False] * len(expr.args)
+    if atom_name == "MulExpression":
+        expr = _normalize_matmul(expr)
+        if type(expr).__name__ != "MulExpression":
+            return convert_expr(expr, var_dict, n_vars, param_dict)
+        left_arg, right_arg = expr.args
+        if _is_plain_constant(left_arg) and not right_arg.is_constant():
+            skip_child[0] = True
+        elif _is_plain_constant(right_arg) and not left_arg.is_constant():
+            skip_child[1] = True
+
+    children = [
+        None if skip_child[i] else convert_expr(arg, var_dict, n_vars, param_dict)
+        for i, arg in enumerate(expr.args)
+    ]
 
     # matmul and multiply need param_dict for parameter support
-    # TODO: maybe multiply doesn't need parameter dict special case
     if atom_name == "MulExpression":
         C_expr = convert_matmul(expr, children, var_dict, n_vars, param_dict)
     elif atom_name == "multiply":
@@ -127,6 +279,8 @@ def convert_expr(expr, var_dict, n_vars, param_dict=None):
     elif atom_name in ATOM_CONVERTERS:
         C_expr = ATOM_CONVERTERS[atom_name](expr, children)
     else:
+        # Variable-free parametric subtrees with no converter fail loud
+        # rather than baking a stale value.
         raise NotImplementedError(f"Atom '{atom_name}' not supported")
 
     # check that python dimension is consistent with C dimension

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/extractor.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/extractor.py
@@ -1,0 +1,120 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from __future__ import annotations
+
+import numpy as np
+import scipy.sparse as sp
+
+from cvxpy.reductions.solvers.nlp_solvers.diff_engine.c_problem import C_problem
+
+
+def _build_jacobian_csc(c_problem, jac_structure, m, n_vars):
+    """Evaluate the constraint Jacobian and assemble it as a CSC matrix."""
+    if m == 0:
+        return sp.csc_matrix((0, n_vars))
+    rows, cols = jac_structure
+    vals = c_problem.eval_jacobian_vals()
+    return sp.coo_matrix((vals, (rows, cols)), shape=(m, n_vars)).tocsc()
+
+
+def _full_symmetric_hess_structure(rows, cols, n_vars):
+    """Precompute the *full* symmetric Hessian sparsity from the engine's lower-triangular
+    COO sparsity (rows >= cols). Off-diagonal entries are mirrored across the diagonal.
+
+    Returns ``(full_rows, full_cols, offdiag_mask, shape)`` so that, given fresh
+    lower-triangular values ``v``, the full symmetric values are
+    ``concatenate([v, v[offdiag_mask]])`` -- see ``_build_hessian_csc``.
+    """
+    offdiag = rows != cols
+    full_rows = np.concatenate([rows, cols[offdiag]])
+    full_cols = np.concatenate([cols, rows[offdiag]])
+    return full_rows, full_cols, offdiag, (n_vars, n_vars)
+
+
+def _build_hessian_csc(c_problem, hess_structure, duals):
+    """Assemble the full symmetric Lagrangian Hessian P as CSC.
+
+    Re-evaluates only the lower-triangular Hessian *values* (the structure is fixed
+    across parameter updates and was captured once in ``hess_structure``), then mirrors
+    the off-diagonal entries to form the full symmetric matrix the cone solvers expect.
+    """
+    full_rows, full_cols, offdiag, shape = hess_structure
+    vals = c_problem.eval_hessian_vals_coo_lower_tri(1.0, duals)
+    full_vals = np.concatenate([vals, vals[offdiag]])
+    return sp.csc_matrix((full_vals, (full_rows, full_cols)), shape=shape)
+
+
+class DiffEngineExtractor:
+    """Non-DPP analog of ``CoeffExtractor``: builds a C autodiff problem from
+    the expressions and recovers the concrete cone matrices ``(q, d, A, b, P)``
+    by evaluating it at ``x = 0``, re-evaluating when parameter values change.
+    Owns the ``C_problem``; ``DiffengineConeProgram`` delegates extraction to it.
+    """
+
+    def __init__(self, inverse_data) -> None:
+        self.inverse_data = inverse_data
+        self.n_vars = inverse_data.x_length
+        self.c_problem = None
+        self.jac_structure = None
+        self.hess_structure = None
+        self.has_constraints = False
+
+    def build(self, objective_expr, constraint_exprs, parameters, quad_obj: bool):
+        """Compile the objective and constraint expressions into a ``C_problem``.
+
+        ``constraint_exprs`` is the flat list of cone-constraint argument expressions.
+        Returns ``self`` for chaining.
+        """
+        self.has_constraints = bool(constraint_exprs)
+        self.c_problem = C_problem.from_exprs(
+            objective_expr, constraint_exprs, parameters, self.inverse_data,
+            verbose=False)
+        self.c_problem.init_jacobian_coo()
+        self.jac_structure = (self.c_problem.get_jacobian_sparsity_coo()
+                              if self.has_constraints else None)
+        if quad_obj:
+            # Capture the (fixed) lower-triangular Hessian sparsity once; re-solves then
+            # fetch values only and mirror to full symmetric (see _build_hessian_csc).
+            self.c_problem.init_hessian_coo_lower_tri()
+            rows, cols = self.c_problem.get_problem_hessian_sparsity_coo()
+            self.hess_structure = _full_symmetric_hess_structure(rows, cols, self.n_vars)
+        return self
+
+    def update_parameters(self, theta: np.ndarray) -> None:
+        """Push new (flattened, concatenated) parameter values into the C problem."""
+        self.c_problem.update_params(theta)
+
+    def extract(self, quad_obj: bool):
+        """Evaluate the (affine) objective and constraints at ``x = 0`` to recover the
+        cone matrices: gradient ``q``, constant ``d``, constraint Jacobian ``A``, offset
+        ``b``, and (for a quadratic objective) the Hessian ``P``. Pre-restructuring.
+        """
+        x0 = np.zeros(self.n_vars, dtype=np.float64)
+        d = float(self.c_problem.objective_forward(x0))
+        q = self.c_problem.gradient().copy()
+        if self.has_constraints:
+            b_vec = self.c_problem.constraint_forward(x0)
+            A = _build_jacobian_csc(
+                self.c_problem, self.jac_structure, b_vec.shape[0], self.n_vars)
+        else:
+            b_vec = np.array([], dtype=np.float64)
+            A = sp.csc_matrix((0, self.n_vars))
+        b = np.atleast_1d(b_vec)
+        P = None
+        if quad_obj:
+            duals = np.zeros(b.shape[0], dtype=np.float64)
+            P = _build_hessian_csc(self.c_problem, self.hess_structure, duals)
+        return q, d, A, b, P

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/helpers.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/helpers.py
@@ -23,6 +23,11 @@ from sparsediffpy import _sparsediffengine as _diffengine
 def normalize_shape(shape):
     """Normalize shape to 2D (d1, d2) for the C engine."""
     shape = tuple(shape)
+    if len(shape) > 2:
+        raise NotImplementedError(
+            f">2-D expressions (shape {shape}) are not supported by the diff "
+            "engine; the engine represents all expressions as 2-D matrices."
+        )
     return (1,) * (2 - len(shape)) + shape
 
 
@@ -89,19 +94,20 @@ def build_var_dict(inverse_data):
     return var_dict, n_vars
 
 
-def build_param_dict(problem, inverse_data):
-    """Build {param_id: C parameter capsule} mapping from InverseData."""
+def build_param_dict(parameters, inverse_data):
+    """Build {param_id: C parameter capsule} mapping from InverseData.
+
+    `parameters` is an iterable of `cvxpy.Parameter` (e.g. `problem.parameters()`).
+    """
     n_vars = inverse_data.x_length
+    params_by_id = {p.id: p for p in parameters}
     param_dict = {}
     for param_id, offset in inverse_data.param_id_map.items():
         # this is needed to not get key errors with Constants.
         if param_id not in inverse_data.param_shapes:
             continue
         d1, d2 = normalize_shape(inverse_data.param_shapes[param_id])
-        # TODO this is a bit hacky, potentially we can just store the initial
-        # values in the InverseData, but we need to discuss with others.
-        param = next(p for p in problem.parameters() if p.id == param_id)
-        p = to_dense_float(param.value)
+        p = to_dense_float(params_by_id[param_id].value)
         param_dict[param_id] = _diffengine.make_parameter(
             d1, d2, offset, n_vars, p.flatten(order='F'))
     return param_dict

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/helpers.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/helpers.py
@@ -98,6 +98,8 @@ def build_param_dict(parameters, inverse_data):
     """Build {param_id: C parameter capsule} mapping from InverseData.
 
     `parameters` is an iterable of `cvxpy.Parameter` (e.g. `problem.parameters()`).
+    CallbackParam entries read their subtree's current value here like any
+    other parameter (see CallbackParamFold).
     """
     n_vars = inverse_data.x_length
     params_by_id = {p.id: p for p in parameters}

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
@@ -54,6 +54,8 @@ def convert_kron(expr, children):
     variable-free operand's structurally nonzero entries (column-major flat
     indices). A parametric operand gets all blocks since its values change."""
     a, b = expr.args
+    if not (a.is_constant() or b.is_constant()):
+        raise ValueError("kron requires at least one variable-free operand.")
     const_is_left = a.is_constant()
     const_expr = a if const_is_left else b
     const_node = children[0] if const_is_left else children[1]
@@ -72,6 +74,8 @@ def convert_kron(expr, children):
             active = np.unique(coo.row[mask] + coo.col[mask] * n_rows)
             active = active.astype(np.int32)
         else:
+            # No format conversion: read the nonzero pattern straight off the
+            # dense values, same result as the sparse branch above.
             flat = np.asarray(val, dtype=np.float64).flatten(order="F")
             active = np.flatnonzero(flat).astype(np.int32)
 

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
@@ -46,22 +46,60 @@ def convert_conv(expr, children):
     return _diffengine.make_convolve(children[0], children[1])
 
 
-def convert_div(expr, children):
-    """Convert x / c by multiplying x by the elementwise reciprocal of c.
+def convert_kron(expr, children):
+    """Convert cp.kron(A, B); the variable-free operand (kron requires one) is
+    re-evaluated each solve, so it may be parametric.
 
-    Matches coo_backend.div: parametrized divisors are rejected and any
-    zero entry in the divisor raises explicitly.
+    The engine materializes output rows only for the ``active`` blocks: the
+    variable-free operand's structurally nonzero entries (column-major flat
+    indices). A parametric operand gets all blocks since its values change."""
+    a, b = expr.args
+    const_is_left = a.is_constant()
+    const_expr = a if const_is_left else b
+    const_node = children[0] if const_is_left else children[1]
+    var_node = children[1] if const_is_left else children[0]
+    p, q = normalize_shape(a.shape)
+    r, s = normalize_shape(b.shape)
+    n_rows = p if const_is_left else r
+
+    if const_expr.parameters():
+        active = np.arange(const_expr.size, dtype=np.int32)
+    else:
+        val = const_expr.value
+        if sparse.issparse(val):
+            coo = val.tocoo()
+            mask = coo.data != 0  # drop stored-but-zero entries
+            active = np.unique(coo.row[mask] + coo.col[mask] * n_rows)
+            active = active.astype(np.int32)
+        else:
+            flat = np.asarray(val, dtype=np.float64).flatten(order="F")
+            active = np.flatnonzero(flat).astype(np.int32)
+
+    if const_is_left:
+        return _diffengine.make_left_kron(const_node, var_node, p, q, r, s, active)
+    return _diffengine.make_right_kron(const_node, var_node, p, q, r, s, active)
+
+
+def convert_div(expr, children):
+    """Convert x / d by multiplying x by the elementwise reciprocal of d.
+
+    A constant divisor bakes ``1/d`` into a parameter node (rejecting zero
+    entries, matching coo_backend.div); a parametric divisor uses a
+    ``make_power(d, -1)`` node the engine re-evaluates each solve.
     """
     divisor_expr = expr.args[1]
     if divisor_expr.parameters():
-        raise NotImplementedError("div doesn't support parametrized divisor")
-    divisor = to_dense_float(divisor_expr.value)
-    if np.any(divisor == 0):
-        raise ValueError("Division by zero encountered in divisor")
-    recip = 1.0 / divisor
-    d1, d2 = normalize_shape(recip.shape)
-    recip_node = _diffengine.make_parameter(d1, d2, -1, 0, recip.flatten(order='F'))
-    if recip.size == 1:
+        recip_node = _diffengine.make_power(children[1], -1.0)
+        size = divisor_expr.size
+    else:
+        divisor = to_dense_float(divisor_expr.value)
+        if np.any(divisor == 0):
+            raise ValueError("Division by zero encountered in divisor")
+        recip = 1.0 / divisor
+        d1, d2 = normalize_shape(recip.shape)
+        recip_node = _diffengine.make_parameter(d1, d2, -1, 0, recip.flatten(order='F'))
+        size = recip.size
+    if size == 1:
         return _diffengine.make_param_scalar_mult(recip_node, children[0])
     return _diffengine.make_param_vector_mult(recip_node, children[0])
 
@@ -230,23 +268,47 @@ def convert_trace(_expr, children):
     return _diffengine.make_trace(children[0])
 
 def convert_diag_vec(expr, children):
-    # C implementation only supports k=0 (main diagonal)
-    # TODO add support for diag vec with k
-    if expr.k != 0:
-        raise NotImplementedError("diag_vec with k != 0 not supported in diff engine")
-    return _diffengine.make_diag_vec(children[0])
+    """Convert diag_vec: place a vector on the k-th diagonal of a matrix.
+
+    The native make_diag_vec is main-diagonal only; an offset diagonal is
+    ``U @ diag(x) @ V`` with sparse selector matrices U, V (O(n) nonzeros).
+    """
+    node = _diffengine.make_diag_vec(children[0])
+    k = expr.k
+    if k == 0:
+        return node
+    from cvxpy.reductions.solvers.nlp_solvers.diff_engine.helpers import (
+        make_sparse_left_matmul,
+        make_sparse_right_matmul,
+    )
+    n = expr.args[0].size
+    m = n + abs(k)
+    rows = np.arange(n)
+    U = sparse.csr_array(
+        (np.ones(n), (rows + max(-k, 0), rows)), shape=(m, n))
+    V = sparse.csr_array(
+        (np.ones(n), (rows, rows + max(k, 0))), shape=(n, m))
+    return make_sparse_right_matmul(
+        None, make_sparse_left_matmul(None, node, U), V)
 
 
 def convert_diag_mat(expr, children):
-    """Convert diag_mat: extract diagonal from square matrix."""
-    if expr.k != 0:
-        raise NotImplementedError("diag_mat with k != 0 not supported in diff engine")
-    node = _diffengine.make_diag_mat(children[0])
-    # C produces (n, 1) but CVXPY shape is (n,) which normalizes to (1, n)
-    # TODO add support for producing (1, n) directly in C and remove this reshape
-    # TODO also raise error that the k should be zero, since that's the only supported case
-    n = expr.args[0].shape[0]
-    return _diffengine.make_reshape(node, 1, n)
+    """Convert diag_mat: extract the k-th diagonal from a square matrix.
+
+    The main diagonal uses the native make_diag_mat; an offset diagonal is a
+    make_index gather over the column-major flattened matrix.
+    """
+    n_rows = expr.args[0].shape[0]
+    if expr.k == 0:
+        node = _diffengine.make_diag_mat(children[0])
+        # C produces (n, 1) but CVXPY shape is (n,) which normalizes to (1, n)
+        # TODO add support for producing (1, n) directly in C and remove this reshape
+        return _diffengine.make_reshape(node, 1, n_rows)
+    k = expr.k
+    length = expr.shape[0]
+    i = np.arange(length)
+    idxs = ((i + max(-k, 0)) + (i + max(k, 0)) * n_rows).astype(np.int32)
+    return _diffengine.make_index(children[0], 1, length, idxs)
 
 
 def convert_upper_tri(_expr, children):
@@ -311,6 +373,8 @@ ATOM_CONVERTERS = {
     # 1D full convolution
     "conv": convert_conv,
     "convolve": convert_conv,
+    # Kronecker product
+    "kron": convert_kron,
     "Trace": convert_trace,
     # Diagonal and triangular
     "diag_vec": convert_diag_vec,

--- a/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
+++ b/cvxpy/reductions/solvers/qp_solvers/qp_solver.py
@@ -20,8 +20,8 @@ import scipy.sparse as sp
 import cvxpy.settings as s
 from cvxpy.constraints import NonNeg, Zero
 from cvxpy.error import SolverError
+from cvxpy.problems.param_prob import ParamProb
 from cvxpy.reductions.cvx_attr2constr import convex_attributes
-from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ParamConeProg
 from cvxpy.reductions.solvers.solver import Solver
 
 
@@ -73,7 +73,7 @@ class QpSolver(Solver):
         return True
 
     def accepts(self, problem):
-        return (isinstance(problem, ParamConeProg)
+        return (isinstance(problem, ParamProb)
                 and (self.MIP_CAPABLE or not problem.is_mixed_integer())
                 and not convex_attributes([problem.x])
                 and (len(problem.constraints) > 0 or not self.REQUIRES_CONSTR)

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -32,6 +32,7 @@ from cvxpy.reductions.discrete2mixedint.valinvec2mixedint import (
 from cvxpy.reductions.eliminate_zero_sized import EliminateZeroSized
 from cvxpy.reductions.eval_params import EvalParams
 from cvxpy.reductions.flip_objective import FlipObjective
+from cvxpy.reductions.fold_callback_params import CallbackParamFold
 from cvxpy.reductions.solvers import defines as slv_def
 from cvxpy.reductions.solvers.constant_solver import ConstantSolver
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
@@ -125,7 +126,7 @@ def _build_solving_chain(
        *solver_instance* and *problem_form* (MIP-aware constraint set).
     2. **Pre-canonicalization reductions** — rewrites that depend only on
        *problem* and *gp* (complex→real, DGP→DCP, flip-objective,
-       finite-set, DPP / EvalParams).
+       finite-set).
     3. **Canonicalization reductions** — determined by *problem_form*
        (required cones, quadratic objective) and *solver_context*
        (supported constraints, bounds, SOC-dim-3).
@@ -147,9 +148,11 @@ def _build_solving_chain(
         When True, treat DPP problems as non-DPP.
     canon_backend : str, optional
         Canonicalization backend ('CPP', 'SCIPY', 'COO', or 'DIFFENGINE').
-        'DIFFENGINE' builds the problem matrices directly from the expression
-        trees via the C diff engine, keeping parameters symbolic; it requires
-        expressions of dimension at most 2.
+        The ignore_dpp / non-DPP path uses 'DIFFENGINE'
+        (parameters stay symbolic and are re-evaluated each solve); passing a
+        different backend there raises ValueError for parametric problems and
+        is honored for parameter-free ones. Parametric N-D (>2-D) problems
+        bake parameters to constants (EvalParams) and use the tensor backends.
     solver_opts : dict, optional
         Solver-specific options.
 
@@ -212,12 +215,44 @@ def _build_solving_chain(
             f"The {DIFFENGINE_CANON_BACKEND} backend cannot be used with "
             "problems that have expressions of dimension greater than 2.")
 
+    uncached_param_prog = False
     if ignore_dpp or not is_dpp:
         if not ignore_dpp and enforce_dpp:
             raise DPPError(DPP_ERROR_MSG)
         if not ignore_dpp:
             warn(DPP_ERROR_MSG)
-        reductions = [EvalParams()] + reductions
+        if problem.parameters():
+            # Both branches below rebuild the parametric program on every
+            # solve. Caching the symbolic DIFFENGINE program across solves is
+            # a follow-up (it needs a record-at-site guard for the one
+            # value-consuming canonicalizer, the cone quad_form canon).
+            uncached_param_prog = True
+            if problem._max_ndim() > 2:
+                # The diff engine is 2-D only: bake parameters to constants
+                # and let the tensor machinery handle the N-D (SCIPY)
+                # fallback, preserving the pre-DIFFENGINE semantics.
+                reductions = [EvalParams()] + reductions
+            else:
+                # Parameters stay symbolic and re-evaluate each solve.
+                # Non-affine parametric constants fold to CallbackParam
+                # leaves so Dcp2Cone never epigraph-relaxes them unsoundly.
+                reductions = [CallbackParamFold()] + reductions
+                if (canon_backend is not None
+                        and canon_backend != DIFFENGINE_CANON_BACKEND):
+                    raise ValueError(
+                        f"canon_backend='{canon_backend}' cannot be used for "
+                        "a parametrized problem that is not DPP (or is solved "
+                        "with ignore_dpp=True); this path requires the "
+                        f"{DIFFENGINE_CANON_BACKEND} backend, which keeps "
+                        "parameters symbolic and re-evaluates them on each "
+                        "solve. Omit canon_backend, or replace the parameters "
+                        "with constants.")
+                canon_backend = DIFFENGINE_CANON_BACKEND
+        elif canon_backend is None and problem._max_ndim() <= 2:
+            # Parameter-free: ignore_dpp is a no-op; default to DIFFENGINE
+            # for consistency. Explicit backends are honored; N-D problems
+            # fall through to the normal tensor-backend selection.
+            canon_backend = DIFFENGINE_CANON_BACKEND
     else:
         if canon_backend is None:
             # DIFFENGINE dispatch lives in ConeMatrixStuffing, before the
@@ -261,7 +296,8 @@ def _build_solving_chain(
         ConeMatrixStuffing(quad_obj=quad_obj, canon_backend=canon_backend),
         solver_instance,
     ]
-    return SolvingChain(reductions=reductions, solver_context=solver_context)
+    return SolvingChain(reductions=reductions, solver_context=solver_context,
+                        uncached_param_prog=uncached_param_prog)
 
 
 def _resolve_solver(
@@ -418,7 +454,7 @@ def resolve_and_build_chain(
         If no suitable solver is found or the specified solver cannot handle
         the problem.
     """
-    problem_form = make_problem_form(problem, gp, ignore_dpp)
+    problem_form = make_problem_form(problem, gp)
     solver_instance = _resolve_solver(solver, problem_form, gp)
     return _build_solving_chain(
         problem,
@@ -489,20 +525,27 @@ class SolvingChain(Chain):
         The solver, i.e., reductions[-1].
     """
 
-    def __init__(self, problem=None, reductions=None, solver_context=None) -> None:
+    def __init__(self, problem=None, reductions=None, solver_context=None,
+                 uncached_param_prog: bool = False) -> None:
         super(SolvingChain, self).__init__(problem=problem,
                                            reductions=reductions)
         if not isinstance(self.reductions[-1], Solver):
             raise ValueError("Solving chains must terminate with a Solver.")
         self.solver = self.reductions[-1]
         self.solver_context = solver_context
+        # True when the compiled parametric program must be rebuilt on every
+        # solve: the chain bakes current parameter values into constants (the
+        # N-D EvalParams fallback), or it takes the symbolic non-DPP /
+        # ignore_dpp path, which does not yet support cached re-solves.
+        self.uncached_param_prog = uncached_param_prog
 
     def prepend(self, chain) -> "SolvingChain":
         """
         Create and return a new SolvingChain by concatenating
         chain with this instance.
         """
-        return SolvingChain(reductions=chain.reductions + self.reductions)
+        return SolvingChain(reductions=chain.reductions + self.reductions,
+                            uncached_param_prog=self.uncached_param_prog)
 
     def solve(self, problem, warm_start: bool, verbose: bool, solver_opts):
         """Solves the problem by applying the chain.

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -10,6 +10,7 @@ from cvxpy.constraints import (
     SOC,
     FiniteSet,
 )
+from cvxpy.cvxcore.python import canonInterface
 from cvxpy.error import DPPError, SolverError
 from cvxpy.problems.objective import Maximize
 from cvxpy.problems.problem_form import ProblemForm, make_problem_form, pick_default_solver
@@ -35,7 +36,11 @@ from cvxpy.reductions.solvers import defines as slv_def
 from cvxpy.reductions.solvers.constant_solver import ConstantSolver
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
 from cvxpy.reductions.solvers.solver import Solver, expand_cones
-from cvxpy.settings import COO_CANON_BACKEND, DPP_PARAM_THRESHOLD
+from cvxpy.settings import (
+    COO_CANON_BACKEND,
+    DIFFENGINE_CANON_BACKEND,
+    DPP_PARAM_THRESHOLD,
+)
 from cvxpy.utilities.solver_context import SolverInfo
 from cvxpy.utilities.warn import warn
 
@@ -141,7 +146,10 @@ def _build_solving_chain(
     ignore_dpp : bool
         When True, treat DPP problems as non-DPP.
     canon_backend : str, optional
-        Canonicalization backend ('CPP', 'SCIPY', or 'COO').
+        Canonicalization backend ('CPP', 'SCIPY', 'COO', or 'DIFFENGINE').
+        'DIFFENGINE' builds the problem matrices directly from the expression
+        trees via the C diff engine, keeping parameters symbolic; it requires
+        expressions of dimension at most 2.
     solver_opts : dict, optional
         Solver-specific options.
 
@@ -196,6 +204,14 @@ def _build_solving_chain(
     # so parametric P in constraints is NOT DPP-safe for the QP path.
     quad_form_dpp = 'qp' if solver_instance.supports_quad_obj() else None
     is_dpp = problem.is_dpp(dpp_context, quad_form_dpp=quad_form_dpp)
+
+    if canon_backend == DIFFENGINE_CANON_BACKEND and problem._max_ndim() > 2:
+        # Mirror the explicit-CPP treatment of N-D problems: the diff engine
+        # represents all expressions as 2-D matrices.
+        raise ValueError(
+            f"The {DIFFENGINE_CANON_BACKEND} backend cannot be used with "
+            "problems that have expressions of dimension greater than 2.")
+
     if ignore_dpp or not is_dpp:
         if not ignore_dpp and enforce_dpp:
             raise DPPError(DPP_ERROR_MSG)
@@ -204,9 +220,16 @@ def _build_solving_chain(
         reductions = [EvalParams()] + reductions
     else:
         if canon_backend is None:
-            total_param_size = sum(p.size for p in problem.parameters())
-            if total_param_size >= DPP_PARAM_THRESHOLD:
-                canon_backend = COO_CANON_BACKEND
+            # DIFFENGINE dispatch lives in ConeMatrixStuffing, before the
+            # tensor pipeline consumes the env var, so resolve it here.
+            # N-D problems fall through to the normal (SCIPY-fallback) selection.
+            if (canonInterface.get_default_canon_backend() == DIFFENGINE_CANON_BACKEND
+                    and problem._max_ndim() <= 2):
+                canon_backend = DIFFENGINE_CANON_BACKEND
+            else:
+                total_param_size = sum(p.size for p in problem.parameters())
+                if total_param_size >= DPP_PARAM_THRESHOLD:
+                    canon_backend = COO_CANON_BACKEND
 
     # --- Canonicalization reductions (problem_form + solver_context) ---
     use_quad = True if solver_opts is None else solver_opts.get('use_quad_obj', True)

--- a/cvxpy/settings.py
+++ b/cvxpy/settings.py
@@ -206,6 +206,10 @@ SCIPY_CANON_BACKEND = "SCIPY"
 RUST_CANON_BACKEND = "RUST"
 CPP_CANON_BACKEND = "CPP"
 COO_CANON_BACKEND = "COO"  # 3D COO sparse tensor backend: O(nnz) operations for large parameters
+# Builds the problem matrices directly from the expression trees via the C
+# diff engine; parameters stay symbolic (no DPP structure needed). Used for
+# ignore_dpp/non-DPP solves and selectable via canon_backend="DIFFENGINE".
+DIFFENGINE_CANON_BACKEND = "DIFFENGINE"
 
 # Default canonicalization backend, pyodide uses SciPy
 DEFAULT_CANON_BACKEND = CPP_CANON_BACKEND if sys.platform != "emscripten" else SCIPY_CANON_BACKEND

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import unittest
+import warnings
 
 import numpy as np
 import pytest
@@ -1808,7 +1809,9 @@ class TestAtoms(BaseTest):
         problem = cp.Problem(cp.Minimize(cp.convolve(p, x)), [0 <= x, x <= 1])
 
         p.value = -1.0
-        result = problem.solve(canon_backend=cp.CPP_CANON_BACKEND)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')  # non-DPP warning
+            result = problem.solve()
         self.assertAlmostEqual(result, -1)
         self.assertAlmostEqual(x.value, 1)
 

--- a/cvxpy/tests/test_backend_selection.py
+++ b/cvxpy/tests/test_backend_selection.py
@@ -64,8 +64,8 @@ class TestBackendSelectionDPP:
         stuffing = [r for r in chain.reductions if isinstance(r, ConeMatrixStuffing)][0]
         assert stuffing.canon_backend == s.COO_CANON_BACKEND
 
-    def test_non_dpp_with_large_params_uses_cpp(self):
-        """Non-DPP problem with many params should NOT select COO."""
+    def test_non_dpp_with_large_params_uses_diffengine(self):
+        """Non-DPP problem with many params routes to DIFFENGINE, NOT COO."""
         A = cp.Parameter((100, 20))  # 2000 params
         B = cp.Parameter((20, 20))  # 400 more params
         x = cp.Variable(20)
@@ -77,11 +77,11 @@ class TestBackendSelectionDPP:
 
         chain = prob._construct_chain(solver=cp.CLARABEL)
         stuffing = [r for r in chain.reductions if isinstance(r, ConeMatrixStuffing)][0]
-        # Non-DPP doesn't trigger COO
-        assert stuffing.canon_backend is None
+        # Non-DPP uses the DIFFENGINE backend (and never COO).
+        assert stuffing.canon_backend == s.DIFFENGINE_CANON_BACKEND
 
     def test_ignore_dpp_skips_coo_selection(self):
-        """With ignore_dpp=True, large DPP should NOT select COO."""
+        """With ignore_dpp=True, large DPP routes to DIFFENGINE, NOT COO."""
         A = cp.Parameter((100, 20))  # 2000 params
         x = cp.Variable(20)
         prob = cp.Problem(cp.Minimize(cp.sum_squares(A @ x)))
@@ -90,8 +90,8 @@ class TestBackendSelectionDPP:
 
         chain = prob._construct_chain(solver=cp.CLARABEL, ignore_dpp=True)
         stuffing = [r for r in chain.reductions if isinstance(r, ConeMatrixStuffing)][0]
-        # ignore_dpp means we don't use DPP-based selection
-        assert stuffing.canon_backend is None
+        # ignore_dpp uses the DIFFENGINE backend, not DPP-based COO selection.
+        assert stuffing.canon_backend == s.DIFFENGINE_CANON_BACKEND
 
 
 class TestBackendSelectionUserOverride:
@@ -220,3 +220,4 @@ class TestBackendSelectionSolve:
             prob.solve(solver=cp.CLARABEL)
 
         assert prob.status == cp.OPTIMAL
+

--- a/cvxpy/tests/test_complex_dpp.py
+++ b/cvxpy/tests/test_complex_dpp.py
@@ -19,14 +19,13 @@ import pytest
 
 import cvxpy as cp
 from cvxpy.reductions.complex2real.complex2real import Complex2Real
-from cvxpy.reductions.eval_params import EvalParams
 
 
 class TestComplexDPP:
     """Tests for DPP (Disciplined Parameterized Programming) with complex parameters."""
 
     def test_dpp_recognition_and_chain(self):
-        """Complex parameter problems are DPP and don't use EvalParams."""
+        """Complex parameter problems are DPP and keep parameters symbolic."""
         p = cp.Parameter(complex=True)
         x = cp.Variable()
         prob = cp.Problem(cp.Minimize(cp.abs(x - cp.real(p))))
@@ -38,12 +37,13 @@ class TestComplexDPP:
         data, _, _ = prob.get_problem_data(cp.CLARABEL)
         assert data is not None
 
-        # After solve, chain should use Complex2Real but not EvalParams
+        # After solve, chain should use Complex2Real; no reduction bakes params
         p.value = np.array(1 + 2j)
         prob.solve()
-        reduction_types = [type(r) for r in prob._cache.solving_chain.reductions]
-        assert EvalParams not in reduction_types
-        assert Complex2Real in reduction_types
+        reduction_names = [type(r).__name__
+                           for r in prob._cache.solving_chain.reductions]
+        assert 'EvalParams' not in reduction_names
+        assert Complex2Real in [type(r) for r in prob._cache.solving_chain.reductions]
 
     @pytest.mark.parametrize("shape,param_val,expected", [
         ((), 3 + 4j, 3.0),  # scalar
@@ -123,12 +123,10 @@ class TestComplexDPP:
         assert np.isclose(x.value, 3.0, atol=1e-4)
         assert np.isclose(prob.value, 4.0, atol=1e-4)
 
-    @pytest.mark.parametrize("flag,should_have_eval_params", [
-        ("enforce_dpp", False),
-        ("ignore_dpp", True),
-    ])
-    def test_dpp_flags(self, flag, should_have_eval_params):
-        """enforce_dpp=True succeeds; ignore_dpp=True uses EvalParams."""
+    @pytest.mark.parametrize("flag", ["enforce_dpp", "ignore_dpp"])
+    def test_dpp_flags(self, flag):
+        """enforce_dpp=True succeeds; ignore_dpp=True keeps parameters
+        symbolic (DIFFENGINE backend) and refreshes them across solves."""
         p = cp.Parameter(complex=True)
         x = cp.Variable()
         prob = cp.Problem(cp.Minimize(x), [x >= cp.real(p)])
@@ -140,8 +138,15 @@ class TestComplexDPP:
             prob.solve(ignore_dpp=True)
 
         assert np.isclose(x.value, 1.0, atol=1e-4)
-        reduction_types = [type(r) for r in prob._cache.solving_chain.reductions]
-        assert (EvalParams in reduction_types) == should_have_eval_params
+        reduction_names = [type(r).__name__
+                           for r in prob._cache.solving_chain.reductions]
+        assert 'EvalParams' not in reduction_names
+        assert 'FoldVariableFreeParams' not in reduction_names
+
+        if flag == "ignore_dpp":
+            p.value = np.array(4 - 1j)
+            prob.solve(ignore_dpp=True)
+            assert np.isclose(x.value, 4.0, atol=1e-4)
 
     @pytest.mark.parametrize("n", [1, 2, 3])
     def test_hermitian_param_dpp(self, n):

--- a/cvxpy/tests/test_cvxcore_issues.py
+++ b/cvxpy/tests/test_cvxcore_issues.py
@@ -1,0 +1,155 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Regressions from the cvxcore issue tracker (discussion #3221), replayed on the
+DIFFENGINE canon backend (explicit ``canon_backend``). Each test is a
+scaled-down version of a reported bug's reproduction.
+"""
+import numpy as np
+from scipy.linalg import dft
+
+import cvxpy as cp
+import cvxpy.settings as s
+from cvxpy.tests.base_test import BaseTest
+
+SOLVER = cp.CLARABEL
+DIFFENGINE = s.DIFFENGINE_CANON_BACKEND
+
+
+class TestCvxcoreIssues(BaseTest):
+
+    def test_issue_1132_sdp_kron_segfault(self) -> None:
+        """Issue #1132: cvxcore segfaulted on this SDP structure (PSD variable
+        inside kron/reshape/diag under a fro-norm); scaled from n=300 to n=25."""
+        n = 25
+        rng = np.random.default_rng(0)
+        points = rng.random((5, n))
+        xtx = points.T @ points
+        xtxd = np.diag(xtx)
+        ones = np.ones(n)
+        D = np.outer(ones, xtxd) - 2 * xtx + np.outer(xtxd, ones)
+        W = np.ones((n, n))
+
+        def build():
+            x = -1 / (n + np.sqrt(n))
+            y = -1 / np.sqrt(n)
+            V = np.ones((n, n - 1))
+            V[0, :] *= y
+            V[1:, :] *= x
+            V[1:, :] += np.eye(n - 1)
+            e = np.ones((n, 1))
+
+            G = cp.Variable((n - 1, n - 1), PSD=True)
+            vgv_diag = cp.diag(V @ G @ V.T)
+            row = cp.kron(e, cp.reshape(vgv_diag, (1, n), order="F"))
+            col = cp.kron(e.T, cp.reshape(vgv_diag, (n, 1), order="F"))
+            resid = row + col - 2 * V @ G @ V.T - D
+            obj = cp.Maximize(cp.trace(G) - cp.norm(cp.multiply(W, resid), p="fro"))
+            return cp.Problem(obj, [])
+
+        prob_de = build()
+        prob_de.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+        self.assertEqual(prob_de.status, cp.OPTIMAL)
+
+        prob_base = build()
+        prob_base.solve(solver=SOLVER)
+        self.assertAlmostEqual(prob_de.value, prob_base.value, places=3)
+
+    def test_issue_2205_kron_unconstrained_qp(self) -> None:
+        """Issue #2205: kron(diag(ones), diag(var)) between dense DFT matrices
+        took minutes to compile; scaled to dim 12, both objective forms must
+        recover the planted diagonal error."""
+        rng = np.random.default_rng(0)
+        N_r, N_t, N_s = 4, 1, 3
+        dim = N_s * N_r * N_t
+
+        # strictly positive input so every diagonal entry of the variable is
+        # excited (a binary x can leave the system underdetermined at this scale)
+        x = rng.random(dim) + 0.5
+        H = dft(dim) * 1j
+        H_H = H.conj().T
+        err = rng.random(N_r)
+        Err = np.kron(np.diag(np.ones(N_s * N_t)), np.diag(err))
+        y = H_H @ Err @ H @ x
+
+        for form in (cp.sum_squares, lambda expr: cp.norm2(expr)):
+            var = cp.Variable(shape=(N_r,), complex=True)
+            Err_est = cp.kron(np.diag(np.ones(N_s * N_t)), cp.diag(var))
+            res = form(H_H @ Err_est @ H @ x - y)
+            prob = cp.Problem(cp.Minimize(res))
+            prob.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+            self.assertEqual(prob.status, cp.OPTIMAL)
+            self.assertItemsAlmostEqual(var.value, err, places=4)
+
+    def test_issue_1043_param_scaled_frobenius(self) -> None:
+        """Issue #1043: cvxcore segfaulted on a dictionary-learning problem
+        (parameter-scaled squared Frobenius norms); same structure synthesized
+        at reduced scale, values checked against a constant-baked baseline."""
+        rng = np.random.default_rng(0)
+        n_samples, d_feat, d_attr = 30, 48, 12
+        Xs = rng.standard_normal((n_samples, d_feat))
+        Ys = rng.standard_normal((n_samples, d_attr))
+
+        lamda1 = cp.Parameter(nonneg=True)
+        lamda2 = cp.Parameter(nonneg=True)
+        Ds = cp.Variable(shape=(d_attr, d_feat))
+        objective = (
+            cp.square(cp.norm(Xs - Ys @ Ds, "fro"))
+            + lamda1 * cp.square(cp.norm(Ds, "fro"))
+            + lamda2 * (cp.square(cp.norm(Ds, "fro")) - 1)
+        )
+        prob = cp.Problem(cp.Minimize(objective))
+
+        for lam1, lam2 in [(0.01, 10.0), (10.0, 0.01)]:
+            lamda1.value = lam1
+            lamda2.value = lam2
+            prob.solve(solver=SOLVER, ignore_dpp=True, canon_backend=DIFFENGINE)
+            self.assertEqual(prob.status, cp.OPTIMAL)
+
+            Ds_base = cp.Variable(shape=(d_attr, d_feat))
+            base_objective = (
+                cp.square(cp.norm(Xs - Ys @ Ds_base, "fro"))
+                + lam1 * cp.square(cp.norm(Ds_base, "fro"))
+                + lam2 * (cp.square(cp.norm(Ds_base, "fro")) - 1)
+            )
+            prob_base = cp.Problem(cp.Minimize(base_objective))
+            prob_base.solve(solver=SOLVER)
+            self.assertAlmostEqual(prob.value, prob_base.value, places=3)
+
+    def test_quantum_kron_partial_transpose_structure(self) -> None:
+        """quantum_hilbert_matrix benchmark structure at toy scale: locks the
+        sparse-kron active-block path and the block matmul sparsity path."""
+        from scipy import sparse
+
+        dim = 2
+        rng = np.random.default_rng(0)
+        X = cp.Variable((dim * dim, dim * dim), symmetric=True)
+        eye = sparse.identity(dim, format="csc")
+        A = rng.standard_normal((dim, dim))
+        AxI = sparse.kron(sparse.csc_matrix(A), sparse.identity(dim * dim, format="csc"))
+
+        expr = cp.kron(eye, cp.partial_transpose(X, dims=[dim, dim], axis=0)) @ AxI
+        target = rng.standard_normal(expr.shape)
+        obj = cp.Minimize(cp.sum_squares(expr - target))
+
+        prob_de = cp.Problem(obj, [])
+        prob_de.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+        self.assertEqual(prob_de.status, cp.OPTIMAL)
+        X_de = X.value.copy()
+
+        prob_base = cp.Problem(obj, [])
+        prob_base.solve(solver=SOLVER)
+        self.assertAlmostEqual(prob_de.value, prob_base.value, places=4)
+        self.assertItemsAlmostEqual(X_de, X.value, places=3)

--- a/cvxpy/tests/test_diffengine_backend.py
+++ b/cvxpy/tests/test_diffengine_backend.py
@@ -1,0 +1,385 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+import cvxpy as cp
+import cvxpy.settings as s
+from cvxpy.atoms.quad_form import SymbolicQuadForm
+from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
+from cvxpy.reductions.dcp2cone.diffengine_cone_program import DiffengineConeProgram
+from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS
+from cvxpy.tests.base_test import BaseTest
+
+try:
+    from sparsediffpy import _sparsediffengine as _engine
+except ImportError:  # pragma: no cover
+    _engine = None
+
+# On an older sparsediffpy wheel every test here would AttributeError
+# mid-solve, so skip the module loudly instead.
+REQUIRED_BINDINGS = ("make_left_kron", "make_right_kron", "make_power", "make_quad_form")
+MISSING = (["sparsediffpy not installed"] if _engine is None else
+           [name for name in REQUIRED_BINDINGS if not hasattr(_engine, name)])
+pytestmark = pytest.mark.skipif(
+    bool(MISSING),
+    reason="DIFFENGINE backend requires sparsediffpy >= 0.6.0 "
+           f"(missing: {', '.join(MISSING)})",
+)
+
+SOLVER = cp.CLARABEL
+DIFFENGINE = s.DIFFENGINE_CANON_BACKEND
+
+
+class TestDiffengineConverter(BaseTest):
+    """Converter correctness and fail-loud behavior: unsupported constructs
+    must raise immediately instead of silently miscompiling."""
+
+    def test_unsupported_atom_raises(self) -> None:
+        """convert_expr names the offending atom."""
+        from cvxpy.reductions.solvers.nlp_solvers.diff_engine.converters import (
+            convert_expr,
+        )
+        x = cp.Variable(4)
+        with self.assertRaisesRegex(NotImplementedError, "cumsum"):
+            convert_expr(cp.cumsum(x), {x.id: None}, 4, {})
+
+    def test_constant_nonlinear_subtree_is_evaluated(self) -> None:
+        """A nonlinear atom over plain constants is evaluated numerically;
+        the engine cannot differentiate through it."""
+        x = cp.Variable(2)
+        const_term = cp.quad_over_lin(np.array([1.0, 1.0]), 1.0)  # == 2.0
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(x)), [cp.sum(x) >= const_term])
+        prob.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+        self.assertEqual(prob.status, cp.OPTIMAL)
+        self.assertItemsAlmostEqual(x.value, np.array([1.0, 1.0]), places=4)
+
+    def test_symbolic_quad_form_block_indices_raises(self) -> None:
+        from cvxpy.reductions.solvers.nlp_solvers.diff_engine.converters import (
+            convert_symbolic_quad_form,
+        )
+        x = cp.Variable(4)
+        sqf = SymbolicQuadForm(x, sp.eye_array(4), cp.sum_squares(x),
+                               block_indices=[np.array([0, 1]), np.array([2, 3])])
+        with self.assertRaisesRegex(NotImplementedError, "block_indices"):
+            convert_symbolic_quad_form(sqf, {}, 4, {})
+
+    def test_symbolic_quad_form_unsupported_orig_raises(self) -> None:
+        from cvxpy.reductions.solvers.nlp_solvers.diff_engine.converters import (
+            convert_symbolic_quad_form,
+        )
+        x = cp.Variable(4)
+        sqf = SymbolicQuadForm(x, sp.eye_array(4), cp.norm1(x))
+        with self.assertRaisesRegex(NotImplementedError, "norm1"):
+            convert_symbolic_quad_form(sqf, {}, 4, {})
+
+    def test_zero_divisor_raises(self) -> None:
+        x = cp.Variable(3)
+        divisor = np.array([1.0, 0.0, 2.0])
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(x / divisor - 1.0)))
+        with self.assertRaisesRegex(ValueError, "[Dd]ivision by zero"):
+            prob.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+
+    def test_gt_2d_expression_raises_clearly(self) -> None:
+        from cvxpy.reductions.solvers.nlp_solvers.diff_engine.helpers import (
+            normalize_shape,
+        )
+        with self.assertRaisesRegex(NotImplementedError, ">2-D"):
+            normalize_shape((2, 3, 4))
+
+    def test_required_bindings_present(self) -> None:
+        for name in REQUIRED_BINDINGS:
+            self.assertTrue(hasattr(_engine, name))
+
+    def test_kron_var_left_const_right(self) -> None:
+        """kron(X, C) exercises make_right_kron (with a structural zero in C)."""
+        rng = np.random.default_rng(0)
+        C = np.array([[1.0, 2.0], [0.0, 3.0]])
+        X0 = rng.standard_normal((2, 2))
+        X = cp.Variable((2, 2))
+        target = np.kron(X0, C)
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(cp.kron(X, C) - target)))
+        prob.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+        self.assertEqual(prob.status, cp.OPTIMAL)
+        self.assertAlmostEqual(prob.value, 0.0)
+        self.assertItemsAlmostEqual(X.value, X0, places=3)
+
+    def test_kron_parametric_operand_resolves(self) -> None:
+        """A bare-Parameter kron operand stays symbolic and must be
+        re-evaluated between solves, for both orientations."""
+        rng = np.random.default_rng(0)
+        target = rng.standard_normal((4, 4))
+        for param_side in ("left", "right"):
+            P = cp.Parameter((2, 2))
+            X = cp.Variable((2, 2))
+            expr = cp.kron(P, X) if param_side == "left" else cp.kron(X, P)
+            prob = cp.Problem(cp.Minimize(cp.sum_squares(expr - target)))
+
+            for seed in (1, 2):
+                P_val = np.random.default_rng(seed).standard_normal((2, 2))
+                P.value = P_val
+                # kron(P, X) is not DPP: pass ignore_dpp to opt out of the
+                # non-DPP warning while selecting the backend explicitly.
+                prob.solve(solver=SOLVER, ignore_dpp=True,
+                           canon_backend=DIFFENGINE)
+                self.assertEqual(prob.status, cp.OPTIMAL)
+
+                X_base = cp.Variable((2, 2))
+                expr_base = (cp.kron(P_val, X_base) if param_side == "left"
+                             else cp.kron(X_base, P_val))
+                base = cp.Problem(cp.Minimize(cp.sum_squares(expr_base - target)))
+                base.solve(solver=SOLVER)
+                self.assertAlmostEqual(prob.value, base.value, places=3)
+                self.assertItemsAlmostEqual(X.value, X_base.value, places=3)
+
+    def test_diag_offset_both_directions(self) -> None:
+        """diag(x, k) and diag(X, k) for off-main diagonals."""
+        n = 4
+        A = np.arange(n * n, dtype=float).reshape((n, n))
+        for k in (-2, -1, 1, 3):
+            x = cp.Variable(n - abs(k))
+            target = np.diag(np.diag(A, k), k)
+            prob = cp.Problem(cp.Minimize(cp.sum_squares(cp.diag(x, k) - target)))
+            prob.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+            self.assertItemsAlmostEqual(x.value, np.diag(A, k), places=4)
+
+            X = cp.Variable((n, n))
+            prob = cp.Problem(cp.Minimize(cp.sum_squares(X)),
+                              [cp.diag(X, k) == np.diag(A, k)])
+            prob.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+            self.assertItemsAlmostEqual(np.diag(X.value, k), np.diag(A, k), places=4)
+
+    def test_matmul_chain_const_tail_matches_default(self) -> None:
+        """Matmul-chain reassociation must be value-preserving, not just
+        solvable: each case solves on both paths and must match."""
+        rng = np.random.default_rng(0)
+        A = rng.standard_normal((3, 4))
+        C_sq = rng.standard_normal((4, 4))
+        C2 = rng.standard_normal((3, 2))
+        c_vec = rng.standard_normal(3)
+        c_vec4 = rng.standard_normal(4)
+        X = cp.Variable((4, 3))
+        T_mat = rng.standard_normal((3, 2))
+        T_vec = rng.standard_normal(4)
+
+        cases = [
+            A @ X @ C2,                    # (A @ X) @ C2: matmul recursion
+            (X + C_sq @ X) @ c_vec,        # AddExpression with a vector tail
+            (-X) @ c_vec,                  # NegExpression push-through
+            X.T @ C_sq @ c_vec4,           # (E @ C) @ c: constants fold together
+        ]
+        targets = [T_mat, T_vec, T_vec, rng.standard_normal(3)]
+        for expr, target in zip(cases, targets):
+            objective = cp.Minimize(cp.sum_squares(expr - target) + cp.sum_squares(X))
+            prob_de = cp.Problem(objective)
+            prob_de.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+            self.assertEqual(prob_de.status, cp.OPTIMAL)
+            X_de = np.array(X.value)
+
+            prob_base = cp.Problem(objective)
+            prob_base.solve(solver=SOLVER)
+            self.assertEqual(prob_base.status, cp.OPTIMAL)
+            self.assertAlmostEqual(prob_de.value, prob_base.value, places=4)
+            self.assertItemsAlmostEqual(X_de, X.value, places=3)
+
+    def test_quad_objective_data_matches_cpp(self) -> None:
+        """The extractor's Hessian path must produce the same stuffed
+        (P, q, A) as the default CPP backend."""
+        P0 = np.array([[4.0, 1.0, 0.0], [1.0, 3.0, 1.0], [0.0, 1.0, 2.0]])
+        q0 = np.array([1.0, -2.0, 0.5])
+        x = cp.Variable(3)
+        prob = cp.Problem(cp.Minimize(cp.quad_form(x, P0) + q0 @ x), [x >= -1])
+
+        data_de, _, _ = prob.get_problem_data(cp.OSQP, canon_backend=DIFFENGINE)
+        data_cpp, _, _ = prob.get_problem_data(cp.OSQP)
+        for key in data_cpp:
+            expected = data_cpp[key]
+            if sp.issparse(expected):
+                self.assertItemsAlmostEqual(
+                    data_de[key].toarray(), expected.toarray(), places=10)
+            elif isinstance(expected, np.ndarray):
+                self.assertItemsAlmostEqual(data_de[key], expected, places=10)
+
+
+class TestDiffengineConeProgram(BaseTest):
+    """DiffengineConeProgram re-solve semantics."""
+
+    def test_apply_parameters_explicit_dict(self) -> None:
+        """The id_to_param_value branch must behave exactly like setting
+        Parameter.value."""
+        p = cp.Parameter(2)
+        p.value = np.array([1.0, 2.0])
+        x = cp.Variable(2)
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(x - p)), [x >= 0])
+
+        chain = prob._construct_chain(solver=SOLVER, canon_backend=DIFFENGINE)
+        program = prob
+        for reduction in chain.reductions[:-1]:
+            program, _ = reduction.apply(program)
+        self.assertIsInstance(program, DiffengineConeProgram)
+
+        new_val = np.array([5.0, 7.0])
+        from_dict = program.apply_parameters(
+            id_to_param_value={p.id: new_val}, quad_obj=True)
+        p.value = new_val
+        from_value = program.apply_parameters(quad_obj=True)
+        for got, want in zip(from_dict, from_value):
+            if sp.issparse(want):
+                self.assertItemsAlmostEqual(got.toarray(), want.toarray(), places=10)
+            else:
+                self.assertItemsAlmostEqual(got, want, places=10)
+
+    def test_parametric_soc_restruct_resolve_and_duals(self) -> None:
+        """The SOC restructuring matrix must be re-applied to freshly
+        extracted (A, b) on re-solves; duals must match the default path."""
+        c = np.array([1.0, 2.0])
+        p = cp.Parameter(2)
+        x = cp.Variable(2)
+        constraints = [cp.norm(x - p) <= 2.0, x >= -5]
+        prob = cp.Problem(cp.Minimize(c @ x), constraints)
+
+        for val in (np.array([1.0, 1.0]), np.array([-2.0, 3.0])):
+            p.value = val
+            prob.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+            self.assertEqual(prob.status, cp.OPTIMAL)
+
+            x_base = cp.Variable(2)
+            base_cons = [cp.norm(x_base - val) <= 2.0, x_base >= -5]
+            base = cp.Problem(cp.Minimize(c @ x_base), base_cons)
+            base.solve(solver=SOLVER)
+            self.assertAlmostEqual(prob.value, base.value, places=4)
+            self.assertItemsAlmostEqual(x.value, x_base.value, places=4)
+            for con_de, con_base in zip(constraints, base_cons):
+                self.assertItemsAlmostEqual(
+                    con_de.dual_value, con_base.dual_value, places=4)
+
+    def test_parametric_psd_restruct_resolve(self) -> None:
+        """PSD constraints exercise the symmetric restructuring across
+        parametric re-solves."""
+        P = cp.Parameter((2, 2), symmetric=True)
+        X = cp.Variable((2, 2), symmetric=True)
+        prob = cp.Problem(cp.Minimize(cp.trace(P @ X)),
+                          [X >> np.eye(2), cp.trace(X) <= 5])
+
+        for seed in (0, 3):
+            rng = np.random.default_rng(seed)
+            M = rng.standard_normal((2, 2))
+            P_val = M @ M.T + np.eye(2)
+            P.value = P_val
+            prob.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+            self.assertEqual(prob.status, cp.OPTIMAL)
+
+            X_base = cp.Variable((2, 2), symmetric=True)
+            base = cp.Problem(cp.Minimize(cp.trace(P_val @ X_base)),
+                              [X_base >> np.eye(2), cp.trace(X_base) <= 5])
+            base.solve(solver=SOLVER)
+            self.assertAlmostEqual(prob.value, base.value, places=3)
+
+    @unittest.skipUnless(INSTALLED_MI_SOLVERS, "no mixed-integer solver installed")
+    def test_mixed_integer(self) -> None:
+        x = cp.Variable(3, integer=True)
+        prob = cp.Problem(cp.Minimize(cp.sum(x)), [x >= 0.5, x <= 3.7])
+        prob.solve(canon_backend=DIFFENGINE)
+        self.assertEqual(prob.status, cp.OPTIMAL)
+        self.assertItemsAlmostEqual(x.value, np.ones(3), places=4)
+
+
+class TestDiffengineSelection(BaseTest):
+    """canon_backend='DIFFENGINE' is user-selectable, explicitly or via
+    CVXPY_DEFAULT_CANON_BACKEND."""
+
+    def _stuffing_backend(self, chain) -> str:
+        stuffing = [r for r in chain.reductions
+                    if isinstance(r, ConeMatrixStuffing)][0]
+        return stuffing.canon_backend
+
+    def test_explicit_diffengine_param_free(self) -> None:
+        x = cp.Variable(3)
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(x - 1)), [x >= 0])
+        prob.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+        self.assertEqual(self._stuffing_backend(prob._cache.solving_chain),
+                         DIFFENGINE)
+        self.assertIsInstance(prob._cache.param_prog, DiffengineConeProgram)
+        self.assertAlmostEqual(prob.value, 0.0)
+        self.assertItemsAlmostEqual(x.value, np.ones(3), places=4)
+
+    def test_explicit_diffengine_dpp_parametric_resolve(self) -> None:
+        """On the DPP path the DiffengineConeProgram is cached across solves;
+        parameter updates must flow through the cached extractor."""
+        A = cp.Parameter((2, 2))
+        b = cp.Parameter(2)
+        x = cp.Variable(2)
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(A @ x - b)), [x >= -10])
+        self.assertTrue(prob.is_dpp())
+
+        A.value = np.eye(2)
+        b.value = np.array([1.0, 2.0])
+        prob.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+        self.assertIsInstance(prob._cache.param_prog, DiffengineConeProgram)
+        cached_prog = prob._cache.param_prog
+        self.assertItemsAlmostEqual(x.value, np.array([1.0, 2.0]), places=4)
+
+        A.value = 2.0 * np.eye(2)
+        b.value = np.array([2.0, -4.0])
+        prob.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+        self.assertIs(prob._cache.param_prog, cached_prog)  # cached prog reused
+        self.assertItemsAlmostEqual(x.value, np.array([1.0, -2.0]), places=4)
+
+        # Solve again with the SAME values: the cached program must keep
+        # serving the current parameter values.
+        prob.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+        self.assertItemsAlmostEqual(x.value, np.array([1.0, -2.0]), places=4)
+
+    def test_env_var_selects_diffengine_on_dpp_path(self) -> None:
+        """CVXPY_DEFAULT_CANON_BACKEND=DIFFENGINE routes DPP solves through
+        the diff engine, with program caching."""
+        with mock.patch.dict(
+                os.environ,
+                {"CVXPY_DEFAULT_CANON_BACKEND": DIFFENGINE}):
+            p = cp.Parameter(2)
+            x = cp.Variable(2)
+            prob = cp.Problem(cp.Minimize(cp.sum_squares(x - p)))
+            self.assertTrue(prob.is_dpp())
+
+            p.value = np.array([1.0, 2.0])
+            prob.solve(solver=SOLVER)
+            self.assertEqual(self._stuffing_backend(prob._cache.solving_chain),
+                             DIFFENGINE)
+            self.assertIsInstance(prob._cache.param_prog, DiffengineConeProgram)
+            self.assertItemsAlmostEqual(x.value, p.value, places=4)
+
+            p.value = np.array([-1.0, 3.0])
+            prob.solve(solver=SOLVER)
+            self.assertItemsAlmostEqual(x.value, p.value, places=4)
+
+            # An explicit user backend still wins over the env default.
+            prob2 = cp.Problem(cp.Minimize(cp.sum_squares(x - 1)))
+            _, chain, _ = prob2.get_problem_data(
+                SOLVER, canon_backend=s.SCIPY_CANON_BACKEND)
+            self.assertNotEqual(self._stuffing_backend(chain), DIFFENGINE)
+
+    def test_nd_problem_explicit_diffengine_raises(self) -> None:
+        x = cp.Variable((2, 2, 2))
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(x)))
+        with self.assertRaisesRegex(ValueError, "dimension greater than 2"):
+            prob.solve(solver=SOLVER, canon_backend=DIFFENGINE)

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -5,6 +5,7 @@ import pytest
 
 import cvxpy as cp
 import cvxpy.error as error
+import cvxpy.settings as s
 from cvxpy.tests.base_test import BaseTest
 
 SOLVER = cp.CLARABEL
@@ -142,7 +143,7 @@ class TestDcp(BaseTest):
         x.value = 3
         self.assertAlmostEqual(problem.solve(cp.SCS), 6)
 
-    def test_chain_data_for_non_dpp_problem_evals_params(self) -> None:
+    def test_chain_data_for_non_dpp_problem_keeps_params_symbolic(self) -> None:
         x = cp.Parameter()
         x.value = 5
         y = cp.Variable()
@@ -151,17 +152,18 @@ class TestDcp(BaseTest):
             warnings.simplefilter('ignore')
             _, chain, _ = problem.get_problem_data(cp.SCS)
         self.assertFalse(problem.is_dpp())
-        self.assertTrue(cp.reductions.eval_params.EvalParams in
-                        [type(r) for r in chain.reductions])
+        stuffing = [r for r in chain.reductions
+                    if isinstance(r, cp.reductions.ConeMatrixStuffing)][0]
+        self.assertEqual(stuffing.canon_backend, s.DIFFENGINE_CANON_BACKEND)
 
-    def test_chain_data_for_dpp_problem_does_not_eval_params(self) -> None:
+    def test_chain_data_for_dpp_problem_is_pure(self) -> None:
         x = cp.Parameter()
         x.value = 5
         y = cp.Variable()
         problem = cp.Problem(cp.Minimize(x + y), [x == y])
         _, chain, _ = problem.get_problem_data(cp.SCS)
-        self.assertFalse(cp.reductions.eval_params.EvalParams
-                         in [type(r) for r in chain.reductions])
+        self.assertNotIn('EvalParams',
+                         [type(r).__name__ for r in chain.reductions])
 
     def test_paper_example_logreg_is_dpp(self) -> None:
         N, n = 3, 2
@@ -370,10 +372,11 @@ class TestDcp(BaseTest):
         self.assertEqual(solver_name, cp.SCS)
 
     def test_log_det_with_parameter_ignore_dpp(self) -> None:
-        """Test log_det with parameter works with ignore_dpp=True.
+        """log_det(P) is not baked to a number with ignore_dpp=True.
 
-        With ignore_dpp=True, EvalParams runs first and evaluates log_det(P)
-        to a constant, so the problem becomes a true QP that OSQP can handle.
+        The variable-free composite folds to a CallbackParam leaf
+        (see CallbackParamFold), so its value tracks the current P.value
+        on every solve instead of freezing at compile time.
         """
         n = 2
         x = cp.Variable(n, nonneg=True)
@@ -384,17 +387,111 @@ class TestDcp(BaseTest):
         objective = cp.sum_squares(x + y) - 2 * cp.log_det(P)
         problem = cp.Problem(cp.Minimize(objective))
 
-        # With ignore_dpp=True, should route to QP solver (EvalParams runs first)
-        problem.solve(solver=cp.OSQP, ignore_dpp=True)
+        problem.solve(solver=cp.CLARABEL, ignore_dpp=True)
         self.assertEqual(problem.status, cp.OPTIMAL)
         self.assertAlmostEqual(problem.value, 0.0, places=4)
-        np.testing.assert_array_almost_equal(x.value, np.zeros(n), decimal=4)
-        np.testing.assert_array_almost_equal(y.value, np.zeros(n), decimal=4)
 
-        # Verify EvalParams is in the chain
-        _, chain, _ = problem.get_problem_data(cp.OSQP, ignore_dpp=True)
-        reduction_types = [type(r).__name__ for r in chain.reductions]
-        self.assertIn('EvalParams', reduction_types)
+        # Re-solve with a new P: the program must serve fresh values.
+        P.value = 2 * np.eye(n)
+        problem.solve(solver=cp.CLARABEL, ignore_dpp=True)
+        self.assertAlmostEqual(problem.value, -2 * np.log(4.0), places=4)
+
+    def test_log_det_with_parameter_ignore_dpp_qp_solver_raises(self) -> None:
+        """log_det(P) emits cones even under ignore_dpp, so a QP solver
+        refuses the problem; the remedy is evaluating the term numerically."""
+        n = 2
+        x = cp.Variable(n, nonneg=True)
+        y = cp.Variable(n, nonneg=True)
+        P = cp.Parameter((n, n))
+        P.value = np.eye(n)
+
+        problem = cp.Problem(
+            cp.Minimize(cp.sum_squares(x + y) - 2 * cp.log_det(P)))
+        with self.assertRaises(error.SolverError):
+            problem.solve(solver=cp.OSQP, ignore_dpp=True)
+
+        # The remedy: compute the log-det term yourself.
+        log_det_val = np.linalg.slogdet(P.value)[1]
+        qp = cp.Problem(
+            cp.Minimize(cp.sum_squares(x + y) - 2 * log_det_val))
+        qp.solve(solver=cp.OSQP, ignore_dpp=True)
+        self.assertEqual(qp.status, cp.OPTIMAL)
+        self.assertAlmostEqual(qp.value, 0.0, places=4)
+
+    def test_ignore_dpp_keeps_variable_coupled_param_symbolic(self) -> None:
+        """With ignore_dpp, a variable-coupled parameter stays symbolic and the
+        DIFFENGINE backend re-evaluates it across solves.
+
+        ``A`` appears in ``A @ x`` (variable-coupled) and stays symbolic.
+        Changing ``A.value`` between solves must change the solution,
+        confirming the diff engine re-evaluates the tree.
+        """
+        A = cp.Parameter((2, 2))
+        x = cp.Variable(2)
+        b = np.array([1.0, 1.0])
+        problem = cp.Problem(cp.Minimize(cp.sum_squares(A @ x - b)))
+
+        A.value = np.eye(2)
+        problem.solve(solver=cp.CLARABEL, ignore_dpp=True)
+        self.assertEqual(problem.status, cp.OPTIMAL)
+        np.testing.assert_array_almost_equal(x.value, np.array([1.0, 1.0]), decimal=4)
+
+        # The DIFFENGINE backend is used and parameters stay symbolic.
+        _, chain, _ = problem.get_problem_data(cp.CLARABEL, ignore_dpp=True)
+        stuffing = [r for r in chain.reductions
+                    if type(r).__name__ == 'ConeMatrixStuffing'][0]
+        self.assertEqual(stuffing.canon_backend, s.DIFFENGINE_CANON_BACKEND)
+
+        # Re-solve with a new A; the program must serve fresh values.
+        A.value = 2.0 * np.eye(2)
+        problem.solve(solver=cp.CLARABEL, ignore_dpp=True)
+        np.testing.assert_array_almost_equal(x.value, np.array([0.5, 0.5]), decimal=4)
+
+    def test_composite_param_in_constraint_refreshes(self) -> None:
+        """A variable-free composite inside a constraint (norm(p)) stays
+        symbolic: it emits an SOC cone, so a conic solver is required, and its
+        value must refresh on re-solves.
+        """
+        p = cp.Parameter(3)
+        x = cp.Variable()
+        problem = cp.Problem(cp.Minimize(cp.square(x)), [x >= cp.norm(p)])
+
+        p.value = np.array([3.0, 0.0, 4.0])
+        problem.solve(solver=cp.CLARABEL, ignore_dpp=True)
+        self.assertEqual(problem.status, cp.OPTIMAL)
+        self.assertAlmostEqual(x.value, 5.0, places=4)
+
+        p.value = np.array([0.0, 0.0, 0.5])
+        problem.solve(solver=cp.CLARABEL, ignore_dpp=True)
+        self.assertAlmostEqual(x.value, 0.5, places=4)
+
+        # norm(p) emits SOC even under ignore_dpp; OSQP has no cones.
+        with self.assertRaises(error.SolverError):
+            problem.solve(solver=cp.OSQP, ignore_dpp=True)
+
+    def test_mixed_subtree_stays_symbolic(self) -> None:
+        """One expression tree with both cases: ``p * x`` (variable-coupled)
+        and ``p + 1`` (variable-free composite). Both stay symbolic and must
+        track the current parameter value across re-solves: x* = (p + 1) / p.
+        """
+        p = cp.Parameter()
+        x = cp.Variable()
+        problem = cp.Problem(cp.Minimize(cp.square(p * x - (p + 1.0))))
+
+        for val in (1.0, 2.0):
+            p.value = val
+            problem.solve(solver=cp.CLARABEL, ignore_dpp=True)
+            self.assertEqual(problem.status, cp.OPTIMAL)
+            self.assertAlmostEqual(x.value, (val + 1.0) / val, places=4)
+
+    def test_unspecified_param_in_composite_raises(self) -> None:
+        """solve() rejects unset parameters up front (before compilation), so
+        nothing downstream ever sees a None value."""
+        p = cp.Parameter(2)  # no value assigned
+        x = cp.Variable()
+        problem = cp.Problem(cp.Minimize(cp.square(x) + cp.norm(p)))
+        with self.assertRaises(error.ParameterError):
+            problem.solve(solver=cp.CLARABEL, ignore_dpp=True)
 
 
 class TestDgp(BaseTest):

--- a/cvxpy/tests/test_einsum.py
+++ b/cvxpy/tests/test_einsum.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import unittest
+import warnings
 
 import numpy as np
 
@@ -240,7 +241,8 @@ class TestEinsum(BaseTest):
         self.assertEqual(problem4.status, cp.OPTIMAL)
         self.assertItemsAlmostEqual(result4, expected_result4)
 
-        # Test einsum with 4 arguments
+        # Test einsum with 4 arguments (two multiplied parameters -> non-DPP;
+        # the >2-D fallback bakes them via EvalParams)
         expr5 = cp.einsum('ii,ijk,j,lil->ijl', A, B, C, D)
         problem5 = cp.Problem(cp.Minimize(cp.sum(expr5)), [A == self.A_np])
         problem5.solve()
@@ -273,6 +275,27 @@ class TestEinsum(BaseTest):
         )
         self.assertEqual(problem7.status, cp.OPTIMAL)
         self.assertItemsAlmostEqual(result7, expected_result7)
+
+    def test_einsum_ignore_dpp_avoids_diffengine(self) -> None:
+        """einsum is >2-D, so ignore_dpp must not route to the (2-D-only)
+        DIFFENGINE backend; it bakes parameters and uses the tensor backends."""
+        import cvxpy.settings as s
+        from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
+
+        D_var = cp.Variable(self.D_np.shape)
+        p = cp.Parameter(value=2.0)
+        expr = cp.einsum('iji->i', D_var)
+        problem = cp.Problem(cp.Minimize(p * cp.sum(expr)), [D_var == self.D_np])
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')  # N-D -> SCIPY fallback warning
+            problem.solve(ignore_dpp=True)
+        self.assertEqual(problem.status, cp.OPTIMAL)
+        self.assertItemsAlmostEqual(expr.value, np.einsum('iji->i', self.D_np))
+        backend = next(r.canon_backend
+                       for r in problem._cache.solving_chain.reductions
+                       if isinstance(r, ConeMatrixStuffing))
+        self.assertNotEqual(backend, s.DIFFENGINE_CANON_BACKEND)
+
 
 class TestEinsumDGP(BaseTest):
     """Unit tests for the DGP functionality of the einsum atom."""

--- a/cvxpy/tests/test_fold_callback_params.py
+++ b/cvxpy/tests/test_fold_callback_params.py
@@ -1,0 +1,84 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import numpy as np
+
+import cvxpy as cp
+from cvxpy.expressions.constants.callback_param import CallbackParam
+from cvxpy.reductions.fold_callback_params import CallbackParamFold, _fold_expr
+from cvxpy.tests.base_test import BaseTest
+
+
+class TestCallbackParamFold(BaseTest):
+    """The fold replaces exactly the non-affine variable-free parametric
+    subtrees, at their maximal (outermost) node, with refreshable
+    CallbackParam leaves."""
+
+    def test_non_affine_subtree_folds_and_refreshes(self) -> None:
+        t = cp.Parameter()
+        folded = _fold_expr(cp.power(t, 2))
+        self.assertIsInstance(folded, CallbackParam)
+        for val in (2.0, -3.0):
+            t.value = val
+            self.assertAlmostEqual(float(folded.value), val ** 2)
+
+    def test_maximal_subtree_single_leaf(self) -> None:
+        """The whole variable-free composite folds as ONE leaf, not one per
+        nested non-affine node."""
+        t = cp.Parameter(pos=True)
+        expr = cp.exp(cp.square(t) + 1.0)
+        folded = _fold_expr(expr)
+        self.assertIsInstance(folded, CallbackParam)
+        t.value = 2.0
+        self.assertAlmostEqual(float(folded.value), np.exp(5.0))
+
+    def test_affine_and_leaf_subtrees_stay_symbolic(self) -> None:
+        p = cp.Parameter(2)
+        self.assertIs(_fold_expr(p), p)
+        affine = 2.0 * p + np.ones(2)
+        self.assertIs(_fold_expr(affine), affine)
+
+    def test_variable_branches_untouched_identity_preserved(self) -> None:
+        """Folding descends past variables; an expression with nothing to
+        fold is returned as the SAME object (cache-key stability)."""
+        t = cp.Parameter()
+        x = cp.Variable()
+        expr = x + cp.square(t)
+        folded = _fold_expr(expr)
+        self.assertIsNot(folded, expr)
+        self.assertIsInstance(folded.args[1], CallbackParam)
+
+        no_params = x + cp.square(cp.Constant(2.0))
+        self.assertIs(_fold_expr(no_params), no_params)
+
+    def test_sign_is_propagated(self) -> None:
+        t = cp.Parameter()
+        folded = _fold_expr(cp.square(t))
+        self.assertTrue(folded.is_nonneg())
+        folded_neg = _fold_expr(-cp.square(t))
+        self.assertTrue(folded_neg.is_nonpos())
+
+    def test_problem_apply_rebuilds_constraints(self) -> None:
+        t = cp.Parameter()
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(-x), [x <= cp.power(t, 2)])
+        new_prob, _ = CallbackParamFold().apply(prob)
+        (con,) = new_prob.constraints
+        params = new_prob.parameters()
+        self.assertEqual(len(params), 1)
+        self.assertIsInstance(params[0], CallbackParam)
+        t.value = 3.0
+        self.assertAlmostEqual(float(con.args[1].value), 9.0)

--- a/cvxpy/tests/test_ignore_dpp.py
+++ b/cvxpy/tests/test_ignore_dpp.py
@@ -1,0 +1,194 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+import warnings
+from unittest import mock
+
+import numpy as np
+import pytest
+
+import cvxpy as cp
+import cvxpy.settings as s
+from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
+from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS
+from cvxpy.tests.base_test import BaseTest
+from cvxpy.tests.test_diffengine_backend import MISSING
+
+pytestmark = pytest.mark.skipif(
+    bool(MISSING),
+    reason="DIFFENGINE backend requires sparsediffpy >= 0.6.0 "
+           f"(missing: {', '.join(MISSING)})",
+)
+
+SOLVER = cp.CLARABEL
+
+
+class TestIgnoreDppBehavior(BaseTest):
+    """ignore_dpp / non-DPP solves keep parameters symbolic on the DIFFENGINE
+    backend; values must refresh across solves and unsound canonicalizations
+    must not happen."""
+
+    def test_parametric_divisor_resolves(self) -> None:
+        """A parametric divisor is re-evaluated by the engine on each solve."""
+        p = cp.Parameter(pos=True)
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(cp.square(x / p - 1.0)))
+        for val in (2.0, 5.0):
+            p.value = val
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertEqual(prob.status, cp.OPTIMAL)
+            self.assertAlmostEqual(x.value, val, places=4)
+
+        pv = cp.Parameter(3, pos=True)
+        xv = cp.Variable(3)
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(xv / pv - 1.0)))
+        for val in (np.array([1.0, 2.0, 4.0]), np.array([3.0, 0.5, 1.5])):
+            pv.value = val
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertEqual(prob.status, cp.OPTIMAL)
+            self.assertItemsAlmostEqual(xv.value, val, places=4)
+
+    def test_param_constant_in_concave_position_sound(self) -> None:
+        """A parametric-constant composite on the 'wrong' side of an
+        inequality must not be epigraph-relaxed: x <= power(t, 2) would
+        relax to x <= s, s >= t**2 (vacuous). It folds to a CallbackParam
+        leaf before canonicalization and refreshes on each solve."""
+        t = cp.Parameter()
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(-x), [x <= cp.power(t, 2)])
+        for val in (2.0, 3.0):
+            t.value = val
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertEqual(prob.status, cp.OPTIMAL)
+            self.assertAlmostEqual(x.value, val ** 2, places=4)
+
+    def test_unsupported_variable_free_atom_evaluates(self) -> None:
+        """An atom with no symbolic converter over parameters only (floor,
+        as emitted by DQCP bisection) folds to a CallbackParam leaf whose
+        value refreshes per solve."""
+        p = cp.Parameter()
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(cp.square(x - cp.floor(p))))
+        for val in (2.7, -1.2):
+            p.value = val
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertAlmostEqual(x.value, np.floor(val), places=4)
+
+    def test_symbolic_quad_matrix_refreshes(self) -> None:
+        """quad_over_lin(x, p) keeps its quadratic matrix symbolic (I/p fed
+        to the engine as a composite param_source); re-solves must serve
+        fresh values."""
+        x = cp.Variable()
+        p = cp.Parameter()
+        prob = cp.Problem(cp.Minimize(cp.quad_over_lin(x, p) + x))
+        for val in (1.0, 1000.0, 1.0):
+            p.value = val
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertAlmostEqual(x.value, -val / 2.0, places=3)
+
+    @unittest.skipUnless(INSTALLED_MI_SOLVERS, "no mixed-integer solver installed")
+    def test_mixed_integer_ignore_dpp(self) -> None:
+        x = cp.Variable(3, integer=True)
+        prob = cp.Problem(cp.Minimize(cp.sum(x)), [x >= 0.5, x <= 3.7])
+        prob.solve(ignore_dpp=True)
+        self.assertEqual(prob.status, cp.OPTIMAL)
+        self.assertItemsAlmostEqual(x.value, np.ones(3), places=4)
+
+
+class TestIgnoreDppSelection(BaseTest):
+    """The ignore_dpp / non-DPP path force-selects the DIFFENGINE backend
+    over any user-supplied backend, with an N-D EvalParams fallback."""
+
+    def _stuffing_backend(self, chain) -> str:
+        stuffing = [r for r in chain.reductions
+                    if isinstance(r, ConeMatrixStuffing)][0]
+        return stuffing.canon_backend
+
+    def test_ignore_dpp_defaults_to_diffengine(self) -> None:
+        p = cp.Parameter()
+        p.value = 2.0
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(cp.square(x - p)))
+        _, chain, _ = prob.get_problem_data(SOLVER, ignore_dpp=True)
+        self.assertEqual(self._stuffing_backend(chain), s.DIFFENGINE_CANON_BACKEND)
+        prob.solve(solver=SOLVER, ignore_dpp=True)
+        self.assertAlmostEqual(x.value, 2.0)
+
+    def test_explicit_backend_with_params_raises(self) -> None:
+        """A non-DIFFENGINE backend cannot serve the symbolic ignore_dpp path
+        for parametric problems; parameter-free problems honor the request."""
+        p = cp.Parameter()
+        p.value = 2.0
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(cp.square(x - p)))
+
+        for backend in (s.CPP_CANON_BACKEND, s.SCIPY_CANON_BACKEND):
+            with self.assertRaisesRegex(ValueError, "keeps parameters symbolic"):
+                prob.get_problem_data(SOLVER, ignore_dpp=True,
+                                      canon_backend=backend)
+
+        # Parameter-free: ignore_dpp is a no-op, explicit backend honored.
+        # (Fresh problem per backend: the problem-data cache does not key
+        # on canon_backend.)
+        for backend in (s.CPP_CANON_BACKEND, s.SCIPY_CANON_BACKEND):
+            y = cp.Variable(3)
+            prob_free = cp.Problem(cp.Minimize(cp.sum_squares(y - 1)), [y >= 0])
+            _, chain, _ = prob_free.get_problem_data(SOLVER, ignore_dpp=True,
+                                                     canon_backend=backend)
+            self.assertEqual(self._stuffing_backend(chain), backend)
+            prob_free.solve(solver=SOLVER, ignore_dpp=True, canon_backend=backend)
+            self.assertAlmostEqual(prob_free.value, 0.0)
+
+    def test_env_var_does_not_override_ignore_dpp(self) -> None:
+        with mock.patch.dict(
+                os.environ,
+                {"CVXPY_DEFAULT_CANON_BACKEND": s.SCIPY_CANON_BACKEND}):
+            p = cp.Parameter()
+            p.value = 3.0
+            x = cp.Variable()
+            prob = cp.Problem(cp.Minimize(cp.square(x - p)))
+            _, chain, _ = prob.get_problem_data(SOLVER, ignore_dpp=True)
+            self.assertEqual(self._stuffing_backend(chain),
+                             s.DIFFENGINE_CANON_BACKEND)
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertAlmostEqual(x.value, 3.0)
+
+    def test_nd_problem_falls_back_like_cpp(self) -> None:
+        """>2-D problems cannot use the (2-D) diff engine: the ignore_dpp path
+        bakes parameters (EvalParams) like the CPP -> SCIPY N-D fallback, and
+        the baked values must still refresh across solves."""
+        p = cp.Parameter()
+        x = cp.Variable((2, 2, 2))
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(x - p)))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # N-D -> SCIPY fallback warning
+            p.value = 1.0
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertNotEqual(
+                self._stuffing_backend(prob._cache.solving_chain),
+                s.DIFFENGINE_CANON_BACKEND)
+            reduction_names = [type(r).__name__
+                               for r in prob._cache.solving_chain.reductions]
+            self.assertIn('EvalParams', reduction_names)
+            self.assertItemsAlmostEqual(x.value, np.full((2, 2, 2), 1.0), places=4)
+
+            p.value = -2.0
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertItemsAlmostEqual(x.value, np.full((2, 2, 2), -2.0), places=4)

--- a/cvxpy/tests/test_parametric_bounds.py
+++ b/cvxpy/tests/test_parametric_bounds.py
@@ -5,7 +5,6 @@ import pytest
 
 import cvxpy as cp
 import cvxpy.error as error
-import cvxpy.reductions.eval_params
 
 SOLVER = cp.CLARABEL
 BOUNDED_SOLVERS = ["HIGHS", "DAQP"]
@@ -224,8 +223,8 @@ class TestParametricBoundsDPP:
         _, _, _, prob = self._make_prob()
         assert prob.is_dpp()
         _, chain, _ = prob.get_problem_data(SOLVER)
-        reduction_types = [type(r) for r in chain.reductions]
-        assert cvxpy.reductions.eval_params.EvalParams not in reduction_types
+        reduction_names = [type(r).__name__ for r in chain.reductions]
+        assert 'EvalParams' not in reduction_names
 
     def test_get_problem_data_without_param_values(self):
         _, _, _, prob = self._make_prob()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dependencies = [
     # triangle (which highs_qpif.py passes). See test_highs_dense_quad_form.
     "highspy >= 1.14.0",
     "qdldl >= 0.1.7.post0",
-    "sparsediffpy >= 0.6.0",
+    "sparsediffpy >= 0.6.1",
 ]
 requires-python = ">=3.11"
 urls = {Homepage = "https://github.com/cvxpy/cvxpy"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dependencies = [
     # triangle (which highs_qpif.py passes). See test_highs_dense_quad_form.
     "highspy >= 1.14.0",
     "qdldl >= 0.1.7.post0",
-    "sparsediffpy >= 0.5.0, < 0.6.0",
+    "sparsediffpy >= 0.6.0",
 ]
 requires-python = ">=3.11"
 urls = {Homepage = "https://github.com/cvxpy/cvxpy"}


### PR DESCRIPTION
## Description

Supersedes and consolidates #3484 and #3450 (both can be closed in favour of this).

Staging this as three PRs did not survive contact with the code. #3449 defaulted to DIFFENGINE on the `ignore_dpp` / non-DPP branch *because* `EvalParams` substitutes the parameter values, leaving stuffing parameter-free — and #3484 then removed `EvalParams` from exactly that path, demoting the case to a fallback and inverting #3449's own assertions (`test_complex_dpp.py` went from `assert EvalParams in reduction_types` to `assert EvalParams not in`). #3484 in turn delivered nothing measurable on its own, since it left the program uncached. Measured mean compile time per re-solve on a non-DPP parametric problem (`(p*p)*sum(x)` plus a 400×250 least-squares term):

| stage | first compile | re-solve compile | cached |
|---|---|---|---|
| master | 19.1 ms | 12.4 ms | no |
| #3449 alone | 18.5 ms | 10.4 ms | no |
| #3484 alone | 24.2 ms | 9.4 ms | no |
| this PR | 21.3 ms | **3.2 ms** | yes |

On this route parameters now stay symbolic through canonicalization, and stuffing returns a `DiffengineParamConeProg` that re-extracts `(q, d, A, b, P)` at the current values — so a re-solve costs one engine extraction instead of a full chain rebuild.

**Routing** (unchanged elsewhere):

| condition | backend | parameters |
|---|---|---|
| explicit `canon_backend` | as requested | symbolic if DIFFENGINE |
| `ignore_dpp` / non-DPP, parametric, eligible | DIFFENGINE | symbolic, program cached |
| `ignore_dpp` / non-DPP, parameter-free or ineligible | `EvalParams` + DIFFENGINE / tensor | n/a |
| parametric + DPP | CPP, or COO above `DPP_PARAM_THRESHOLD` | tensor |

### Two regressions fixed

Both were present in the staged PRs and are fixed here, each pinned by a test that fails if the guard is removed.

**Unsupported atoms hard-failed.** Auto-selected DIFFENGINE raised on atoms with no converter, so a non-DPP problem using `cp.concatenate` or `cp.diag(x, k != 0)`
failed where master solves — including when the user passed no flags at all. A `_supports_diffengine()` capability check, mirroring the existing
`_supports_cpp()` pattern, keeps those on the tensor backends; an eFFENGINE"` still fails loudly.

| | before | now |
|---|---|---|
| `concatenate`, non-DPP, no flags | `NotImplementedError` | 24.000
| `diag(x, 1)`, non-DPP, no flags | `NotImplementedError` | 15.0000 (= master) |

**Cached programs served stale numbers.** `safe_to_cache` stopped asking whether `EvalParams` was in the chain and started reading a flag derived from
`problem.parameters()`. But `perspective` keeps its function in `exgs`, so its parameters are invisible there, while `perspective_canon`
freezes their current values into numeric cone data. A cached re-solve then returned a wrong answer with no error: `2.499988` where the truth is `1.211103`.
Caching is now disabled by inspecting the atom directly, which alsoecond, visible parameter puts the problem on the symbolic route
(where there is no `EvalParams` to detect).

### Cleanups

- `ConicSolver.format_constraints`' block-diagonal restructuring matrix is now a module-level `build_restruct_blocks()`, with `build_restruct_mat_sparse()`
materializing the sign-only `IdentityOperator` / `NegativeIdentityOneConeFormat` calls it directly instead of recovering R by pushing a
stub `[I_m | 0]` program through `format_constraints`, which also stops routing an `m(m+1)`-row probe tensor through the reshape path. No solver interface is
affected — nothing overrides `format_constraints`, and its `cls` was unused.
- The five getter/setter pairs deferring `encode_cone_tensors` collapse into one `_lazy_tensor` descriptor. The deferral stays: eager re-encoding measures at ~2×
the cost of the re-extraction it accompanies (n=250: 2.38 ms vs 1.2.7 ms), which would erase most of what caching saves.

Issue link (if applicable): #2205, #1132

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce