### PR TITLE
Add regression tests: composed parametric coefficients refresh across re-solves

### DIFF
--- a/cvxpy/tests/nlp_tests/test_nlp_parameters.py
+++ b/cvxpy/tests/nlp_tests/test_nlp_parameters.py
@@ -460,3 +460,54 @@ class TestNlpParameters:
 
         assert np.allclose(param_sol1, hardcoded_sol1)
         assert np.allclose(param_sol2, hardcoded_sol2)
+
+
+@pytest.mark.skipif('IPOPT' not in INSTALLED_SOLVERS, reason='IPOPT is not installed.')
+class TestComposedParametricRefreshNlp:
+    """Cached NLP oracles must serve fresh values when a composed parameter
+    expression scales a coefficient (see TestComposedParametricRefresh in
+    tests/test_dpp.py for the conic-path counterparts).
+
+    The NLP path caches the compiled diff-engine problem across solves and
+    pushes new parameter values into it, so these tests exercise the engine's
+    composite param_source refresh. They fail against sparsediffpy releases
+    that predate the refresh fix (SparseDiffEngine#107): the re-solve then
+    optimizes the problem frozen at the first parameter value.
+    """
+
+    XFAIL_REASON = (
+        "composed parametric coefficients go stale on cached NLP re-solves "
+        "with sparsediffpy <= 0.6.0; fixed by SparseDiffEngine#107 — drop "
+        "this marker once the pinned release contains it"
+    )
+
+    @pytest.mark.xfail(reason=XFAIL_REASON, strict=False)
+    def test_composed_matrix_coefficient_resolve(self):
+        """min ||(p*A) @ x - 1||^2: the optimum x = (pA)^{-1} 1 tracks p."""
+        A = np.array([[1.0, 2.0], [3.0, 4.0]])
+        target = np.ones(2)
+        x = cp.Variable(2)
+        p = cp.Parameter(nonneg=True)
+        prob = cp.Problem(cp.Minimize(cp.sum_squares((p * A) @ x - target)))
+        for val in (1.0, 10.0, 1.0):
+            p.value = val
+            x.value = None
+            prob.solve(nlp=True, solver='IPOPT', verbose=False)
+            expected = np.linalg.solve(val * A, target)
+            np.testing.assert_allclose(x.value, expected, atol=1e-5)
+
+    @pytest.mark.xfail(reason=XFAIL_REASON, strict=False)
+    def test_composed_quad_matrix_resolve(self):
+        """min x'(g*Sigma)x - 2*sum(x): the optimum x = (g*Sigma)^{-1} 1
+        tracks g."""
+        Sigma = np.array([[2.0, 0.0], [0.0, 3.0]])
+        x = cp.Variable(2)
+        g = cp.Parameter(nonneg=True)
+        prob = cp.Problem(cp.Minimize(
+            cp.quad_form(x, g * Sigma, assume_PSD=True) - 2.0 * cp.sum(x)))
+        for val in (1.0, 50.0, 1.0):
+            g.value = val
+            x.value = None
+            prob.solve(nlp=True, solver='IPOPT', verbose=False)
+            expected = np.array([1.0 / (2 * val), 1.0 / (3 * val)])
+            np.testing.assert_allclose(x.value, expected, atol=1e-5)

--- a/cvxpy/tests/nlp_tests/test_nlp_parameters.py
+++ b/cvxpy/tests/nlp_tests/test_nlp_parameters.py
@@ -460,3 +460,44 @@ class TestNlpParameters:
 
         assert np.allclose(param_sol1, hardcoded_sol1)
         assert np.allclose(param_sol2, hardcoded_sol2)
+
+
+@pytest.mark.skipif('IPOPT' not in INSTALLED_SOLVERS, reason='IPOPT is not installed.')
+class TestComposedParametricRefreshNlp:
+    """Cached NLP oracles must serve fresh values when a composed parameter
+    expression scales a coefficient (see TestComposedParametricRefresh in
+    tests/test_dpp.py for the conic-path counterparts).
+
+    The NLP path caches the compiled diff-engine problem across solves and
+    pushes new parameter values into it, so these tests exercise the engine's
+    composite param_source refresh.
+    """
+
+    def test_composed_matrix_coefficient_resolve(self):
+        """min ||(p*A) @ x - 1||^2: the optimum x = (pA)^{-1} 1 tracks p."""
+        A = np.array([[1.0, 2.0], [3.0, 4.0]])
+        target = np.ones(2)
+        x = cp.Variable(2)
+        p = cp.Parameter(nonneg=True)
+        prob = cp.Problem(cp.Minimize(cp.sum_squares((p * A) @ x - target)))
+        for val in (1.0, 10.0, 1.0):
+            p.value = val
+            x.value = None
+            prob.solve(nlp=True, solver='IPOPT', verbose=False)
+            expected = np.linalg.solve(val * A, target)
+            np.testing.assert_allclose(x.value, expected, atol=1e-5)
+
+    def test_composed_quad_matrix_resolve(self):
+        """min x'(g*Sigma)x - 2*sum(x): the optimum x = (g*Sigma)^{-1} 1
+        tracks g."""
+        Sigma = np.array([[2.0, 0.0], [0.0, 3.0]])
+        x = cp.Variable(2)
+        g = cp.Parameter(nonneg=True)
+        prob = cp.Problem(cp.Minimize(
+            cp.quad_form(x, g * Sigma, assume_PSD=True) - 2.0 * cp.sum(x)))
+        for val in (1.0, 50.0, 1.0):
+            g.value = val
+            x.value = None
+            prob.solve(nlp=True, solver='IPOPT', verbose=False)
+            expected = np.array([1.0 / (2 * val), 1.0 / (3 * val)])
+            np.testing.assert_allclose(x.value, expected, atol=1e-5)

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -954,3 +954,61 @@ class TestCallbackParam(BaseTest):
 
         with pytest.raises(NotImplementedError, match="Cannot set the value of a CallbackParam"):
             callback_param.value = 1.0
+
+
+class TestComposedParametricRefresh(BaseTest):
+    """Re-solves must produce fresh problem data when a *composed* parameter
+    expression scales a coefficient matrix.
+
+    Expressions like ``(p * A) @ x`` or ``quad_form(x, g * Sigma)`` reach the
+    canonicalization backend as a parameter expression scaling a constant, and
+    ``quad_over_lin(x, p)`` canonicalizes to a quadratic matrix ``I/p`` derived
+    from the parameter. Whatever a backend caches across solves, reassigning
+    the parameter must be reflected in the next solution.
+
+    The formulations deliberately make the *optimal point* depend on the
+    parameter: the reported objective is recomputed from the live expression
+    at unpack time, so a parameter-invariant argmin would mask stale problem
+    data. Each shape is exercised on the default path and with
+    ``ignore_dpp=True``.
+    """
+
+    def _sweep(self, prob, param, values, check):
+        for kwargs in ({}, {"ignore_dpp": True}):
+            for val in values:
+                param.value = val
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    prob.solve(solver=SOLVER, **kwargs)
+                check(val)
+
+    def test_scaled_matrix_coefficient_refreshes(self) -> None:
+        A = np.array([[1.0, 2.0], [3.0, 4.0]])
+        x = cp.Variable(2)
+        p = cp.Parameter(nonneg=True)
+        prob = cp.Problem(cp.Minimize(cp.sum(x)), [(p * A) @ x >= 1, x >= 0])
+        self._sweep(
+            prob, p, (1.0, 100.0, 1.0),
+            lambda val: self.assertAlmostEqual(prob.value, 0.5 / val, places=4))
+
+    def test_scaled_quad_matrix_refreshes(self) -> None:
+        Sigma = np.array([[2.0, 0.0], [0.0, 3.0]])
+        x = cp.Variable(2)
+        g = cp.Parameter(nonneg=True)
+        prob = cp.Problem(cp.Minimize(
+            cp.quad_form(x, g * Sigma, assume_PSD=True) - 2.0 * cp.sum(x)))
+
+        def check(val):
+            self.assertAlmostEqual(prob.value, -5.0 / (6.0 * val), places=4)
+            self.assertItemsAlmostEqual(
+                x.value, [1.0 / (2 * val), 1.0 / (3 * val)], places=4)
+
+        self._sweep(prob, g, (1.0, 50.0, 1.0), check)
+
+    def test_derived_quad_matrix_refreshes(self) -> None:
+        x = cp.Variable()
+        p = cp.Parameter()
+        prob = cp.Problem(cp.Minimize(cp.quad_over_lin(x, p) + x))
+        self._sweep(
+            prob, p, (1.0, 1000.0, 1.0),
+            lambda val: self.assertAlmostEqual(x.value, -val / 2.0, places=3))

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -954,3 +954,59 @@ class TestCallbackParam(BaseTest):
 
         with pytest.raises(NotImplementedError, match="Cannot set the value of a CallbackParam"):
             callback_param.value = 1.0
+
+
+class TestComposedParametricRefresh(BaseTest):
+    """Re-solves must produce fresh problem data when a *composed* parameter
+    expression scales a coefficient matrix.
+
+    Expressions like ``(p * A) @ x`` or ``quad_form(x, g * Sigma)`` reach the
+    canonicalization backend as a parameter expression scaling a constant, and
+    ``quad_over_lin(x, p)`` canonicalizes to a quadratic matrix ``I/p`` derived
+    from the parameter. Whatever a backend caches across solves, reassigning
+    the parameter must be reflected in the next solution.
+
+    The formulations deliberately make the *optimal point* depend on the
+    parameter: the reported objective is recomputed from the live expression
+    at unpack time, so a parameter-invariant argmin would mask stale problem
+    data. Each shape is exercised on the default path and with
+    ``ignore_dpp=True``.
+    """
+
+    def _sweep(self, prob, param, values, check):
+        for kwargs in ({}, {"ignore_dpp": True}):
+            for val in values:
+                param.value = val
+                prob.solve(solver=SOLVER, **kwargs)
+                check(val)
+
+    def test_scaled_matrix_coefficient_refreshes(self) -> None:
+        A = np.array([[1.0, 2.0], [3.0, 4.0]])
+        x = cp.Variable(2)
+        p = cp.Parameter(nonneg=True)
+        prob = cp.Problem(cp.Minimize(cp.sum(x)), [(p * A) @ x >= 1, x >= 0])
+        self._sweep(
+            prob, p, (1.0, 100.0, 1.0),
+            lambda val: self.assertAlmostEqual(prob.value, 0.5 / val, places=4))
+
+    def test_scaled_quad_matrix_refreshes(self) -> None:
+        Sigma = np.array([[2.0, 0.0], [0.0, 3.0]])
+        x = cp.Variable(2)
+        g = cp.Parameter(nonneg=True)
+        prob = cp.Problem(cp.Minimize(
+            cp.quad_form(x, g * Sigma, assume_PSD=True) - 2.0 * cp.sum(x)))
+
+        def check(val):
+            self.assertAlmostEqual(prob.value, -5.0 / (6.0 * val), places=4)
+            self.assertItemsAlmostEqual(
+                x.value, [1.0 / (2 * val), 1.0 / (3 * val)], places=4)
+
+        self._sweep(prob, g, (1.0, 50.0, 1.0), check)
+
+    def test_derived_quad_matrix_refreshes(self) -> None:
+        x = cp.Variable()
+        p = cp.Parameter()
+        prob = cp.Problem(cp.Minimize(cp.quad_over_lin(x, p) + x))
+        self._sweep(
+            prob, p, (1.0, 1000.0, 1.0),
+            lambda val: self.assertAlmostEqual(x.value, -val / 2.0, places=3))


### PR DESCRIPTION
## Description
Regression tests for a correctness contract that no current test pins: when a **composed parameter expression** scales a coefficient, reassigning the parameter must be reflected in the next solution, whatever the canonicalization backend caches across solves. Three shapes:

- `(p * A) @ x` — a scaled constant matrix as a linear coefficient;
- `quad_form(x, g * Sigma)` — a scaled constant matrix as the quadratic form;
- `quad_over_lin(x, p)` — a quadratic matrix (`I/p`) *derived* from the parameter by canonicalization.

Each is exercised on the default path and with `ignore_dpp=True`, with formulations whose **optimal point depends on the parameter** — the reported objective is recomputed from the live expression at unpack time, so a parameter-invariant argmin would silently mask stale problem data (we learned this the hard way while writing them).

All tests pass on master (58 insertions in `cvxpy/tests/test_dpp.py`, no source changes). Motivation: on the DIFFENGINE backend stack (#3448/#3449/#3450), these exact shapes served **stale values** across cached re-solves with released `sparsediffpy 0.6.0` (e.g. optimum stuck at `0.5` instead of `0.005` after `p: 1 -> 100`); fixed at the engine level in [SparseDiffEngine#107](https://github.com/SparseDifferentiation/SparseDiffEngine/pull/107). These backend-agnostic tests guard the contract for every backend, current and future.

Issue link (if applicable): #3455

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [x] Run the benchmarks to make sure your change doesn't introduce a regression.

(Tests only; no benchmark-relevant code touched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Update — NLP path**: the same contract is *violated on master today* via the DNLP path (`solve(nlp=True)`), which caches the compiled diff-engine problem across solves: with the pinned `sparsediffpy 0.6.0`, the repro in #3455 returns the p=1 optimum after `p -> 10`. This PR therefore also adds NLP-path tests (`tests/nlp_tests/test_nlp_parameters.py`, IPOPT-gated) marked `xfail` with a pointer to [SparseDiffEngine#107](https://github.com/SparseDifferentiation/SparseDiffEngine/pull/107); they xpass on an engine build containing the fix, and the marker should be dropped when the pin moves to a release that includes it. Fixes are engine-side only — no cvxpy source change needed.
