### PR TITLE
docs: use default solver in graphical LASSO example

### DIFF
--- a/doc/source/examples/applications/sparse_covariance_est.rst
+++ b/doc/source/examples/applications/sparse_covariance_est.rst
@@ -95,7 +95,7 @@ Solve for several :math:`\alpha` values
         
         # Form and solve optimization problem.
         prob = cp.Problem(obj, constraints)
-        prob.solve(solver=cp.CVXOPT)
+        prob.solve()
         if prob.status != cp.OPTIMAL:
             raise Exception('CVXPY Error')
     


### PR DESCRIPTION
## Summary

- let CVXPY choose a compatible installed solver in the graphical LASSO example
- remove the obsolete explicit CVXOPT selection

## Why

The example uses cone types that are not supported by the current CVXOPT path. CVXPY's default solver selection chooses a compatible solver while still allowing a better installed solver to be selected automatically.

Closes #2177.

## Validation

- executed the first two RST code blocks: all 3 solves reached `optimal` status using the default SCS solver
- related example tests: 9 passed
- related `log_det` atom tests: 2 passed, 119 deselected
- full Sphinx HTML build: 212 pages generated; remote font fetching was disabled for the offline build and the configuration was restored afterward
- `ruff check cvxpy`
- `pyright`: 0 errors, 0 warnings
- equivalent pinned pre-commit checks, including actionlint
- `git diff --check`

## Disclosure

This contribution was prepared, validated, and submitted by an automated Codex agent using AI assistance. It has not been reviewed by a human acting for this GitHub account. An independent AI review found no blocking issues. The change is intentionally limited to the solver-selection line requested in the issue.
