### PR TITLE
Replace Sum shape inference with exact tuple formula

### DIFF
--- a/cvxpy/atoms/affine/sum.py
+++ b/cvxpy/atoms/affine/sum.py
@@ -20,6 +20,7 @@ from types import GeneratorType
 
 import numpy as np
 from numpy.exceptions import AxisError
+from numpy.lib.array_utils import normalize_axis_tuple
 
 import cvxpy.interface as intf
 import cvxpy.lin_ops.lin_op as lo
@@ -87,15 +88,19 @@ class Sum(AxisAtom, AffAtom):
         super(AxisAtom, self).validate_arguments()
 
     def shape_from_args(self) -> tuple[int, ...]:
-        """Returns shape using NumPy's sum shape calculation."""
+        """Returns shape using an exact tuple calculation."""
+        input_shape = self.args[0].shape
+        ndim = len(input_shape)
+        if self.axis is None:
+            return (1,) * ndim if self.keepdims else ()
         try:
-            return np.sum(
-                np.empty(self.args[0].shape, dtype=np.int8),
-                axis=self.axis,
-                keepdims=self.keepdims
-            ).shape
+            axes = normalize_axis_tuple(self.axis, ndim)
         except (ValueError, AxisError, TypeError) as e:
             raise ValueError(f"Invalid arguments for cp.sum: {e}") from e
+        if self.keepdims:
+            return tuple(1 if i in axes else d for i, d in enumerate(input_shape))
+        else:
+            return tuple(d for i, d in enumerate(input_shape) if i not in axes)
 
     def numeric(self, values):
         """Sums the entries of value."""
@@ -153,9 +158,7 @@ class Sum(AxisAtom, AffAtom):
 
 
 @wraps(Sum)
-def sum(
-    expr, axis: int | tuple[int, ...] | None = None, keepdims: bool = False
-) -> Expression:
+def sum(expr, axis: int | tuple[int, ...] | None = None, keepdims: bool = False) -> Expression:
     """
     Wrapper for Sum class.
     """

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -2800,6 +2800,50 @@ class TestAtoms(BaseTest):
         S = Variable((3, 3), symmetric=True)
         self.assertTrue(cp.real(S).is_symmetric())
 
+    def test_sum_shape_inference(self):
+        """
+        Test shape inference for cp.sum with exact tuple formula,
+        verifying match with NumPy's axis and keepdims semantics.
+        """
+        x = cp.Variable((2, 3, 4))
+
+        # 1. Default (axis=None)
+        assert cp.sum(x).shape == ()
+        assert cp.sum(x, keepdims=True).shape == (1, 1, 1)
+
+        # 2. Single integer axis
+        assert cp.sum(x, axis=0).shape == (3, 4)
+        assert cp.sum(x, axis=1).shape == (2, 4)
+        assert cp.sum(x, axis=-1).shape == (2, 3)  # Negative indexing
+
+        # 3. Single integer axis with keepdims=True
+        assert cp.sum(x, axis=0, keepdims=True).shape == (1, 3, 4)
+        assert cp.sum(x, axis=1, keepdims=True).shape == (2, 1, 4)
+        assert cp.sum(x, axis=-1, keepdims=True).shape == (2, 3, 1)
+
+        # 4. Tuple of axes
+        assert cp.sum(x, axis=(0, 2)).shape == (3,)
+        assert cp.sum(x, axis=(0, -1)).shape == (3,)  # Mixed positive/negative
+        assert cp.sum(x, axis=(0, 1, 2)).shape == ()
+
+        # 5. Tuple of axes with keepdims=True
+        assert cp.sum(x, axis=(0, 2), keepdims=True).shape == (1, 3, 1)
+        assert cp.sum(x, axis=(0, 1, 2), keepdims=True).shape == (1, 1, 1)
+
+        # 6. Scalar variables
+        scalar = cp.Variable()
+        assert cp.sum(scalar).shape == ()
+        assert cp.sum(scalar, keepdims=True).shape == ()
+
+        # 7. Error cases (caught by normalize_axis_tuple)
+        with pytest.raises(ValueError):
+            cp.sum(x, axis=3)  # Out of bounds (positive)
+
+        with pytest.raises(ValueError):
+            cp.sum(x, axis=-4) # Out of bounds (negative)
+
+        with pytest.raises(ValueError):
+            cp.sum(x, axis=(0, 0))  # Duplicate axes
 
 class TestDotsort(BaseTest):
     """ Unit tests for the dotsort atom. """


### PR DESCRIPTION
## Description
This PR refactors Sum.shape_from_args by replacing the dummy np.sum array allocation with an explicit tuple-based formula. 

Following the maintainer suggestion, this implementation utilizes NumPy's `numpy.lib.array_utils.normalize_axis_tuple` to natively handle edge cases like negative indices, shorthands, and out-of-bounds validation without runtime overhead.

Issue link (if applicable): Closes #3459

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.