### PR TITLE
Fix matrix_frac crash on a matrix argument with an ndarray P

### DIFF
--- a/cvxpy/atoms/matrix_frac.py
+++ b/cvxpy/atoms/matrix_frac.py
@@ -146,7 +146,9 @@ class MatrixFrac(Atom):
 
 @wraps(MatrixFrac)
 def matrix_frac(X, P) -> Expression:
-    if isinstance(P, np.ndarray):
+    # The QuadForm shortcut only accepts a vector x, so restrict it to that case;
+    # a matrix X must go through MatrixFrac (which also handles an ndarray P).
+    if isinstance(P, np.ndarray) and Expression.cast(X).shape in [(P.shape[0], 1), (P.shape[0],)]:
         invP = LA.inv(P)
         return QuadForm(X, (invP + np.conj(invP).T) / 2.0)
     else:

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -356,6 +356,17 @@ class TestAtoms(BaseTest):
         atom = cp.matrix_frac(self.x, self.A)
         self.assertEqual(atom.shape, tuple())
         self.assertEqual(atom.curvature, s.CONVEX)
+
+        # A matrix X with an ndarray P must not crash (the ndarray shortcut only
+        # accepts a vector); its value must match the Constant(P) path.
+        Xmat = Variable((3, 2))
+        Pnd = np.eye(3) * 2.0
+        mf = cp.matrix_frac(Xmat, Pnd)
+        self.assertEqual(mf.shape, tuple())
+        self.assertEqual(mf.curvature, s.CONVEX)
+        Xmat.value = np.arange(6).reshape(3, 2).astype(float)
+        self.assertAlmostEqual(mf.value, cp.matrix_frac(Xmat, cp.Constant(Pnd)).value)
+
         # Test matrix_frac shape validation.
         with self.assertRaises(Exception) as cm:
             cp.matrix_frac(self.x, self.C)


### PR DESCRIPTION
## Description

`cp.matrix_frac(X, P)` computes `tr(Xᵀ P⁻¹ X)`, and a matrix `X` (shape `(n, k)`, `k > 1`) is a supported, tested case. But when `P` is a numpy `ndarray` — the most natural way to pass a constant matrix, e.g. `cp.matrix_frac(X, np.eye(n))` — it raises `ValueError: Invalid dimensions for arguments to quad_form`, and a `Problem` using it cannot even be constructed.

The `matrix_frac` wrapper takes a `QuadForm` shortcut whenever `P` is an `ndarray`, but `QuadForm` only accepts a vector `x`. The same `X, P` succeed through every other path — `cp.Constant(P)`, a `Variable` `P`, and `P.tolist()` — all returning the correct `tr(Xᵀ P⁻¹ X)`. So the failure is triggered purely by the *type* of `P`, not the math.

The fix restricts the `QuadForm` shortcut to a vector `x`; a matrix `X` falls through to `MatrixFrac`, which already handles an `ndarray` `P` by casting it to a `Constant`. A vector `x` still uses the shortcut unchanged, and mismatched dimensions still raise the proper error.

Verified: `cvxpy/tests/test_atoms.py` passes (122), the value matches `np.trace(X.T @ inv(P) @ X)` and the `Constant(P)` path, and a full `Problem(Minimize(cp.matrix_frac(Variable((n, k)), P)))` now constructs and solves to `optimal`. Added a regression test.

Issue link (if applicable): none — found during atom-behavior verification.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files. *(N/A — no new files; only `cvxpy/atoms/matrix_frac.py` and `cvxpy/tests/test_atoms.py` are edited.)*
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing. *(`test_atoms.py`: 122 passed.)*
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression. *(Not run; the change only narrows a dispatch condition and adds no work on the existing vector path.)*

---

*Disclosure: this change was found, fixed, tested and described by an AI coding agent (Claude Code) running on this account. The account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.*
