### PR TITLE
Stop internal parameter checks warning about sparse .value reads

### DIFF
--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -450,7 +450,7 @@ class Atom(Expression):
 
     @property
     def value(self) -> ExpressionValue | None:
-        if any([p.value is None for p in self.parameters()]):
+        if any([not p._has_value for p in self.parameters()]):
             return None
         return self._value_impl()
 

--- a/cvxpy/expressions/constants/callback_param.py
+++ b/cvxpy/expressions/constants/callback_param.py
@@ -53,3 +53,8 @@ class CallbackParam(Parameter):
     @value.setter
     def value(self, _val):
         raise NotImplementedError("Cannot set the value of a CallbackParam.")
+
+    @property
+    def _has_value(self) -> bool:
+        """A CallbackParam's value comes from its callback, not from _value."""
+        return self.value is not None

--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -602,16 +602,32 @@ class Leaf(expression.Expression):
     @property
     def value(self) -> expression.ExpressionValue | None:
         """The numeric value of the expression."""
-        if self.sparse_idx is None:
-            return self._value
-        else:
+        if self.sparse_idx is not None:
             warn('Reading from a sparse CVXPY expression via `.value` is discouraged.'
                   ' Use `.value_sparse` instead', RuntimeWarning)
-            if self._value is None:
-                return None
-            val = np.zeros(self.shape, dtype=self._value.dtype)
-            val[self.sparse_idx] = self._value
-            return val
+        return self._value_dense()
+
+    def _value_dense(self) -> expression.ExpressionValue | None:
+        """The value of the leaf, densified when sparse, without warning.
+
+        `value` steers users towards `value_sparse` for sparse leaves. CVXPY's own
+        internals need the same data without emitting that warning at the user.
+        """
+        if self.sparse_idx is None:
+            return self._value
+        if self._value is None:
+            return None
+        val = np.zeros(self.shape, dtype=self._value.dtype)
+        val[self.sparse_idx] = self._value
+        return val
+
+    def _value_impl(self) -> expression.ExpressionValue | None:
+        return self._value_dense()
+
+    @property
+    def _has_value(self) -> bool:
+        """Whether a value has been assigned, without reading it through `value`."""
+        return self._value is not None
 
     @value.setter
     def value(self, val) -> None:

--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -1017,7 +1017,7 @@ class Problem(u.Canonical):
         if verbose:
             print(_HEADER)
         for parameter in self.parameters():
-            if parameter.value is None:
+            if not parameter._has_value:
                 raise error.ParameterError(
                     "A Parameter (whose name is '%s') does not have a value "
                     "associated with it; all Parameter objects must have "

--- a/cvxpy/reductions/cvx_attr2constr.py
+++ b/cvxpy/reductions/cvx_attr2constr.py
@@ -281,7 +281,7 @@ class CvxAttr2Constr(Reduction):
                         new_attr[key] = None if key == 'bounds' else False
                 reduced_param = Parameter(n, name=param.name(), **new_attr)
                 self._parameters[param] = reduced_param
-                if param.value is not None:
+                if param._has_value:
                     reduced_param.value = lower_value(param)
                 obj = build_dim_reduced_expression(param, reduced_param)
                 id2new_obj[id(param)] = obj
@@ -307,7 +307,7 @@ class CvxAttr2Constr(Reduction):
     def update_parameters(self, problem) -> None:
         """Update reduced parameter values from original parameters."""
         for param, reduced_param in self._parameters.items():
-            if param.value is not None:
+            if param._has_value:
                 reduced_param.value = lower_value(param)
 
     def var_backward(self, del_vars):

--- a/cvxpy/tests/test_attributes.py
+++ b/cvxpy/tests/test_attributes.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 
 import numpy as np
 import pytest
@@ -113,6 +114,56 @@ class TestAttributes:
                   ' for Parameter value.'
         ):
             A.value_sparse = sp.coo_array(([1], ([0], [0])), (3, 3))
+
+    def test_solve_does_not_warn_on_sparse_parameter(self):
+        """Solving must not warn about `.value` on a user's behalf.
+
+        `Problem.solve` and the reductions it runs check whether each Parameter has a
+        value. Reading those through `.value` emitted the sparse-read warning from
+        CVXPY's own internals, so a user who only ever touches `.value_sparse` was
+        still warned on every solve.
+        """
+        x = cp.Variable(2)
+        P = cp.Parameter((2, 2), sparsity=([0, 1], [0, 1]))
+        P.value_sparse = sp.eye(2).tocoo()
+
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(P @ x - 1)))
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            prob.solve(solver=cp.CLARABEL)
+
+        sparse_warnings = [
+            w for w in caught
+            if issubclass(w.category, RuntimeWarning)
+            and 'sparse CVXPY expression via `.value`' in str(w.message)
+        ]
+        assert not sparse_warnings, [str(w.message) for w in sparse_warnings]
+        assert prob.status == cp.OPTIMAL
+        assert np.allclose(x.value, [1.0, 1.0])
+
+        # The DPP re-solve path reads parameter values again, through a different
+        # code path than the first solve, and must stay quiet too.
+        P.value_sparse = sp.coo_array((np.array([2.0, 2.0]), ([0, 1], [0, 1])), shape=(2, 2))
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            prob.solve(solver=cp.CLARABEL)
+
+        sparse_warnings = [
+            w for w in caught
+            if issubclass(w.category, RuntimeWarning)
+            and 'sparse CVXPY expression via `.value`' in str(w.message)
+        ]
+        assert not sparse_warnings, [str(w.message) for w in sparse_warnings]
+        assert np.allclose(x.value, [0.5, 0.5])
+
+    def test_sparse_parameter_without_value_still_raises(self):
+        """The value check the warning came from must keep rejecting unset Parameters."""
+        x = cp.Variable(2)
+        P = cp.Parameter((2, 2), sparsity=([0, 1], [0, 1]))
+
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(P @ x - 1)))
+        with pytest.raises(cp.error.ParameterError):
+            prob.solve(solver=cp.CLARABEL)
 
     def test_sparsity_read_value(self):
         sparsity = [(0, 2, 1, 2), (0, 1, 2, 2)]


### PR DESCRIPTION
## Description
Reading `.value` on a leaf that has a sparsity pattern warns and points the user at `.value_sparse`. Several of CVXPY's own checks read parameter values through that same property, so a user who only ever touches `.value_sparse` — as the warning asks — still gets warned on every `solve()`, from CVXPY's internals rather than from their own code. Downstream packages that legitimately use sparse-pattern parameters (DCCP is the example in the issue) currently suppress it by hand.

Reproducing on `main`, this emits the warning four times:

```python
x = cp.Variable(2)
P = cp.Parameter((2, 2), sparsity=([0, 1], [0, 1]))
P.value_sparse = sp.eye(2).tocoo()
cp.Problem(cp.Minimize(cp.sum_squares(P @ x - 1))).solve()
```

Tracing every warning back to its caller turned up five internal sites, one more than the issue identifies:

- `Problem._solve` — `if parameter.value is None`
- `Atom.value` — `if any([p.value is None for p in self.parameters()])`
- `CvxAttr2Constr.apply` — `if param.value is not None`
- `CvxAttr2Constr.update_parameters` — `if param.value is not None`
- `Expression._value_impl` — `return self.value`, reached for a leaf

The fifth (`update_parameters`) only fires on the **DPP re-solve** path, so it survives a fix that only covers the first solve. It is already visible as a stray warning in the existing `test_sparse_parameter` test output on `main`.

Four of the five only need to know *whether* a value was assigned, not what it is.

## Change

- Split the densification in `Leaf.value` out into `_value_dense()`, which does the same work without warning, so the warning now sits in `value` alone and the logic is not duplicated.
- Add a `Leaf._has_value` predicate for the assigned-or-not checks.
- Point the four checks at `_has_value` and override `Leaf._value_impl` to use `_value_dense()`.

Reading or writing `.value` directly on a sparse leaf still warns — that is the case the warning exists for, and it is covered by the existing `test_sparsity_read_value`.

`_has_value` is equivalent to the old check in both cases: for a dense leaf `value` returns `_value` directly, and for a sparse leaf `value` returns `None` exactly when `_value is None`.

Issue link: closes #3367

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.

Notes on the two unchecked boxes, rather than leaving them silent:

- **License headers** — no new files were added, so there was nothing to add a header to.
- **Benchmarks** — I did not run them. The change removes work rather than adding it (`_has_value` is an attribute test where the old code densified a sparse leaf into a full `np.zeros` array just to compare against `None`), so I would expect it to be neutral-to-faster on the sparse-parameter path and unchanged elsewhere. Happy to run them if you would like that confirmed before merge.

## Tests

Added to `cvxpy/tests/test_attributes.py`:

- `test_solve_does_not_warn_on_sparse_parameter` — asserts no sparse-`.value` warning escapes `solve()`, and separately re-solves after updating `value_sparse` to cover the DPP path that the fifth call site sits on. Fails on `main`.
- `test_sparse_parameter_without_value_still_raises` — the checks being changed are the ones that reject unset Parameters, so this pins that `ParameterError` is still raised.

`pytest cvxpy/tests/test_attributes.py cvxpy/tests/test_problem.py cvxpy/tests/test_expressions.py cvxpy/tests/test_param_cone_prog.py cvxpy/tests/test_param_quad_prog.py cvxpy/tests/test_parametric_bounds.py` → **331 passed, 4 skipped**. `ruff` clean on all five files.
