### PR TITLE
Modify type annotation for constraints argument of Problem constructor.

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import time
 from collections import namedtuple
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -144,7 +145,7 @@ class Problem(u.Canonical):
     ---------
     objective : Minimize or Maximize
         The problem's objective.
-    constraints : list
+    constraints : iterable
         The constraints on the problem variables.
     """
 
@@ -152,7 +153,7 @@ class Problem(u.Canonical):
     REGISTERED_SOLVE_METHODS = {}
 
     def __init__(
-        self, objective: Minimize | Maximize, constraints: list[Constraint] | None = None
+        self, objective: Minimize | Maximize, constraints: Iterable[Constraint] | None = None
     ) -> None:
         if constraints is None:
             constraints = []


### PR DESCRIPTION
## Description

Fixes https://github.com/cvxpy/cvxpy/issues/1785.

Modifies the type annotation for the [`constraints` argument of the `Problem` constructor](https://www.cvxpy.org/api_reference/cvxpy.problems.html#cvxpy.Problem.__init__.constraints). The current type, `list`, causes problems for type checkers.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.