### PR TITLE
Add cp.block with NumPy-compatible nesting

### DIFF
--- a/cvxpy/atoms/__init__.py
+++ b/cvxpy/atoms/__init__.py
@@ -18,6 +18,7 @@ from cvxpy.atoms.affine.add_expr import AddExpression
 from cvxpy.atoms.affine.binary_operators import (matmul, MulExpression, multiply,
                                                  vdot, scalar_product, outer,)
 from cvxpy.atoms.affine.bmat import bmat
+from cvxpy.atoms.affine.block import block
 from cvxpy.atoms.affine.broadcast_to import broadcast_to
 from cvxpy.atoms.affine.conj import conj
 from cvxpy.atoms.affine.conv import conv, convolve

--- a/cvxpy/atoms/affine/block.py
+++ b/cvxpy/atoms/affine/block.py
@@ -37,7 +37,7 @@ def block(arrays) -> Expression:
         The assembled expression.
     """
     if not isinstance(arrays, list):
-        return Expression.cast_to_const(arrays)
+        return Expression.cast(arrays)
 
     list_depth = _list_depth(arrays)
     result_ndim = max(list_depth, _max_ndim(arrays))
@@ -64,12 +64,12 @@ def _max_ndim(arrays) -> int:
     if isinstance(arrays, list):
         return max(_max_ndim(item) for item in arrays)
 
-    return Expression.cast_to_const(arrays).ndim
+    return Expression.cast(arrays).ndim
 
 
 def _block(arrays, list_depth, result_ndim):
     if not isinstance(arrays, list):
-        expr = Expression.cast_to_const(arrays)
+        expr = Expression.cast(arrays)
         return _promote(expr, result_ndim)
 
     children = [

--- a/cvxpy/atoms/affine/block.py
+++ b/cvxpy/atoms/affine/block.py
@@ -1,0 +1,89 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from cvxpy.atoms.affine.concatenate import concatenate
+from cvxpy.atoms.affine.reshape import reshape
+from cvxpy.expressions.expression import Expression
+
+
+def block(arrays) -> Expression:
+    """Assemble an expression from nested lists of expressions.
+
+    The innermost lists are concatenated along the last axis,
+    the next level along the second-to-last axis, and so on.
+    Lower-dimensional inputs are prepended with dimensions of size one.
+
+    Parameters
+    ----------
+    arrays
+        An expression or nested list of expressions.
+
+    Returns
+    -------
+    Expression
+        The assembled expression.
+    """
+    if not isinstance(arrays, list):
+        return Expression.cast_to_const(arrays)
+
+    list_depth = _list_depth(arrays)
+    result_ndim = max(list_depth, _max_ndim(arrays))
+
+    return _block(arrays, list_depth, result_ndim)
+
+
+def _list_depth(arrays) -> int:
+    if not isinstance(arrays, list):
+        return 0
+
+    if not arrays:
+        raise ValueError("List at arrays cannot be empty")
+
+    depths = [_list_depth(item) for item in arrays]
+
+    if len(set(depths)) != 1:
+        raise ValueError("List depths are mismatched")
+
+    return 1 + depths[0]
+
+
+def _max_ndim(arrays) -> int:
+    if isinstance(arrays, list):
+        return max(_max_ndim(item) for item in arrays)
+
+    return Expression.cast_to_const(arrays).ndim
+
+
+def _block(arrays, list_depth, result_ndim):
+    if not isinstance(arrays, list):
+        expr = Expression.cast_to_const(arrays)
+        return _promote(expr, result_ndim)
+
+    children = [
+        _block(item, list_depth - 1, result_ndim)
+        for item in arrays
+    ]
+
+    axis = result_ndim - list_depth
+    return concatenate(children, axis=axis)
+
+
+def _promote(expr: Expression, ndim: int) -> Expression:
+    if expr.ndim == ndim:
+        return expr
+
+    new_shape = (1,) * (ndim - expr.ndim) + expr.shape
+    return reshape(expr, new_shape, order="F")

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1740,6 +1740,89 @@ class TestAtoms(BaseTest):
         ref = np.block([[7.0, x.value.T], [x.value, np.identity(2)]])
         self.assertItemsAlmostEqual(expr.value, ref)
 
+    def test_block_bare_expression(self) -> None:
+        """Test block with a bare expression."""
+        x = cp.Variable((2, 3))
+
+        expr = cp.block(x)
+
+        self.assertEqual(expr.shape, (2, 3))
+        self.assertTrue(expr.is_affine())
+
+    def test_block_flat_list(self) -> None:
+        """Test block concatenates a flat list along the last axis."""
+        x = cp.Variable((2, 2))
+        y = cp.Variable((2, 3))
+
+        expr = cp.block([x, y])
+
+        self.assertEqual(expr.shape, (2, 5))
+        self.assertTrue(expr.is_affine())
+
+    def test_block_nested_2d(self) -> None:
+        """Test arbitrary nesting depth and 2-D concatenation axes."""
+        A = np.array([[1.0, 2.0], [3.0, 4.0]])
+        B = np.array([[5.0], [6.0]])
+        C = np.array([[7.0, 8.0]])
+        D = np.array([[9.0]])
+
+        expr = cp.block([[A, B], [C, D]])
+        ref = np.block([[A, B], [C, D]])
+
+        self.assertEqual(expr.shape, ref.shape)
+        self.assertItemsAlmostEqual(expr.value, ref)
+
+    def test_block_nested_nd(self) -> None:
+        """Test arbitrary nesting depth and N-D concatenation axes."""
+        arrays = [
+            [
+                [np.array([[[1.0]]]), np.array([[[2.0]]])],
+                [np.array([[[3.0]]]), np.array([[[4.0]]])],
+            ],
+            [
+                [np.array([[[5.0]]]), np.array([[[6.0]]])],
+                [np.array([[[7.0]]]), np.array([[[8.0]]])],
+            ],
+        ]
+
+        expr = cp.block(arrays)
+        ref = np.block(arrays)
+
+        self.assertEqual(expr.shape, ref.shape)
+        self.assertItemsAlmostEqual(expr.value, ref)
+
+    def test_block_nd(self) -> None:
+        """Test block supports N-dimensional inputs."""
+        A = np.ones((2, 3, 4))
+        B = 2 * np.ones((2, 3, 5))
+
+        expr = cp.block([A, B])
+        ref = np.block([A, B])
+
+        self.assertEqual(expr.shape, ref.shape)
+        self.assertItemsAlmostEqual(expr.value, ref)
+
+    def test_block_promotes_scalars(self) -> None:
+        """Test block promotes scalars and 1-D inputs like numpy.block."""
+        expr = cp.block([[1, np.array([2.0, 3.0])]])
+        ref = np.block([[1, np.array([2.0, 3.0])]])
+
+        self.assertEqual(expr.shape, ref.shape)
+        self.assertItemsAlmostEqual(expr.value, ref)
+
+    def test_block_empty_list(self) -> None:
+        """Test block rejects empty lists."""
+        with self.assertRaises(ValueError):
+            cp.block([])
+
+        with self.assertRaises(ValueError):
+            cp.block([[]])
+
+    def test_block_mismatched_depth(self) -> None:
+        """Test block rejects mismatched list depths."""
+        with self.assertRaises(ValueError):
+            cp.block([[1, 2], 3])
+
     def test_conv(self) -> None:
         """Test the conv atom.
         """

--- a/doc/source/api_reference/cvxpy.atoms.affine.rst
+++ b/doc/source/api_reference/cvxpy.atoms.affine.rst
@@ -35,6 +35,13 @@ bmat
 
 .. autofunction:: cvxpy.bmat
 
+.. _block:
+
+block
+---------------------------------
+
+.. autofunction:: cvxpy.block
+
 .. _conj:
 
 conj

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -881,6 +881,12 @@ Expression and a negative Expression) then the returned Expression will have unk
      - |affine| affine
      - |incr| incr.
 
+   * - :ref:`block(arrays) <block>`
+     - NumPy-style block assembly
+     - nested lists of array-like expressions
+     - |affine| affine
+     - |incr| incr.
+
    * - :ref:`convolve(c, x) <convolve>`
 
        :math:`c\in\mathbf{R}^m`
@@ -1006,6 +1012,11 @@ Clarifications on vector and matrix functions
 The input to :math:`\texttt{bmat}` is a list of lists of CVXPY expressions.
 It constructs a block matrix.
 The elements of each inner list are stacked horizontally and then the resulting block matrices are stacked vertically.
+
+The input to :math:`\texttt{block}` is a nested list of CVXPY expressions.
+The innermost lists are concatenated along the last axis, the next level along
+the second-to-last axis, and so on, following NumPy's ``block`` semantics.
+Lower-dimensional inputs are prepended with dimensions of size one as needed.
 
 The output :math:`y = \texttt{convolve}(c, x)` has size :math:`n+m-1` and is defined as
 :math:`y_k =\sum_{j=0}^{k} c[j]x[k-j]`.


### PR DESCRIPTION
## Description
Adds a new `cp.block` function with NumPy-compatible block assembly semantics.

Unlike `cp.bmat`, `cp.block` supports:

- bare expressions,
- flat lists,
- arbitrary nesting depth,
- N-dimensional concatenation axes, and
- promotion of lower-dimensional inputs by prepending singleton dimensions.

The implementation recursively assembles nested blocks using existing `concatenate` and `reshape` atoms.

Tests cover bare expressions, flat lists, nested 2-D and N-D inputs, scalar promotion, empty lists, and mismatched nesting depths.

Closes #3469

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

(`ruff check cvxpy/atoms/affine/block.py cvxpy/tests/test_atoms.py` passes. Full test suite: 2543 passed, 852 skipped. Benchmarks were not run; this change composes existing affine atoms and does not modify solver or canonicalization internals.)