### PR TITLE
Add MIP start support to the SCIP interface

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scip_conif.py
@@ -135,6 +135,9 @@ class SCIP(ConicSolver):
         data[s.LOWER_BOUNDS] = problem.lower_bounds
         data[s.UPPER_BOUNDS] = problem.upper_bounds
 
+        # Add initial guess. NaN marks entries the user did not provide.
+        data['init_value'] = utilities.stack_vals(problem.variables, np.nan)
+
         return data, inv_data
 
     def invert(self, solution: dict[str, Any], inverse_data: dict[str, Any]) -> Solution:
@@ -186,6 +189,8 @@ class SCIP(ConicSolver):
         model.redirectOutput()
         A, b, c, dims = self._define_data(data)
         variables = self._create_variables(model, data, c)
+        if warm_start:
+            self._set_initial_solution(model, variables, data)
         constraints = self._add_constraints(model, variables, A, b, dims)
         self._set_params(model, verbose, solver_opts, data, dims)
         solution = self._solve(model, variables, constraints, data, dims)
@@ -224,6 +229,29 @@ class SCIP(ConicSolver):
                 )
             )
         return variables
+
+    def _set_initial_solution(
+            self, model: ScipModel, variables: list, data: dict[str, Any]
+    ) -> None:
+        """Pass the values set on the user's variables to SCIP as a MIP start.
+
+        Values are read from ``Variable.value`` and may be set on only some of
+        the variables, so the start is registered as a *partial* solution and
+        SCIP's ``completesol`` heuristic fills in the rest. ``addSol`` is used
+        rather than ``trySol`` because the model is still in SCIP's problem
+        creation stage, where ``trySol`` cannot be called.
+        """
+        init_value = data.get('init_value')
+        if init_value is None:
+            return
+        init_value = np.asarray(init_value, dtype=float)
+        known = np.flatnonzero(~np.isnan(init_value))
+        if known.size == 0:
+            return
+        solution = model.createPartialSol()
+        for idx in known:
+            model.setSolVal(solution, variables[idx], init_value[idx])
+        model.addSol(solution)
 
     def _add_constraints(
             self,

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2606,6 +2606,43 @@ class TestSCIP(unittest.TestCase):
         assert np.allclose(data['init_value'][:2], [2.0, 3.0])
         assert np.isnan(data['init_value'][2])
 
+    @staticmethod
+    def completesol_calls(prob) -> int:
+        """How many times SCIP ran the heuristic that consumes a partial start.
+
+        Read from SCIP's own statistics: the ``completesol`` row of the primal
+        heuristics table, whose third numeric column is the call count.
+        """
+        model = prob.solver_stats.extra_stats["model"]
+        path = tempfile.mktemp(suffix=".txt")
+        try:
+            model.writeStatistics(path)
+            with open(path) as stats:
+                for line in stats:
+                    if line.strip().startswith("completesol"):
+                        return int(line.split(":", 1)[1].split()[2])
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+        return 0
+
+    def test_scip_mip_start_reaches_solver(self) -> None:
+        """The start is handed to SCIP, not silently dropped.
+
+        Both solves pass ``warm_start=True``; the only difference is whether
+        the user set any variable values. SCIP's ``completesol`` heuristic
+        exists to complete a partial start, so it runs in the second case
+        and not in the first.
+        """
+        prob, x, y = self.get_mip_problem()
+        prob.solve(solver=cp.SCIP, warm_start=True)
+        assert self.completesol_calls(prob) == 0
+
+        prob, x, y = self.get_mip_problem()
+        x.value = np.array([2.0, 3.0])
+        prob.solve(solver=cp.SCIP, warm_start=True)
+        assert self.completesol_calls(prob) > 0
+
     def test_scip_mip_start(self) -> None:
         """A MIP start does not change the optimum."""
         prob, x, y = self.get_mip_problem()
@@ -2620,12 +2657,14 @@ class TestSCIP(unittest.TestCase):
         x.value = None
         y.value = None
         assert prob.solve(solver=cp.SCIP, warm_start=True) == 9.0
+        assert self.completesol_calls(prob) == 0
 
     def test_scip_mip_start_infeasible_values(self) -> None:
-        """An unusable start is discarded by SCIP, not propagated."""
+        """An unusable start is offered to SCIP but does not corrupt the result."""
         prob, x, y = self.get_mip_problem()
         x.value = np.array([99.0, 99.0])
         assert prob.solve(solver=cp.SCIP, warm_start=True) == 9.0
+        assert self.completesol_calls(prob) > 0
 
     def test_scip_test_params__no_params_set(self) -> None:
         prob = self.get_simple_problem()

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2584,6 +2584,49 @@ class TestSCIP(unittest.TestCase):
         prob = cp.Problem(obj, constraints)
         return prob
 
+    def get_mip_problem(self):
+        """Small MILP with one integer and one continuous variable."""
+        x = cp.Variable(2, integer=True)
+        y = cp.Variable()
+        constraints = [x >= 0, x <= 5, y >= 0, y <= 3, cp.sum(x) + y <= 6]
+        prob = cp.Problem(cp.Maximize(cp.sum(x) + 2 * y), constraints)
+        return prob, x, y
+
+    def test_scip_mip_start_init_value(self) -> None:
+        """Variable values are collected for the MIP start, NaN where unset."""
+        prob, x, y = self.get_mip_problem()
+
+        # Nothing set: every entry is unknown.
+        data, _, _ = prob.get_problem_data(solver=cp.SCIP)
+        assert np.all(np.isnan(data['init_value']))
+
+        # Only x set: its values are passed through, y stays unknown.
+        x.value = np.array([2.0, 3.0])
+        data, _, _ = prob.get_problem_data(solver=cp.SCIP)
+        assert np.allclose(data['init_value'][:2], [2.0, 3.0])
+        assert np.isnan(data['init_value'][2])
+
+    def test_scip_mip_start(self) -> None:
+        """A MIP start does not change the optimum."""
+        prob, x, y = self.get_mip_problem()
+        expected = prob.solve(solver=cp.SCIP, warm_start=False)
+
+        x.value = np.array([2.0, 3.0])
+        assert prob.solve(solver=cp.SCIP, warm_start=True) == expected
+
+    def test_scip_mip_start_without_values(self) -> None:
+        """warm_start with no values set is a no-op rather than an error."""
+        prob, x, y = self.get_mip_problem()
+        x.value = None
+        y.value = None
+        assert prob.solve(solver=cp.SCIP, warm_start=True) == 9.0
+
+    def test_scip_mip_start_infeasible_values(self) -> None:
+        """An unusable start is discarded by SCIP, not propagated."""
+        prob, x, y = self.get_mip_problem()
+        x.value = np.array([99.0, 99.0])
+        assert prob.solve(solver=cp.SCIP, warm_start=True) == 9.0
+
     def test_scip_test_params__no_params_set(self) -> None:
         prob = self.get_simple_problem()
         prob.solve(solver="SCIP")


### PR DESCRIPTION
## Description

`SCIP.solve_via_data` accepts a `warm_start` flag and ignores it, so there is currently no way to hand SCIP an incumbent from Python. GUROBI already supports this through `data['init_value']`; this brings SCIP in line.

`apply()` collects `Variable.value` through `utilities.stack_vals` — the same helper GUROBI uses — and `solve_via_data` registers the values before the constraints are added.

Two things differ from the GUROBI path, both forced by SCIP's API:

- The start is registered with `createPartialSol()` rather than `createSol()`. Users typically set values on a subset of their variables, and SCIP's `completesol` heuristic is built to fill in the rest. GUROBI uses `GRB.UNDEFINED` as its "not provided" sentinel; SCIP has no equivalent, so NaN is what lets the interface tell an unset entry apart from a genuine zero.
- `addSol()` rather than `trySol()`. At the point where CVXPY builds the model SCIP is still in the problem creation stage, and `trySol` raises `method cannot be called at this time in solution process` there.

**Verification that the values reach the solver**, rather than being silently discarded — from SCIP's own statistics output:

    without a start:  completesol : 0  0  0
    with a start:     completesol : 1  1  1
                      Primal Bound: ... found by <completesol>

The heuristic is never called without a start, is called once with one, and the resulting incumbent is attributed to it.

**Caveat, stated plainly:** I could not measure a speedup on the instances I tried — SCIP's own heuristics found better incumbents than the greedy ones I supplied. This exposes a capability that is currently not expressible at all; it is not a performance improvement by default.

**Compatibility:** behaviour changes only when `warm_start=True` and variable values are set, which previously did nothing for SCIP. The optimum is unaffected (covered by tests); the search path may differ.

Scope note: this covers the `Variable.value` path from #849. Re-using a previous solve via `solver_cache`, which GUROBI also implements, is not addressed here — the SCIP interface does not populate `solver_cache` at all.

Partial fix for #849

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files. — N/A, no new files
- [x] Check that your code adheres to our coding style. — `ruff` 0.8.1 (the pre-commit pin) reports no findings
- [x] Write unittests. — four, in `TestSCIP`: `init_value` contents, that a start does not change the optimum, `warm_start` with no values set, and an unusable start
- [x] Run the unittests and check that they're passing. — 45/45 SCIP, 142/142 in `test_conic_solvers.py`, no regressions
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression. — not run locally: the benchmark suite exercises the default solvers and does not touch the SCIP interface. The CI benchmark job will cover it.