### PR TITLE
Keep parameters symbolic on the ignore_dpp/non-DPP DIFFENGINE path

### DIFF
--- a/cvxpy/problems/problem.py
+++ b/cvxpy/problems/problem.py
@@ -41,7 +41,6 @@ from cvxpy.problems.objective import Maximize, Minimize
 from cvxpy.reductions import InverseData
 from cvxpy.reductions.chain import Chain
 from cvxpy.reductions.dqcp2dcp import dqcp2dcp
-from cvxpy.reductions.eval_params import EvalParams
 from cvxpy.reductions.flip_objective import FlipObjective
 from cvxpy.reductions.solution import INF_OR_UNB_MESSAGE
 from cvxpy.reductions.solvers import bisection
@@ -879,8 +878,7 @@ class Problem(u.Canonical):
             safe_to_cache = (
                 isinstance(data, dict)
                 and s.PARAM_PROB in data
-                and not any(isinstance(reduction, EvalParams)
-                            for reduction in solving_chain.reductions)
+                and not solving_chain.uncached_param_prog
             )
             self._compilation_time = time.time() - start
             if verbose:

--- a/cvxpy/reductions/__init__.py
+++ b/cvxpy/reductions/__init__.py
@@ -26,4 +26,5 @@ from cvxpy.reductions.dgp2dcp.dgp2dcp import Dgp2Dcp
 from cvxpy.reductions.dqcp2dcp.dqcp2dcp import Dqcp2Dcp
 from cvxpy.reductions.eval_params import EvalParams
 from cvxpy.reductions.flip_objective import FlipObjective
+from cvxpy.reductions.fold_callback_params import CallbackParamFold
 from cvxpy.reductions.solvers.solving_chain import SolvingChain

--- a/cvxpy/reductions/dcp2cone/canonicalizers/perspective_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/perspective_canon.py
@@ -20,6 +20,7 @@ from cvxpy.atoms.affine.diag import diag
 from cvxpy.atoms.affine.vec import vec
 from cvxpy.expressions.variable import Variable
 from cvxpy.problems.objective import Maximize, Minimize
+from cvxpy.settings import CPP_CANON_BACKEND
 from cvxpy.utilities.perspective_utils import form_cone_constraint
 from cvxpy.utilities.solver_context import SolverInfo
 
@@ -34,7 +35,11 @@ def perspective_canon(expr, args, solver_context: SolverInfo | None = None):
     # value at opt?
     solver_opts = {"use_quad_obj": False}
     solver = solver_context.solver_name if solver_context is not None else None
-    chain = aux_prob._construct_chain(solver=solver, solver_opts=solver_opts, ignore_dpp=True)
+    # Pin the internal chain to the CPP backend: this canonicalizer's aux
+    # chains should not silently ride backend-default changes on the
+    # ignore_dpp path (it also unpacks the raw .q/.A tensors below).
+    chain = aux_prob._construct_chain(solver=solver, solver_opts=solver_opts, ignore_dpp=True,
+                                      canon_backend=CPP_CANON_BACKEND)
     chain.reductions = chain.reductions[:-1]  # skip solver reduction
     prob_canon = chain.apply(aux_prob)[0]  # grab problem instance
     # get cone representation of c, A, and b for some problem.

--- a/cvxpy/reductions/dcp2cone/canonicalizers/perspective_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/perspective_canon.py
@@ -20,6 +20,7 @@ from cvxpy.atoms.affine.diag import diag
 from cvxpy.atoms.affine.vec import vec
 from cvxpy.expressions.variable import Variable
 from cvxpy.problems.objective import Maximize, Minimize
+from cvxpy.reductions.eval_params import EvalParams
 from cvxpy.settings import CPP_CANON_BACKEND
 from cvxpy.utilities.perspective_utils import form_cone_constraint
 from cvxpy.utilities.solver_context import SolverInfo
@@ -31,6 +32,12 @@ def perspective_canon(expr, args, solver_context: SolverInfo | None = None):
     # Only working for minimization right now.
 
     aux_prob = Problem((Minimize if expr.f.is_convex() else Maximize)(expr.f))
+    if aux_prob.parameters():
+        # Pre-bake parameter values: the ignore_dpp chain below no longer
+        # inserts EvalParams for parametric problems (they stay symbolic on
+        # the DIFFENGINE path), but this canonicalizer needs concrete
+        # tensors, matching its pre-existing bake-at-canon semantics.
+        aux_prob, _ = EvalParams().apply(aux_prob)
     # Does numerical solution value of epigraph t coincide with expr.f numerical
     # value at opt?
     solver_opts = {"use_quad_obj": False}

--- a/cvxpy/reductions/fold_callback_params.py
+++ b/cvxpy/reductions/fold_callback_params.py
@@ -1,0 +1,81 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from cvxpy import problems
+from cvxpy.expressions.constants.callback_param import CallbackParam
+from cvxpy.reductions.reduction import Reduction
+from cvxpy.utilities import scopes
+
+
+def _fold_expr(expr):
+    """Replace maximal non-affine variable-free parametric subtrees.
+
+    Such a subtree (e.g. ``power(t, 2)``, ``floor(t)``, ``log_det(P)``)
+    becomes a ``CallbackParam`` evaluating it on each access. Parameter-affine
+    subtrees (a bare ``Parameter``, ``2 * p + A``) stay symbolic.
+    """
+    if not expr.parameters():
+        return expr
+    if not expr.variables():
+        with scopes.dpp_scope():
+            if expr.is_affine():
+                return expr
+        return CallbackParam(
+            callback=lambda e=expr: e.value,
+            shape=expr.shape,
+            nonneg=expr.is_nonneg(),
+            nonpos=expr.is_nonpos(),
+        )
+    new_args = [_fold_expr(arg) for arg in expr.args]
+    if all(id(new) == id(old) for new, old in zip(new_args, expr.args)):
+        return expr
+    return expr.copy(new_args)
+
+
+class CallbackParamFold(Reduction):
+    """Fold non-affine parametric-constant subtrees into CallbackParams.
+
+    Runs before canonicalization on chains where parameters stay symbolic
+    across solves: canonicalizing such subtrees would be unsound there
+    (``x <= power(t, 2)`` would epigraph-relax vacuously), and unlike
+    ``EvalParams`` the folded values refresh per solve, so compiled programs
+    stay cacheable.
+    """
+
+    def accepts(self, problem) -> bool:
+        return True
+
+    def apply(self, problem):
+        if len(problem.objective.parameters()) > 0:
+            obj_expr = _fold_expr(problem.objective.expr)
+            objective = type(problem.objective)(obj_expr)
+        else:
+            objective = problem.objective
+
+        constraints = []
+        for c in problem.constraints:
+            args = [_fold_expr(arg) for arg in c.args]
+            if all(id(new) == id(old) for new, old in zip(args, c.args)):
+                constraints.append(c)
+            else:
+                data = c.get_data()
+                if data is not None:
+                    constraints.append(type(c)(*(args + data)))
+                else:
+                    constraints.append(type(c)(*args))
+        return problems.problem.Problem(objective, constraints), []
+
+    def invert(self, solution, inverse_data):
+        return solution

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/IGNORE_DPP_BEHAVIOR.md
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/IGNORE_DPP_BEHAVIOR.md
@@ -1,0 +1,85 @@
+# The symbolic ignore_dpp / non-DPP path
+
+## What changes
+
+On the `ignore_dpp` / non-DPP branch, parameters are no longer baked to
+constants by `EvalParams`. The chain becomes
+
+```
+[CallbackParamFold, ..., Dcp2Cone, ..., ConeMatrixStuffing(DIFFENGINE),
+ (DiffengineConeFormat,) solver]
+```
+
+and canonicalization keeps `Parameter` leaves symbolic. `ConeMatrixStuffing`
+dispatches to `diff_engine/cone_stuffing.py::stuff_cone_program`, which
+compiles the canonicalized expression trees into a C diff-engine program and
+returns a `DiffengineParamConeProg` (`diff_engine/parametric_program.py`) — a
+`ParamConeProg` subclass that re-evaluates `(q, d, A, b, P)` at the current
+parameter values on every `apply_parameters()` call, instead of multiplying
+parameter tensors.
+
+Parameter-free problems produce a stock parameter-free `ParamConeProg`
+(single constant-column tensors) and run the unmodified tensor-path code
+downstream.
+
+## CallbackParamFold
+
+`Dcp2Cone` epigraph-relaxes nonlinear atoms. For a *variable-free parametric*
+subtree in a concave position (e.g. `x <= power(t, 2)` with parameter `t`)
+that relaxation is unsound — the epigraph variable is unconstrained by data.
+`CallbackParamFold` (`cvxpy/reductions/fold_callback_params.py`) walks the
+tree first and replaces every maximal variable-free parametric subtree that is
+NOT parameter-affine (checked under `dpp_scope`) with a `CallbackParam` whose
+callback re-evaluates the subtree. Canonicalization then sees an opaque
+parameter leaf; its value refreshes on every solve because `CallbackParam.value`
+re-runs the closure.
+
+Parameter-affine subtrees stay symbolic (the engine handles them natively),
+and anything containing a variable is untouched.
+
+## Formatting (conic solvers)
+
+`ConicSolver.format_constraints` constructs a stock `ParamConeProg` — it would
+silently replace the re-extractable program at format time. The chain therefore
+inserts `DiffengineConeFormat` (`diff_engine/formatting.py`) between stuffing
+and a conic solver for parametric problems: it materializes the solver's
+cone-restructuring matrix `R` once — by an identity probe of the real
+`format_constraints`, so it cannot drift from upstream conventions — and hands
+the solver the program with `R` pre-applied and `formatted=True`.
+`apply_parameters()` re-applies the stored `R` to freshly extracted `(A, b)`.
+QP solvers consume the program directly and need no formatting step.
+
+## Selection and fallbacks
+
+- Default (no `canon_backend`): the branch selects DIFFENGINE when the problem
+  is ≤2-D, not DGP, and has no parametric variable bounds. Otherwise it falls
+  back silently to `EvalParams` + the tensor backends (N-D SCIPY fallback,
+  bounds tensors, DGP's post-EvalParams parameters).
+- An explicit tensor `canon_backend` on the symbolic parametric branch raises:
+  tensor backends cannot keep parameters symbolic here. Parameter-free
+  problems honor any explicit backend.
+- An explicit `canon_backend="DIFFENGINE"` on a DPP problem also takes the
+  symbolic path.
+- The perspective canonicalizer pins its internal aux chains to CPP and
+  pre-bakes their parameters, preserving its bake-at-canon semantics.
+
+## Error semantics
+
+- Cone-emitting parametric composites (e.g. `log_det(P)`) now count their
+  cones in problem analysis even under `ignore_dpp`, so a QP-only solver
+  raises `SolverError` instead of silently solving a baked approximation.
+  Evaluate the term numerically (e.g. `np.linalg.slogdet`) if that is wanted.
+- The parameter differentiation contract (`requires_grad`,
+  `problem.derivative`/`backward`, diffcp's `keep_zeros`) is not supported:
+  `DiffengineParamConeProg` raises `NotImplementedError` — the engine
+  re-evaluates a nonlinear map rather than applying a stored linear one.
+
+## Caching status
+
+The compiled symbolic program is NOT yet cached across solves
+(`SolvingChain.uncached_param_prog`): every solve rebuilds the chain and the
+engine program, and the first solve extracts twice (once at stuffing, once in
+the solver's `apply_parameters`). Caching with a theta short-circuit and a
+record-at-site guard for the one value-consuming canonicalizer (the cone
+quad_form canon calls `decomp_quad` on the current `P.value`) is the follow-up
+PR.

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/c_problem.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/c_problem.py
@@ -50,8 +50,12 @@ class C_problem:
         self._capsule = _diffengine.make_problem(c_obj, c_constraints, verbose)
 
         if param_dict:
+            # Keep the node capsules alive alongside the problem capsule: a
+            # registered parameter can appear in no converted expression,
+            # and the engine must be able to update it on every later solve.
+            self._param_capsules = list(param_dict.values())
             _diffengine.problem_register_params(
-                self._capsule, list(param_dict.values()))
+                self._capsule, self._param_capsules)
             # Set initial parameter values
             theta = np.concatenate([
                 np.asarray(p.value, dtype=np.float64).flatten(order='F')

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/cone_stuffing.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/cone_stuffing.py
@@ -47,33 +47,41 @@ from cvxpy.reductions.solvers.nlp_solvers.diff_engine.extractor import DiffEngin
 from cvxpy.reductions.utilities import group_constraints
 
 
-def stuff_cone_program(problem, cons, inverse_data, quad_obj):
-    """Stuff a parameter-free problem by evaluating the expression trees
-    with the C diff engine instead of building parameter tensors.
+def encode_cone_tensors(q, d, A, b, P, n):
+    """Write concrete cone matrices into the single constant column of the
+    coefficient tensor ParamConeProg decodes: [q; d] for the objective,
+    [A | b] flattened column-major for the constraints, and P flattened
+    column-major for the quadratic term. Matching that layout is what lets
+    formatting, the solver interfaces and inversion run unmodified."""
+    q_col = sp.csr_array(np.concatenate([q, [d]])[:, None])
+    A_col = sp.csc_array(
+        sp.hstack([A, sp.csc_array(b[:, None])]).reshape((-1, 1), order='F'))
+    P_col = (sp.csc_array(P.reshape((n * n, 1), order='F'))
+             if P is not None else None)
+    return q_col, A_col, P_col
 
-    Produces the same artifact as the tensor path: a ParamConeProg whose
+
+def stuff_cone_program(problem, cons, inverse_data, quad_obj):
+    """Stuff a problem by evaluating the expression trees with the C diff
+    engine instead of building parameter tensors.
+
+    A parameter-free problem produces a stock ParamConeProg whose
     single-column tensors hold the constant slice, so every downstream
     consumer (formatting, solvers, inversion) runs the stock code path.
+    A parametric problem produces a DiffengineParamConeProg, which keeps the
+    engine program alive and re-extracts on every apply_parameters().
 
     ``cons`` are the lowered (but not yet ordered) constraints from
     ``ConeMatrixStuffing.apply``. Returns ``(new_prob, inverse_data)``.
     """
+    from cvxpy.reductions.solvers.nlp_solvers.diff_engine.parametric_program import (
+        DiffengineParamConeProg,
+    )
     variables = problem.variables()
     if _has_parametric_bounds(variables):
         raise NotImplementedError(
             f"The {s.DIFFENGINE_CANON_BACKEND} canonicalization backend "
             "does not support parametric variable bounds.")
-    if problem.parameters():
-        # Staged: parametric problems keep their parameters symbolic on the
-        # follow-up PR, which replaces this rejection.
-        raise ValueError(
-            f"The {s.DIFFENGINE_CANON_BACKEND} canonicalization backend "
-            "does not yet support parametric problems. Solve with "
-            "ignore_dpp=True to evaluate parameters before "
-            "canonicalization. If you already passed ignore_dpp=True, the "
-            "remaining parameters most likely come from parametric "
-            "variable bounds, which the DIFFENGINE backend does not "
-            "support.")
 
     # Reorder constraints to Zero, NonNeg, SOC, PSD, EXP, PowCone3D, PowConeND
     constr_map = group_constraints(cons)
@@ -87,21 +95,25 @@ def stuff_cone_program(problem, cons, inverse_data, quad_obj):
 
     # One-shot extraction of the concrete cone matrices at x = 0.
     expr_list = [arg for c in ordered_cons for arg in c.args]
+    params = problem.parameters()
     extractor = DiffEngineExtractor(inverse_data).build(
-        problem.objective.expr, expr_list, quad_obj)
+        problem.objective.expr, expr_list, params, quad_obj)
     q, d, A, b, P = extractor.extract(quad_obj)
 
     n = inverse_data.x_length
-    # Parameter-free, so the constant column is the whole coefficient tensor;
-    # matching that layout is what keeps every downstream consumer unmodified.
-    q_col = sp.csr_array(np.concatenate([q, [d]])[:, None])
-    A_col = sp.csc_array(
-        sp.hstack([A, sp.csc_array(b[:, None])]).reshape((-1, 1), order='F'))
-    P_col = (sp.csc_array(P.reshape((n * n, 1), order='F'))
-             if P is not None else None)
-
     boolean, integer = extract_mip_idx(variables)
     x = Variable(n, boolean=boolean, integer=integer)
+    lower_bounds = extract_lower_bounds(variables, n)
+    upper_bounds = extract_upper_bounds(variables, n)
+
+    if params:
+        new_prob = DiffengineParamConeProg(
+            extractor, x, variables, inverse_data.var_offsets, ordered_cons,
+            params, inverse_data.param_id_map, q, d, A, b, P,
+            lower_bounds=lower_bounds, upper_bounds=upper_bounds)
+        return new_prob, inverse_data
+
+    q_col, A_col, P_col = encode_cone_tensors(q, d, A, b, P, n)
     new_prob = ParamConeProg(
         q_col,
         x,
@@ -112,7 +124,7 @@ def stuff_cone_program(problem, cons, inverse_data, quad_obj):
         [],
         inverse_data.param_id_map,
         P=P_col,
-        lower_bounds=extract_lower_bounds(variables, n),
-        upper_bounds=extract_upper_bounds(variables, n),
+        lower_bounds=lower_bounds,
+        upper_bounds=upper_bounds,
     )
     return new_prob, inverse_data

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/converters.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/converters.py
@@ -21,6 +21,7 @@ from sparsediffpy import _sparsediffengine as _diffengine
 
 import cvxpy as cp
 import cvxpy.settings as s
+from cvxpy.atoms.affine.wraps import Wrap
 from cvxpy.atoms.elementwise.power import Power
 from cvxpy.atoms.quad_form import QuadForm
 from cvxpy.atoms.quad_over_lin import quad_over_lin
@@ -115,9 +116,10 @@ def convert_symbolic_quad_form(expr, var_dict, n_vars, param_dict):
     """Convert a SymbolicQuadForm (Dcp2Cone quadratic-objective placeholder).
 
     Scalar x'Px (QuadForm / quad_over_lin / sum_squares) uses the native quad_form
-    binding, routed by how P is stored: the sparse CSR path for a sparse P, the
-    dense path otherwise. power/PowerApprox is the elementwise square, lowered
-    to multiply.
+    binding. A parametric P becomes a matrix-valued child the engine re-evaluates
+    each solve; a constant P is routed by how it is stored -- the sparse CSR path
+    for a sparse P, the dense path otherwise. power/PowerApprox is the elementwise
+    square, lowered to multiply.
     """
     if expr.block_indices is not None:
         raise NotImplementedError(
@@ -129,13 +131,17 @@ def convert_symbolic_quad_form(expr, var_dict, n_vars, param_dict):
     if isinstance(orig, (QuadForm, quad_over_lin)):
         x = expr.args[0]
         P = expr.args[1]
-        if P.parameters():
-            # Unreachable through the gated DIFFENGINE backend (the stuffing
-            # rejects parametric problems); fail loud for direct callers.
-            raise NotImplementedError(
-                "SymbolicQuadForm with a parametric P is not supported by "
-                "the diff engine.")
         x_c = convert_expr(x, var_dict, n_vars, param_dict)
+        n = x.size
+        if P.parameters():
+            # P is affine in the parameters and independent of x (Hessian still 2P):
+            # feed it as a matrix-valued child evaluated each solve. Peel value-identity
+            # Wrap atoms (e.g. psd_wrap) the converter can't build directly.
+            P_inner = P
+            while isinstance(P_inner, Wrap):
+                P_inner = P_inner.args[0]
+            P_c = convert_expr(P_inner, var_dict, n_vars, param_dict)
+            return _diffengine.make_quad_form(P_c, x_c, "dense", None, n)
         P_val = P.value
         if sparse.issparse(P_val):
             P_csr = P_val.tocsr()
@@ -147,7 +153,7 @@ def convert_symbolic_quad_form(expr, var_dict, n_vars, param_dict):
                 P_csr.shape[0], P_csr.shape[1])
         P_dense = to_dense_float(P_val)
         return _diffengine.make_quad_form(
-            None, x_c, "dense", P_dense.flatten(order='F'), x.size)
+            None, x_c, "dense", P_dense.flatten(order='F'), n)
 
     if isinstance(orig, Power):  # PowerApprox subclasses Power; canon only p == 2
         # The elementwise square, rebuilt over the leaf arg: the engine's

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/extractor.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/extractor.py
@@ -63,9 +63,9 @@ def _build_hessian_csc(c_problem, hess_structure, duals):
 
 
 class DiffEngineExtractor:
-    """Parameter-free analog of ``CoeffExtractor``: builds a C autodiff problem
-    from the expressions and recovers the concrete cone matrices
-    ``(q, d, A, b, P)`` by evaluating it at ``x = 0``.
+    """Non-DPP analog of ``CoeffExtractor``: builds a C autodiff problem from
+    the expressions and recovers the concrete cone matrices ``(q, d, A, b, P)``
+    by evaluating it at ``x = 0``, re-evaluating when parameter values change.
     """
 
     def __init__(self, inverse_data) -> None:
@@ -76,16 +76,16 @@ class DiffEngineExtractor:
         self.hess_structure = None
         self.has_constraints = False
 
-    def build(self, objective_expr, constraint_exprs, quad_obj: bool):
+    def build(self, objective_expr, constraint_exprs, parameters, quad_obj: bool):
         """Compile the objective and constraint expressions into a ``C_problem``.
 
         ``constraint_exprs`` is the flat list of cone-constraint argument expressions.
         Returns ``self`` for chaining.
         """
         self.has_constraints = bool(constraint_exprs)
-        # Parameter-free: no parameters and so no parameter capsules.
         self.c_problem = C_problem(
-            objective_expr, constraint_exprs, self.inverse_data, verbose=False)
+            objective_expr, constraint_exprs, self.inverse_data,
+            parameters=parameters, verbose=False)
         self.c_problem.init_jacobian_coo()
         self.jac_structure = (self.c_problem.get_jacobian_sparsity_coo()
                               if self.has_constraints else None)
@@ -96,6 +96,10 @@ class DiffEngineExtractor:
             rows, cols = self.c_problem.get_problem_hessian_sparsity_coo()
             self.hess_structure = _full_symmetric_hess_structure(rows, cols, self.n_vars)
         return self
+
+    def update_parameters(self, theta: np.ndarray) -> None:
+        """Push new (flattened, concatenated) parameter values into the C problem."""
+        self.c_problem.update_params(theta)
 
     def extract(self, quad_obj: bool):
         """Evaluate the (affine) objective and constraints at ``x = 0`` to recover the

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/formatting.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/formatting.py
@@ -1,0 +1,80 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Chain step that pre-applies the solver's cone-restructuring matrix to the
+symbolic parametric DIFFENGINE program, so it reaches the solver already
+``formatted=True`` and is never replaced by a stock ParamConeProg inside
+``ConicSolver.format_constraints``.
+"""
+from __future__ import annotations
+
+import numpy as np
+import scipy.sparse as sp
+
+from cvxpy.expressions.variable import Variable
+from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ParamConeProg
+from cvxpy.reductions.reduction import Reduction
+
+
+def build_restruct_mat(solver, constraints, m):
+    """Materialize the solver's cone-restructuring matrix R as CSC.
+
+    Implemented as an identity probe of the frozen
+    ``ConicSolver.format_constraints``: a stub parameter-free ParamConeProg
+    whose constraint matrix is ``[I_m | 0]`` is formatted, and R is read off
+    the restructured result. This cannot drift from the solver's actual
+    restructuring conventions because it *is* the solver's restructuring.
+    """
+    # Encode [I_m | 0] with x.size == m: flat row of entry (i, i) is i*(m+1).
+    flat_rows = np.arange(m, dtype=np.int64) * (m + 1)
+    A_probe = sp.csc_array(
+        (np.ones(m), (flat_rows, np.zeros(m, dtype=np.int64))),
+        shape=(m * (m + 1), 1))
+    q_probe = sp.csr_array((m + 1, 1))
+    stub = ParamConeProg(
+        q_probe, Variable(m), A_probe,
+        variables=[], var_id_to_col={},
+        constraints=constraints, parameters=[], param_id_to_col={})
+    formatted = type(solver).format_constraints(stub, solver.EXP_CONE_ORDER)
+    m_out = formatted.A.shape[0] // (m + 1)
+    M = formatted.A.reshape((m_out, m + 1), order='F').tocsc()
+    return M[:, :m]
+
+
+class DiffengineConeFormat(Reduction):
+    """Pre-format the symbolic DIFFENGINE program for a conic solver."""
+
+    def __init__(self, solver) -> None:
+        super().__init__()
+        self.solver = solver
+
+    def accepts(self, problem) -> bool:
+        return True
+
+    def apply(self, problem):
+        from cvxpy.reductions.solvers.nlp_solvers.diff_engine.parametric_program import (
+            DiffengineParamConeProg,
+        )
+        if not isinstance(problem, DiffengineParamConeProg):
+            # Canonicalization consumed every parameter (e.g. a constraint
+            # quad_form factorized at its current value), so stuffing
+            # produced a stock program; the solver formats it normally.
+            return problem, None
+        R = build_restruct_mat(
+            self.solver, problem.constraints, problem.A.shape[0] // (problem.x.size + 1))
+        return problem.with_restruct(R), None
+
+    def invert(self, solution, inverse_data):
+        return solution

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/parametric_program.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/parametric_program.py
@@ -1,0 +1,128 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+The symbolic-parametric cone program of the DIFFENGINE backend: a
+ParamConeProg subclass that owns a live diff-engine extractor and
+re-evaluates the expression trees at the current parameter values on
+every apply_parameters() call.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ParamConeProg
+from cvxpy.reductions.utilities import ReducedMat
+
+
+class DiffengineParamConeProg(ParamConeProg):
+    """A ParamConeProg whose matrices are re-extracted by the C diff engine.
+
+    Parameters stay symbolic in the compiled engine program; each
+    ``apply_parameters()`` pushes the current values and re-evaluates
+    ``(q, d, A, b, P)`` directly, instead of multiplying parameter tensors.
+    The instance always reaches the solver already ``formatted=True`` (the
+    cone-restructuring matrix ``R`` pre-applied by ``DiffengineConeFormat``),
+    so ``ConicSolver.format_constraints`` never replaces it with a stock
+    program that could not re-extract.
+    """
+
+    def __init__(self, extractor, x, variables, var_id_to_col, constraints,
+                 parameters, param_id_to_col, q, d, A, b, P,
+                 formatted: bool = False, restruct_mat=None,
+                 lower_bounds=None, upper_bounds=None) -> None:
+        from cvxpy.reductions.solvers.nlp_solvers.diff_engine.cone_stuffing import (
+            encode_cone_tensors,
+        )
+        self.extractor = extractor
+        self._restruct_mat = restruct_mat
+        # The concrete matrices at the currently-pushed parameter values,
+        # post-restructuring. with_restruct() and the tensor refresh both
+        # read from here.
+        self._raw = (q, d, A, b, P)
+        q_t, A_t, P_t = encode_cone_tensors(q, d, A, b, P, x.size)
+        super().__init__(q_t, x, A_t, variables, var_id_to_col, constraints,
+                         parameters, param_id_to_col, P=P_t,
+                         formatted=formatted,
+                         lower_bounds=lower_bounds, upper_bounds=upper_bounds)
+
+    def _param_vec(self, id_to_param_value=None):
+        """Flatten and concatenate parameter values (the extractor's encoding).
+
+        CallbackParam values re-run their fold closure on access, so composite
+        parametric coefficients are refreshed here as well.
+        """
+        values = ((lambda p: id_to_param_value[p.id])
+                  if id_to_param_value is not None else (lambda p: p.value))
+        return np.concatenate([
+            np.asarray(values(p), dtype=np.float64).flatten(order='F')
+            for p in self.parameters])
+
+    def _refresh_tensors(self) -> None:
+        """Re-encode the stored raw matrices into the ParamConeProg tensor
+        attributes, so direct readers of .q/.A/.P stay consistent."""
+        from cvxpy.reductions.solvers.nlp_solvers.diff_engine.cone_stuffing import (
+            encode_cone_tensors,
+        )
+        q, d, A, b, P = self._raw
+        self.q, self.A, self.P = encode_cone_tensors(q, d, A, b, P, self.x.size)
+        self.reduced_A = ReducedMat(self.A, self.x.size)
+        self.reduced_P = ReducedMat(self.P, self.x.size, quad_form=True)
+
+    def apply_parameters(self, id_to_param_value=None, zero_offset: bool = False,
+                         keep_zeros: bool = False, quad_obj: bool = False):
+        """Re-evaluate the engine program at the current parameter values."""
+        if zero_offset or keep_zeros:
+            # These flags belong to the DPP-tensor differentiation contract
+            # (diffcp / problem.derivative), which the diff engine does not
+            # implement: it re-evaluates a nonlinear map rather than applying
+            # a stored linear one.
+            raise NotImplementedError(
+                "The DIFFENGINE backend does not support the parameter "
+                "differentiation contract (zero_offset/keep_zeros); solve "
+                "without requires_grad, or use a tensor canon backend.")
+        theta = self._param_vec(id_to_param_value)
+        self.extractor.update_parameters(theta)
+        q, d, A, b, P = self.extractor.extract(quad_obj)
+        if self._restruct_mat is not None:
+            A = self._restruct_mat @ A
+            b = np.asarray(self._restruct_mat @ b).flatten()
+        self._raw = (q, d, A, b, P)
+        self._refresh_tensors()
+        if quad_obj:
+            return P, q, d, A, b
+        return q, d, A, b
+
+    def with_restruct(self, R):
+        """Return the formatted sibling with the cone-restructuring matrix
+        ``R`` pre-applied. Shares the extractor (and its engine program)."""
+        q, d, A, b, P = self._raw
+        if R is not None:
+            A = R @ A
+            b = np.asarray(R @ b).flatten()
+        return DiffengineParamConeProg(
+            self.extractor, self.x, self.variables, self.var_id_to_col,
+            self.constraints, self.parameters, self.param_id_to_col,
+            q, d, A, b, P, formatted=True, restruct_mat=R,
+            lower_bounds=self.lower_bounds, upper_bounds=self.upper_bounds)
+
+    def split_adjoint(self, del_vars=None):
+        raise NotImplementedError(
+            "The DIFFENGINE backend does not support the parameter "
+            "differentiation contract (problem.backward/derivative).")
+
+    def apply_param_jac(self, delc, deld, delA, delb, active_params=None):
+        raise NotImplementedError(
+            "The DIFFENGINE backend does not support the parameter "
+            "differentiation contract (problem.backward/derivative).")

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
@@ -86,21 +86,32 @@ def convert_kron(expr, children):
 
 
 def convert_div(expr, children):
-    """Convert x / c by multiplying x by the elementwise reciprocal of c.
+    """Convert x / d by multiplying x by the elementwise reciprocal of d.
 
-    Matches coo_backend.div: parametrized divisors are rejected and any
-    zero entry in the divisor raises explicitly.
+    A constant divisor bakes ``1/d`` into a parameter node (rejecting zero
+    entries, matching coo_backend.div); a parametric divisor uses a
+    ``make_power(d, -1)`` node the engine re-evaluates each solve.
     """
     divisor_expr = expr.args[1]
     if divisor_expr.parameters():
-        raise NotImplementedError("div doesn't support parametrized divisor")
-    divisor = to_dense_float(divisor_expr.value)
-    if np.any(divisor == 0):
-        raise ValueError("Division by zero encountered in divisor")
-    recip = 1.0 / divisor
-    d1, d2 = normalize_shape(recip.shape)
-    recip_node = _diffengine.make_parameter(d1, d2, -1, 0, recip.flatten(order='F'))
-    if recip.size == 1:
+        # The engine re-evaluates make_power(d, -1) each solve; check the
+        # current value here so a zero divisor fails loudly at conversion
+        # like the constant branch does. A zero introduced by a later
+        # parameter update still surfaces as inf from the engine.
+        div_val = divisor_expr.value
+        if div_val is not None and np.any(to_dense_float(div_val) == 0):
+            raise ValueError("Division by zero encountered in divisor")
+        recip_node = _diffengine.make_power(children[1], -1.0)
+        size = divisor_expr.size
+    else:
+        divisor = to_dense_float(divisor_expr.value)
+        if np.any(divisor == 0):
+            raise ValueError("Division by zero encountered in divisor")
+        recip = 1.0 / divisor
+        d1, d2 = normalize_shape(recip.shape)
+        recip_node = _diffengine.make_parameter(d1, d2, -1, 0, recip.flatten(order='F'))
+        size = recip.size
+    if size == 1:
         return _diffengine.make_param_scalar_mult(recip_node, children[0])
     return _diffengine.make_param_vector_mult(recip_node, children[0])
 

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -32,6 +32,7 @@ from cvxpy.reductions.discrete2mixedint.valinvec2mixedint import (
 from cvxpy.reductions.eliminate_zero_sized import EliminateZeroSized
 from cvxpy.reductions.eval_params import EvalParams
 from cvxpy.reductions.flip_objective import FlipObjective
+from cvxpy.reductions.fold_callback_params import CallbackParamFold
 from cvxpy.reductions.matrix_stuffing import _has_parametric_bounds
 from cvxpy.reductions.solvers import defines as slv_def
 from cvxpy.reductions.solvers.constant_solver import ConstantSolver
@@ -213,26 +214,58 @@ def _build_solving_chain(
             f"The {DIFFENGINE_CANON_BACKEND} backend cannot be used with "
             "problems that have expressions of dimension greater than 2.")
 
+    uncached_param_prog = False
     if ignore_dpp or not is_dpp:
         if not ignore_dpp and enforce_dpp:
             raise DPPError(DPP_ERROR_MSG)
         if not ignore_dpp:
             warn(DPP_ERROR_MSG)
-        reductions = [EvalParams()] + reductions
-        # EvalParams bakes the parameters, so the stuffed problem is
-        # parameter-free and the diff engine can build its matrices directly
-        # from the expression trees -- far cheaper than the tensor pipeline
-        # for large or kron-heavy trees. Default selection falls back
-        # silently to the tensor backends for the cases the backend does not
-        # cover (N-D expressions; parametric variable bounds, which
-        # EvalParams does not bake; DGP chains, where Dgp2Dcp introduces
-        # fresh parameters after EvalParams has run); an explicit
-        # canon_backend="DIFFENGINE" request for those still fails loud in
-        # the backend's own guards.
-        if (canon_backend is None and not gp and problem._max_ndim() <= 2
-                and not _has_parametric_bounds(problem.variables())):
+        # The diff engine builds the matrices directly from the expression
+        # trees -- far cheaper than the tensor pipeline for large or
+        # kron-heavy trees -- and keeps parameters symbolic, re-evaluating
+        # them on each solve. It does not cover N-D expressions, parametric
+        # variable bounds (which EvalParams does not bake either), or DGP
+        # chains (Dgp2Dcp introduces fresh parameters after EvalParams);
+        # those fall back silently to EvalParams + the tensor backends.
+        # dir_cone_kinds: ExtractDirectCones reconstructs the stuffed program
+        # as a stock ParamConeProg, which would silently discard the symbolic
+        # program's re-extraction; leave those solvers on the tensor path.
+        diffengine_ok = (not gp and problem._max_ndim() <= 2
+                         and not _has_parametric_bounds(problem.variables())
+                         and not dir_cone_kinds)
+        if problem.parameters() and diffengine_ok:
+            # Parameters stay symbolic through canonicalization. Non-affine
+            # parametric constants fold to CallbackParam leaves so Dcp2Cone
+            # never epigraph-relaxes them unsoundly. Caching the compiled
+            # symbolic program across solves is a follow-up.
+            uncached_param_prog = True
+            reductions = [CallbackParamFold()] + reductions
+            if (canon_backend is not None
+                    and canon_backend != DIFFENGINE_CANON_BACKEND):
+                raise ValueError(
+                    f"canon_backend='{canon_backend}' cannot be used for "
+                    "a parametrized problem that is not DPP (or is solved "
+                    "with ignore_dpp=True); this path requires the "
+                    f"{DIFFENGINE_CANON_BACKEND} backend, which keeps "
+                    "parameters symbolic and re-evaluates them on each "
+                    "solve. Omit canon_backend, or replace the parameters "
+                    "with constants.")
             canon_backend = DIFFENGINE_CANON_BACKEND
+        else:
+            reductions = [EvalParams()] + reductions
+            if problem.parameters():
+                # Baked parameter values: the program must be rebuilt on
+                # every solve.
+                uncached_param_prog = True
+            if canon_backend is None and diffengine_ok:
+                # Parameter-free: ignore_dpp is a no-op; default to
+                # DIFFENGINE for consistency. Explicit backends are honored.
+                canon_backend = DIFFENGINE_CANON_BACKEND
     else:
+        if canon_backend == DIFFENGINE_CANON_BACKEND and problem.parameters():
+            # Explicit DIFFENGINE on a DPP-parametric problem takes the
+            # symbolic path too; caching its compiled program is a follow-up.
+            uncached_param_prog = True
         if canon_backend is None:
             total_param_size = sum(p.size for p in problem.parameters())
             if total_param_size >= DPP_PARAM_THRESHOLD:
@@ -268,8 +301,21 @@ def _build_solving_chain(
         ConeMatrixStuffing(quad_obj=quad_obj, canon_backend=canon_backend))
     if dir_cone_kinds:
         reductions.append(ExtractDirectCones(solver_context=solver_context))
+    if (canon_backend == DIFFENGINE_CANON_BACKEND and problem.parameters()
+            and not isinstance(solver_instance, QpSolver)):
+        # The symbolic parametric program must reach the solver already
+        # formatted (cone restructuring pre-applied): ConicSolver's
+        # format_constraints would otherwise replace it with a stock
+        # ParamConeProg that cannot re-extract on parameter updates.
+        # Mutually exclusive with ExtractDirectCones above: the symbolic
+        # route is not selected for a solver advertising DIR_CONE_KINDS.
+        from cvxpy.reductions.solvers.nlp_solvers.diff_engine.formatting import (
+            DiffengineConeFormat,
+        )
+        reductions.append(DiffengineConeFormat(solver_instance))
     reductions.append(solver_instance)
-    return SolvingChain(reductions=reductions, solver_context=solver_context)
+    return SolvingChain(reductions=reductions, solver_context=solver_context,
+                        uncached_param_prog=uncached_param_prog)
 
 
 def _resolve_solver(
@@ -497,20 +543,27 @@ class SolvingChain(Chain):
         The solver, i.e., reductions[-1].
     """
 
-    def __init__(self, problem=None, reductions=None, solver_context=None) -> None:
+    def __init__(self, problem=None, reductions=None, solver_context=None,
+                 uncached_param_prog: bool = False) -> None:
         super(SolvingChain, self).__init__(problem=problem,
                                            reductions=reductions)
         if not isinstance(self.reductions[-1], Solver):
             raise ValueError("Solving chains must terminate with a Solver.")
         self.solver = self.reductions[-1]
         self.solver_context = solver_context
+        # True when the compiled parametric program must be rebuilt on every
+        # solve: the chain bakes current parameter values into constants (the
+        # EvalParams fallbacks), or it takes the symbolic non-DPP /
+        # ignore_dpp path, which does not yet support cached re-solves.
+        self.uncached_param_prog = uncached_param_prog
 
     def prepend(self, chain) -> "SolvingChain":
         """
         Create and return a new SolvingChain by concatenating
         chain with this instance.
         """
-        return SolvingChain(reductions=chain.reductions + self.reductions)
+        return SolvingChain(reductions=chain.reductions + self.reductions,
+                            uncached_param_prog=self.uncached_param_prog)
 
     def solve(self, problem, warm_start: bool, verbose: bool, solver_opts):
         """Solves the problem by applying the chain.

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -32,6 +32,7 @@ from cvxpy.reductions.discrete2mixedint.valinvec2mixedint import (
 from cvxpy.reductions.eliminate_zero_sized import EliminateZeroSized
 from cvxpy.reductions.eval_params import EvalParams
 from cvxpy.reductions.flip_objective import FlipObjective
+from cvxpy.reductions.matrix_stuffing import _has_parametric_bounds
 from cvxpy.reductions.solvers import defines as slv_def
 from cvxpy.reductions.solvers.constant_solver import ConstantSolver
 from cvxpy.reductions.solvers.qp_solvers.qp_solver import QpSolver
@@ -218,6 +219,19 @@ def _build_solving_chain(
         if not ignore_dpp:
             warn(DPP_ERROR_MSG)
         reductions = [EvalParams()] + reductions
+        # EvalParams bakes the parameters, so the stuffed problem is
+        # parameter-free and the diff engine can build its matrices directly
+        # from the expression trees -- far cheaper than the tensor pipeline
+        # for large or kron-heavy trees. Default selection falls back
+        # silently to the tensor backends for the cases the backend does not
+        # cover (N-D expressions; parametric variable bounds, which
+        # EvalParams does not bake; DGP chains, where Dgp2Dcp introduces
+        # fresh parameters after EvalParams has run); an explicit
+        # canon_backend="DIFFENGINE" request for those still fails loud in
+        # the backend's own guards.
+        if (canon_backend is None and not gp and problem._max_ndim() <= 2
+                and not _has_parametric_bounds(problem.variables())):
+            canon_backend = DIFFENGINE_CANON_BACKEND
     else:
         if canon_backend is None:
             total_param_size = sum(p.size for p in problem.parameters())

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import unittest
+import warnings
 from fractions import Fraction
 from unittest.mock import patch
 
@@ -1999,7 +2000,9 @@ class TestAtoms(BaseTest):
         problem = cp.Problem(cp.Minimize(cp.convolve(p, x)), [0 <= x, x <= 1])
 
         p.value = -1.0
-        result = problem.solve(canon_backend=cp.CPP_CANON_BACKEND)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')  # non-DPP warning
+            result = problem.solve()
         self.assertAlmostEqual(result, -1)
         self.assertAlmostEqual(x.value, 1)
 

--- a/cvxpy/tests/test_backend_selection.py
+++ b/cvxpy/tests/test_backend_selection.py
@@ -77,8 +77,9 @@ class TestBackendSelectionDPP:
 
         chain = prob._construct_chain(solver=cp.CLARABEL)
         stuffing = [r for r in chain.reductions if isinstance(r, ConeMatrixStuffing)][0]
-        # Non-DPP doesn't trigger COO
-        assert stuffing.canon_backend is None
+        # Non-DPP doesn't trigger COO; it defaults to the DIFFENGINE backend
+        # (parameters are baked by EvalParams before stuffing).
+        assert stuffing.canon_backend == s.DIFFENGINE_CANON_BACKEND
 
     def test_ignore_dpp_skips_coo_selection(self):
         """With ignore_dpp=True, large DPP should NOT select COO."""
@@ -90,8 +91,9 @@ class TestBackendSelectionDPP:
 
         chain = prob._construct_chain(solver=cp.CLARABEL, ignore_dpp=True)
         stuffing = [r for r in chain.reductions if isinstance(r, ConeMatrixStuffing)][0]
-        # ignore_dpp means we don't use DPP-based selection
-        assert stuffing.canon_backend is None
+        # ignore_dpp means we don't use DPP-based selection; the branch
+        # defaults to the DIFFENGINE backend instead.
+        assert stuffing.canon_backend == s.DIFFENGINE_CANON_BACKEND
 
 
 class TestBackendSelectionUserOverride:

--- a/cvxpy/tests/test_complex_dpp.py
+++ b/cvxpy/tests/test_complex_dpp.py
@@ -123,12 +123,10 @@ class TestComplexDPP:
         assert np.isclose(x.value, 3.0, atol=1e-4)
         assert np.isclose(prob.value, 4.0, atol=1e-4)
 
-    @pytest.mark.parametrize("flag,should_have_eval_params", [
-        ("enforce_dpp", False),
-        ("ignore_dpp", True),
-    ])
-    def test_dpp_flags(self, flag, should_have_eval_params):
-        """enforce_dpp=True succeeds; ignore_dpp=True uses EvalParams."""
+    @pytest.mark.parametrize("flag", ["enforce_dpp", "ignore_dpp"])
+    def test_dpp_flags(self, flag):
+        """enforce_dpp=True succeeds; ignore_dpp=True keeps parameters
+        symbolic (DIFFENGINE backend) and refreshes them across solves."""
         p = cp.Parameter(complex=True)
         x = cp.Variable()
         prob = cp.Problem(cp.Minimize(x), [x >= cp.real(p)])
@@ -141,7 +139,12 @@ class TestComplexDPP:
 
         assert np.isclose(x.value, 1.0, atol=1e-4)
         reduction_types = [type(r) for r in prob._cache.solving_chain.reductions]
-        assert (EvalParams in reduction_types) == should_have_eval_params
+        assert EvalParams not in reduction_types
+
+        if flag == "ignore_dpp":
+            p.value = np.array(4 - 1j)
+            prob.solve(ignore_dpp=True)
+            assert np.isclose(x.value, 4.0, atol=1e-4)
 
     @pytest.mark.parametrize("n", [1, 2, 3])
     def test_hermitian_param_dpp(self, n):

--- a/cvxpy/tests/test_diffengine_backend.py
+++ b/cvxpy/tests/test_diffengine_backend.py
@@ -61,16 +61,25 @@ class TestDiffengineConverter(BaseTest):
         with self.assertRaisesRegex(NotImplementedError, "norm1"):
             convert_symbolic_quad_form(sqf, {}, 4, {})
 
-    def test_symbolic_quad_form_parametric_P_raises(self) -> None:
-        """A parametric P is out of scope for the diff engine; the converter
-        must fail loud rather than freeze the current value."""
-        n = 4
-        x = cp.Variable(n)
-        P = cp.Parameter((n, n), PSD=True)
-        P.value = np.eye(n)
-        sqf = SymbolicQuadForm(x, cp.psd_wrap(P), cp.quad_form(x, cp.psd_wrap(P)))
-        with self.assertRaisesRegex(NotImplementedError, "parametric P"):
-            convert_symbolic_quad_form(sqf, {x.id: None}, n, {P.id: None})
+    def test_kron_parametric_operand_resolves(self) -> None:
+        """A bare-Parameter kron operand stays symbolic and is re-evaluated
+        between solves."""
+        rng = np.random.default_rng(0)
+        target = rng.standard_normal((4, 4))
+        P = cp.Parameter((2, 2))
+        X = cp.Variable((2, 2))
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(cp.kron(P, X) - target)))
+        for seed in (1, 2):
+            P_val = np.random.default_rng(seed).standard_normal((2, 2))
+            P.value = P_val
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertEqual(prob.status, cp.OPTIMAL)
+
+            X_base = cp.Variable((2, 2))
+            base = cp.Problem(
+                cp.Minimize(cp.sum_squares(cp.kron(P_val, X_base) - target)))
+            base.solve(solver=SOLVER)
+            self.assertAlmostEqual(prob.value, base.value, places=3)
 
 class TestDiffengineBackend(BaseTest):
     """End-to-end behavior of canon_backend='DIFFENGINE': same stuffed data
@@ -182,15 +191,17 @@ class TestDiffengineBackend(BaseTest):
         base.solve(solver=SOLVER)
         self.assertAlmostEqual(prob.value, base.value, places=3)
 
-    def test_parametric_problem_rejected(self) -> None:
-        """Explicit DIFFENGINE on a DPP-parametric problem must raise and
-        point the user at ignore_dpp."""
+    def test_explicit_diffengine_on_dpp_parametric_solves(self) -> None:
+        """Explicit DIFFENGINE on a DPP-parametric problem takes the symbolic
+        path and tracks parameter values across solves."""
         p = cp.Parameter()
-        p.value = 1.0
         x = cp.Variable()
         prob = cp.Problem(cp.Minimize(cp.square(x - p)))
-        with self.assertRaisesRegex(ValueError, "ignore_dpp"):
-            prob.get_problem_data(SOLVER, canon_backend=DIFFENGINE)
+        for val in (1.0, -2.0):
+            p.value = val
+            prob.solve(solver=SOLVER, canon_backend=DIFFENGINE)
+            self.assertEqual(prob.status, cp.OPTIMAL)
+            self.assertAlmostEqual(x.value, val, places=5)
 
     def test_ignore_dpp_parametric_solves_and_tracks_values(self) -> None:
         """With ignore_dpp=True, EvalParams bakes the parameters and the
@@ -204,21 +215,15 @@ class TestDiffengineBackend(BaseTest):
             self.assertEqual(prob.status, cp.OPTIMAL)
             self.assertAlmostEqual(x.value, val, places=5)
 
-    def test_parametric_bounds_rejected_both_routes(self) -> None:
-        """EvalParams does not bake variable bounds, so they leak past
-        ignore_dpp by two routes, both of which must fail loudly naming the
-        cause: as bounds attributes (bounds-capable solver), or lowered by
-        CvxAttr2Constr into constraints that still carry live Parameters
-        (non-bounds solver)."""
+    def test_parametric_bounds_rejected_on_explicit_request(self) -> None:
+        """Parametric variable bounds are unsupported: an explicit DIFFENGINE
+        request fails loudly (default selection falls back instead)."""
         lb = cp.Parameter(2)
         lb.value = np.array([0.5, 0.5])
         x = cp.Variable(2, bounds=[lb, 10])
         prob = cp.Problem(cp.Minimize(cp.sum(x)))
         with self.assertRaisesRegex(NotImplementedError, "parametric variable bounds"):
             prob.get_problem_data(cp.SCIPY, canon_backend=DIFFENGINE,
-                                  ignore_dpp=True)
-        with self.assertRaisesRegex(ValueError, "parametric variable bounds"):
-            prob.get_problem_data(SOLVER, canon_backend=DIFFENGINE,
                                   ignore_dpp=True)
 
     @unittest.skipUnless(INSTALLED_MI_SOLVERS, "no mixed-integer solver installed")

--- a/cvxpy/tests/test_dpp.py
+++ b/cvxpy/tests/test_dpp.py
@@ -5,6 +5,7 @@ import pytest
 
 import cvxpy as cp
 import cvxpy.error as error
+import cvxpy.settings as s
 from cvxpy.tests.base_test import BaseTest
 
 SOLVER = cp.CLARABEL
@@ -142,7 +143,7 @@ class TestDcp(BaseTest):
         x.value = 3
         self.assertAlmostEqual(problem.solve(cp.SCS), 6)
 
-    def test_chain_data_for_non_dpp_problem_evals_params(self) -> None:
+    def test_chain_data_for_non_dpp_problem_keeps_params_symbolic(self) -> None:
         x = cp.Parameter()
         x.value = 5
         y = cp.Variable()
@@ -151,8 +152,9 @@ class TestDcp(BaseTest):
             warnings.simplefilter('ignore')
             _, chain, _ = problem.get_problem_data(cp.SCS)
         self.assertFalse(problem.is_dpp())
-        self.assertTrue(cp.reductions.eval_params.EvalParams in
-                        [type(r) for r in chain.reductions])
+        stuffing = [r for r in chain.reductions
+                    if isinstance(r, cp.reductions.ConeMatrixStuffing)][0]
+        self.assertEqual(stuffing.canon_backend, s.DIFFENGINE_CANON_BACKEND)
 
     def test_chain_data_for_dpp_problem_does_not_eval_params(self) -> None:
         x = cp.Parameter()
@@ -370,10 +372,11 @@ class TestDcp(BaseTest):
         self.assertEqual(solver_name, cp.SCS)
 
     def test_log_det_with_parameter_ignore_dpp(self) -> None:
-        """Test log_det with parameter works with ignore_dpp=True.
+        """log_det(P) is not baked to a number with ignore_dpp=True.
 
-        With ignore_dpp=True, EvalParams runs first and evaluates log_det(P)
-        to a constant, so the problem becomes a true QP that OSQP can handle.
+        The variable-free composite folds to a CallbackParam leaf
+        (see CallbackParamFold), so its value tracks the current P.value
+        on every solve instead of freezing at compile time.
         """
         n = 2
         x = cp.Variable(n, nonneg=True)
@@ -384,17 +387,35 @@ class TestDcp(BaseTest):
         objective = cp.sum_squares(x + y) - 2 * cp.log_det(P)
         problem = cp.Problem(cp.Minimize(objective))
 
-        # With ignore_dpp=True, should route to QP solver (EvalParams runs first)
+        problem.solve(solver=cp.CLARABEL, ignore_dpp=True)
+        self.assertEqual(problem.status, cp.OPTIMAL)
+        self.assertAlmostEqual(problem.value, 0.0, places=4)
+
+        # Re-solve with a new P: the program must serve fresh values.
+        P.value = 2 * np.eye(n)
+        problem.solve(solver=cp.CLARABEL, ignore_dpp=True)
+        self.assertAlmostEqual(problem.value, -2 * np.log(4.0), places=4)
+
+    def test_log_det_with_parameter_ignore_dpp_qp_solver(self) -> None:
+        """A QP solver still takes the problem: the variable-free log_det(P)
+        folds to a CallbackParam leaf, so it emits no cones and the problem
+        stays a QP. Unlike the EvalParams route the leaf is not frozen, so
+        the term tracks P.value across re-solves."""
+        n = 2
+        x = cp.Variable(n, nonneg=True)
+        y = cp.Variable(n, nonneg=True)
+        P = cp.Parameter((n, n))
+        P.value = np.eye(n)
+
+        problem = cp.Problem(
+            cp.Minimize(cp.sum_squares(x + y) - 2 * cp.log_det(P)))
         problem.solve(solver=cp.OSQP, ignore_dpp=True)
         self.assertEqual(problem.status, cp.OPTIMAL)
         self.assertAlmostEqual(problem.value, 0.0, places=4)
-        np.testing.assert_array_almost_equal(x.value, np.zeros(n), decimal=4)
-        np.testing.assert_array_almost_equal(y.value, np.zeros(n), decimal=4)
 
-        # Verify EvalParams is in the chain
-        _, chain, _ = problem.get_problem_data(cp.OSQP, ignore_dpp=True)
-        reduction_types = [type(r).__name__ for r in chain.reductions]
-        self.assertIn('EvalParams', reduction_types)
+        P.value = 2 * np.eye(n)
+        problem.solve(solver=cp.OSQP, ignore_dpp=True)
+        self.assertAlmostEqual(problem.value, -2 * np.log(4.0), places=4)
 
     def test_cumsum_of_parameter(self) -> None:
         """cumsum of a parameter-only expression must stay parameter-affine.

--- a/cvxpy/tests/test_fold_callback_params.py
+++ b/cvxpy/tests/test_fold_callback_params.py
@@ -1,0 +1,84 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import numpy as np
+
+import cvxpy as cp
+from cvxpy.expressions.constants.callback_param import CallbackParam
+from cvxpy.reductions.fold_callback_params import CallbackParamFold, _fold_expr
+from cvxpy.tests.base_test import BaseTest
+
+
+class TestCallbackParamFold(BaseTest):
+    """The fold replaces exactly the non-affine variable-free parametric
+    subtrees, at their maximal (outermost) node, with refreshable
+    CallbackParam leaves."""
+
+    def test_non_affine_subtree_folds_and_refreshes(self) -> None:
+        t = cp.Parameter()
+        folded = _fold_expr(cp.power(t, 2))
+        self.assertIsInstance(folded, CallbackParam)
+        for val in (2.0, -3.0):
+            t.value = val
+            self.assertAlmostEqual(float(folded.value), val ** 2)
+
+    def test_maximal_subtree_single_leaf(self) -> None:
+        """The whole variable-free composite folds as ONE leaf, not one per
+        nested non-affine node."""
+        t = cp.Parameter(pos=True)
+        expr = cp.exp(cp.square(t) + 1.0)
+        folded = _fold_expr(expr)
+        self.assertIsInstance(folded, CallbackParam)
+        t.value = 2.0
+        self.assertAlmostEqual(float(folded.value), np.exp(5.0))
+
+    def test_affine_and_leaf_subtrees_stay_symbolic(self) -> None:
+        p = cp.Parameter(2)
+        self.assertIs(_fold_expr(p), p)
+        affine = 2.0 * p + np.ones(2)
+        self.assertIs(_fold_expr(affine), affine)
+
+    def test_variable_branches_untouched_identity_preserved(self) -> None:
+        """Folding descends past variables; an expression with nothing to
+        fold is returned as the SAME object (cache-key stability)."""
+        t = cp.Parameter()
+        x = cp.Variable()
+        expr = x + cp.square(t)
+        folded = _fold_expr(expr)
+        self.assertIsNot(folded, expr)
+        self.assertIsInstance(folded.args[1], CallbackParam)
+
+        no_params = x + cp.square(cp.Constant(2.0))
+        self.assertIs(_fold_expr(no_params), no_params)
+
+    def test_sign_is_propagated(self) -> None:
+        t = cp.Parameter()
+        folded = _fold_expr(cp.square(t))
+        self.assertTrue(folded.is_nonneg())
+        folded_neg = _fold_expr(-cp.square(t))
+        self.assertTrue(folded_neg.is_nonpos())
+
+    def test_problem_apply_rebuilds_constraints(self) -> None:
+        t = cp.Parameter()
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(-x), [x <= cp.power(t, 2)])
+        new_prob, _ = CallbackParamFold().apply(prob)
+        (con,) = new_prob.constraints
+        params = new_prob.parameters()
+        self.assertEqual(len(params), 1)
+        self.assertIsInstance(params[0], CallbackParam)
+        t.value = 3.0
+        self.assertAlmostEqual(float(con.args[1].value), 9.0)

--- a/cvxpy/tests/test_ignore_dpp.py
+++ b/cvxpy/tests/test_ignore_dpp.py
@@ -1,0 +1,173 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+import cvxpy as cp
+import cvxpy.settings as s
+from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
+from cvxpy.reductions.eval_params import EvalParams
+from cvxpy.tests.base_test import BaseTest
+
+SOLVER = cp.CLARABEL
+DIFFENGINE = s.DIFFENGINE_CANON_BACKEND
+
+
+def _stuffing_backend(chain) -> str | None:
+    stuffing = [r for r in chain.reductions
+                if isinstance(r, ConeMatrixStuffing)][0]
+    return stuffing.canon_backend
+
+
+class TestIgnoreDppSelection(BaseTest):
+    """The ignore_dpp / non-DPP branch defaults to the DIFFENGINE backend when
+    the stuffed problem is parameter-free, and falls back silently otherwise."""
+
+    def test_ignore_dpp_defaults_to_diffengine(self) -> None:
+        x = cp.Variable(3)
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(x - 1)), [x >= 0])
+        prob.solve(solver=SOLVER, ignore_dpp=True)
+        self.assertEqual(_stuffing_backend(prob._cache.solving_chain), DIFFENGINE)
+        # EvalParams chains are never cached; the program is rebuilt per solve.
+        self.assertIsNone(prob._cache.param_prog)
+        self.assertItemsAlmostEqual(x.value, np.ones(3), places=4)
+
+    def test_parametric_ignore_dpp_bakes_then_defaults(self) -> None:
+        """Parametric problems stay in scope: EvalParams bakes the values, so
+        the stuffed problem is parameter-free and tracks the parameter across
+        (fully recompiled) re-solves."""
+        p = cp.Parameter()
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(cp.square(x - p * p)))  # not DPP
+        for val in (1.0, -3.0):
+            p.value = val
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertEqual(_stuffing_backend(prob._cache.solving_chain),
+                             DIFFENGINE)
+            chain_types = [type(r) for r in prob._cache.solving_chain.reductions]
+            self.assertIn(EvalParams, chain_types)
+            self.assertAlmostEqual(x.value, val * val, places=5)
+
+    def test_non_dpp_defaults_to_diffengine(self) -> None:
+        """The non-DPP branch (without an explicit ignore_dpp) selects the
+        backend the same way."""
+        p = cp.Parameter()
+        p.value = 2.0
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(cp.square(x - p * p)))
+        with pytest.warns(UserWarning, match="not DPP"):
+            prob.solve(solver=SOLVER)
+        self.assertEqual(_stuffing_backend(prob._cache.solving_chain), DIFFENGINE)
+        self.assertAlmostEqual(x.value, 4.0, places=5)
+
+    def test_baked_parametric_data_matches_cpp(self) -> None:
+        """Stuffed data on the default DIFFENGINE route equals an explicit CPP
+        request at the same parameter values."""
+        p = cp.Parameter(2)
+        p.value = np.array([1.0, -2.0])
+        x = cp.Variable(2)
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(x - p)),
+                          [cp.norm2(x) <= 3, cp.sum(x) == 0.5])
+        data_de, _, _ = prob.get_problem_data(SOLVER, ignore_dpp=True)
+        data_cpp, _, _ = prob.get_problem_data(
+            SOLVER, ignore_dpp=True, canon_backend=s.CPP_CANON_BACKEND)
+        for key in data_cpp:
+            expected = data_cpp[key]
+            if sp.issparse(expected):
+                self.assertItemsAlmostEqual(
+                    data_de[key].toarray(), expected.toarray(), places=10)
+            elif isinstance(expected, np.ndarray):
+                self.assertItemsAlmostEqual(data_de[key], expected, places=10)
+
+    def test_nd_problem_falls_back(self) -> None:
+        """N-D expressions fall back to the tensor backends silently."""
+        x = cp.Variable((2, 2, 2))
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(x)))
+        prob.solve(solver=SOLVER, ignore_dpp=True)
+        self.assertNotEqual(_stuffing_backend(prob._cache.solving_chain),
+                            DIFFENGINE)
+        self.assertAlmostEqual(prob.value, 0.0, places=6)
+
+    def test_parametric_bounds_fall_back(self) -> None:
+        """Parametric variable bounds survive EvalParams, so default selection
+        must fall back to the tensor backends instead of tripping the
+        backend's guards."""
+        lb = cp.Parameter(2)
+        lb.value = np.array([0.5, 0.25])
+        x = cp.Variable(2, bounds=[lb, 10])
+        prob = cp.Problem(cp.Minimize(cp.sum(x)))
+        prob.solve(solver=SOLVER, ignore_dpp=True)
+        self.assertNotEqual(_stuffing_backend(prob._cache.solving_chain),
+                            DIFFENGINE)
+        self.assertItemsAlmostEqual(x.value, lb.value, places=4)
+
+    def test_parametric_pow_cone_alpha(self) -> None:
+        """PowCone3D's alpha lives outside the constraint args and survives
+        EvalParams; it must flow to the solver identically on the default
+        DIFFENGINE route."""
+        alpha = cp.Parameter()
+        alpha.value = 0.4
+        x = cp.Variable(pos=True)
+        y = cp.Variable(pos=True)
+        z = cp.Variable()
+        cons = [cp.constraints.PowCone3D(x, y, z, alpha), x <= 2, y <= 3]
+        prob = cp.Problem(cp.Maximize(z), cons)
+        prob.solve(solver=SOLVER, ignore_dpp=True)
+        self.assertEqual(_stuffing_backend(prob._cache.solving_chain), DIFFENGINE)
+
+        x2 = cp.Variable(pos=True)
+        y2 = cp.Variable(pos=True)
+        z2 = cp.Variable()
+        base = cp.Problem(cp.Maximize(z2),
+                          [cp.constraints.PowCone3D(x2, y2, z2, 0.4),
+                           x2 <= 2, y2 <= 3])
+        base.solve(solver=SOLVER, canon_backend=s.CPP_CANON_BACKEND,
+                   ignore_dpp=True)
+        self.assertAlmostEqual(prob.value, base.value, places=4)
+
+    def test_explicit_backend_still_honored(self) -> None:
+        """An explicit canon_backend on the ignore_dpp path wins over the
+        default."""
+        x = cp.Variable(3)
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(x - 1)))
+        _, chain, _ = prob.get_problem_data(
+            SOLVER, ignore_dpp=True, canon_backend=s.SCIPY_CANON_BACKEND)
+        self.assertEqual(_stuffing_backend(chain), s.SCIPY_CANON_BACKEND)
+
+    def test_dpp_path_unaffected(self) -> None:
+        """DPP solves without ignore_dpp keep the tensor pipeline."""
+        p = cp.Parameter()
+        p.value = 1.0
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(x - p)))
+        prob.solve(solver=SOLVER)
+        self.assertNotEqual(_stuffing_backend(prob._cache.solving_chain),
+                            DIFFENGINE)
+
+    def test_perspective_solves_with_pinned_internal_chain(self) -> None:
+        """The perspective canonicalizer's internal ignore_dpp chain is pinned
+        to CPP; perspective problems keep solving correctly."""
+        x = cp.Variable()
+        t = cp.Variable(pos=True)
+        persp = cp.perspective(cp.square(x), s=t)
+        prob = cp.Problem(cp.Minimize(persp + t), [x >= 2, t <= 4])
+        prob.solve(solver=SOLVER)
+        self.assertEqual(prob.status, cp.OPTIMAL)
+        # x^2/t + t minimized at t = min(x=2 -> 2), value 2^2/2+2 = 4 at t=2
+        self.assertAlmostEqual(prob.value, 4.0, places=3)

--- a/cvxpy/tests/test_ignore_dpp.py
+++ b/cvxpy/tests/test_ignore_dpp.py
@@ -15,14 +15,22 @@ limitations under the License.
 """
 from __future__ import annotations
 
+import unittest
+from unittest import mock
+
 import numpy as np
 import pytest
 import scipy.sparse as sp
 
 import cvxpy as cp
 import cvxpy.settings as s
-from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeMatrixStuffing
+from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import (
+    ConeMatrixStuffing,
+    ParamConeProg,
+)
 from cvxpy.reductions.eval_params import EvalParams
+from cvxpy.reductions.fold_callback_params import CallbackParamFold
+from cvxpy.reductions.solvers.defines import INSTALLED_MI_SOLVERS
 from cvxpy.tests.base_test import BaseTest
 
 SOLVER = cp.CLARABEL
@@ -44,14 +52,14 @@ class TestIgnoreDppSelection(BaseTest):
         prob = cp.Problem(cp.Minimize(cp.sum_squares(x - 1)), [x >= 0])
         prob.solve(solver=SOLVER, ignore_dpp=True)
         self.assertEqual(_stuffing_backend(prob._cache.solving_chain), DIFFENGINE)
-        # EvalParams chains are never cached; the program is rebuilt per solve.
-        self.assertIsNone(prob._cache.param_prog)
+        # Parameter-free programs are cacheable (nothing to re-evaluate).
+        self.assertIsInstance(prob._cache.param_prog, ParamConeProg)
         self.assertItemsAlmostEqual(x.value, np.ones(3), places=4)
 
-    def test_parametric_ignore_dpp_bakes_then_defaults(self) -> None:
-        """Parametric problems stay in scope: EvalParams bakes the values, so
-        the stuffed problem is parameter-free and tracks the parameter across
-        (fully recompiled) re-solves."""
+    def test_parametric_ignore_dpp_stays_symbolic(self) -> None:
+        """Parametric problems keep their parameters symbolic: the chain
+        folds non-affine parametric constants (no EvalParams), and values
+        track the parameter across re-solves."""
         p = cp.Parameter()
         x = cp.Variable()
         prob = cp.Problem(cp.Minimize(cp.square(x - p * p)))  # not DPP
@@ -61,7 +69,8 @@ class TestIgnoreDppSelection(BaseTest):
             self.assertEqual(_stuffing_backend(prob._cache.solving_chain),
                              DIFFENGINE)
             chain_types = [type(r) for r in prob._cache.solving_chain.reductions]
-            self.assertIn(EvalParams, chain_types)
+            self.assertIn(CallbackParamFold, chain_types)
+            self.assertNotIn(EvalParams, chain_types)
             self.assertAlmostEqual(x.value, val * val, places=5)
 
     def test_non_dpp_defaults_to_diffengine(self) -> None:
@@ -76,17 +85,18 @@ class TestIgnoreDppSelection(BaseTest):
         self.assertEqual(_stuffing_backend(prob._cache.solving_chain), DIFFENGINE)
         self.assertAlmostEqual(x.value, 4.0, places=5)
 
-    def test_baked_parametric_data_matches_cpp(self) -> None:
-        """Stuffed data on the default DIFFENGINE route equals an explicit CPP
-        request at the same parameter values."""
+    def test_symbolic_data_matches_dpp_tensor_path(self) -> None:
+        """Stuffed data on the symbolic DIFFENGINE route equals the DPP
+        tensor path at the same parameter values."""
         p = cp.Parameter(2)
         p.value = np.array([1.0, -2.0])
         x = cp.Variable(2)
         prob = cp.Problem(cp.Minimize(cp.sum_squares(x - p)),
                           [cp.norm2(x) <= 3, cp.sum(x) == 0.5])
+        self.assertTrue(prob.is_dpp())
         data_de, _, _ = prob.get_problem_data(SOLVER, ignore_dpp=True)
         data_cpp, _, _ = prob.get_problem_data(
-            SOLVER, ignore_dpp=True, canon_backend=s.CPP_CANON_BACKEND)
+            SOLVER, canon_backend=s.CPP_CANON_BACKEND)
         for key in data_cpp:
             expected = data_cpp[key]
             if sp.issparse(expected):
@@ -94,6 +104,17 @@ class TestIgnoreDppSelection(BaseTest):
                     data_de[key].toarray(), expected.toarray(), places=10)
             elif isinstance(expected, np.ndarray):
                 self.assertItemsAlmostEqual(data_de[key], expected, places=10)
+
+    def test_explicit_tensor_backend_with_params_raises(self) -> None:
+        """An explicit tensor backend cannot serve the symbolic parametric
+        path."""
+        p = cp.Parameter()
+        p.value = 2.0
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(cp.square(x - p * p)))
+        with self.assertRaisesRegex(ValueError, "keeps parameters symbolic"):
+            prob.get_problem_data(SOLVER, ignore_dpp=True,
+                                  canon_backend=s.CPP_CANON_BACKEND)
 
     def test_nd_problem_falls_back(self) -> None:
         """N-D expressions fall back to the tensor backends silently."""
@@ -116,6 +137,23 @@ class TestIgnoreDppSelection(BaseTest):
         self.assertNotEqual(_stuffing_backend(prob._cache.solving_chain),
                             DIFFENGINE)
         self.assertItemsAlmostEqual(x.value, lb.value, places=4)
+
+    def test_direct_cone_solver_falls_back(self) -> None:
+        """ExtractDirectCones rebuilds the stuffed program as a stock
+        ParamConeProg, which would discard the symbolic program's
+        re-extraction; solvers advertising DIR_CONE_KINDS therefore stay on
+        the tensor path."""
+        A = np.array([[1.0, 2.0], [3.0, 4.0]])
+        x = cp.Variable(2)
+        p = cp.Parameter(nonneg=True)
+        p.value = 1.0
+        prob = cp.Problem(cp.Minimize(cp.sum(x)), [(p * A) @ x >= 1, x >= 0])
+        solver_cls = type(prob._construct_chain(solver=SOLVER).solver)
+        with mock.patch.object(solver_cls, "DIR_CONE_KINDS",
+                               frozenset({"nonneg", "soc"})):
+            chain = prob._construct_chain(solver=SOLVER, ignore_dpp=True)
+        self.assertNotEqual(_stuffing_backend(chain), DIFFENGINE)
+        self.assertTrue(any(isinstance(r, EvalParams) for r in chain.reductions))
 
     def test_parametric_pow_cone_alpha(self) -> None:
         """PowCone3D's alpha lives outside the constraint args and survives
@@ -171,3 +209,137 @@ class TestIgnoreDppSelection(BaseTest):
         self.assertEqual(prob.status, cp.OPTIMAL)
         # x^2/t + t minimized at t = min(x=2 -> 2), value 2^2/2+2 = 4 at t=2
         self.assertAlmostEqual(prob.value, 4.0, places=3)
+
+
+class TestIgnoreDppBehavior(BaseTest):
+    """ignore_dpp / non-DPP solves keep parameters symbolic on the DIFFENGINE
+    backend; values must refresh across solves and unsound canonicalizations
+    must not happen."""
+
+    def test_parametric_divisor_resolves(self) -> None:
+        """A parametric divisor is re-evaluated by the engine on each solve."""
+        p = cp.Parameter(pos=True)
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(cp.square(x / p - 1.0)))
+        for val in (2.0, 5.0):
+            p.value = val
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertEqual(prob.status, cp.OPTIMAL)
+            self.assertAlmostEqual(x.value, val, places=4)
+
+        pv = cp.Parameter(3, pos=True)
+        xv = cp.Variable(3)
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(xv / pv - 1.0)))
+        for val in (np.array([1.0, 2.0, 4.0]), np.array([3.0, 0.5, 1.5])):
+            pv.value = val
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertEqual(prob.status, cp.OPTIMAL)
+            self.assertItemsAlmostEqual(xv.value, val, places=4)
+
+    def test_param_constant_in_concave_position_sound(self) -> None:
+        """A parametric-constant composite on the 'wrong' side of an
+        inequality must not be epigraph-relaxed: x <= power(t, 2) would
+        relax to x <= s, s >= t**2 (vacuous). It folds to a CallbackParam
+        leaf before canonicalization and refreshes on each solve."""
+        t = cp.Parameter()
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(-x), [x <= cp.power(t, 2)])
+        for val in (2.0, 3.0):
+            t.value = val
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertEqual(prob.status, cp.OPTIMAL)
+            self.assertAlmostEqual(x.value, val ** 2, places=4)
+
+    def test_unsupported_variable_free_atom_evaluates(self) -> None:
+        """An atom with no symbolic converter over parameters only (floor,
+        as emitted by DQCP bisection) folds to a CallbackParam leaf whose
+        value refreshes per solve."""
+        p = cp.Parameter()
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(cp.square(x - cp.floor(p))))
+        for val in (2.7, -1.2):
+            p.value = val
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertAlmostEqual(x.value, np.floor(val), places=4)
+
+    def test_symbolic_quad_matrix_refreshes(self) -> None:
+        """quad_over_lin(x, p) keeps its quadratic matrix symbolic (I/p fed
+        to the engine as a composite param_source); re-solves must serve
+        fresh values."""
+        x = cp.Variable()
+        p = cp.Parameter()
+        prob = cp.Problem(cp.Minimize(cp.quad_over_lin(x, p) + x))
+        for val in (1.0, 1000.0, 1.0):
+            p.value = val
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertAlmostEqual(x.value, -val / 2.0, places=3)
+
+    def test_soc_restruct_resolve_and_duals(self) -> None:
+        """The pre-applied SOC restructuring matrix must act on freshly
+        extracted (A, b) on re-solves; duals must match the default path."""
+        c = np.array([1.0, 2.0])
+        p = cp.Parameter(2)
+        x = cp.Variable(2)
+        constraints = [cp.norm(x - p) <= 2.0, x >= -5]
+        prob = cp.Problem(cp.Minimize(c @ x), constraints)
+
+        for val in (np.array([1.0, 1.0]), np.array([-2.0, 3.0])):
+            p.value = val
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertEqual(prob.status, cp.OPTIMAL)
+
+            x_base = cp.Variable(2)
+            base_cons = [cp.norm(x_base - val) <= 2.0, x_base >= -5]
+            base = cp.Problem(cp.Minimize(c @ x_base), base_cons)
+            base.solve(solver=SOLVER)
+            self.assertAlmostEqual(prob.value, base.value, places=4)
+            self.assertItemsAlmostEqual(x.value, x_base.value, places=4)
+            for con_de, con_base in zip(constraints, base_cons):
+                self.assertItemsAlmostEqual(
+                    con_de.dual_value, con_base.dual_value, places=4)
+
+    def test_psd_restruct_resolve(self) -> None:
+        """PSD constraints exercise the symmetric restructuring across
+        parametric re-solves."""
+        P = cp.Parameter((2, 2), symmetric=True)
+        X = cp.Variable((2, 2), symmetric=True)
+        prob = cp.Problem(cp.Minimize(cp.trace(P @ X)),
+                          [X >> np.eye(2), cp.trace(X) <= 5])
+
+        for seed in (0, 3):
+            rng = np.random.default_rng(seed)
+            M = rng.standard_normal((2, 2))
+            P_val = M @ M.T + np.eye(2)
+            P.value = P_val
+            prob.solve(solver=SOLVER, ignore_dpp=True)
+            self.assertEqual(prob.status, cp.OPTIMAL)
+
+            X_base = cp.Variable((2, 2), symmetric=True)
+            base = cp.Problem(cp.Minimize(cp.trace(P_val @ X_base)),
+                              [X_base >> np.eye(2), cp.trace(X_base) <= 5])
+            base.solve(solver=SOLVER)
+            self.assertAlmostEqual(prob.value, base.value, places=3)
+
+    def test_derivative_contract_rejected(self) -> None:
+        """The symbolic program refuses the DPP-tensor differentiation
+        contract loudly instead of returning silently wrong derivatives."""
+        p = cp.Parameter()
+        p.value = 1.0
+        x = cp.Variable()
+        prob = cp.Problem(cp.Minimize(cp.square(x - p)))
+        data, _, _ = prob.get_problem_data(SOLVER, ignore_dpp=True)
+        param_prog = data[s.PARAM_PROB]
+        with self.assertRaisesRegex(NotImplementedError, "differentiation"):
+            param_prog.apply_parameters({p.id: 0.5}, zero_offset=True)
+        with self.assertRaisesRegex(NotImplementedError, "differentiation"):
+            param_prog.split_adjoint({})
+        with self.assertRaisesRegex(NotImplementedError, "differentiation"):
+            param_prog.apply_param_jac(None, None, None, None)
+
+    @unittest.skipUnless(INSTALLED_MI_SOLVERS, "no mixed-integer solver installed")
+    def test_mixed_integer_ignore_dpp(self) -> None:
+        x = cp.Variable(3, integer=True)
+        prob = cp.Problem(cp.Minimize(cp.sum(x)), [x >= 0.5, x <= 3.7])
+        prob.solve(ignore_dpp=True)
+        self.assertEqual(prob.status, cp.OPTIMAL)
+        self.assertItemsAlmostEqual(x.value, np.ones(3), places=4)


### PR DESCRIPTION
## Description

Stacked on #3449. On the `ignore_dpp` / non-DPP branch, parameters are no longer baked to constants by `EvalParams`: canonicalization keeps `Parameter` leaves symbolic, and stuffing returns a `DiffengineParamConeProg` — a `ParamConeProg` subclass owning the compiled engine program, which re-extracts `(q, d, A, b, P)` at the current parameter values on every `apply_parameters()` call. Two supporting mechanisms:

- **`CallbackParamFold`** (new reduction): `Dcp2Cone` epigraph-relaxes nonlinear atoms, which is unsound for a variable-free parametric subtree in a concave position (`x <= power(t, 2)`). The fold replaces every maximal variable-free parametric subtree that is not parameter-affine with a `CallbackParam` whose callback re-evaluates it, so canonicalization sees an opaque leaf and its value refreshes each solve.
- **`DiffengineConeFormat`** (new chain step): `ConicSolver.format_constraints` constructs a stock `ParamConeProg`, which would silently replace the re-extractable program at format time. The step materializes the solver's cone-restructuring matrix once — via an identity probe of the real `format_constraints`, so it cannot drift from upstream conventions — and hands the solver the program pre-formatted. QP solvers need no formatting step.

Fallbacks keep `EvalParams` + the tensor backends: N-D expressions, parametric variable bounds, DGP chains. An explicit tensor backend on the symbolic parametric route raises (it cannot keep parameters symbolic); the parameter differentiation contract (`requires_grad`, `zero_offset`/`keep_zeros`, `split_adjoint`/`apply_param_jac`) is rejected loudly. Cone-emitting parametric composites (e.g. `log_det(P)`) now count their cones in problem analysis, so a QP-only solver raises `SolverError` instead of silently solving a baked approximation. The perspective canonicalizer pins its internal chains to CPP and pre-bakes their parameters, preserving its bake-at-canon semantics exactly.

The compiled program is rebuilt on every solve in this PR (`SolvingChain.uncached_param_prog`); caching it across re-solves is the follow-up (#3450). Design notes: `diff_engine/IGNORE_DPP_BEHAVIOR.md`.

**Correctness:** behavior tests cover the epigraph-soundness fold, parametric divisors/kron/quad matrices refreshing across solves, SOC restructuring parity with duals, PSD parity, the QP-path, and the loud rejections. Externally, stuffed-data equivalence on the cvxpy benchmarks (ConvexPlasticity vs upstream CPP+ignore_dpp; HuberRegression, FactorCovarianceModel vs the CPP tensor path): `P/c/A/b` identical.

Frozen-surface note: `ConeMatrixStuffing`'s dispatch, `conic_solver.py`, `qp_solver.py`, and `canonInterface.py` are untouched; `problem.py` changes by 5 lines (`safe_to_cache` reads the chain flag).

Issue link (if applicable): —

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.