### PR TITLE
Clarify that warm_start initial-guess support is not yet implemented …

### DIFF
--- a/doc/source/tutorial/solvers/index.rst
+++ b/doc/source/tutorial/solvers/index.rst
@@ -291,6 +291,13 @@ warm start would only be a good initial point.
 
 Warm start can also be used to provide an initial guess the first time a problem is solved.
 The initial guess is constructed from the ``value`` field of the problem variables.
+
+.. note::
+   As of now, this initial-guess behavior is not implemented for most solver
+   backends. Setting a variable's ``value`` before the first solve currently
+   has no effect on the result. See `#1355
+   <https://github.com/cvxpy/cvxpy/issues/1355>`_ for details and status.
+
 If the same problem is solved a second time, the initial guess is constructed from the
 cached previous solution as described above (rather than from the ``value`` field).
 


### PR DESCRIPTION
]Fixes #2912

Adds a note clarifying that the "initial guess on first solve" behavior
described in the warm start docs is not currently implemented for most
solver backends, as reported in #1355. This avoids misleading users who
set variable values expecting them to be used as an initial guess before
the first solve.