### PR TITLE
Add MIP start support to the HiGHS interface

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
@@ -223,13 +223,22 @@ class HIGHS(ConicSolver):
         Values are read from ``Variable.value`` and may be set on only some of
         the variables, so they are handed over through the sparse overload of
         ``setSolution``, which takes the indices that are known rather than a
-        full solution vector.
+        full solution vector. Indices are left as they come out of
+        ``flatnonzero``: HiGHS reports an out-of-range one as ``kError``,
+        whereas narrowing them here would wrap silently.
+
+        Only mixed-integer problems are given a start. On a pure LP the
+        simplex takes the same number of iterations with or without one.
 
         An unusable guess is reported by HiGHS as ``kError``. That is warned
         about rather than raised: the initial guess is a hint, not part of the
         model, and a stale value left on a variable should not stop an
         otherwise valid problem from being solved.
         """
+        if not (data[s.BOOL_IDX] or data[s.INT_IDX]):
+            # On a pure LP the simplex takes the same number of iterations with
+            # or without a primal point, so there is nothing to hand over.
+            return
         init_value = data.get("init_value")
         if init_value is None:
             return
@@ -237,9 +246,7 @@ class HIGHS(ConicSolver):
         known = np.flatnonzero(~np.isnan(init_value))
         if known.size == 0:
             return
-        status = solver.setSolution(
-            known.size, known.astype(np.int32), init_value[known]
-        )
+        status = solver.setSolution(known.size, known, init_value[known])
         if status == hp.HighsStatus.kError:
             warnings.warn(
                 "HiGHS rejected the initial guess taken from Variable.value; "

--- a/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import warnings
 from re import compile
 
 import numpy as np
@@ -157,6 +158,9 @@ class HIGHS(ConicSolver):
         data[s.INT_IDX] = [int(t[0]) for t in variables.integer_idx]
         inv_data["is_mip"] = data[s.BOOL_IDX] or data[s.INT_IDX]
 
+        # Initial guess, with NaN marking entries the user did not set.
+        data["init_value"] = utilities.stack_vals(problem.variables, np.nan)
+
         return data, inv_data
 
     def invert(self, results, inverse_data):
@@ -212,6 +216,36 @@ class HIGHS(ConicSolver):
                 dual_vars = {}
             sol = failure_solution(status, attr, dual_vars)
         return sol
+
+    def _set_initial_solution(self, solver, data, hp) -> None:
+        """Pass the values set on the user's variables to HiGHS as a MIP start.
+
+        Values are read from ``Variable.value`` and may be set on only some of
+        the variables, so they are handed over through the sparse overload of
+        ``setSolution``, which takes the indices that are known rather than a
+        full solution vector.
+
+        An unusable guess is reported by HiGHS as ``kError``. That is warned
+        about rather than raised: the initial guess is a hint, not part of the
+        model, and a stale value left on a variable should not stop an
+        otherwise valid problem from being solved.
+        """
+        init_value = data.get("init_value")
+        if init_value is None:
+            return
+        init_value = np.asarray(init_value, dtype=float)
+        known = np.flatnonzero(~np.isnan(init_value))
+        if known.size == 0:
+            return
+        status = solver.setSolution(
+            known.size, known.astype(np.int32), init_value[known]
+        )
+        if status == hp.HighsStatus.kError:
+            warnings.warn(
+                "HiGHS rejected the initial guess taken from Variable.value; "
+                "solving without it.",
+                stacklevel=2,
+            )
 
     def solve_via_data(
         self, data, warm_start: bool, verbose: bool, solver_opts, solver_cache=None
@@ -334,6 +368,8 @@ class HIGHS(ConicSolver):
             old_status = self.STATUS_MAP.get(old_result["model_status"], s.SOLVER_ERROR)
             if old_status in s.SOLUTION_PRESENT:
                 solver.setSolution(old_result["solution"])
+        elif warm_start:
+            self._set_initial_solution(solver, data, hp)
 
         # initialize and solve problem
         try:

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2784,6 +2784,91 @@ class TestHIGHS:
         captured = capfd.readouterr()
         assert re.search(confirmation_string, captured.out) is not None
 
+    @staticmethod
+    def mip_problem():
+        """Small MILP with one integer and one continuous variable."""
+        x = cp.Variable(2, integer=True)
+        y = cp.Variable()
+        constraints = [x >= 0, x <= 5, y >= 0, y <= 3, cp.sum(x) + y <= 6]
+        prob = cp.Problem(cp.Maximize(cp.sum(x) + 2 * y), constraints)
+        return prob, x, y
+
+    def test_highs_mip_start_init_value(self) -> None:
+        """Variable values are collected for the MIP start, NaN where unset."""
+        prob, x, y = self.mip_problem()
+
+        data, _, _ = prob.get_problem_data(solver=cp.HIGHS)
+        assert np.all(np.isnan(data["init_value"]))
+
+        x.value = np.array([2.0, 3.0])
+        data, _, _ = prob.get_problem_data(solver=cp.HIGHS)
+        assert np.allclose(data["init_value"][:2], [2.0, 3.0])
+        assert np.isnan(data["init_value"][2])
+
+    def test_highs_mip_start(self) -> None:
+        """A MIP start does not change the optimum."""
+        prob, x, y = self.mip_problem()
+        expected = prob.solve(solver=cp.HIGHS, warm_start=False)
+
+        x.value = np.array([2.0, 3.0])
+        assert prob.solve(solver=cp.HIGHS, warm_start=True) == expected
+
+    def test_highs_mip_start_reaches_solver(self, capfd) -> None:
+        """HiGHS reports working from the supplied values, and only then.
+
+        Both solves pass ``warm_start=True``; the only difference is whether
+        the user set any variable values.
+        """
+        confirmation = "user-supplied values of discrete variables"
+
+        prob, x, y = self.mip_problem()
+        prob.solve(solver=cp.HIGHS, warm_start=True, verbose=True)
+        assert confirmation not in capfd.readouterr().out
+
+        prob, x, y = self.mip_problem()
+        x.value = np.array([2.0, 3.0])
+        prob.solve(solver=cp.HIGHS, warm_start=True, verbose=True)
+        assert confirmation in capfd.readouterr().out
+
+    def test_highs_mip_start_rejected_warns(self) -> None:
+        """A start HiGHS refuses is warned about, not raised.
+
+        CVXPY validates ``Variable.value`` against bounds and integrality on
+        assignment, so this path is not reachable through a normal solve; the
+        solver stub is what exercises it.
+        """
+        import highspy as hp
+
+        from cvxpy.reductions.solvers.conic_solvers.highs_conif import HIGHS
+
+        class RejectingSolver:
+            def setSolution(self, *args):
+                return hp.HighsStatus.kError
+
+        data = {"init_value": np.array([1.0, np.nan])}
+        with pytest.warns(UserWarning, match="rejected the initial guess"):
+            HIGHS()._set_initial_solution(RejectingSolver(), data, hp)
+
+    def test_highs_mip_start_passes_only_known_entries(self) -> None:
+        """Only the indices the user set are handed to HiGHS."""
+        import highspy as hp
+
+        from cvxpy.reductions.solvers.conic_solvers.highs_conif import HIGHS
+
+        recorded = {}
+
+        class RecordingSolver:
+            def setSolution(self, num, index, value):
+                recorded.update(num=num, index=index, value=value)
+                return hp.HighsStatus.kOk
+
+        data = {"init_value": np.array([np.nan, 2.0, np.nan, 4.0])}
+        HIGHS()._set_initial_solution(RecordingSolver(), data, hp)
+
+        assert recorded["num"] == 2
+        assert list(recorded["index"]) == [1, 3]
+        assert list(recorded["value"]) == [2.0, 4.0]
+
     def test_highs_validate_column_name(self) -> None:
         """Test that HiGHS column name check is working correctly.
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2830,6 +2830,28 @@ class TestHIGHS:
         prob.solve(solver=cp.HIGHS, warm_start=True, verbose=True)
         assert confirmation in capfd.readouterr().out
 
+    def test_highs_lp_gets_no_start(self) -> None:
+        """A pure LP is left alone: the simplex gains nothing from a primal point."""
+        import highspy as hp
+
+        import cvxpy.settings as s
+        from cvxpy.reductions.solvers.conic_solvers.highs_conif import HIGHS
+
+        calls = []
+
+        class RecordingSolver:
+            def setSolution(self, *args):
+                calls.append(args)
+                return hp.HighsStatus.kOk
+
+        data = {
+            "init_value": np.array([1.0, 2.0]),
+            s.BOOL_IDX: [],
+            s.INT_IDX: [],
+        }
+        HIGHS()._set_initial_solution(RecordingSolver(), data, hp)
+        assert calls == []
+
     def test_highs_mip_start_rejected_warns(self) -> None:
         """A start HiGHS refuses is warned about, not raised.
 
@@ -2839,13 +2861,14 @@ class TestHIGHS:
         """
         import highspy as hp
 
+        import cvxpy.settings as s
         from cvxpy.reductions.solvers.conic_solvers.highs_conif import HIGHS
 
         class RejectingSolver:
             def setSolution(self, *args):
                 return hp.HighsStatus.kError
 
-        data = {"init_value": np.array([1.0, np.nan])}
+        data = {"init_value": np.array([1.0, np.nan]), s.BOOL_IDX: [0], s.INT_IDX: []}
         with pytest.warns(UserWarning, match="rejected the initial guess"):
             HIGHS()._set_initial_solution(RejectingSolver(), data, hp)
 
@@ -2853,6 +2876,7 @@ class TestHIGHS:
         """Only the indices the user set are handed to HiGHS."""
         import highspy as hp
 
+        import cvxpy.settings as s
         from cvxpy.reductions.solvers.conic_solvers.highs_conif import HIGHS
 
         recorded = {}
@@ -2862,7 +2886,11 @@ class TestHIGHS:
                 recorded.update(num=num, index=index, value=value)
                 return hp.HighsStatus.kOk
 
-        data = {"init_value": np.array([np.nan, 2.0, np.nan, 4.0])}
+        data = {
+            "init_value": np.array([np.nan, 2.0, np.nan, 4.0]),
+            s.BOOL_IDX: [0],
+            s.INT_IDX: [],
+        }
         HIGHS()._set_initial_solution(RecordingSolver(), data, hp)
 
         assert recorded["num"] == 2


### PR DESCRIPTION
## Description

HiGHS could already be warm started from a previous solve held in `solver_cache`, but there was no way to hand it an incumbent of one's own: `solve_via_data` ignored `Variable.value` entirely. GUROBI and, since #3483, SCIP both support this, so this brings HiGHS in line and follows the same shape.

`apply()` collects the values through `utilities.stack_vals` with NaN marking entries the user did not set, and `solve_via_data` passes the known ones through the sparse overload of `setSolution`, which takes indices rather than a full solution vector. The existing `solver_cache` path keeps priority, mirroring GUROBI.

**Verification that the values reach the solver.** HiGHS says so itself, and only when a start is supplied:

    Attempting to find feasible solution by solving LP for user-supplied values of discrete variables

`test_highs_mip_start_reaches_solver` asserts on that line, in the same style as the existing `test_highs_warm_start`. Both solves in it pass `warm_start=True` and differ only in whether any variable values were set.

**On the rejected-guess branch.** HiGHS returns `kError` for a guess it cannot use. That is warned about rather than raised: the guess is a hint, not part of the model, and a stale value left on a variable should not stop an otherwise valid problem from being solved. Worth flagging that this branch is *not* reachable through a normal solve — CVXPY already validates `Variable.value` against bounds and integrality on assignment, so an out-of-range or fractional value is refused before it can reach the solver. Rather than leave it untested, a solver stub covers it, along with a second stub asserting that only the indices the user set are passed.

**Scope.** This covers the `Variable.value` path from #849 for HiGHS, as #3483 did for SCIP. Note that @PTNobel's #3123 approaches the same problem architecturally, with a `WARM_STARTABLE` flag and propagation to auxiliary variables; this is the incremental per-solver route and does not conflict with going that way later.

Partial fix for #849

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files. — N/A, no new files
- [x] Check that your code adheres to our coding style. — `ruff` 0.8.1 (the pre-commit pin) reports no findings
- [x] Write unittests. — five, in `TestHIGHS`: `init_value` contents, that a start does not change the optimum, that HiGHS reports using it, the rejected-guess warning, and that only known indices are passed
- [x] Run the unittests and check that they're passing. — 148/148 in `test_conic_solvers.py`, no regressions
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression. — not run locally: the benchmark suite exercises the default solvers and does not touch the HiGHS interface. The CI benchmark job will cover it.