### PR TITLE
Fixed PSD and NSD check to allow for complex coefficients

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -575,7 +575,7 @@ class Leaf(expression.Expression):
                   key in ['symmetric', 'PSD', 'NSD']]):
             if val.dtype.kind in 'ib':
                 val = val.astype(float)
-            val = val + np.swapaxes(val, -2, -1)
+            val = val + np.swapaxes(val, -2, -1).conj()
             val /= 2.
             if self.attributes['symmetric']:
                 return val
@@ -590,7 +590,7 @@ class Leaf(expression.Expression):
                 if not bad.any():
                     return val
                 w[bad] = 0
-            return (V * w[..., np.newaxis, :]) @ np.swapaxes(V, -2, -1)
+            return (V * w[..., np.newaxis, :]) @ np.swapaxes(V, -2, -1).conj()
         elif self.attributes['sparsity'] and not sparse_path:
             warn('Accessing a sparse CVXPY expression via a dense representation.'
                   ' Please report this as a bug to the CVXPY Discord or GitHub.',


### PR DESCRIPTION
Minor change so that a complex valued PSD matrix does not fail the PSD validation check (which for now only works for real coefficients since only the transpose is done and not the complex conjugation)