### PR TITLE
Fix trace canonicalization for scalar and elementwise products

### DIFF
--- a/cvxpy/atoms/affine/trace.py
+++ b/cvxpy/atoms/affine/trace.py
@@ -39,13 +39,16 @@ def trace(expr) -> Expression:
     both real and complex matrices (no conjugation on A is needed).
 
     When the MulExpression is Hermitian (e.g. X @ X^H for Hermitian X), the
-    result is provably real; it is wrapped with real() so that is_real()
-    correctly returns True without routing to the O(n^3) Trace(expr) path.
+    result is provably real. If that fact is not already known from the
+    result's arguments, it is wrapped with real() so that is_real() correctly
+    returns True without routing to the O(n^3) Trace(expr) path.
     """
-    if isinstance(expr, MulExpression):
+    # Use an exact type check: `multiply` subclasses `MulExpression`, but this
+    # rewrite is valid only for matrix multiplication.
+    if type(expr) is MulExpression:
         # trace(A @ B) = sum(A * B.T), correct for real and complex matrices.
         result = cvxpy_sum(multiply(expr.args[0], expr.args[1].T))
-        if expr.is_hermitian():
+        if expr.is_hermitian() and not result.is_real():
             # trace of a Hermitian matrix is provably real.
             # Wrap with real() so is_real() == True propagates upward.
             return real_atom(result)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -928,6 +928,37 @@ class TestAtoms(BaseTest):
         prob.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(prob.value, np.trace(C @ X.value), places=4)
 
+    def test_trace_scalar_real_products(self) -> None:
+        """Real scalar-shaped products should canonicalize without real()."""
+        X = cp.Variable((1, 1))
+        constant = np.array([[2.]])
+
+        matmul_trace = cp.trace(constant @ X)
+        self.assertIsInstance(matmul_trace, Sum)
+        matmul_trace.canonical_form
+
+        elementwise_trace = cp.trace(cp.multiply(constant, X))
+        self.assertIsInstance(elementwise_trace, cp.Trace)
+        elementwise_trace.canonical_form
+
+    def test_trace_AB_hermitian_complex(self) -> None:
+        """Complex Hermitian products should retain their real trace property."""
+        X = cp.Variable((2, 2), hermitian=True)
+        constant = np.array([[2., 1 + 1j], [1 - 1j, 3.]])
+        trace_expr = cp.trace(cp.multiply(constant, X))
+
+        self.assertIsInstance(trace_expr, cp.Trace)
+        self.assertTrue(trace_expr.is_real())
+
+    def test_trace_elementwise_multiply(self) -> None:
+        """Trace of an elementwise product must only sum its diagonal."""
+        A = np.array([[1., 2.], [3., 4.]])
+        B = np.array([[5., 6.], [7., 8.]])
+        trace_expr = cp.trace(cp.multiply(A, B))
+
+        self.assertIsInstance(trace_expr, cp.Trace)
+        self.assertAlmostEqual(trace_expr.value, np.trace(A * B))
+
     def test_trace_complex2real(self) -> None:
         X = cp.Variable((2, 2), complex=True)
         problem = cp.Problem(cp.Minimize(cp.norm(cp.trace(X))), [X==2])


### PR DESCRIPTION
## Description

Fixes `trace()` canonicalization for the 1×1 product cases reported in #3480.

The fast path for `trace(A @ B)` treated every `MulExpression` subclass as matrix multiplication. That included elementwise `multiply`, whose trace is not generally `sum(A * B.T)`. For real 1×1 matrix products, the same path also wrapped an already-real scalar in `real()`, which has no direct graph implementation and raised `NotImplementedError` during canonicalization.

This change:

- limits the `trace(A @ B)` rewrite to actual matrix-multiplication expressions;
- avoids a redundant `real()` wrapper when the rewritten result is already real;
- adds regressions for both 1×1 reproductions, general elementwise trace semantics, and complex Hermitian inputs.

Issue link: Closes #3480

## Type of change

- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## Verification

- `pytest -q cvxpy/tests/test_atoms.py` — 134 passed
- `pytest -q cvxpy/tests/test_complex.py cvxpy/tests/test_expressions.py` — 219 passed
- `ruff check cvxpy`
- `git diff --check`

## Contribution checklist

- [x] Add our license to new files (no new files)
- [x] Check that the code adheres to the project coding style
- [x] Write unit tests
- [x] Run the unit tests and check that they pass
- [ ] Run benchmarks (not run; this is a small correctness fix with no new hot-path operations)
