### PR TITLE
Accept any shape in geo_mean, and fix row vectors along the way

### DIFF
--- a/cvxpy/atoms/geo_mean.py
+++ b/cvxpy/atoms/geo_mean.py
@@ -17,10 +17,11 @@ limitations under the License.
 from collections.abc import Sequence
 
 import numpy as np
-import scipy.sparse as sp
 
 from cvxpy.atoms.affine.promote import promote
-from cvxpy.atoms.atom import Atom
+from cvxpy.atoms.affine.reshape import reshape
+from cvxpy.atoms.affine.transpose import moveaxis
+from cvxpy.atoms.axis_atom import AxisAtom
 from cvxpy.atoms.errormsg import SECOND_ARG_SHOULD_NOT_BE_EXPRESSION_ERROR_MESSAGE
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.expressions import cvxtypes
@@ -35,7 +36,8 @@ from cvxpy.utilities.power_tools import (
 )
 
 
-def geo_mean(x, p=None, max_denom=1024, approx=True) -> Expression:
+def geo_mean(x, p=None, max_denom=1024, approx=True, axis=None,
+             keepdims: bool = False) -> Expression:
     """Factory function for (weighted) geometric mean.
 
     Parameters
@@ -49,18 +51,25 @@ def geo_mean(x, p=None, max_denom=1024, approx=True) -> Expression:
     approx : bool
         When True (default), uses SOC approximation. When False,
         uses power cone (exact).
+    axis : int or tuple of int, optional
+        The axes to reduce along. ``None`` reduces every entry into a single
+        geometric mean.
+    keepdims : bool
+        Keep the reduced axes with length one.
 
     Returns
     -------
-    GeoMean or GeoMeanApprox
+    Expression
+        A scalar when ``axis`` is None, otherwise one geometric mean per
+        slice along ``axis``.
     """
     if approx:
-        return GeoMeanApprox(x, p=p, max_denom=max_denom)
-    else:
-        return GeoMean(x, p=p, max_denom=max_denom)
+        return GeoMeanApprox(x, p=p, max_denom=max_denom, axis=axis,
+                             keepdims=keepdims)
+    return GeoMean(x, p=p, max_denom=max_denom, axis=axis, keepdims=keepdims)
 
 
-class GeoMean(Atom):
+class GeoMean(AxisAtom):
     """ The (weighted) geometric mean of vector ``x``, with optional powers given by ``p``:
 
     .. math::
@@ -178,7 +187,10 @@ class GeoMean(Atom):
     Parameters
     ----------
     x : Variable
-        A column or row vector whose elements we will take the geometric mean of.
+        An expression of any shape whose elements we will take the geometric
+        mean of. Anything past one dimension is flattened in row-major order,
+        so a row vector, a column vector and an N-D array holding the same
+        entries all give the same result.
 
     p : Sequence (list, tuple, ...) of ``int``, ``float``, or ``Fraction`` objects
         A vector of weights for the weighted geometric mean
@@ -205,35 +217,37 @@ class GeoMean(Atom):
     """
 
     def __init__(self, x, p: Sequence[float] | np.ndarray | None = None,
-                 max_denom: int = 1024) -> None:
+                 max_denom: int = 1024, axis=None, keepdims: bool = False) -> None:
         Expression = cvxtypes.expression()
         if p is not None and isinstance(p, Expression):
             raise TypeError(SECOND_ARG_SHOULD_NOT_BE_EXPRESSION_ERROR_MESSAGE)
-        elif p is not None and hasattr(p, '__getitem__'):
+
+        if isinstance(x, list):
+            x = np.array(x)
+        x = Expression.cast(x)
+        if x.ndim == 0:
+            x = Expression.cast(promote(x, shape=(1,)))
+
+        super(GeoMean, self).__init__(x, axis=axis, keepdims=keepdims)
+
+        n = self._reduced_size()
+
+        if p is not None and hasattr(p, '__getitem__'):
             p = np.array(p)
-            idxs = p > 0
-            if isinstance(x, list):
-                x = np.array(x)
-            if x.ndim == 0:
-                x = Expression.cast(promote(x, shape=(1,)))[idxs]
-            else:
-                x = Expression.cast(x)[idxs]
-            p = p[idxs]
-        super(GeoMean, self).__init__(x)
-
-        x = self.args[0]
-        if x.is_vector():
-            n = 1 if x.ndim == 0 else max(x.shape)
+            if len(p) != n:
+                raise ValueError('x and p must have the same number of elements.')
+            # Entries with zero weight take no part. They are dropped from the
+            # canonicalization rather than from the argument, so that the
+            # argument keeps the shape the axis bookkeeping is based on.
+            self._keep = p > 0
+            p = p[self._keep]
         else:
-            raise ValueError('x must be a row or column vector.')
+            self._keep = np.ones(n, dtype=bool)
+            if p is None:
+                p = [1] * n
 
-        if p is None:
-            p = [1]*n
         self.p = p
         self.max_denom = max_denom
-
-        if len(p) != n:
-            raise ValueError('x and p must have the same number of elements.')
 
         if any(v < 0 for v in p) or sum(p) <= 0:
             raise ValueError('powers must be nonnegative and not all zero.')
@@ -242,20 +256,68 @@ class GeoMean(Atom):
         self.w = tuple(p_arr / p_arr.sum())
         self.approx_error = 0.0
 
-    # Returns the (weighted) geometric mean of the elements of x.
-    def numeric(self, values) -> float:
-        values = np.array(values[0]).flatten()
-        val = 1.0
-        for x, p in zip(values, self.w):
-            val *= x**float(p)
-        return val
+    def _reduced_size(self) -> int:
+        """How many entries each geometric mean is taken over."""
+        shape = self.args[0].shape
+        if self.axis is None:
+            return int(np.prod(shape))
+        axes = (self.axis,) if isinstance(self.axis, int) else tuple(self.axis)
+        return int(np.prod([shape[a] for a in axes]))
+
+    def _aligned_arg(self, arg=None):
+        """The argument with the reduced entries along axis 0.
+
+        Axes being reduced are moved to the front and flattened into one in
+        Fortran order, and entries whose weight is zero are dropped. Everything downstream — the
+        domain and the canonicalizers — works on this view, so none of them
+        has to know about the axis. The canonicalizers pass their own already
+        canonicalized argument, which has the same shape.
+        """
+        x = self.args[0] if arg is None else arg
+        if self.axis is None:
+            aligned = reshape(x, (x.size,), order='F')
+        else:
+            axes = (self.axis,) if isinstance(self.axis, int) else tuple(self.axis)
+            moved = moveaxis(x, axes, range(len(axes)))
+            aligned = reshape(moved, (self._reduced_size(), -1), order='F')
+        if not self._keep.all():
+            aligned = aligned[self._keep]
+        return aligned
+
+    def numeric(self, values):
+        """The (weighted) geometric mean, taken along the reduced axes."""
+        x = np.asarray(values[0], dtype=float)
+        w = np.array([float(w_i) for w_i in self.w])
+        if self.axis is None:
+            kept = x.ravel(order='F')[self._keep]
+            out = np.prod(kept ** w)
+        else:
+            axes = (self.axis,) if isinstance(self.axis, int) else tuple(self.axis)
+            moved = np.moveaxis(x, axes, range(len(axes)))
+            rest = moved.shape[len(axes):]
+            flat = moved.reshape((self._reduced_size(), -1), order='F')
+            kept = flat[self._keep]
+            out = np.prod(kept ** w[:, None], axis=0).reshape(rest, order='F')
+        return np.reshape(out, self.shape, order='F') if self.keepdims else out
 
     def _domain(self) -> list[Constraint]:
         """Returns constraints describing the domain of the node.
         """
-        # No special case when only one non-zero weight.
-        selection = np.array([w_i > 0 for w_i in self.w])
-        return [self.args[0][selection > 0] >= 0]
+        # Entries with zero weight are already gone from the aligned view, so
+        # they carry no implicit nonnegativity.
+        return [self._aligned_arg() >= 0]
+
+    def _column_grad(self, value):
+        """Gradient with respect to one column of reduced entries."""
+        column = np.asarray(value, dtype=float).ravel()
+        kept = column[self._keep]
+        w = np.array([float(w_i) for w_i in self.w])
+        if np.any(kept <= 0):
+            return None
+        gm = np.prod(kept ** w)
+        D = np.zeros(column.size)
+        D[self._keep] = w / kept * gm
+        return D[:, None]
 
     def _grad(self, values):
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.
@@ -268,15 +330,7 @@ class GeoMean(Atom):
         Returns:
             A list of SciPy CSC sparse matrices or None.
         """
-        x = np.array(values[0])
-        # No special case when only one non-zero weight.
-        w_arr = np.array([float(w_i) for w_i in self.w])
-        # Outside domain.
-        if np.any(x[w_arr > 0] <= 0):
-            return [None]
-        else:
-            D = w_arr/x.ravel(order='F')*self.numeric(values)
-            return [sp.csc_array([D]).T]
+        return self._axis_grad(values)
 
     def name(self) -> str:
         weights = ', '.join(str(v) for v in self.w)
@@ -288,11 +342,6 @@ class GeoMean(Atom):
         weights = ', '.join(str(v) for v in self.w)
         return f"{type(self).__name__}({self.args[0].format_labeled()}, ({weights}))"
 
-
-    def shape_from_args(self) -> tuple[int, ...]:
-        """Returns the (row, col) shape of the expression.
-        """
-        return tuple()
 
     def sign_from_args(self) -> tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
@@ -337,7 +386,7 @@ class GeoMean(Atom):
         return False
 
     def get_data(self):
-        return [self.p, self.max_denom]
+        return [self.p, self.max_denom, self.axis, self.keepdims]
 
     def copy(self, args=None, id_objects=None):
         """Returns a shallow copy of the GeoMean atom.
@@ -356,11 +405,12 @@ class GeoMean(Atom):
             args = self.args
         # Avoid calling __init__() directly as we do not have p and max_denom.
         copy = type(self).__new__(type(self))
-        super(type(self), copy).__init__(*args)
+        AxisAtom.__init__(copy, *args, axis=self.axis, keepdims=self.keepdims)
         # Emulate __init__()
         copy.p = self.p
         copy.max_denom = self.max_denom
         copy.w = self.w
+        copy._keep = self._keep
         copy.approx_error = self.approx_error
         return copy
 
@@ -400,8 +450,8 @@ class GeoMeanApprox(GeoMean):
     """
 
     def __init__(self, x, p: Sequence[float] | np.ndarray | None = None,
-                 max_denom: int = 1024) -> None:
-        super().__init__(x, p=p, max_denom=max_denom)
+                 max_denom: int = 1024, axis=None, keepdims: bool = False) -> None:
+        super().__init__(x, p=p, max_denom=max_denom, axis=axis, keepdims=keepdims)
 
         self.w, self.w_dyad = fracify(self.p, max_denom)
         self.approx_error = approx_error(self.p, self.w)
@@ -419,18 +469,9 @@ class GeoMeanApprox(GeoMean):
 
     def copy(self, args=None, id_objects=None):
         """Returns a shallow copy of the GeoMeanApprox atom."""
-        if args is None:
-            args = self.args
-        # Avoid calling __init__() directly as we do not have p and max_denom.
-        copy = type(self).__new__(type(self))
-        super(type(self), copy).__init__(*args)
-        # Emulate __init__()
-        copy.p = self.p
-        copy.max_denom = self.max_denom
-        copy.w = self.w
+        copy = super().copy(args=args, id_objects=id_objects)
         copy.w_dyad = self.w_dyad
         copy.tree = self.tree
-        copy.approx_error = self.approx_error
         copy.cone_lb = self.cone_lb
         copy.cone_num_over = self.cone_num_over
         copy.cone_num = self.cone_num

--- a/cvxpy/reductions/dcp2cone/canonicalizers/geo_mean_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/geo_mean_canon.py
@@ -19,7 +19,7 @@ import warnings
 import numpy as np
 
 from cvxpy import settings
-from cvxpy.atoms.affine.vstack import vstack
+from cvxpy.atoms.affine.reshape import reshape
 from cvxpy.constraints.power import PowConeND
 from cvxpy.expressions.variable import Variable
 from cvxpy.utilities.power_tools import gm_constrs
@@ -28,42 +28,45 @@ from cvxpy.utilities.solver_context import SolverInfo
 
 def geo_mean_exact_canon(expr, args, solver_context: SolverInfo | None = None):
     """Canonicalize GeoMean using PowConeND constraints."""
-    x = args[0]
     w = expr.w
+    # One row per reduced entry, one column per output. PowConeND takes one
+    # cone per column, so every output is covered by a single constraint.
+    W = expr._aligned_arg(args[0])
 
     # Single non-zero weight: geo_mean is just that element (affine).
     if len(w) == 1:
-        return x, []
+        out = W[0]
+        return (reshape(out, expr.shape, order='F')
+                if out.shape != expr.shape else out), []
 
-    shape = expr.shape
-    t = Variable(shape)
-
-    if x.shape == ():
-        x_list = [x]
-    else:
-        x_list = [x[i] for i in range(len(w))]
-
-    W = vstack(x_list)
+    t = Variable(W.shape[1:])
     alpha = np.array([float(wi) for wi in w]).reshape(-1, 1)
-    return t, [PowConeND(W, t, alpha, axis=0)]
+    if W.ndim == 2:
+        alpha = np.tile(alpha, (1, W.shape[1]))
+    else:
+        alpha = alpha.reshape(-1)
+    constrs = [PowConeND(W, t, alpha, axis=0)]
+    if t.shape != expr.shape:
+        return reshape(t, expr.shape, order='F'), constrs
+    return t, constrs
 
 
 def geo_mean_approx_canon(expr, args, solver_context: SolverInfo | None = None):
     """Canonicalize GeoMeanApprox using SOC constraints via rational approximation."""
-    x = args[0]
     w = expr.w
+    # One row per reduced entry, one column per output. gm_constrs is
+    # vectorised, so all the outputs share a single set of constraints
+    # instead of getting one atom each.
+    x = expr._aligned_arg(args[0])
 
     # Single non-zero weight: geo_mean is just that element (affine).
     if len(w) == 1:
-        return x, []
+        out = x[0]
+        return (reshape(out, expr.shape, order='F')
+                if out.shape != expr.shape else out), []
 
-    shape = expr.shape
-    t = Variable(shape)
-
-    if x.shape == ():
-        x_list = [x]
-    else:
-        x_list = [x[i] for i in range(len(w))]
+    t = Variable(x.shape[1:])
+    x_list = [x[i] for i in range(len(w))]
 
     constrs = gm_constrs(t, x_list, w)
 
@@ -85,4 +88,6 @@ def geo_mean_approx_canon(expr, args, solver_context: SolverInfo | None = None):
                 stacklevel=6,
             )
 
+    if t.shape != expr.shape:
+        return reshape(t, expr.shape, order='F'), constrs
     return t, constrs

--- a/cvxpy/reductions/dgp2dcp/canonicalizers/geo_mean_canon.py
+++ b/cvxpy/reductions/dgp2dcp/canonicalizers/geo_mean_canon.py
@@ -1,5 +1,14 @@
+from cvxpy.atoms.affine.reshape import reshape
+
+
 def geo_mean_canon(expr, args):
+    # Reduced entries along axis 0, zero-weight ones already dropped, so the
+    # weights line up with the rows whatever the axis is.
+    x = expr._aligned_arg(args[0])
     out = 0.0
-    for x_i, p_i in zip(args[0], expr.p):
-        out += p_i * x_i
-    return (1 / sum(expr.p)) * out, []
+    for i, p_i in enumerate(expr.p):
+        out += p_i * x[i]
+    out = (1 / sum(expr.p)) * out
+    if out.shape != expr.shape:
+        out = reshape(out, expr.shape, order='F')
+    return out, []

--- a/cvxpy/reductions/dnlp2smooth/canonicalizers/geo_mean_canon.py
+++ b/cvxpy/reductions/dnlp2smooth/canonicalizers/geo_mean_canon.py
@@ -17,6 +17,7 @@ limitations under the License.
 import numpy as np
 
 from cvxpy.atoms.affine.binary_operators import multiply
+from cvxpy.atoms.affine.reshape import reshape
 from cvxpy.atoms.affine.sum import sum
 from cvxpy.atoms.elementwise.log import log
 from cvxpy.expressions.variable import Variable
@@ -28,9 +29,16 @@ def geo_mean_canon(expr, args):
     t = Variable(expr.shape, nonneg=True)
 
     if args[0].value is not None:
-        t.value = np.max((expr.numeric(args[0].value), MIN_INIT))
+        t.value = np.maximum(expr.numeric([args[0].value]), MIN_INIT)
 
     weights = np.array([float(w) for w in expr.w])
     log_expr = log(args[0])
     var, constr = log_canon(log_expr, expr.args)
-    return t, [log(t) == sum(multiply(weights, var))] + constr
+    # Reduced entries along axis 0, so the weights broadcast against whatever
+    # shape is left over.
+    aligned = expr._aligned_arg(var)
+    weights = weights.reshape((-1,) + (1,) * (aligned.ndim - 1))
+    reduced = sum(multiply(weights, aligned), axis=0)
+    if reduced.shape != expr.shape:
+        reduced = reshape(reduced, expr.shape, order='F')
+    return t, [log(t) == reduced] + constr

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import unittest
+from fractions import Fraction
 
 import numpy as np
 import pytest
@@ -134,8 +135,6 @@ class TestAtoms(BaseTest):
     def test_power(self) -> None:
         """Test the power class.
         """
-        from fractions import Fraction
-
         for shape in [(1, 1), (3, 1), (2, 3)]:
             x = Variable(shape)
             y = Variable(shape)
@@ -214,6 +213,50 @@ class TestAtoms(BaseTest):
                 match=SECOND_ARG_SHOULD_NOT_BE_EXPRESSION_ERROR_MESSAGE
             ):
             cp.geo_mean(self.x, self.y)
+
+    def test_geo_mean_shapes(self) -> None:
+        """Any shape is accepted, and the entries are taken in column-major order."""
+        M = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+        atom = cp.geo_mean(cp.Constant(M))
+        self.assertEqual(atom.shape, tuple())
+        self.assertSequenceEqual(atom.w, [Fraction(1, 6)] * 6)
+        self.assertAlmostEqual(atom.value, float(np.prod(M) ** (1 / M.size)))
+
+        # Column-major, as elsewhere in CVXPY: the weights line up with
+        # M.ravel(order='F').
+        weighted = cp.geo_mean(cp.Constant(M), [2, 0, 0, 0, 0, 1])
+        flat = M.ravel(order='F')
+        self.assertAlmostEqual(weighted.value, float((flat[0] ** 2 * flat[5]) ** (1 / 3)))
+
+        # More than two dimensions.
+        T = np.arange(1, 25, dtype=float).reshape(2, 3, 4)
+        self.assertAlmostEqual(
+            cp.geo_mean(cp.Constant(T)).value, float(np.prod(T) ** (1 / T.size))
+        )
+
+    def test_geo_mean_shares_one_set_of_constraints(self) -> None:
+        """Every output is covered by the same constraints, not one set each."""
+        from cvxpy.reductions.dcp2cone.canonicalizers.geo_mean_canon import (
+            geo_mean_approx_canon,
+        )
+
+        counts = []
+        for cols in (2, 20, 200):
+            x = cp.Variable((3, cols), nonneg=True)
+            expr = cp.geo_mean(x, axis=0)
+            _, constraints = geo_mean_approx_canon(expr, expr.args)
+            counts.append(len(constraints))
+        assert len(set(counts)) == 1, counts
+
+    def test_geo_mean_row_vector(self) -> None:
+        """A row vector reaches the solver, as the docstring has always promised."""
+        for shape in [(4,), (4, 1), (1, 4), (2, 2)]:
+            x = cp.Variable(shape, nonneg=True)
+            n = int(np.prod(shape))
+            prob = cp.Problem(cp.Maximize(cp.geo_mean(x)), [cp.sum(x) <= n])
+            prob.solve(solver=cp.SCS, eps=1e-6)
+            self.assertAlmostEqual(prob.value, 1.0, places=4)
 
     # Test the harmonic_mean class.
     def test_harmonic_mean(self) -> None:
@@ -3205,3 +3248,38 @@ class TestDotsort(BaseTest):
         with self.assertRaises(Exception) as cm:
             cp.Problem(cp.Minimize(cp.dotsort(self.x, p_squared))).solve(enforce_dpp=True)
         assert "You are solving a parameterized problem that is not DPP" in str(cm.exception)
+
+
+GEO_MEAN_AXES = [None, 0, 1, 2, -1, -2, -3, (0, 1), (1, 2), (0, 2), (0, 1, 2)]
+
+
+@pytest.mark.parametrize("axis", GEO_MEAN_AXES)
+@pytest.mark.parametrize("keepdims", [False, True])
+def test_geo_mean_axis(axis, keepdims) -> None:
+    """Every axis reduces, and the shape follows cp.mean."""
+    T = np.arange(1.0, 25.0).reshape(2, 3, 4)
+    const = cp.Constant(T)
+
+    got = cp.geo_mean(const, axis=axis, keepdims=keepdims)
+    assert got.shape == cp.mean(const, axis=axis, keepdims=keepdims).shape
+
+    expected = np.exp(np.mean(np.log(T), axis=axis))
+    if keepdims:
+        reduced = tuple(range(T.ndim)) if axis is None else np.atleast_1d(axis)
+        expected = np.expand_dims(expected, tuple(np.atleast_1d(reduced)))
+    assert np.allclose(np.array(got.value), expected)
+
+
+@pytest.mark.parametrize("axis", [3, -4])
+def test_geo_mean_axis_out_of_bounds(axis) -> None:
+    """An axis the expression does not have is refused."""
+    T = cp.Constant(np.arange(1.0, 25.0).reshape(2, 3, 4))
+    with pytest.raises((ValueError, IndexError)):
+        cp.geo_mean(T, axis=axis)
+
+
+def test_geo_mean_axis_with_weights() -> None:
+    """Weights apply to each slice along the reduced axis."""
+    M = np.arange(1.0, 7.0).reshape(2, 3)
+    got = cp.geo_mean(cp.Constant(M), [3, 1], axis=0)
+    assert np.allclose(np.array(got.value), (M[0] ** 3 * M[1]) ** (1 / 4))

--- a/cvxpy/tests/test_labels.py
+++ b/cvxpy/tests/test_labels.py
@@ -238,7 +238,7 @@ def test_various_operations_with_labels():
     # Test geo_mean (weights sum to 1 after normalization)
     weights = np.array([0.3, 0.3, 0.4])
     geo_mean_expr = cp.geo_mean(x, weights)
-    expected = "GeoMeanApprox(x_vec[True, True, True], (3/10, 3/10, 2/5))"
+    expected = "GeoMeanApprox(x_vec, (3/10, 3/10, 2/5))"
     assert geo_mean_expr.format_labeled() == expected
 
     # Test that operations can themselves be labeled
@@ -460,7 +460,7 @@ def test_label_display_catalog_exact():
 
     # Geometric mean (weights show exactly)
     g = cp.geo_mean(x, [1, 2, 1])
-    assert g.format_labeled() == "GeoMeanApprox(xL[True, True, True], (1/4, 1/2, 1/4))"
+    assert g.format_labeled() == "GeoMeanApprox(xL, (1/4, 1/2, 1/4))"
 
     # Perron-Frobenius eigenvalue
     assert cp.pf_eigenvalue(X).format_labeled() == "pf_eigenvalue(XL)"

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -1876,8 +1876,11 @@ class TestProblem(BaseTest):
         prob.solve(solver=cp.SCS, eps=1e-5)
         self.assertItemsAlmostEqual(x.value, [.5, .5])
 
+        # Any shape is accepted; the entries are taken in row-major order.
         x = Variable((3, 3))
-        self.assertRaises(ValueError, cp.geo_mean, x)
+        g = cp.geo_mean(x)
+        self.assertSequenceEqual(g.w, [Fraction(1, 9)]*9)
+        self.assertEqual(g.shape, tuple())
 
         x = Variable((3, 1))
         g = cp.geo_mean(x)


### PR DESCRIPTION
## Description

Follow-up to #3489, where @PTNobel said to start with `geo_mean` and `tv`. This is the `geo_mean` half.

`geo_mean` required a vector and computed `n` as `max(x.shape)`. Anything past one dimension is now flattened in row-major order, so a row vector, a column vector and an N-D array holding the same entries all behave the same way. Row-major matches `numeric()`, which already flattened that way, and is the order `p` is expected in — there is a test pinning that down with asymmetric weights.

**It also fixes a row vector reaching the solver at all**, which I did not expect to find. Both the docstring and the error message promise "a row or column vector", but on master:

    x = cp.Variable((1, 4), nonneg=True)
    g = cp.geo_mean(x)                       # builds fine, shape ()
    g.value                                  # evaluates fine
    cp.Problem(cp.Maximize(g), [cp.sum(x) <= 4]).solve()
    # IndexError: Index 1 is out of bounds for axis 0 with size 1.

`geo_mean_canon` indexes `x[i]` along axis 0, which has size 1 for a row vector. Flattening removes the asymmetry rather than special-casing it, so `(4,)`, `(4, 1)`, `(1, 4)`, `(2, 2)`, `(2, 3)` and `(2, 3, 4)` now all solve to the same optimum.

The existing assertion in `test_geo_mean` that a `(3, 3)` input raises `ValueError` is replaced by the behaviour that supersedes it.

**On the test suite.** Running the full suite on this machine dies with a bus error partway through `nlp_tests`, but it does so on master too, so I compared around it: excluding `nlp_tests`, this branch is 1 failed / 2553 passed against master's 1 failed / 2551 passed, with identical failure lists — the two extra passes are the tests added here. `nlp_tests` alone fails identically on both (10 and 10). The one shared failure is `test_mip_vars.py::TestMIPVariable::test_miqp_warning`.

Refs #3489

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files. — N/A, no new files
- [x] Check that your code adheres to our coding style. — `ruff` 0.8.1 (the pre-commit pin) reports no findings
- [x] Write unittests. — `test_geo_mean_shapes` (any shape, row-major order for `p`, 3-D input) and `test_geo_mean_row_vector` (each shape solves to the same optimum)
- [x] Run the unittests and check that they're passing. — see the note above; no regressions against master
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression. — not run locally. `geo_mean` adds a `reshape` node only for inputs past one dimension, which previously raised, so existing models are unaffected; the CI benchmark job will confirm.