### PR TITLE
Read a 3-D value in tv as channels

### DIFF
--- a/cvxpy/atoms/total_variation.py
+++ b/cvxpy/atoms/total_variation.py
@@ -27,10 +27,17 @@ def tv(value, *args) -> Expression:
     Uses L1 norm of discrete gradients for vectors and
     L2 norm of discrete gradients for matrices.
 
+    Channels are coupled: the gradients of every channel at a pixel are
+    stacked into one vector before its L2 norm is taken, so this is colour
+    total variation and not the sum of the per-channel ones. Differences are
+    taken along the two spatial axes only.
+
     Parameters
     ----------
     value : Expression or numeric constant
-        The value to take the total variation of.
+        The value to take the total variation of. A three-dimensional value
+        of shape ``(m, n, k)`` is read as ``k`` channels of an ``m`` by ``n``
+        image, equivalent to passing its slices as separate arguments.
     *args : Matrix constants/expressions
         Additional matrices extending the third dimension of value.
 
@@ -45,19 +52,27 @@ def tv(value, *args) -> Expression:
     # L1 norm for vectors.
     elif value.ndim == 1:
         return norm(value[1:] - value[0:value.shape[0]-1], 1)
+
+    extra = [Expression.cast(arg) for arg in args]
     # L2 norm for matrices.
-    elif value.ndim == 2:
-        rows, cols = value.shape
-        args = map(Expression.cast, args)
-        values = [value] + list(args)
-        diffs = []
-        for mat in values:
-            diffs += [
-                mat[0:rows-1, 1:cols] - mat[0:rows-1, 0:cols-1],
-                mat[1:rows, 0:cols-1] - mat[0:rows-1, 0:cols-1],
-            ]
-        length = diffs[0].shape[0]*diffs[1].shape[1]
-        stacked = vstack([reshape(diff, (1, length), order='F') for diff in diffs])
-        return sum(norm(stacked, p=2, axis=0))
+    if value.ndim == 2:
+        values = [value] + extra
+    elif value.ndim == 3:
+        # The trailing axis holds channels, which is what *args already
+        # extends: an (m, n, k) array means the same as passing its k slices
+        # separately. Differences stay along the two spatial axes, so this is
+        # colour total variation rather than a variation over a volume.
+        values = [value[:, :, i] for i in range(value.shape[2])] + extra
     else:
-        raise ValueError("tv cannot have input arrays with more than 2 dimensions.")
+        raise ValueError("tv cannot have input arrays with more than 3 dimensions.")
+
+    rows, cols = values[0].shape
+    diffs = []
+    for mat in values:
+        diffs += [
+            mat[0:rows-1, 1:cols] - mat[0:rows-1, 0:cols-1],
+            mat[1:rows, 0:cols-1] - mat[0:rows-1, 0:cols-1],
+        ]
+    length = diffs[0].shape[0]*diffs[1].shape[1]
+    stacked = vstack([reshape(diff, (1, length), order='F') for diff in diffs])
+    return sum(norm(stacked, p=2, axis=0))

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -258,6 +258,39 @@ class TestAtoms(BaseTest):
             prob.solve(solver=cp.SCS, eps=1e-6)
             self.assertAlmostEqual(prob.value, 1.0, places=4)
 
+    def test_tv_three_dimensional(self) -> None:
+        """A 3-D value is read as channels, the same as passing them separately."""
+        rng = np.random.default_rng(0)
+        R, G, B = (rng.random((4, 5)) for _ in range(3))
+        A = np.stack([R, G, B], axis=-1)
+
+        separate = cp.tv(cp.Constant(R), cp.Constant(G), cp.Constant(B)).value
+        stacked = cp.tv(cp.Constant(A)).value
+        self.assertAlmostEqual(stacked, separate, places=10)
+
+        # Channels are coupled, so this is not the sum of the per-channel ones.
+        per_channel = sum(cp.tv(cp.Constant(M)).value for M in (R, G, B))
+        self.assertNotAlmostEqual(stacked, per_channel, places=6)
+
+        # A 3-D value composes with further channels given as arguments.
+        X = rng.random((4, 5))
+        self.assertAlmostEqual(
+            cp.tv(cp.Constant(A), cp.Constant(X)).value,
+            cp.tv(cp.Constant(R), cp.Constant(G), cp.Constant(B), cp.Constant(X)).value,
+            places=10,
+        )
+
+        # One dimension further is still refused.
+        with pytest.raises(ValueError, match="more than 3 dimensions"):
+            cp.tv(cp.Constant(rng.random((2, 3, 4, 5))))
+
+    def test_tv_unchanged_for_vectors_and_matrices(self) -> None:
+        """The vector and matrix cases keep their existing values."""
+        self.assertAlmostEqual(cp.tv(cp.Constant(np.array([1.0, 3.0, 2.0, 7.0]))).value, 8.0)
+        self.assertAlmostEqual(
+            cp.tv(cp.Constant(np.array([[-5.0, 2.0], [-3.0, 1.0]]))).value, np.sqrt(53)
+        )
+
     # Test the harmonic_mean class.
     def test_harmonic_mean(self) -> None:
         atom = cp.harmonic_mean(self.x)


### PR DESCRIPTION
## Description

The other half of @PTNobel's "let's start with geo_mean and TV" in #3489, after #3493.

**A correction to what I wrote in that issue first.** I described 3-D `tv` as volumetric and video denoising. That was imprecise, and looking at the atom properly changes what the right generalisation is. `tv` already has a third dimension, reached through `*args`: `tv(R, G, B)` is *colour* total variation, where the gradients of every channel at a pixel are stacked into one vector before its L2 norm is taken. It is not the sum of the per-channel variations — on a random 4x5 example, `tv(R, G, B)` is 12.93 while `tv(R) + tv(G) + tv(B)` is 20.47 — and the differences stay along the two spatial axes.

So the generalisation that matches the atom is channels, not volume. An `(m, n, k)` array now means the same as passing its `k` slices:

    tv(A) == tv(A[:, :, 0], ..., A[:, :, k - 1])

verified to machine precision. The two spellings also compose: `tv(A, X)` equals `tv(A[:, :, 0], A[:, :, 1], A[:, :, 2], X)`.

Vectors and matrices are untouched. Four dimensions still raise: a variation over a volume would take differences along the third axis as well, which is a different operator, and I would rather not guess which one is wanted. The message now says which shapes are accepted. **If volumetric TV is something you'd want, say so and I'll open it separately** — it is a genuinely different atom rather than an extension of this one.

**Tests.** Against master, excluding `nlp_tests` (which dies with a bus error on this machine, on master as well): 1 failed / 2561 passed here against 1 failed / 2559 passed on master, the two extra passes being the tests added. Same single pre-existing failure, `test_mip_vars.py::TestMIPVariable::test_miqp_warning`.

Refs #3489

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files. — N/A, no new files
- [x] Check that your code adheres to our coding style. — `ruff` 0.8.1 (the pre-commit pin) reports no findings
- [x] Write unittests. — `test_tv_three_dimensional` (the two spellings agree, channels stay coupled, composition with further arguments, 4-D still refused) and `test_tv_unchanged_for_vectors_and_matrices`
- [x] Run the unittests and check that they're passing. — see above; no regressions
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression. — not run locally. The 2-D and 1-D paths are unchanged and the 3-D one previously raised, so existing models are unaffected; the CI benchmark job will confirm.