### PR TITLE
Add constraint-level complementarity checks

### DIFF
--- a/cvxpy/constraints/constraint.py
+++ b/cvxpy/constraints/constraint.py
@@ -333,6 +333,49 @@ class Constraint(u.Canonical):
             return 0.0
         return float(np.linalg.norm(residual_arr.ravel(), ord=np.inf))
 
+    @property
+    def complementarity_residual(self):
+        """The shape-preserving complementarity residual.
+
+        This residual measures complementary slackness for constraints where
+        it is well-defined. The reduction to a scalar happens in
+        ``complementarity_violation``.
+
+        Returns
+        -------
+        NumPy.ndarray or None
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement "
+            "complementarity_residual."
+        )
+
+    def complementarity_violation(self):
+        """Scalar complementarity violation.
+
+        The violation is the infinity norm of ``complementarity_residual``,
+        matching the scalar violation convention for primal and dual residuals.
+
+        Returns
+        -------
+        float
+
+        Raises
+        ------
+        ValueError
+            If the primal or dual variable has no value.
+        """
+        residual = self.complementarity_residual
+        if residual is None:
+            raise ValueError(
+                "Cannot compute complementarity violation: missing primal "
+                "or dual value."
+            )
+        residual_arr = np.asarray(residual)
+        if residual_arr.size == 0:
+            return 0.0
+        return float(np.linalg.norm(residual_arr.ravel(), ord=np.inf))
+
     def is_dual_feasible(self, tolerance: float = 1e-8) -> bool:
         """Whether the dual variable satisfies the dual cone constraint.
 

--- a/cvxpy/constraints/nonpos.py
+++ b/cvxpy/constraints/nonpos.py
@@ -105,6 +105,13 @@ class NonPos(Constraint):
             return None
         return -np.minimum(dv, 0.0)
 
+    @property
+    def complementarity_residual(self):
+        expr_val = self.expr.value
+        dv = self.dual_variables[0].value
+        if expr_val is None or dv is None:
+            return None
+        return dv * (-expr_val)
 
 class NonNeg(Constraint):
     """A constraint of the form :math:`x \\geq 0`.
@@ -170,6 +177,13 @@ class NonNeg(Constraint):
             return None
         return -np.minimum(dv, 0.0)
 
+    @property
+    def complementarity_residual(self):
+        expr_val = self.expr.value
+        dv = self.dual_variables[0].value
+        if expr_val is None or dv is None:
+            return None
+        return dv * expr_val
 
 class Inequality(Constraint):
     """A constraint of the form :math:`x \\leq y`.
@@ -274,3 +288,11 @@ class Inequality(Constraint):
         if dv is None:
             return None
         return -np.minimum(dv, 0.0)
+
+    @property
+    def complementarity_residual(self):
+        expr_val = self.expr.value
+        dv = self.dual_variables[0].value
+        if expr_val is None or dv is None:
+            return None
+        return dv * (-expr_val)

--- a/cvxpy/constraints/psd.py
+++ b/cvxpy/constraints/psd.py
@@ -158,6 +158,36 @@ class PSD(Cone):
         op_norms = np.linalg.norm(residual, ord=2, axis=(-2, -1))
         return float(np.max(op_norms))
 
+    @property
+    def complementarity_residual(self):
+        """Shape-preserving PSD complementarity residual.
+
+        For a PSD constraint with primal matrix X and dual matrix S, this
+        returns the matrix product X S, computed from the Hermitian/symmetric
+        parts of the primal and dual values.
+        """
+        expr_val = self.expr.value
+        dv = self.dual_variables[0].value
+        if expr_val is None or dv is None:
+            return None
+
+        sym_expr = (expr_val + np.conjugate(np.swapaxes(expr_val, -2, -1))) / 2
+        sym_dv = (dv + np.conjugate(np.swapaxes(dv, -2, -1))) / 2
+        return np.matmul(sym_expr, sym_dv)
+
+    def complementarity_violation(self):
+        """Scalar PSD complementarity violation using the operator norm."""
+        residual = self.complementarity_residual
+        if residual is None:
+            raise ValueError(
+                "Cannot compute complementarity violation: missing primal "
+                "or dual value."
+            )
+        if residual.size == 0:
+            return 0.0
+        op_norms = np.linalg.norm(residual, ord=2, axis=(-2, -1))
+        return float(np.max(op_norms))
+
 
 class SvecPSD(Cone):
     """A PSD constraint in scaled vectorized (svec) form.

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -1026,3 +1026,66 @@ class TestConstraints(BaseTest):
         np.testing.assert_allclose(constr.dual_residual, expected, atol=1e-9)
         assert constr.dual_violation() == pytest.approx(2.0)
         assert not constr.is_dual_feasible()
+
+    def test_psd_complementarity_residual_and_violation(self):
+        X = cp.Variable((2, 2), symmetric=True)
+        constr = X >> 0
+
+        with pytest.raises(ValueError, match="missing primal or dual value"):
+            constr.complementarity_violation()
+
+        X.value = np.diag([2.0, 0.0])
+        constr.dual_variables[0].value = np.diag([0.0, 3.0])
+        np.testing.assert_allclose(
+            constr.complementarity_residual,
+            np.zeros((2, 2)),
+            atol=1e-9,
+        )
+        assert constr.complementarity_violation() == pytest.approx(0.0)
+
+        constr.dual_variables[0].value = np.diag([4.0, 3.0])
+        np.testing.assert_allclose(
+            constr.complementarity_residual,
+            np.diag([8.0, 0.0]),
+            atol=1e-9,
+        )
+        assert constr.complementarity_violation() == pytest.approx(8.0)
+
+    def test_psd_complementarity_residual_uses_matrix_product(self):
+        X = cp.Variable((2, 2), symmetric=True)
+        constr = X >> 0
+
+        X.value = np.array([[1.0, 0.0], [0.0, 0.0]])
+        constr.dual_variables[0].value = np.array([[1.0, 1.0], [1.0, 1.0]])
+
+        expected = np.array([[1.0, 1.0], [0.0, 0.0]])
+        np.testing.assert_allclose(
+            constr.complementarity_residual,
+            expected,
+            atol=1e-9,
+        )
+        assert constr.complementarity_violation() == pytest.approx(np.sqrt(2.0))
+
+    def test_psd_complementarity_residual_batched_is_worst_case_block(self):
+        X = cp.Variable((2, 2, 2), symmetric=True)
+        constr = X >> 0
+
+        X.value = np.stack([
+            np.diag([2.0, 0.0]),
+            np.array([[1.0, 0.0], [0.0, 0.0]]),
+        ])
+        constr.dual_variables[0].value = np.stack([
+            np.diag([0.0, 3.0]),
+            np.array([[1.0, 1.0], [1.0, 1.0]]),
+        ])
+
+        expected = np.stack([
+            np.zeros((2, 2)),
+            np.array([[1.0, 1.0], [0.0, 0.0]]),
+        ])
+        np.testing.assert_allclose(
+            constr.complementarity_residual,
+            expected,
+            atol=1e-9,
+        )
+        assert constr.complementarity_violation() == pytest.approx(np.sqrt(2.0))

--- a/cvxpy/tests/test_constraints.py
+++ b/cvxpy/tests/test_constraints.py
@@ -913,6 +913,70 @@ class TestConstraints(BaseTest):
         assert constr.dual_violation() == pytest.approx(2.0)
         assert not constr.is_dual_feasible()
 
+    def test_nonpos_complementarity_residual(self) -> None:
+        x = cp.Variable(3)
+        constr = cp.NonPos(x)
+        x.value = np.array([-2.0, 0.0, -4.0])
+        constr.dual_variables[0].value = np.array([0.0, 3.0, 0.0])
+
+        np.testing.assert_allclose(
+            constr.complementarity_residual,
+            np.array([0.0, 0.0, 0.0]),
+        )
+        assert constr.complementarity_violation() == pytest.approx(0.0)
+
+        constr.dual_variables[0].value = np.array([2.0, 3.0, 0.0])
+        np.testing.assert_allclose(
+            constr.complementarity_residual,
+            np.array([4.0, 0.0, 0.0]),
+        )
+        assert constr.complementarity_violation() == pytest.approx(4.0)
+
+    def test_nonneg_complementarity_residual(self) -> None:
+        x = cp.Variable(3)
+        constr = cp.NonNeg(x)
+        x.value = np.array([2.0, 0.0, 4.0])
+        constr.dual_variables[0].value = np.array([0.0, 3.0, 0.0])
+
+        np.testing.assert_allclose(
+            constr.complementarity_residual,
+            np.array([0.0, 0.0, 0.0]),
+        )
+        assert constr.complementarity_violation() == pytest.approx(0.0)
+
+        constr.dual_variables[0].value = np.array([2.0, 3.0, 0.0])
+        np.testing.assert_allclose(
+            constr.complementarity_residual,
+            np.array([4.0, 0.0, 0.0]),
+        )
+        assert constr.complementarity_violation() == pytest.approx(4.0)
+
+    def test_inequality_complementarity_residual(self) -> None:
+        x = cp.Variable(3)
+        constr = x <= np.array([1.0, 2.0, 3.0])
+        x.value = np.array([0.0, 2.0, 1.0])
+        constr.dual_variables[0].value = np.array([0.0, 3.0, 0.0])
+
+        np.testing.assert_allclose(
+            constr.complementarity_residual,
+            np.array([0.0, 0.0, 0.0]),
+        )
+        assert constr.complementarity_violation() == pytest.approx(0.0)
+
+        constr.dual_variables[0].value = np.array([2.0, 3.0, 0.0])
+        np.testing.assert_allclose(
+            constr.complementarity_residual,
+            np.array([2.0, 0.0, 0.0]),
+        )
+        assert constr.complementarity_violation() == pytest.approx(2.0)
+
+    def test_complementarity_violation_raises_without_values(self) -> None:
+        x = cp.Variable()
+        constr = x <= 1
+
+        with pytest.raises(ValueError, match="missing primal or dual value"):
+            constr.complementarity_violation()
+
     def test_equality_dual_residual_is_always_zero(self):
         # Equality/Zero dual variables are free (unconstrained), so their
         # dual cone is the whole space and the residual is always zero.


### PR DESCRIPTION
## Description

This follows the post-solver feasibility design note in #3362, which frames primal violation, dual feasibility, and complementarity as first-pass checks that can be evaluated from unpacked primal/dual values in the original problem space.

With primal residual/violation consistency merged in #3434 and dual feasibility merged in #3441, this draft starts the next layer: constraint-level complementarity checks where well-defined.

Initial scope:
- add a constraint-level `complementarity_residual`
- add scalar `complementarity_violation()` reduction
- implement complementarity checks for `Inequality`, `NonPos`, `NonNeg`, and `PSD`
- use matrix-product complementarity for PSD constraints with operator-norm scalar reduction
- add tests for active/inactive complementarity behavior, PSD matrix-product behavior, batched PSD constraints, and missing values

Out of scope for this first draft:
- SOC / ExpCone / PowCone complementarity
- problem-level aggregation
- stationarity / duality gap

Issue link (if applicable): Related to #3362 and #3418. Builds on #3434 and #3441.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files. No new files added.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.