### PR TITLE
Support broader axis handling in stats atoms

### DIFF
--- a/cvxpy/atoms/stats.py
+++ b/cvxpy/atoms/stats.py
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import numbers
+
 import numpy as np
+from numpy.lib.array_utils import normalize_axis_tuple
 
 from cvxpy.atoms.affine.sum import sum as cvxpy_sum
 from cvxpy.atoms.norm import norm
@@ -22,16 +25,19 @@ from cvxpy.atoms.sum_squares import sum_squares
 from cvxpy.expressions.expression import Expression
 
 
+def _axis_size(x, axis=None) -> int:
+    """Return the number of entries reduced by an axis argument."""
+    if axis is None:
+        return x.size
+    axes = normalize_axis_tuple(axis, len(x.shape), "axis")
+    return int(np.prod([x.shape[a] for a in axes]))
+
+
 def mean(x, axis=None, keepdims=False) -> Expression:
     """
     Returns the mean of x.
     """
-    if axis is None:
-        return cvxpy_sum(x, axis, keepdims) / x.size
-    elif axis in (0, 1):
-        return cvxpy_sum(x, axis, keepdims) / x.shape[axis]
-    else:
-        raise UserWarning("cp.mean doesn't yet support axis values other than 0 or 1.")
+    return cvxpy_sum(x, axis=axis, keepdims=keepdims) / _axis_size(x, axis)
 
 
 def std(x, axis=None, keepdims=False, ddof=0) -> Expression:
@@ -42,11 +48,12 @@ def std(x, axis=None, keepdims=False, ddof=0) -> Expression:
     """
     if axis is None:
         return norm((x - mean(x)).flatten(order='F'), 2) / np.sqrt(x.size - ddof)
-    elif axis in (0, 1):
+    elif isinstance(axis, numbers.Integral):
         return norm(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims) \
-                / np.sqrt(x.shape[axis] - ddof)
+                / np.sqrt(_axis_size(x, axis) - ddof)
     else:
-        raise ValueError("cp.std doesn't yet support axis values other than 0 or 1.")
+        raise ValueError("cp.std doesn't yet support tuple axis values.")
+
 
 def var(x, axis=None, keepdims=False, ddof=0) -> Expression:
     """
@@ -54,16 +61,8 @@ def var(x, axis=None, keepdims=False, ddof=0) -> Expression:
 
     `ddof` is the quantity to use in the Bessel correction.
     """
-    if axis is None:
-        return sum_squares(x - mean(x)) / (x.size - ddof)
-    elif axis in (0, 1):
-        raise NotImplementedError(
-            """axis and keepdims are not yet supported for var.
-            Use square(std(...)) instead.
-            """
-        )
-        # TODO when sum_squares implements axis and keepdims uncomment:
-        # return sum_squares(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims) \
-        #         / (x.shape[axis] - ddof)
-    else:
-        raise ValueError("cp.var doesn't yet support axis values other than 0 or 1.")
+    return sum_squares(
+        x - mean(x, axis, True),
+        axis=axis,
+        keepdims=keepdims,
+    ) / (_axis_size(x, axis) - ddof)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1968,7 +1968,7 @@ class TestAtoms(BaseTest):
     def test_stats(self) -> None:
         """Test the mean, std, var atoms.
         """
-        a = np.array([[10., 10., 3.0], [6., 0., 1.5]])
+        a = np.arange(24., dtype=float).reshape(2, 3, 4)
         expr_mean = cp.mean(a)
         expr_var = cp.var(a)
         expr_std = cp.std(a)
@@ -1987,19 +1987,26 @@ class TestAtoms(BaseTest):
             assert np.isclose(a.var(ddof=ddof), expr_var.value)
             assert np.isclose(a.std(ddof=ddof), expr_std.value)
 
-        for axis in [0, 1]:
+        for axis in [0, 1, 2, (0, 1), (1, 2), (0, 2), None]:
             for keepdims in [True, False]:
                 expr_mean = cp.mean(a, axis=axis, keepdims=keepdims)
-                # expr_var = cp.var(a, axis=axis, keepdims=keepdims)
-                expr_std = cp.std(a, axis=axis, keepdims=keepdims)
+                expr_var = cp.var(a, axis=axis, keepdims=keepdims)
 
                 assert expr_mean.shape == a.mean(axis=axis, keepdims=keepdims).shape
-                # assert expr_var.shape == a.var(axis=axis, keepdims=keepdims).shape
-                assert expr_std.shape == a.std(axis=axis, keepdims=keepdims).shape
+                assert expr_var.shape == a.var(axis=axis, keepdims=keepdims).shape
 
                 assert np.allclose(a.mean(axis=axis, keepdims=keepdims), expr_mean.value)
-                # assert np.allclose(a.var(axis=axis, keepdims=keepdims), expr_var.value)
+                assert np.allclose(a.var(axis=axis, keepdims=keepdims), expr_var.value)
+
+        for axis in [0, 1, 2]:
+            for keepdims in [True, False]:
+                expr_std = cp.std(a, axis=axis, keepdims=keepdims)
+
+                assert expr_std.shape == a.std(axis=axis, keepdims=keepdims).shape
                 assert np.allclose(a.std(axis=axis, keepdims=keepdims), expr_std.value)
+
+        with self.assertRaises(ValueError):
+            cp.std(a, axis=(0, 1))
 
     def test_partial_optimize_dcp(self) -> None:
         """Test DCP properties of partial optimize.


### PR DESCRIPTION
## Description

This updates the stats helper atoms to support broader axis handling while keeping tuple-axis `std` support out of scope.

Changes:
- `cp.mean` now supports arbitrary integer axes and tuple axes.
- `cp.var` now supports arbitrary integer axes and tuple axes, using the newer `sum_squares(axis=..., keepdims=...)` support.
- `cp.std` now supports arbitrary integer axes through the existing `norm(..., axis=...)` path.
- Tuple-axis support for `cp.std` is left out of scope because that should be handled through native tuple-axis support in `norm`/`pnorm`.
- The stats test now covers 3-D inputs, integer axes, tuple axes for mean/var, `keepdims`, and the tuple-axis `std` error case.

Issue link (if applicable): Follow-up to the `sum_squares` axis/keepdims support.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files. No new files added.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.