### PR TITLE
Give cvar the same axis behavior as var

### DIFF
--- a/cvxpy/atoms/axis_atom.py
+++ b/cvxpy/atoms/axis_atom.py
@@ -40,6 +40,14 @@ def normalize_axis(
         return axes
 
 
+def axis_size(x, axis: None | int | tuple[int, ...] = None) -> int:
+    """Return the number of entries reduced by an axis argument."""
+    if axis is None:
+        return x.size
+    axes = normalize_axis_tuple(axis, len(x.shape), "axis")
+    return int(np.prod([x.shape[a] for a in axes]))
+
+
 class AxisAtom(Atom):
     """
     An abstract base class for atoms that can be applied along an axis.

--- a/cvxpy/atoms/cvar.py
+++ b/cvxpy/atoms/cvar.py
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from cvxpy.atoms.axis_atom import axis_size
 from cvxpy.atoms.sum_largest import sum_largest
 from cvxpy.expressions.expression import Expression
 
 
-def cvar(x, beta) -> Expression:
+def cvar(x, beta, axis=None, keepdims=False) -> Expression:
     r"""The conditional value at risk (CVaR) of a random variable represented by
     the vector of samples ``x``.
 
@@ -29,10 +30,18 @@ def cvar(x, beta) -> Expression:
     Parameters
     ----------
     x : Expression or numeric constant
-        A vector of samples representing the distribution. Must be one-dimensional.
+        The samples representing the distribution. With ``axis`` given, the
+        samples of each distribution run along the reduced axes, so an array of
+        shape ``(m, n)`` with ``axis=0`` holds ``n`` distributions of ``m``
+        samples each.
     beta : float
         The probability level. Must be in the range :math:`[0, 1)`.
         For example, :math:`\beta = 0.95` gives the average of the worst 5% of outcomes.
+    axis : int or tuple of ints, optional
+        The axis or axes along which the samples are taken. The default,
+        ``None``, treats all the entries of ``x`` as one distribution.
+    keepdims : bool, optional
+        If True, the reduced axes are kept with size one.
 
     Returns
     -------
@@ -41,15 +50,12 @@ def cvar(x, beta) -> Expression:
 
             \frac{1}{(1-\beta)m} \sum\nolimits_{\text{largest } (1-\beta)m} x_i
 
-        where :math:`m` is the length of :math:`x`. When :math:`(1-\beta)m` is not an
-        integer, the fractional part is handled via linear interpolation.
+        where :math:`m` is the number of samples reduced, that is the size of
+        :math:`x` along ``axis``. When :math:`(1-\beta)m` is not an integer, the
+        fractional part is handled via linear interpolation.
     """
     if not 0 <= beta < 1:
         raise ValueError(f"The probability level beta must be in the range [0, 1), got {beta}")
 
-    if len(x.shape) != 1:
-        raise ValueError(f"cvar input must be a 1d array, got shape {x.shape}")
-
-    k = (1 - beta) * x.shape[0]
-    return sum_largest(x, k) / k
-
+    k = (1 - beta) * axis_size(x, axis)
+    return sum_largest(x, k, axis=axis, keepdims=keepdims) / k

--- a/cvxpy/atoms/stats.py
+++ b/cvxpy/atoms/stats.py
@@ -17,27 +17,19 @@ limitations under the License.
 import numbers
 
 import numpy as np
-from numpy.lib.array_utils import normalize_axis_tuple
 
 from cvxpy.atoms.affine.sum import sum as cvxpy_sum
+from cvxpy.atoms.axis_atom import axis_size
 from cvxpy.atoms.norm import norm
 from cvxpy.atoms.sum_squares import sum_squares
 from cvxpy.expressions.expression import Expression
-
-
-def _axis_size(x, axis=None) -> int:
-    """Return the number of entries reduced by an axis argument."""
-    if axis is None:
-        return x.size
-    axes = normalize_axis_tuple(axis, len(x.shape), "axis")
-    return int(np.prod([x.shape[a] for a in axes]))
 
 
 def mean(x, axis=None, keepdims=False) -> Expression:
     """
     Returns the mean of x.
     """
-    return cvxpy_sum(x, axis=axis, keepdims=keepdims) / _axis_size(x, axis)
+    return cvxpy_sum(x, axis=axis, keepdims=keepdims) / axis_size(x, axis)
 
 
 def std(x, axis=None, keepdims=False, ddof=0) -> Expression:
@@ -50,7 +42,7 @@ def std(x, axis=None, keepdims=False, ddof=0) -> Expression:
         return norm((x - mean(x)).flatten(order='F'), 2) / np.sqrt(x.size - ddof)
     elif isinstance(axis, numbers.Integral):
         return norm(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims) \
-                / np.sqrt(_axis_size(x, axis) - ddof)
+                / np.sqrt(axis_size(x, axis) - ddof)
     else:
         raise ValueError("cp.std doesn't yet support tuple axis values.")
 
@@ -65,4 +57,4 @@ def var(x, axis=None, keepdims=False, ddof=0) -> Expression:
         x - mean(x, axis, True),
         axis=axis,
         keepdims=keepdims,
-    ) / (_axis_size(x, axis) - ddof)
+    ) / (axis_size(x, axis) - ddof)

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -1747,6 +1747,50 @@ class TestAtoms(BaseTest):
         cvar_value = cp.cvar(A @ x.value, beta).value
         self.assertTrue(cvar_value <= kappa)
 
+    def test_cvar_axis(self) -> None:
+        """cvar reduces along an axis the way the other stats atoms do."""
+        rng = np.random.default_rng(0)
+        a = rng.standard_normal((5, 4, 3))
+
+        # The output shape follows the same reduction rule as the other atoms.
+        for axis in [0, 1, 2, (0, 1), (1, 2), (0, 2), None]:
+            for keepdims in [True, False]:
+                expr = cp.cvar(a, 0.9, axis=axis, keepdims=keepdims)
+                assert expr.shape == np.mean(a, axis=axis, keepdims=keepdims).shape
+
+        # Reducing over one axis agrees with the atom applied to each slice.
+        m = rng.standard_normal((6, 4))
+        for beta in [0.0, 0.5, 0.9]:
+            assert np.allclose(cp.cvar(m, beta, axis=0).value,
+                               [cp.cvar(m[:, j], beta).value for j in range(m.shape[1])])
+            assert np.allclose(cp.cvar(m, beta, axis=1).value,
+                               [cp.cvar(m[i, :], beta).value for i in range(m.shape[0])])
+
+        # A tuple of axes pools the samples of every axis it names.
+        pooled = cp.cvar(a, 0.9, axis=(0, 2)).value
+        assert np.allclose(pooled,
+                           [cp.cvar(a[:, j, :].flatten(), 0.9).value for j in range(a.shape[1])])
+
+        # Negative axes count from the end.
+        assert np.allclose(cp.cvar(a, 0.9, axis=-1).value, cp.cvar(a, 0.9, axis=2).value)
+
+        # Without an axis the whole array is one distribution.
+        assert np.isclose(cp.cvar(a, 0.9).value, cp.cvar(a.flatten(), 0.9).value)
+
+        # beta = 0 keeps every sample, so cvar is the mean.
+        for axis in [0, 1, (0, 2), None]:
+            assert np.allclose(cp.cvar(a, 0.0, axis=axis).value, np.mean(a, axis=axis))
+
+        # The axis form canonicalizes and solves.
+        X = cp.Variable((6, 4))
+        prob = cp.Problem(cp.Minimize(cp.sum(cp.cvar(X, 0.75, axis=0))), [X >= 1])
+        prob.solve()
+        self.assertEqual(prob.status, cp.OPTIMAL)
+        self.assertAlmostEqual(prob.value, 4.0)
+
+        with self.assertRaises(ValueError):
+            cp.cvar(a, 1.0, axis=0)
+
     def test_index(self) -> None:
         """Test the copy function for index.
         """

--- a/doc/source/tutorial/functions/index.rst
+++ b/doc/source/tutorial/functions/index.rst
@@ -84,7 +84,7 @@ and returns a scalar.
      - average of the :math:`(1-\beta)`
        
        fraction of largest values in :math:`x`
-     - :math:`x \in \mathbf{R}^m`
+     - :math:`x \in \mathbf{R}^{m \times n}`
       
        :math:`\beta \in (0,1)`
      - sign depends on :math:`x`
@@ -521,8 +521,8 @@ The CVXPY function ``sum`` sums all the entries in a single expression. The buil
 Functions along an axis
 -----------------------
 
-The functions ``sum``, ``norm``, ``max``, ``min``, ``mean``, ``std``, ``var``, and ``ptp`` can
-be applied along an axis.
+The functions ``sum``, ``norm``, ``max``, ``min``, ``mean``, ``std``, ``var``, ``ptp``,
+``sum_largest`` and ``cvar`` can be applied along an axis.
 Given an ``m`` by ``n`` expression ``expr``, the syntax ``func(expr, axis=0, keepdims=True)``
 applies ``func`` to each column, returning a 1 by ``n`` expression.
 The syntax ``func(expr, axis=1, keepdims=True)`` applies ``func`` to each row,


### PR DESCRIPTION
`cvar` now takes `axis` and `keepdims`, following #3489 item 1.

The restriction was only ever in the wrapper. `cvar` is `sum_largest(x, k) / k`,
and `sum_largest` has been an `AxisAtom` with `axis` and `keepdims` for a while,
so the 1-d check was refusing inputs the machinery underneath already handled.
Both arguments now pass straight through. An array with `axis=None` is one
distribution over all of its entries rather than a `ValueError` — the same thing
`var` does.

`k` is the part that needed care: it is `(1 - beta) * m`, with `m` the number of
samples reduced rather than `len(x)`. That is the same count `mean`, `std` and
`var` divide by, so `_axis_size` moved out of `stats.py` to sit next to
`normalize_axis` in `axis_atom.py`, where `cvar` can reach it without a third
copy of four lines. Say the word if you'd rather I duplicate it and leave
`stats.py` alone.

Checked against the one-dimensional atom applied slice by slice, over every
single axis and every pair of a (5, 4, 3) array, with and without `keepdims`:
shapes match the corresponding numpy reduction and values agree to 1e-9.
`beta = 0` keeps every sample and so must return the mean along the axis, which
pins the sample count down independently of `sum_largest`. The vector case is
unchanged and still matches the Rockafellar-Uryasev program. The axis form
canonicalizes through the same path as the vector one, with no backend fallback.

In the docs, `cvar` and `sum_largest` join the list of functions that can be
applied along an axis — `sum_largest` was already missing from it.

You mentioned wanting to talk to Steven before this is merged; that still
stands as far as I'm concerned, this is just the implementation to look at.
## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files. — N/A, no new files
- [x] Check that your code adheres to our coding style. — `ruff` 0.8.1 (the pre-commit pin) reports no findings, `pyright` none on the three changed modules
- [x] Write unittests. — `test_cvar_axis`: shapes against a numpy reduction, values against the 1-d atom slice by slice, tuple and negative axes, `beta = 0` against the mean, and a solve through the axis form
- [x] Run the unittests and check that they're passing. — 2586 passed against 2585 on the merge base, with `--collect-only` diffed: one test added, none lost
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression. — not run locally. `cvar` only gains keyword arguments and the vector path builds the same expression as before, so existing models are unaffected; the CI benchmark job will confirm.

Note: the docs build is not part of PR CI — `docs.yml` is `workflow_dispatch` only — so I ran it
locally instead. The full sphinx build produces the same 412 warnings as master, none of them from
the two lines this PR touches.