### PR TITLE
Raise on an axis with the fro and nuc norms

### DIFF
--- a/cvxpy/atoms/norm.py
+++ b/cvxpy/atoms/norm.py
@@ -66,13 +66,23 @@ def norm(x, p: int | str = 2, axis=None, keepdims: bool = False) -> Expression:
         else:
             raise RuntimeError('Unsupported matrix norm.')
     else:
+        if axis is not None and str(p).lower() in ("fro", "nuc"):
+            # Both are matrix norms, defined over a whole matrix rather than
+            # along one of its axes. Without this the fro branch below vecs
+            # the argument first and then hands the axis to a 1-D expression,
+            # which silently returned the norm of the whole array for axis=0.
+            raise ValueError(
+                f"The axis parameter is not supported for the '{p}' norm, which is "
+                "defined over a whole matrix. Use norm(x, 2, axis=...) for the "
+                "2-norm along an axis."
+            )
         if p == 1 or x.is_scalar():
             return norm1(x, axis=axis, keepdims=keepdims)
         elif str(p).lower() == "inf":
             return norm_inf(x, axis=axis, keepdims=keepdims)
         elif str(p).lower() == "fro":
             # TODO should not work for vectors.
-            return pnorm(vec(x, order='F'), 2, axis)
+            return pnorm(vec(x, order='F'), 2)
         elif isinstance(p, str):
             raise RuntimeError(f'Unsupported norm option {p} for non-matrix.')
         else:

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -125,6 +125,21 @@ class TestAtoms(BaseTest):
         self.assertTrue(str(cm.exception) in (
             "Unsupported norm option nuc for non-matrix."))
 
+        # A matrix norm has no meaning along a single axis. This used to return
+        # the norm of the whole array for axis=0 and raise an AxisError from
+        # inside the flattened expression for anything else.
+        X = cp.Variable((3, 4))
+        for p in ('fro', 'nuc', 'Fro'):
+            for axis in (0, 1, (0, 1)):
+                with self.assertRaises(ValueError) as cm:
+                    cp.norm(X, p, axis=axis)
+                assert "not supported for the" in str(cm.exception)
+
+        # Without an axis both are unchanged.
+        A = np.arange(12., dtype=float).reshape(3, 4)
+        assert np.isclose(cp.norm(cp.Constant(A), 'fro').value, np.linalg.norm(A, 'fro'))
+        assert np.isclose(cp.norm(cp.Constant(A), 'nuc').value, np.linalg.norm(A, 'nuc'))
+
     def test_quad_form(self) -> None:
         """Test quad_form atom.
         """


### PR DESCRIPTION
Refs #3489, and the "better errors on fro" you asked for.

`norm(X, 'fro', axis=0)` returned the Frobenius norm of the whole array as a scalar, quietly ignoring the axis. With any other axis it raised `AxisError: axis 1 is out of bounds for array of dimension 1` about a 1-D array the caller never wrote. The branch vecs its argument and then hands the axis to the flattened expression, so by the time the axis is used it refers to something that no longer has the caller's shape. There is a `# TODO should not work for vectors.` sitting above it.

Both `'fro'` and `'nuc'` are matrix norms, defined over a matrix rather than along one of its axes, so pairing them with an axis is a mistake worth naming. It now raises a `ValueError` pointing at `norm(x, 2, axis=...)`, which is what someone reaching for a per-slice norm actually wants. `'nuc'` already raised, but with "Unsupported norm option nuc for non-matrix" — misleading, since the argument usually *is* a matrix and the axis is the problem.

Nothing without an axis changes. I left the TODO alone: `norm(vector, 'fro')` returning the 2-norm is an existing leniency, and making it raise would break callers rather than correct them. Happy to do it separately if you want it.

On your first point I checked rather than trust my memory of it. `cp.norm` and `np.linalg.norm` agree on **every** matrix case I could construct: ord in {1, 2, 'fro', 'nuc', inf} against shapes (3,4), (4,1), (1,4) and (1,1), twenty comparisons, all equal. Where the two part company is dimensionality, and deliberately: numpy refuses every ord for a 3-D array and refuses `'fro'` for a vector, while cvxpy reads both as the flattened p-norm. So the divergence is real but it is about ndim, not about matrices.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files. — N/A, no new files
- [x] Check that your code adheres to our coding style. — `ruff` 0.8.1 (the pre-commit pin) reports no findings, `pyright` none
- [x] Write unittests. — extends `test_norm_exceptions`
- [x] Run the unittests and check that they're passing. — 2585 passed, same as the merge base
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression. — not run locally; this only adds a guard on an argument combination that previously gave a wrong answer, so no model that solves today changes shape. The CI benchmark job will confirm.