### PR TITLE
Support tuple axes in std

### DIFF
--- a/cvxpy/atoms/stats.py
+++ b/cvxpy/atoms/stats.py
@@ -19,7 +19,9 @@ import numbers
 import numpy as np
 from numpy.lib.array_utils import normalize_axis_tuple
 
+from cvxpy.atoms.affine.reshape import reshape
 from cvxpy.atoms.affine.sum import sum as cvxpy_sum
+from cvxpy.atoms.affine.transpose import moveaxis
 from cvxpy.atoms.norm import norm
 from cvxpy.atoms.sum_squares import sum_squares
 from cvxpy.expressions.expression import Expression
@@ -48,11 +50,24 @@ def std(x, axis=None, keepdims=False, ddof=0) -> Expression:
     """
     if axis is None:
         return norm((x - mean(x)).flatten(order='F'), 2) / np.sqrt(x.size - ddof)
-    elif isinstance(axis, numbers.Integral):
-        return norm(x - mean(x, axis, True), 2, axis=axis, keepdims=keepdims) \
-                / np.sqrt(_axis_size(x, axis) - ddof)
-    else:
-        raise ValueError("cp.std doesn't yet support tuple axis values.")
+
+    centered = x - mean(x, axis, True)
+    scale = np.sqrt(_axis_size(x, axis) - ddof)
+    if isinstance(axis, numbers.Integral):
+        return norm(centered, 2, axis=axis, keepdims=keepdims) / scale
+
+    # A tuple of axes pools the entries of every axis it names, which is one
+    # vector per remaining position. norm takes a single axis, so the pooled
+    # axes are moved to the front and flattened into one, in Fortran order,
+    # and the result is folded back into the shape those axes left behind.
+    axes = normalize_axis_tuple(axis, x.ndim, "axis")
+    kept = tuple(d for d in range(x.ndim) if d not in axes)
+    moved = moveaxis(centered, axes, range(len(axes)))
+    pooled = norm(reshape(moved, (_axis_size(x, axis), -1), order='F'), 2, axis=0) / scale
+    out_shape = tuple(x.shape[d] for d in kept)
+    if keepdims:
+        out_shape = tuple(1 if d in axes else x.shape[d] for d in range(x.ndim))
+    return reshape(pooled, out_shape, order='F')
 
 
 def var(x, axis=None, keepdims=False, ddof=0) -> Expression:

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -2072,15 +2072,22 @@ class TestAtoms(BaseTest):
                 assert np.allclose(a.mean(axis=axis, keepdims=keepdims), expr_mean.value)
                 assert np.allclose(a.var(axis=axis, keepdims=keepdims), expr_var.value)
 
-        for axis in [0, 1, 2]:
+        for axis in [0, 1, 2, (0, 1), (1, 2), (0, 2), (0,), (0, 1, 2), (-3, -1)]:
             for keepdims in [True, False]:
-                expr_std = cp.std(a, axis=axis, keepdims=keepdims)
+                for ddof in [0, 1]:
+                    expr_std = cp.std(a, axis=axis, keepdims=keepdims, ddof=ddof)
+                    want = a.std(axis=axis, keepdims=keepdims, ddof=ddof)
 
-                assert expr_std.shape == a.std(axis=axis, keepdims=keepdims).shape
-                assert np.allclose(a.std(axis=axis, keepdims=keepdims), expr_std.value)
+                    assert expr_std.shape == want.shape
+                    assert np.allclose(want, expr_std.value)
 
-        with self.assertRaises(ValueError):
-            cp.std(a, axis=(0, 1))
+        # A tuple of axes stays DCP and solves.
+        X = cp.Variable((2, 3, 4))
+        prob = cp.Problem(cp.Minimize(cp.sum(cp.std(X, axis=(0, 2)))), [X >= 1])
+        assert prob.is_dcp()
+        prob.solve()
+        self.assertEqual(prob.status, cp.OPTIMAL)
+        self.assertAlmostEqual(prob.value, 0.0, places=6)
 
     def test_partial_optimize_dcp(self) -> None:
         """Test DCP properties of partial optimize.


### PR DESCRIPTION
Refs #3489, item 2  the `std` half, following your "happy to do different behavior on std and norm even if that adds complexity to std". It does not touch `norm`.

A tuple of axes pools the entries of every axis it names into one sample set per remaining position. `norm` takes a single axis, so the pooled axes are moved to the front with `moveaxis`, flattened into one in Fortran order, reduced with `norm(..., 2, axis=0)`, and the result folded back into the shape the pooled axes left behind. That is the same alignment `geo_mean` has used since #3493, order included.

`std` is the one atom here that cannot borrow `var`'s route: `var` is `sum_squares` over the axes and takes tuples already, but the square root of a convex expression is not DCP, which is why `std` goes through `norm` in the first place.

Checked against numpy over `(0,1)`, `(1,2)`, `(0,2)`, the one-element `(0,)`, the full `(0,1,2)` and the negative `(-3,-1)`, each crossed with `keepdims` and `ddof` in {0, 1}: shapes and values all agree. The `int` and `None` paths are untouched and still match. The tuple form is DCP and solves.

Note this **drops an existing assertion** in `test_stats` that `cp.std(a, axis=(0, 1))` raises `ValueError`  it was pinning the gap this closes.

No new backend fallback: `std(X, axis=0)` on a three-dimensional variable already falls back to SCIPY, because the CPP backend does not take expressions past two dimensions, so the reshape adds nothing there.

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files. — N/A, no new files
- [x] Check that your code adheres to our coding style. — `ruff` 0.8.1 (the pre-commit pin) reports no findings, `pyright` none
- [x] Write unittests. — extends `test_stats` to tuple axes, `keepdims` and `ddof`, plus a DCP and solve check
- [x] Run the unittests and check that they're passing. — 2585 passed, same as the merge base
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression. — not run locally. Only the tuple branch is new; `axis=None` and integer axes build exactly the expression they built before, so existing models are unaffected. The CI benchmark job will confirm.