### PR TITLE
Add dual variables to ConstantSolver for feasible constant problems

### DIFF
--- a/cvxpy/reductions/solvers/constant_solver.py
+++ b/cvxpy/reductions/solvers/constant_solver.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import cvxpy.settings as s
 from cvxpy.reductions.solution import Solution
 from cvxpy.reductions.solvers.solver import Solver
@@ -32,7 +34,8 @@ class ConstantSolver(Solver):
 
     def solve(self, problem, warm_start: bool, verbose: bool, solver_opts):
         if all(c.value() for c in problem.constraints):
-            return Solution(s.OPTIMAL, problem.objective.value, {}, {}, {})
+            dual_vars = {c.id: np.zeros(c.shape) for c in problem.constraints}
+            return Solution(s.OPTIMAL, problem.objective.value, {}, dual_vars, {})
         else:
             return Solution(s.INFEASIBLE, None, {}, {}, {})
 

--- a/cvxpy/reductions/solvers/constant_solver.py
+++ b/cvxpy/reductions/solvers/constant_solver.py
@@ -1,8 +1,28 @@
 import numpy as np
 
 import cvxpy.settings as s
+from cvxpy.constraints.second_order import RSOC, SOC
 from cvxpy.reductions.solution import Solution
 from cvxpy.reductions.solvers.solver import Solver
+
+
+def _zero_dual(constr):
+    """Return a zero dual in the representation used in ``Solution.dual_vars``.
+
+    Mirrors the packed representations real solvers produce via
+    ``utilities.get_dual_values`` / ``extract_dual_value`` and the reshape step
+    in ``cone_matrix_stuffing.ConeMatrixStuffing.invert``: SOC duals stay flat with
+    size equal to the packed cone size, RSOC duals use the ``[dt, du, dX]``
+    list that ``RSOC.save_dual_value`` consumes, and all other constraints use a
+    shape-matching array.
+    """
+    if isinstance(constr, SOC):
+        return np.zeros(constr.size)
+    if isinstance(constr, RSOC):
+        n_cones = constr.args[1].size
+        n_x = constr.args[2].size // n_cones
+        return [np.zeros(n_cones), np.zeros(n_cones), np.zeros((n_cones, n_x))]
+    return np.zeros(constr.shape)
 
 
 class ConstantSolver(Solver):
@@ -34,7 +54,7 @@ class ConstantSolver(Solver):
 
     def solve(self, problem, warm_start: bool, verbose: bool, solver_opts):
         if all(c.value() for c in problem.constraints):
-            dual_vars = {c.id: np.zeros(c.shape) for c in problem.constraints}
+            dual_vars = {c.id: _zero_dual(c) for c in problem.constraints}
             return Solution(s.OPTIMAL, problem.objective.value, {}, dual_vars, {})
         else:
             return Solution(s.INFEASIBLE, None, {}, {}, {})

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -2373,3 +2373,37 @@ class TestProblem(BaseTest):
         result = reduction.invert(sol, inv_data)
         assert result.dual_vars is None
 
+    def test_constant_solver_duals(self) -> None:
+        """Test that ConstantSolver returns zero dual values for feasible problems."""
+        # Satisfied inequality constraint
+        prob = Problem(cp.Minimize(1), [2 >= 1])
+        prob.solve()
+        self.assertEqual(prob.status, s.OPTIMAL)
+        self.assertEqual(prob.constraints[0].dual_value, 0.0)
+
+        # Equality constraint
+        prob = Problem(cp.Minimize(1), [cp.Constant(1) == cp.Constant(1)])
+        prob.solve()
+        self.assertEqual(prob.status, s.OPTIMAL)
+        self.assertEqual(prob.constraints[0].dual_value, 0.0)
+
+        # Multiple constraints
+        prob = Problem(cp.Minimize(1), [2 >= 1, 3 >= 2])
+        prob.solve()
+        self.assertEqual(prob.status, s.OPTIMAL)
+        for c in prob.constraints:
+            self.assertEqual(c.dual_value, 0.0)
+
+        # Vector constraint
+        prob = Problem(cp.Minimize(1),
+                       [cp.Constant(np.array([2, 3, 4])) >= cp.Constant(np.array([1, 2, 3]))])
+        prob.solve()
+        self.assertEqual(prob.status, s.OPTIMAL)
+        self.assertItemsAlmostEqual(prob.constraints[0].dual_value, [0, 0, 0])
+
+        # Infeasible problem (dual should be None)
+        prob = Problem(cp.Minimize(1), [0 >= 1])
+        prob.solve()
+        self.assertEqual(prob.status, s.INFEASIBLE)
+        self.assertIsNone(prob.constraints[0].dual_value)
+

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -2388,7 +2388,9 @@ class TestProblem(BaseTest):
         self.assertEqual(prob.constraints[0].dual_value, 0.0)
 
         # Satisfied multiple constraints
-        prob = Problem(cp.Minimize(1), [cp.Constant(2) >= cp.Constant(1), cp.Constant(3) >= cp.Constant(2)])
+        prob = Problem(cp.Minimize(1), [
+            cp.Constant(2) >= cp.Constant(1),
+            cp.Constant(3) >= cp.Constant(2)])
         prob.solve()
         self.assertEqual(prob.status, s.OPTIMAL)
         for c in prob.constraints:

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -2375,8 +2375,8 @@ class TestProblem(BaseTest):
 
     def test_constant_solver_duals(self) -> None:
         """Test that ConstantSolver returns zero dual values for feasible problems."""
-        # Satisfied inequality constraint
-        prob = Problem(cp.Minimize(1), [2 >= 1])
+        # Satisfied scalar inequality constraint
+        prob = Problem(cp.Minimize(1), [cp.Constant(2) >= cp.Constant(1)])
         prob.solve()
         self.assertEqual(prob.status, s.OPTIMAL)
         self.assertEqual(prob.constraints[0].dual_value, 0.0)
@@ -2387,23 +2387,50 @@ class TestProblem(BaseTest):
         self.assertEqual(prob.status, s.OPTIMAL)
         self.assertEqual(prob.constraints[0].dual_value, 0.0)
 
-        # Multiple constraints
-        prob = Problem(cp.Minimize(1), [2 >= 1, 3 >= 2])
+        # Satisfied multiple constraints
+        prob = Problem(cp.Minimize(1), [cp.Constant(2) >= cp.Constant(1), cp.Constant(3) >= cp.Constant(2)])
         prob.solve()
         self.assertEqual(prob.status, s.OPTIMAL)
         for c in prob.constraints:
             self.assertEqual(c.dual_value, 0.0)
 
-        # Vector constraint
+        # Vector inequality constraint
         prob = Problem(cp.Minimize(1),
                        [cp.Constant(np.array([2, 3, 4])) >= cp.Constant(np.array([1, 2, 3]))])
         prob.solve()
         self.assertEqual(prob.status, s.OPTIMAL)
         self.assertItemsAlmostEqual(prob.constraints[0].dual_value, [0, 0, 0])
 
-        # Infeasible problem (dual should be None)
-        prob = Problem(cp.Minimize(1), [0 >= 1])
+        # Infeasible inequality constraint (dual is None)
+        prob = Problem(cp.Minimize(1), [cp.Constant(0) >= cp.Constant(1)])
         prob.solve()
         self.assertEqual(prob.status, s.INFEASIBLE)
         self.assertIsNone(prob.constraints[0].dual_value)
+
+        # Parameter-only problem reaches ConstantSolver and tracks the Parameter value.
+        # Feasible at value=2 -> optimal with zero dual; infeasible at value=0 -> None.
+        p = cp.Parameter(value=2)
+        prob = Problem(cp.Minimize(1), [p >= 1])
+        prob.solve()
+        self.assertEqual(prob.status, s.OPTIMAL)
+        self.assertEqual(prob.constraints[0].dual_value, 0.0)
+
+        p.value = 0
+        prob.solve()
+        self.assertEqual(prob.status, s.INFEASIBLE)
+        self.assertIsNone(prob.constraints[0].dual_value)
+
+        # Explicit constant SOC reaches ConstantSolver with a zero dual.
+        prob = Problem(cp.Minimize(1),
+                       [cp.SOC(cp.Constant(1), cp.Constant([1.0, 0.0]))])
+        prob.solve()
+        self.assertEqual(prob.status, s.OPTIMAL)
+        dv = prob.constraints[0].dual_value
+        # SOC duals are stored as a two-element list, not a tuple.
+        self.assertIsInstance(dv, list)
+        self.assertEqual(len(dv), 2)
+        self.assertEqual(dv[0].shape, (1,))
+        self.assertEqual(dv[1].shape, (2, 1))
+        self.assertTrue(np.all(dv[0] == 0.0))
+        self.assertTrue(np.all(dv[1] == 0.0))
 


### PR DESCRIPTION
This adds dual variable values to `ConstantSolver` for feasible constant problems. The solver now returns zero valued duals keyed by constraint ID and matching each constraint's shape so `constraint.dual_value` is populated instead of remaining none. Infeasible constant problems retain the existing behavior. 

The change is minimal: 4 lines in constant_solver.py plus regression coverage for inequality , equality , vector and infeasible cases.