### PR TITLE
Fix 3.14t and windows-2022 builds in GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         # exluding this build because it is failing and blocks wheels
         exclude:
           - os: windows-2022
-          - python-version: 3.14t
+            python-version: 3.14t
 
     env:
       RUNNER_OS: ${{ matrix.os }}


### PR DESCRIPTION
## Description
PR #2960 probably added a typo which now excludes *all* 3.14t and *all* windows-2022 builds from GitHub actions instead of the single one failing.

Example: https://github.com/cvxpy/cvxpy/actions/runs/33549462457 has 8 build jobs, 28 build_wheel jobs, because the build_wheel job does not have that alleged typo.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [x] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [x] Run the benchmarks to make sure your change doesn’t introduce a regression.