### PR TITLE
CI: isolate OR-Tools tests from HiGHS to prevent native symbol conflicts

### DIFF
--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -65,10 +65,10 @@ jobs:
       # symbol conflicts (google/or-tools#5246). Run OR-Tools tests
       # (GLOP/PDLP) in a separate process to avoid this.
       - name: Run test_conic_solvers
-        run: uv run pytest -rs -m "not knitro" -k "not (GLOP or PDLP)" cvxpy/tests/test_conic_solvers.py
+        run: uv run pytest -rs -m "not knitro and not ortools" cvxpy/tests/test_conic_solvers.py
       - name: Run test_conic_solvers (OR-Tools)
         if: always()
-        run: uv run pytest -rs -k "GLOP or PDLP" cvxpy/tests/test_conic_solvers.py
+        run: uv run pytest -rs -m ortools cvxpy/tests/test_conic_solvers.py
       - name: Run test_conic_solvers (KNITRO)
         if: always()
         run: uv run pytest -rs -m knitro cvxpy/tests/test_conic_solvers.py

--- a/.github/workflows/test_optional_solvers.yml
+++ b/.github/workflows/test_optional_solvers.yml
@@ -59,8 +59,16 @@ jobs:
       # OpenBLAS dependency. Loading both in one process can crash inside
       # KNITRO's KN_solve on macOS, so run KNITRO tests in a separate
       # process (mirrors test_nlp_solvers.yml).
+      #
+      # OR-Tools >= 9.14 bundles its own HiGHS inside libortools.so.
+      # Loading highspy and ortools in the same process causes native
+      # symbol conflicts (google/or-tools#5246). Run OR-Tools tests
+      # (GLOP/PDLP) in a separate process to avoid this.
       - name: Run test_conic_solvers
-        run: uv run pytest -rs -m "not knitro" cvxpy/tests/test_conic_solvers.py
+        run: uv run pytest -rs -m "not knitro" -k "not (GLOP or PDLP)" cvxpy/tests/test_conic_solvers.py
+      - name: Run test_conic_solvers (OR-Tools)
+        if: always()
+        run: uv run pytest -rs -k "GLOP or PDLP" cvxpy/tests/test_conic_solvers.py
       - name: Run test_conic_solvers (KNITRO)
         if: always()
         run: uv run pytest -rs -m knitro cvxpy/tests/test_conic_solvers.py

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -3080,6 +3080,13 @@ class TestAllSolvers(BaseTest):
                     pass
                 elif solver is cp.KNITRO and not is_knitro_available():
                     pass
+                # OR-Tools >= 9.14 bundles HiGHS inside libortools.so.
+                # Loading both in the same process causes native symbol
+                # conflicts (google/or-tools#5246); GLOP/PDLP coverage
+                # is provided by TestGLOP/TestPDLP in the isolated
+                # -m ortools pytest invocation.
+                elif solver in ("GLOP", "PDLP"):
+                    pass
                 else:
                     prob.solve(solver=solver)
                     self.assertAlmostEqual(prob.value, 1.0)
@@ -3833,7 +3840,22 @@ class TestCUOPT(unittest.TestCase):
             self.assertIsNone(w.value)
 
 
-@pytest.mark.parametrize("solver", INSTALLED_SOLVERS)
+def _ortools_params(solvers):
+    """Wrap GLOP/PDLP solver names with ``pytest.mark.ortools``.
+
+    This keeps those parameter variants in the isolated OR-Tools pytest
+    process and out of the main conic-solver invocation (google/or-tools#5246).
+    """
+    result = []
+    for s in solvers:
+        if s in ("GLOP", "PDLP"):
+            result.append(pytest.param(s, marks=[pytest.mark.ortools], id=s))
+        else:
+            result.append(s)
+    return result
+
+
+@pytest.mark.parametrize("solver", _ortools_params(INSTALLED_SOLVERS))
 def test_offset_in_opt_val(solver):
     """Solvers must add the constant OFFSET back in invert().
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -1624,6 +1624,7 @@ class TestGLPK(unittest.TestCase):
         sth.verify_primal_values(places=4)
 
 
+@pytest.mark.ortools
 @unittest.skipUnless('GLOP' in INSTALLED_SOLVERS, 'GLOP is not installed.')
 class TestGLOP(unittest.TestCase):
 
@@ -1683,6 +1684,7 @@ class TestGLOP(unittest.TestCase):
         StandardTestLPs.test_lp_bound_attr(solver='GLOP', duals=False)
 
 
+@pytest.mark.ortools
 @unittest.skipUnless('PDLP' in INSTALLED_SOLVERS, 'PDLP is not installed.')
 class TestPDLP(unittest.TestCase):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ testpaths = [
 ]
 markers = [
     "knitro: tests that load the native KNITRO runtime; run in a separate process from other native solvers (see test_nlp_solvers.yml)",
+    "ortools: tests that load the native OR-Tools runtime (libortools.so bundles HiGHS); run in a separate process from HiGHS tests (google/or-tools#5246)",
 ]
 
 [build-system]


### PR DESCRIPTION
`OR Tools >= 9.14` bundles its own HiGHS library , which can conflict with `highspy` when both are loaded in the same process. This separates the GLOP/PDLP tests into a separate pytest invocation so the OR Tools and HiGHS native libraries are not loaded in the same process.

Related: google/or-tools#5246

Feedback on the approach is highly appreciated.
