### PR TITLE
Preserve NumPy scalar axes in sum shape inference

### DIFF
--- a/cvxpy/atoms/affine/sum.py
+++ b/cvxpy/atoms/affine/sum.py
@@ -93,6 +93,14 @@ class Sum(AxisAtom, AffAtom):
         ndim = len(input_shape)
         if self.axis is None:
             return (1,) * ndim if self.keepdims else ()
+        # NumPy accepts integer axes 0 and -1 for scalars, but not tuple axes.
+        if (
+            ndim == 0
+            and isinstance(self.axis, (int, np.integer))
+            and not isinstance(self.axis, (bool, np.bool_))
+            and self.axis in (0, -1)
+        ):
+            return ()
         try:
             axes = normalize_axis_tuple(self.axis, ndim)
         except (ValueError, AxisError, TypeError) as e:

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import unittest
 from fractions import Fraction
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -2996,6 +2997,28 @@ class TestAtoms(BaseTest):
         """real(symmetric) is symmetric."""
         S = Variable((3, 3), symmetric=True)
         self.assertTrue(cp.real(S).is_symmetric())
+
+    def test_sum_scalar_axes(self):
+        scalar = cp.Parameter(value=2.0)
+        for axis in (None, 0, -1, np.int64(0), np.int64(-1), ()):
+            for keepdims in (False, True):
+                with self.subTest(axis=axis, keepdims=keepdims):
+                    expected = np.sum(scalar.value, axis=axis, keepdims=keepdims)
+                    expr = cp.sum(scalar, axis=axis, keepdims=keepdims)
+                    self.assertEqual(expr.shape, expected.shape)
+                    self.assertEqual(expr.value, expected)
+                    self.assertTrue(expr.is_dpp())
+        for axis in (1, -2, (0,), (-1,), (0, -1), 0.0, False):
+            with self.subTest(axis=axis):
+                with self.assertRaisesRegex(ValueError, "Invalid arguments for cp.sum"):
+                    cp.sum(scalar, axis=axis)
+
+    def test_sum_shape_without_allocation(self):
+        x = cp.Variable((2, 3, 4))
+        with patch("numpy.empty", side_effect=AssertionError("Shape inference allocated")):
+            with np.errstate(all="raise"):
+                self.assertEqual(cp.sum(x, axis=(0, -1)).shape, (3,))
+                self.assertEqual(cp.sum(x, axis=(), keepdims=True).shape, x.shape)
 
     def test_sum_shape_inference(self):
         """


### PR DESCRIPTION
## Description
Restore NumPy's scalar `sum` behavior: integer `axis=0` and `axis=-1` return shape `()`, with either value of `keepdims`. The exact tuple calculation introduced in #3460 rejected these previously valid calls. A scalar-only guard preserves Python and NumPy integer axes while continuing to reject tuple axes, floats, and booleans.

The uninitialized-memory reduction reported in #3503 is already gone on master. This patch closes the remaining scalar compatibility gap without allocating an array or performing a numerical reduction. Tests cover scalar shapes and values against NumPy, parameter DPP compliance, invalid axes, and shape inference without `np.empty`.

@Transurgeon — this is the remaining compatibility fix for the upcoming bug-fix release discussed in #3503.

Refs #3503, #3235.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files. (No new files.)
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.

Validation: `pytest cvxpy/tests/test_atoms.py cvxpy/tests/test_constant_atoms.py -q -rs` — 305 passed, 19 subtests passed; no skips. The new scalar regression test fails on unpatched master. Pre-commit checks passed. Benchmarks were not run.
