### PR TITLE
Fix SCS 3.3 compatibility and CI accuracy assumptions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,10 +8,13 @@ on:
 
 jobs:
   claude-review:
-    # Run if PR opened OR if someone comments /claude-review on a PR
+    # Fork pull_request events cannot access the OAuth secret or request OIDC.
+    # Maintainers can still request a fork review with /claude-review.
+    # Run if a same-repository PR opens OR a maintainer requests a review.
     # Important to check author association to prevent prompt injection attacks
     if: |
       (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
        (github.event.pull_request.author_association == 'MEMBER' ||
         github.event.pull_request.author_association == 'OWNER' ||
         github.event.pull_request.author_association == 'COLLABORATOR')) ||

--- a/cvxpy/atoms/suppfunc.py
+++ b/cvxpy/atoms/suppfunc.py
@@ -115,7 +115,7 @@ class SuppFuncAtom(Atom):
             dummy = Variable()
             cons = [dummy == 1]
         prob = Problem(Maximize(y_val @ x_flat), cons)
-        val = prob.solve(solver='SCS', eps=1e-6)
+        val = prob.solve(solver='SCS', eps=1e-8)
         return val
 
     def _grad(self, values):

--- a/cvxpy/atoms/suppfunc.py
+++ b/cvxpy/atoms/suppfunc.py
@@ -115,7 +115,7 @@ class SuppFuncAtom(Atom):
             dummy = Variable()
             cons = [dummy == 1]
         prob = Problem(Maximize(y_val @ x_flat), cons)
-        val = prob.solve(solver='SCS', eps=1e-8)
+        val = prob.solve(solver='CLARABEL')
         return val
 
     def _grad(self, values):

--- a/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
@@ -211,6 +211,13 @@ class SCS(ConicSolver):
             else:
                 solver_opts['eps_abs'] = solver_opts.get('eps_abs', 1e-5)
                 solver_opts['eps_rel'] = solver_opts.get('eps_rel', 1e-5)
+        # SCS 3.3 replaced use_indirect with an explicit linear solver selection.
+        if Version(scs.__version__) >= Version('3.3.0') and "use_indirect" in solver_opts:
+            if "linear_solver" in solver_opts:
+                raise ValueError("Specify only one of use_indirect and linear_solver.")
+            solver_opts["linear_solver"] = (
+                "cpu_indirect" if solver_opts.pop("use_indirect") else "qdldl"
+            )
         # use_quad_obj is only for canonicalization.
         if "use_quad_obj" in solver_opts:
             del solver_opts["use_quad_obj"]

--- a/cvxpy/tests/test_KKT.py
+++ b/cvxpy/tests/test_KKT.py
@@ -358,7 +358,7 @@ class TestKKT_Flags(BaseTest):
 
     def test_kkt_symmetric_var(self, places=4):
         sth = TestKKT_Flags.symmetric_flag()
-        sth.solve(solver='SCS')
+        sth.solve(solver=cp.CLARABEL)
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -129,6 +129,19 @@ class TestECOS(BaseTest):
         StandardTestMixedCPs.test_exp_soc_1(solver='ECOS')
 
 
+@pytest.mark.parametrize("version", ["3.2.11", "3.3.0", "3.3.1"])
+@pytest.mark.parametrize("indirect", [False, True])
+def test_scs_linear_solver_options(version, indirect):
+    with mock.patch("scs.__version__", version):
+        options = SCS.parse_solver_options({"use_indirect": indirect})
+    if Version(version) < Version("3.3.0"):
+        assert options["use_indirect"] == indirect
+        assert "linear_solver" not in options
+    else:
+        assert "use_indirect" not in options
+        assert options["linear_solver"] == ("cpu_indirect" if indirect else "qdldl")
+
+
 class TestSCS(BaseTest):
 
     """ Unit tests for SCS. """
@@ -183,18 +196,7 @@ class TestSCS(BaseTest):
             self.assertAlmostEqual(prob.value, 1.0, places=2)
             self.assertItemsAlmostEqual(x.value, [0, 0], places=2)
 
-    def test_scs_linear_solver_options(self) -> None:
-        for version in ("3.2.11", "3.3.0", "3.3.1"):
-            for indirect in (False, True):
-                with self.subTest(version=version, indirect=indirect):
-                    with mock.patch("scs.__version__", version):
-                        options = SCS.parse_solver_options({"use_indirect": indirect})
-                    if Version(version) < Version("3.3.0"):
-                        self.assertEqual(options["use_indirect"], indirect)
-                    else:
-                        self.assertNotIn("use_indirect", options)
-                        self.assertEqual(options["linear_solver"],
-                                         "cpu_indirect" if indirect else "qdldl")
+    def test_scs_explicit_linear_solver(self) -> None:
         with mock.patch("scs.__version__", "3.3.1"):
             self.assertEqual(SCS.parse_solver_options({"linear_solver": "auto"})[
                 "linear_solver"], "auto")

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -37,6 +37,7 @@ from cvxpy.problems.problem_form import ProblemForm
 from cvxpy.reductions.solvers.conic_solvers.conic_solver import ConicSolver
 from cvxpy.reductions.solvers.conic_solvers.cuopt_conif import CUOPT
 from cvxpy.reductions.solvers.conic_solvers.cvxopt_conif import compress_matrix
+from cvxpy.reductions.solvers.conic_solvers.scs_conif import SCS
 from cvxpy.reductions.solvers.defines import (
     INSTALLED_MI_SOLVERS,
     INSTALLED_SOLVERS,
@@ -175,11 +176,30 @@ class TestSCS(BaseTest):
         EPS = 1e-4
         x = cp.Variable(2, name='x')
         prob = cp.Problem(cp.Minimize(cp.norm(x, 1) + 1.0), [x == 0])
-        for i in range(2):
-            prob.solve(solver=cp.SCS, max_iters=50, eps=EPS, alpha=1.2,
-                       verbose=True, normalize=True, use_indirect=False)
-        self.assertAlmostEqual(prob.value, 1.0, places=2)
-        self.assertItemsAlmostEqual(x.value, [0, 0], places=2)
+        for indirect in (False, True):
+            for _ in range(2):
+                prob.solve(solver=cp.SCS, max_iters=50, eps=EPS, alpha=1.2,
+                           verbose=True, normalize=True, use_indirect=indirect)
+            self.assertAlmostEqual(prob.value, 1.0, places=2)
+            self.assertItemsAlmostEqual(x.value, [0, 0], places=2)
+
+    def test_scs_linear_solver_options(self) -> None:
+        for version in ("3.2.11", "3.3.0", "3.3.1"):
+            for indirect in (False, True):
+                with self.subTest(version=version, indirect=indirect):
+                    with mock.patch("scs.__version__", version):
+                        options = SCS.parse_solver_options({"use_indirect": indirect})
+                    if Version(version) < Version("3.3.0"):
+                        self.assertEqual(options["use_indirect"], indirect)
+                    else:
+                        self.assertNotIn("use_indirect", options)
+                        self.assertEqual(options["linear_solver"],
+                                         "cpu_indirect" if indirect else "qdldl")
+        with mock.patch("scs.__version__", "3.3.1"):
+            self.assertEqual(SCS.parse_solver_options({"linear_solver": "auto"})[
+                "linear_solver"], "auto")
+            with self.assertRaisesRegex(ValueError, "Specify only one"):
+                SCS.parse_solver_options({"use_indirect": True, "linear_solver": "qdldl"})
 
     def test_log_problem(self) -> None:
         # Log in objective.

--- a/cvxpy/tests/test_domain.py
+++ b/cvxpy/tests/test_domain.py
@@ -47,7 +47,7 @@ class TestDomain(BaseTest):
             dom = expr.domain
             constr = [self.a >= -100, self.x >= 0]
             prob = Problem(Minimize(sum(self.x + self.a)), dom + constr)
-            prob.solve(solver=cp.SCS, eps=1e-6)
+            prob.solve(solver=cp.CLARABEL)
             self.assertAlmostEqual(prob.value, 13)
             assert self.a.value >= 0
             assert np.all((self.x + self.a - [5, 8]).value >= -1e-3)

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -483,7 +483,7 @@ class TestDqcp(base_test.BaseTest):
         a = np.ones(2)
         b = np.zeros(2)
         problem = cp.Problem(cp.Minimize(cp.dist_ratio(x, a, b)), [x <= 0.8])
-        problem.solve(cp.SCS, qcp=True)
+        problem.solve(cp.CLARABEL, qcp=True)
         np.testing.assert_almost_equal(problem.objective.value, 0.25, decimal=3)
         np.testing.assert_almost_equal(x.value, np.array([0.8, 0.8]), decimal=3)
 
@@ -773,7 +773,8 @@ class TestDqcp(base_test.BaseTest):
         with pytest.raises(
             cp.SolverError,
             match="(Max iters hit during bisection|"
-                  "Unable to find suitable interval for bisection)"
+                  "Unable to find suitable interval for bisection|"
+                  "Solver failed with status solver_error)"
         ):
             problem.solve(qcp=True, solver=cp.SCS, max_iters=1)
 

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -652,7 +652,7 @@ class TestProblem(BaseTest):
     def test_variable_name_conflict(self) -> None:
         var = Variable(name='a')
         p = Problem(cp.Maximize(self.a + var), [var == 2 + self.a, var <= 3])
-        result = p.solve(solver=cp.SCS, eps=1e-5)
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 4.0)
         self.assertAlmostEqual(self.a.value, 1)
         self.assertAlmostEqual(var.value, 3)

--- a/cvxpy/tests/test_semidefinite_vars.py
+++ b/cvxpy/tests/test_semidefinite_vars.py
@@ -48,7 +48,7 @@ class TestSemidefiniteVariable(BaseTest):
         # PSD in objective.
         obj = cp.Minimize(cp.sum(cp.square(self.X - self.F)))
         p = cp.Problem(obj, [])
-        result = p.solve(solver="SCS")
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 1, places=4)
 
         self.assertAlmostEqual(self.X.value[0, 0], 1, places=3)
@@ -60,7 +60,7 @@ class TestSemidefiniteVariable(BaseTest):
         # ECHU: note to self, apparently this is a source of redundancy
         obj = cp.Minimize(cp.sum(cp.square(self.Y - self.F)))
         p = cp.Problem(obj, [self.Y == Variable((2, 2), PSD=True)])
-        result = p.solve(solver="SCS")
+        result = p.solve(solver=cp.CLARABEL)
         self.assertAlmostEqual(result, 1, places=2)
 
         self.assertAlmostEqual(self.Y.value[0, 0], 1, places=3)
@@ -74,7 +74,7 @@ class TestSemidefiniteVariable(BaseTest):
                            # square(self.X[0,1] - 3) +
                            cp.square(self.X[1, 1] - 4))
         p = cp.Problem(obj, [])
-        result = p.solve(solver="SCS")
+        result = p.solve(solver=cp.CLARABEL)
         print(self.X.value)
         self.assertAlmostEqual(result, 0)
 


### PR DESCRIPTION
## Description
Fix the CI failures reproduced on master and #3512 while retaining support for new SCS releases. This is deliberately a small draft: nine files, no dependency caps, no skipped numerical tests, and unchanged numerical assertions.

- Translate `use_indirect` to SCS 3.3's `linear_solver` option; retain the old option for older SCS. Exercise direct and indirect solves and warm starts, and check option parsing across versions.
- Use CLARABEL in five solver-independent tests (domain, variable names, PSD variables, distance-ratio bisection, and symmetric-variable KKT conditions) whose assertions exceeded the requested SCS accuracy. Use CLARABEL for the support-function numerical evaluation, matching the upgraded default solver and avoiding a solver-specific tolerance workaround. Accept the additional solver-error message that newer SCS can return in the intentionally failing PSD bisection test.
- Don't automatically launch the secret/OIDC-dependent Claude review on fork `pull_request` events. The maintainer `/claude-review` command remains available for forks; this avoids granting privileges to PR-head code.

The original Ubuntu job and master had the identical six failures: [master log](https://github.com/cvxpy/cvxpy/actions/runs/33997699378/job/101390995882). All six reproduced locally with SCS 3.3.1 before these changes and passed afterward. The same failures appear across the build/backend jobs; optional-solver jobs fail on `use_indirect`. The separate CVXPYlayers job has three upstream gradient tests that need tighter solve tolerances; the companion draft is https://github.com/cvxpy/cvxpylayers/pull/243. The upstream default solver is expected to change soon; per review direction, further CVXPYlayers work is out of scope here. This PR cannot fix files cloned from that repository until its upstream change lands.

Validation so far:
- SCS 3.3.1, NumPy 2.4.6, SciPy 1.17.1: full non-NLP suite passed (2,633 passed, 549 optional/dependency skips, 58 subtests).
- SCS 3.2.9: 56 focused tests passed, one skipped because diffcp is absent; six option-parsing subtests passed.
- Windows CI exposed one more accuracy-dependent KKT check; its one-line CLARABEL change passes all 28 KKT tests locally. The four Windows builds are being rechecked.
- Pre-commit: Ruff and both GitHub workflow validators passed.
- GitHub has passed both COO and SCIPY backend suites, the macOS Python 3.14 build, pre-commit, workflow lint, Pyright, and derivative tests. The fork review correctly skips; all Linux/macOS builds and optional-solver jobs also passed on the first revision. A second revision addresses the remaining Windows KKT failure. Maintainer-command execution still requires a live maintainer request.

Relevant existing PRs reviewed:
- #3475 refactors support-function lifting and overlaps the support-function module; this draft changes only its numerical solve tolerance.
- #3417 changes free-threaded/PyOdide packaging. The current free-threaded test failures match the ordinary SCS failures, so this draft does not duplicate that packaging work.
- #3498 is the 1.9.3 backport PR and may need these fixes once reviewed.
- No open CVXPY or CVXPYlayers PR directly addresses this failure set.

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files. (No new files.)
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing. (Focused checks above.)
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.
