### PR TITLE
Fix six test failures under SCS 3.3.1 and tighten suppfunc value accuracy

### DIFF
--- a/cvxpy/atoms/suppfunc.py
+++ b/cvxpy/atoms/suppfunc.py
@@ -115,7 +115,10 @@ class SuppFuncAtom(Atom):
             dummy = Variable()
             cons = [dummy == 1]
         prob = Problem(Maximize(y_val @ x_flat), cons)
-        val = prob.solve(solver='SCS', eps=1e-6)
+        # Solve well below the 1e-6 accuracy callers typically check the
+        # value against; at eps=1e-6 the returned value carried an error of
+        # the same magnitude as the tolerance itself.
+        val = prob.solve(solver='SCS', eps=1e-8)
         return val
 
     def _grad(self, values):

--- a/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/scs_conif.py
@@ -211,6 +211,15 @@ class SCS(ConicSolver):
             else:
                 solver_opts['eps_abs'] = solver_opts.get('eps_abs', 1e-5)
                 solver_opts['eps_rel'] = solver_opts.get('eps_rel', 1e-5)
+            if Version(scs.__version__) >= Version('3.3.0') \
+                    and "use_indirect" in solver_opts:
+                # SCS 3.3.0 replaced the boolean `use_indirect` setting with the
+                # `linear_solver` enum. Translate so that user code written
+                # against earlier 3.x releases keeps working.
+                use_indirect = solver_opts.pop("use_indirect")
+                solver_opts.setdefault(
+                    "linear_solver", "cpu_indirect" if use_indirect else "qdldl"
+                )
         # use_quad_obj is only for canonicalization.
         if "use_quad_obj" in solver_opts:
             del solver_opts["use_quad_obj"]

--- a/cvxpy/tests/test_KKT.py
+++ b/cvxpy/tests/test_KKT.py
@@ -342,7 +342,7 @@ class TestKKT_Flags(BaseTest):
     """
     def test_kkt_nsd_var(self, places=4):
         sth = TestKKT_Flags.nsd_flag()
-        sth.solve(solver='SCS')
+        sth.solve(solver='SCS', eps=1e-8)
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
@@ -350,7 +350,7 @@ class TestKKT_Flags(BaseTest):
 
     def test_kkt_psd_var(self, places=4):
         sth = TestKKT_Flags.psd_flag()
-        sth.solve(solver='SCS')
+        sth.solve(solver='SCS', eps=1e-8)
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
@@ -358,7 +358,7 @@ class TestKKT_Flags(BaseTest):
 
     def test_kkt_symmetric_var(self, places=4):
         sth = TestKKT_Flags.symmetric_flag()
-        sth.solve(solver='SCS')
+        sth.solve(solver='SCS', eps=1e-8)
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
@@ -366,7 +366,7 @@ class TestKKT_Flags(BaseTest):
 
     def test_kkt_nonneg_var(self, places=4):
         sth = TestKKT_Flags.nonneg_flag()
-        sth.solve(solver='SCS')
+        sth.solve(solver='SCS', eps=1e-8)
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)
@@ -374,7 +374,7 @@ class TestKKT_Flags(BaseTest):
 
     def test_kkt_nonpos_var(self, places=4):
         sth = TestKKT_Flags.nonpos_flag()
-        sth.solve(solver='SCS')
+        sth.solve(solver='SCS', eps=1e-8)
         sth.check_primal_feasibility(places)
         sth.check_complementarity(places)
         sth.check_dual_domains(places)

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -181,6 +181,29 @@ class TestSCS(BaseTest):
         self.assertAlmostEqual(prob.value, 1.0, places=2)
         self.assertItemsAlmostEqual(x.value, [0, 0], places=2)
 
+    def test_scs_use_indirect_translation(self) -> None:
+        """SCS 3.3.0 replaced ``use_indirect`` with the ``linear_solver`` enum.
+        """
+        import scs
+
+        from cvxpy.reductions.solvers.conic_solvers.scs_conif import (
+            SCS as SCS_interface,
+        )
+        from cvxpy.utilities.versioning import Version
+        if Version(scs.__version__) < Version('3.3.0'):
+            self.skipTest('use_indirect is still accepted by SCS < 3.3.0')
+        opts = SCS_interface.parse_solver_options({'use_indirect': True})
+        self.assertEqual(opts['linear_solver'], 'cpu_indirect')
+        self.assertNotIn('use_indirect', opts)
+
+        opts = SCS_interface.parse_solver_options({'use_indirect': False})
+        self.assertEqual(opts['linear_solver'], 'qdldl')
+
+        # An explicit linear_solver takes precedence over the translation.
+        opts = SCS_interface.parse_solver_options(
+            {'use_indirect': True, 'linear_solver': 'qdldl'})
+        self.assertEqual(opts['linear_solver'], 'qdldl')
+
     def test_log_problem(self) -> None:
         # Log in objective.
         obj = cp.Maximize(cp.sum(cp.log(self.x)))

--- a/cvxpy/tests/test_domain.py
+++ b/cvxpy/tests/test_domain.py
@@ -47,7 +47,7 @@ class TestDomain(BaseTest):
             dom = expr.domain
             constr = [self.a >= -100, self.x >= 0]
             prob = Problem(Minimize(sum(self.x + self.a)), dom + constr)
-            prob.solve(solver=cp.SCS, eps=1e-6)
+            prob.solve(solver=cp.SCS, eps=1e-8)
             self.assertAlmostEqual(prob.value, 13)
             assert self.a.value >= 0
             assert np.all((self.x + self.a - [5, 8]).value >= -1e-3)

--- a/cvxpy/tests/test_dqcp.py
+++ b/cvxpy/tests/test_dqcp.py
@@ -483,7 +483,7 @@ class TestDqcp(base_test.BaseTest):
         a = np.ones(2)
         b = np.zeros(2)
         problem = cp.Problem(cp.Minimize(cp.dist_ratio(x, a, b)), [x <= 0.8])
-        problem.solve(cp.SCS, qcp=True)
+        problem.solve(SOLVER, qcp=True)
         np.testing.assert_almost_equal(problem.objective.value, 0.25, decimal=3)
         np.testing.assert_almost_equal(x.value, np.array([0.8, 0.8]), decimal=3)
 

--- a/cvxpy/tests/test_problem.py
+++ b/cvxpy/tests/test_problem.py
@@ -652,7 +652,7 @@ class TestProblem(BaseTest):
     def test_variable_name_conflict(self) -> None:
         var = Variable(name='a')
         p = Problem(cp.Maximize(self.a + var), [var == 2 + self.a, var <= 3])
-        result = p.solve(solver=cp.SCS, eps=1e-5)
+        result = p.solve(solver=cp.SCS, eps=1e-8)
         self.assertAlmostEqual(result, 4.0)
         self.assertAlmostEqual(self.a.value, 1)
         self.assertAlmostEqual(var.value, 3)

--- a/cvxpy/tests/test_semidefinite_vars.py
+++ b/cvxpy/tests/test_semidefinite_vars.py
@@ -48,7 +48,7 @@ class TestSemidefiniteVariable(BaseTest):
         # PSD in objective.
         obj = cp.Minimize(cp.sum(cp.square(self.X - self.F)))
         p = cp.Problem(obj, [])
-        result = p.solve(solver="SCS")
+        result = p.solve(solver="SCS", eps=1e-8)
         self.assertAlmostEqual(result, 1, places=4)
 
         self.assertAlmostEqual(self.X.value[0, 0], 1, places=3)
@@ -60,7 +60,7 @@ class TestSemidefiniteVariable(BaseTest):
         # ECHU: note to self, apparently this is a source of redundancy
         obj = cp.Minimize(cp.sum(cp.square(self.Y - self.F)))
         p = cp.Problem(obj, [self.Y == Variable((2, 2), PSD=True)])
-        result = p.solve(solver="SCS")
+        result = p.solve(solver="SCS", eps=1e-8)
         self.assertAlmostEqual(result, 1, places=2)
 
         self.assertAlmostEqual(self.Y.value[0, 0], 1, places=3)
@@ -74,7 +74,7 @@ class TestSemidefiniteVariable(BaseTest):
                            # square(self.X[0,1] - 3) +
                            cp.square(self.X[1, 1] - 4))
         p = cp.Problem(obj, [])
-        result = p.solve(solver="SCS")
+        result = p.solve(solver="SCS", eps=1e-8)
         print(self.X.value)
         self.assertAlmostEqual(result, 0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,12 @@ description = "A domain-specific language for modeling convex optimization probl
 dependencies = [
     "osqp >= 1.0.0",
     "clarabel >= 0.5.0",
-    "scs >= 3.2.4.post1",
+    # SCS 3.3.0 replaced the boolean solver-selection flags (use_indirect,
+    # gpu, mkl, cudss) with a `linear_solver` enum, and its new equilibration
+    # changes delivered accuracy enough to move results that tests and
+    # downstream derivative code depend on. See bodono/scs-python#235 and
+    # cvxpy/cvxpylayers#244. Pinned below 3.3.0 until that is sorted out.
+    "scs >= 3.2.4.post1, < 3.3.0",
     "numpy >= 2.0.0",
     "scipy >= 1.13.0",
     # HiGHS < 1.14.0 only honors the lower triangle in `kTriangular` Hessian


### PR DESCRIPTION
## Description
The declared `scs >= 3.2.4.post1` range admits SCS 3.3.1, on which six tests in
`cvxpy/tests` fail. They turned out to have three distinct root causes, only some of
them SCS-related.

**1. SCS 3.3.0 removed the `use_indirect` setting** in favour of a `linear_solver`
enum, so passing it now raises `TypeError: 'use_indirect' is an invalid keyword
argument`. This breaks user code, not just `test_scs_options` — anyone calling
`prob.solve(solver=cp.SCS, use_indirect=True)` hits it. Rather than only editing the
test, `SCS.parse_solver_options` now translates the option (`True -> cpu_indirect`,
`False -> qdldl`). An explicit `linear_solver` takes precedence, and the shim is
guarded to SCS >= 3.3.0 so older releases are untouched.

**2. Three tests asked for more accuracy than they requested from the solver.**
`test_domain.py:50`, `test_problem.py:655` and `test_semidefinite_vars.py:51,63,77`
asserted 5-decimal equality while passing `eps=1e-5`/`1e-6` — a residual stopping
criterion, not an objective-accuracy guarantee. `eps` is tightened to `1e-8` rather
than loosening the assertions, so the tests keep their strength; the errors drop to
~1e-10 or exact.

**3. `test_dist_ratio` used SCS for a DQCP bisection that returned an infeasible
point** — `x = [0.803531, 0.803531]` violates its own `x <= 0.8` constraint by
3.5e-03, and tightening `eps` did not help. The file already defines
`SOLVER = cp.CLARABEL` (line 25) and every sibling `dist_ratio` test uses it; only
this one hardcoded SCS. CLARABEL solves it to 8.9e-09 and stays feasible.

**Separately: `test_vector2norm` was not SCS-related at all** — it uses CLARABEL.
`SuppFuncAtom._value_impl` recomputed the atom's value with a hardcoded
`SCS, eps=1e-6`, capping accuracy at ~1e-6 — exactly the bound the test checks. The
conic lift and the dual formulation were verified correct (the lifted primal gives
4.8e-09, and the dual optimum is analytically `||y|| + a'y`), leaving the internal
solve tolerance as the only culprit. At `eps=1e-8` the error falls from 1.57e-06 to
1.7e-10. This improves `.value` for **all** support functions, not just this test.

No upper bound was added to the `scs` specifier: with the translation in place one
isn't needed, and pinning would deny users newer SCS.

**4. `test_KKT.py::TestKKT_Flags::test_kkt_symmetric_var` (Windows only).** Same defect
class: all five `TestKKT_Flags` tests call `sth.solve(solver='SCS')` at the default
`eps_abs`/`eps_rel` of 1e-5, then assert KKT conditions to `places=4` (5e-05). On
windows-2022 the stationarity residual comes out at 7.98e-05 and the test fails. Fixed
for all five tests in the class, not just the one that trips today.

Note `eps=1e-8` here rather than the `eps=1e-6` used elsewhere in that file: measured
locally, 1e-6 leaves the residual at ~1e-6 (i.e. no improvement over the default) while
1e-8 brings it to ~1e-8. Windows starts two orders of magnitude worse, so 1e-6 would
likely not have cleared the bar.

### Update: `scs` is now pinned below 3.3.0

`pyproject.toml` now declares `scs >= 3.2.4.post1, < 3.3.0`. SCS 3.3.0 turned out to be a
breaking upgrade in two independent ways:

- **API.** It replaced the boolean solver-selection flags (`use_indirect`, `gpu`, `mkl`,
  `cudss`) with a `linear_solver` enum. All four now raise a bare `TypeError` from the C
  extension, so `prob.solve(solver=cp.SCS, use_indirect=...)` breaks for users on
  upgrade. Reported as bodono/scs-python#235. (The removal *is* documented in the
  scs-python 3.3.0 notes - the request there is about the failure mode, not the change.)
- **Numerics.** Its new equilibration changes delivered accuracy. That is deliberate
  upstream, but it moves results this suite and downstream derivative code rely on:
  cvxpylayers' gradcheck tests fail on `scs >= 3.3.0` and pass on 3.2.11
  (cvxpy/cvxpylayers#244).

Verified: unmodified master `606f6b0e3` with `scs==3.2.11` passes all seven tests this PR
fixes, so the pin alone would have made CI green. The fixes are kept anyway, because each
stands on its own merits:

- the tolerance changes correct tests that asserted more accuracy than they asked the
  solver for - a latent bug that 3.3.0 merely exposed;
- the `suppfunc` fix removes a hardcoded `eps=1e-6` that capped `.value` accuracy for
  *all* support functions, independent of SCS version;
- the `use_indirect` translation is guarded to `scs >= 3.3.0`, so it is inert under the
  pin but protects anyone who installs a newer SCS deliberately. Its regression test
  skips accordingly, which means it is **not exercised by CI while the pin stands**.

`uv.lock` is gitignored in this repo, so no lockfile update accompanies this.

### CI status

All seven test failures this PR set out to fix are green, on every platform:

| Job | master @ `606f6b0e3` | this PR |
| --- | --- | --- |
| build (ubuntu-22.04, 3.11-3.14t) | 6 failed | **pass** |
| build (macos-14, 3.11-3.14t) | 6 failed | **pass** |
| build (windows-2022, 3.11-3.14) | 7 failed | **pass** |
| build_wheels (all 12 windows configs) | - | **pass** |
| pre-commit, pyright, actions-linting | pass | **pass** |

Overall: **57 pass, 2 fail**. Both remaining failures are pre-existing on master and are
*not* addressed here. Details below, since they cost some time to attribute.

#### `test_optional_solvers (ubuntu-22.04)` - COPT native crash, infrastructure

```
Fatal Python error: Illegal instruction        (exit code 132 = SIGILL)
  cvxpy/reductions/solvers/conic_solvers/copt_conif.py:355 in solve_via_data
  cvxpy/reductions/solvers/qp_solvers/copt_qpif.py:202  in solve_via_data
```

This is not a Python assertion but a native crash inside COPT's own binary
(`coptpy==8.0.6`, resolved from the unbounded `coptpy>=8.0.3` in `pyproject.toml`):
the library executes an instruction the runner's CPU does not implement. It is
**runner-dependent, not deterministic** - the same commit passed this job on this PR's
first CI run and crashed on the second.

Because the fault is inside a third-party binary, there is nothing to fix in this
repository. The realistic options are to report it to the COPT vendor, or to bound the
`coptpy` specifier once a known-good version is identified. Pinning blindly would be a
guess: the evidence points at runner CPU heterogeneity rather than a bad release, so a
pin might not help. Worth its own issue.

Note this job also fails on master for an *unrelated* reason in older runs (e.g. run
32678367169 on 2026-08-24 exited with 22 ordinary test failures, not SIGILL), so it has
been red on and off for a while.

#### `test_cvxpylayers` - SCS 3.3.1 again, but downstream of this repo

Three failures, all `torch.autograd.gradcheck.GradcheckError: Jacobian mismatch`:

```
FAILED cvxpylayers/tests/test_dual_variables.py::test_dual_gradcheck_inequality
FAILED cvxpylayers/tests/test_dual_variables.py::test_dual_gradcheck_vector_equality
FAILED cvxpylayers/tests/test_torch.py::test_sdp
```

This job flipped from success to failure between master runs 33929520104 (2026-09-04)
and 33997699174 (2026-09-05). The only cvxpy commit in that window is #3499, which
makes it a tempting culprit - but that is **not** the cause. Reproducing locally and
holding each variable fixed:

| cvxpy | cvxpylayers | scs | result |
| --- | --- | --- | --- |
| `606f6b0e3` + this PR | HEAD | 3.3.1 | 3 failed |
| `b065fa4ce` (before #3499) | HEAD | 3.3.1 | 3 failed |
| `b065fa4ce` (before #3499) | HEAD | **3.2.11** | **3 passed** |

cvxpylayers' own HEAD has not moved since 2026-05-19, so it is not the variable either.
The CI logs confirm the actual difference: the passing run installed `scs==3.2.11`, the
failing run `scs==3.3.1`. `extensions.yml` installs both cvxpylayers and its solver
stack unpinned, so the SCS release landed between the two runs.

So this is the same upstream SCS change this PR is about, surfacing in a different
repository. It is **not fixable in cvxpy**: the derivatives are computed by `diffcp`,
which calls SCS directly - cvxpy is not in that path, and neither
`SCS.parse_solver_options` nor anything else in this repo can influence it.

Two further observations for whoever picks this up:

- It is **not** a tolerance problem. Re-running the SDP gradcheck under SCS 3.3.1 with
  `solver_args={'eps_abs': 1e-10, 'eps_rel': 1e-10}` still fails, so tightening the
  solve does not recover it.
- The analytic gradient is essentially unchanged across the two SCS versions
  (`grad_norm` 3.107825 on 3.2.11 vs 3.107482 on 3.3.1, and the forward solution
  satisfies `trace(X) == 1` to ~1e-8 in both). What moves is the finite-difference
  reference gradcheck compares against.

The fix belongs in `diffcp`/`cvxpylayers` - or an SCS bug report - rather than here. A
short-term option for this repo alone would be pinning `scs` in `extensions.yml` to keep
the job informative, which is a CI decision I have left to the maintainers.

Issue link (if applicable): #3514 (the root-cause analysis there is corrected by this PR)

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

Notes on the checklist:
- *License*: not applicable — no new files, only edits to existing ones.
- *Coding style*: `pre-commit run --all-files` passes (ruff, actionlint,
  workflow/pyproject validators), and `pyright` reports 0 errors.
- *Unittests*: added `TestSCS::test_scs_use_indirect_translation`, covering both
  translation directions and the precedence of an explicit `linear_solver`. It skips
  on SCS < 3.3.0; on 3.3.1 it runs and passes.
- *Unittests passing*: `pytest cvxpy/tests` gives **2634 passed, 0 failed, 872
  skipped** (SCS 3.3.1, CLARABEL 0.11.1), against **6 failed, 2628 passed** before.
  The 872 skips are optional solvers not installed locally.
- *Benchmarks*: **not run** — I don't have a benchmark baseline for this machine.
  The changes are confined to solver-option parsing and test tolerances, so a
  performance impact is unlikely, but please run them if that's required to merge.




