### PR TITLE
cvxcore: Build in python namespace and remove hack to import _cxvcore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
         if: ${{matrix.build-cvxpy-base && env.PIP_INSTALL == 'True'}}
         run: |
           pip install . pytest cplex
-          pytest cvxpy/tests/test_conic_solvers.py -k 'TestCPLEX'
+          pytest --pyargs cvxpy.tests.test_conic_solvers -k 'TestCPLEX'
           # ensure a fresh state for cibuildwheel
           rm -r build
 

--- a/cvxpy/cvxcore/python/__init__.py
+++ b/cvxpy/cvxcore/python/__init__.py
@@ -4,10 +4,3 @@ try:
 	import coptpy
 except ImportError:
 	pass
-
-# TODO(akshayka): This is a hack; the swig-auto-generated cvxcore.py
-# tries to import cvxcore as `from . import _cvxcore`
-try:
-	import _cvxcore
-except ImportError:
-	pass

--- a/setup/extensions.py
+++ b/setup/extensions.py
@@ -37,7 +37,7 @@ compiler_args = [
 #
 # TODO wheels should be compiled with openmp ...
 cvxcore = Extension(
-    '_cvxcore',
+    'cvxpy.cvxcore.python._cvxcore',
     sources=['cvxpy/cvxcore/src/cvxcore.cpp',
              'cvxpy/cvxcore/src/LinOpOperations.cpp',
              'cvxpy/cvxcore/src/Utils.cpp',


### PR DESCRIPTION
## Description
Build cvxcore binary in the correct namespace and remove the cvxcore import hack. SWIG assumes the binary to be in the `cvxcore.python` namespace, but it is built as a global module. (see also: https://setuptools.pypa.io/en/latest/userguide/ext_modules.html#setuptools.Extension)
Removing that hack fixes the unconditional include of `_cvxcore` which enables the GIL when importing `cvxpy`.
Issue link (if applicable): #3110

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.