### PR TITLE
Share the constant-P quad_form binding routing, drop stored zeros

### DIFF
--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/helpers.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/helpers.py
@@ -19,6 +19,8 @@ import numpy as np
 from scipy import sparse
 from sparsediffpy import _sparsediffengine as _diffengine
 
+import cvxpy.settings as s
+
 
 def normalize_shape(shape):
     """Normalize shape to 2D (d1, d2) for the C engine."""
@@ -77,6 +79,36 @@ def make_dense_right_matmul(param_node, child, A):
     m, n = A.shape
     return _diffengine.make_right_matmul(
         param_node, child, 'dense', A.flatten(order='C'), m, n)
+
+
+def make_constant_quad_form(x_c, P_val, n):
+    """Build the engine quad_form node for a plain-constant P, routed by
+    content, not container: a sparse-stored or mostly-zero P takes the sparse
+    CSR binding (a dense-stored diagonal like H * np.eye(n) would otherwise
+    become a dense n^2 Hessian block), a genuinely dense P the dense binding.
+    Explicitly stored zeros are dropped so the engine sees the true pattern.
+
+    ``n`` is the side length of the (square) form, i.e. ``x.size``.
+    """
+    if not sparse.issparse(P_val):
+        P_dense = to_dense_float(P_val)
+        density = np.count_nonzero(P_dense) / P_dense.size if P_dense.size else 1.0
+        if density >= s.SPARSE_DENSITY_THRESHOLD:
+            return _diffengine.make_quad_form(
+                None, x_c, "dense", P_dense.flatten(order='F'), n)
+        P_val = sparse.csr_array(P_dense)
+    P_csr = P_val.tocsr()
+    if (P_csr.data == 0).any():
+        # tocsr() on an already-CSR P aliases the caller's arrays; copy
+        # before eliminate_zeros() so the user's matrix is not mutated.
+        P_csr = P_csr.copy()
+        P_csr.eliminate_zeros()
+    return _diffengine.make_quad_form(
+        None, x_c, "sparse",
+        P_csr.data.astype(np.float64),
+        P_csr.indices.astype(np.int32),
+        P_csr.indptr.astype(np.int32),
+        P_csr.shape[0], P_csr.shape[1])
 
 
 def build_var_dict(inverse_data):

--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/registry.py
@@ -23,9 +23,9 @@ import numpy as np
 from scipy import sparse
 from sparsediffpy import _sparsediffengine as _diffengine
 
-import cvxpy.settings as s
 from cvxpy.reductions.solvers.nlp_solvers.diff_engine.helpers import (
     chain_add,
+    make_constant_quad_form,
     normalize_shape,
     to_dense_float,
 )
@@ -148,11 +148,9 @@ def convert_quad_form(expr, children):
     """Convert the scalar quadratic form ``x.T @ P @ x``.
 
     ``children[0]`` is the converted ``x`` node and ``children[1]`` the converted ``P``.
-    A constant ``P`` goes to the engine's sparse (CSR) or dense ``make_quad_form``
-    binding; a dense-but-mostly-zero ``P`` is routed to the sparse binding (density
-    check) to avoid a dense Hessian block. A parametric ``P`` (depends on parameters,
-    not on ``x``) is fed to the dense path as the matrix-valued child ``children[1]``,
-    which the engine re-evaluates each solve.
+    A constant ``P`` is routed by ``make_constant_quad_form``. A parametric ``P``
+    (depends on parameters, not on ``x``) is fed to the dense path as the
+    matrix-valued child ``children[1]``, which the engine re-evaluates each solve.
     """
     P = expr.args[1]
     n = expr.args[0].size
@@ -170,29 +168,7 @@ def convert_quad_form(expr, children):
             "is not supported by the diff engine."
         )
 
-    if not sparse.issparse(P_val):
-        P_dense = np.asarray(P_val, dtype=np.float64)
-        # A dense but mostly-zero P (e.g. a diagonal written as np.eye) would build a
-        # dense Hessian block; route it to the sparse binding instead, mirroring the
-        # matmul sparse-dispatch.
-        density = np.count_nonzero(P_dense) / P_dense.size if P_dense.size else 1.0
-        if density >= s.SPARSE_DENSITY_THRESHOLD:
-            return _diffengine.make_quad_form(
-                None, children[0], "dense", P_dense.flatten(order='F'), P_dense.shape[0]
-            )
-        P_val = sparse.csr_array(P_dense)
-
-    P_csr = P_val.tocsr()
-    return _diffengine.make_quad_form(
-        None,
-        children[0],
-        "sparse",
-        P_csr.data.astype(np.float64),
-        P_csr.indices.astype(np.int32),
-        P_csr.indptr.astype(np.int32),
-        P_csr.shape[0],
-        P_csr.shape[1],
-    )
+    return make_constant_quad_form(children[0], P_val, n)
 
 
 def convert_reshape(expr, children):

--- a/cvxpy/tests/nlp_tests/stress_tests_diff_engine/test_quad_form.py
+++ b/cvxpy/tests/nlp_tests/stress_tests_diff_engine/test_quad_form.py
@@ -220,6 +220,30 @@ class TestQuadFormDenseSparseDispatch:
             registry._diffengine.make_quad_form = orig
         assert "sparse" in fmts and "dense" not in fmts
 
+    def test_stored_zeros_dropped_from_sparse_P(self):
+        """Explicitly stored zeros (scipy's block_diag of dense blocks stores
+        them) are dropped, so the engine sees the true pattern rather than an
+        inflated one -- and the caller's matrix is not mutated in the process.
+        """
+        from cvxpy.reductions.solvers.nlp_solvers.diff_engine import registry
+        blocks = [np.diag([1.0, 2.0]) for _ in range(5)]  # 2 stored zeros each
+        P = sp.csr_array(sp.block_diag(blocks, format="csr"))
+        assert P.nnz == 20 and np.count_nonzero(P.toarray()) == 10
+        n = P.shape[0]
+        prob = cp.Problem(cp.Minimize(cp.quad_form(self._var(n, seed=23), P)))
+
+        nnz = []
+        orig = registry._diffengine.make_quad_form
+        registry._diffengine.make_quad_form = (
+            lambda *a, **k: nnz.append((a[2], a[3].size if a[2] == "sparse" else None))
+            or orig(*a, **k))
+        try:
+            DerivativeChecker(prob).run_and_assert()
+        finally:
+            registry._diffengine.make_quad_form = orig
+        assert nnz == [("sparse", 10)], nnz
+        assert P.nnz == 20  # the caller's matrix is left alone
+
     def test_dense_diagonal_P_derivative_check(self):
         n = 6
         P = np.diag(np.arange(1, n + 1, dtype=float))


### PR DESCRIPTION
convert_quad_form's constant-P branch moves to a helper, make_constant_quad_form, so the routing policy lives in one place: the sparse CSR binding for a P that is sparse-stored or mostly zeros (a dense-stored diagonal like H * np.eye(n) would otherwise become a dense n^2 Hessian block), the dense binding for a genuinely dense P.

Two behaviour changes fall out of the move:

- Explicitly stored zeros are dropped before the CSR arrays reach the engine, so it sees the true pattern instead of an inflated one. scipy's block_diag over dense blocks stores them, so this is easy to hit; the new test goes from 20 to 10 engine nonzeros. The matrix is copied first, since tocsr() on an already-CSR P aliases the caller's arrays and eliminate_zeros() would otherwise mutate the user's matrix.
- The dense branch reads its values through to_dense_float, matching every other converter.

## Description
Please include a short summary of the change.
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.