### PR TITLE
Reassociate matmul chains that end in a constant factor

### DIFF
--- a/cvxpy/reductions/solvers/nlp_solvers/diff_engine/converters.py
+++ b/cvxpy/reductions/solvers/nlp_solvers/diff_engine/converters.py
@@ -15,12 +15,16 @@ limitations under the License.
 
 Main entry point for converting CVXPY expressions to C diff engine expressions.
 """
+import operator
+from functools import reduce
+
 import numpy as np
 from scipy import sparse
 from sparsediffpy import _sparsediffengine as _diffengine
 
 import cvxpy as cp
 import cvxpy.settings as s
+from cvxpy.expressions.constants import Constant
 from cvxpy.reductions.solvers.nlp_solvers.diff_engine.helpers import (
     make_dense_left_matmul,
     make_dense_right_matmul,
@@ -30,6 +34,66 @@ from cvxpy.reductions.solvers.nlp_solvers.diff_engine.helpers import (
     to_dense_float,
 )
 from cvxpy.reductions.solvers.nlp_solvers.diff_engine.registry import ATOM_CONVERTERS
+
+
+def _is_plain_constant(expr):
+    """Variable-free and parameter-free: a value that never changes between solves."""
+    return expr.is_constant() and not expr.parameters()
+
+
+def _is_vector(expr):
+    """1-D, or 2-D with a singleton dimension."""
+    return len(expr.shape) <= 1 or min(expr.shape) == 1
+
+
+def _apply_constant_right(left, c):
+    """Build an expression equivalent to ``left @ c`` for a plain-constant
+    ``c``, pushing ``c`` toward the leaves so constants multiply constants
+    (each engine node's Jacobian has one row per output, so a chain ending in
+    a constant must not drag wide intermediates -- issue #2205):
+
+      constant @ c   -> Constant(value)
+      (A @ B) @ c    -> A @ (B @ c)
+      (-E) @ c       -> -(E @ c)
+      (E1 + E2) @ c  -> E1 @ c + E2 @ c   (vector c only)
+
+    Only parameter-free constants fold, so parametric factors are never frozen.
+    """
+    if _is_plain_constant(left):
+        return Constant(left.value @ c.value)
+    name = type(left).__name__
+    if name == "MulExpression":
+        a, b = left.args
+        if _is_plain_constant(b):
+            return _apply_constant_right(a, Constant(b.value @ c.value))
+        if _is_vector(c):
+            return a @ _apply_constant_right(b, c)
+        if _is_plain_constant(a):
+            # (C1 @ E) @ C2 -> C1 @ (E @ C2): frees the tail to keep folding
+            # when (E @ C2) is normalized on its own visit.
+            return a @ (b @ c)
+        return left @ c
+    if name == "NegExpression":
+        return -_apply_constant_right(left.args[0], c)
+    if (name == "AddExpression" and _is_vector(c)
+            and all(arg.shape == left.shape for arg in left.args)):
+        return reduce(operator.add, [_apply_constant_right(arg, c) for arg in left.args])
+    return left @ c
+
+
+def _normalize_matmul(expr):
+    """Reassociate ``expr`` when a matmul chain ends in a plain-constant
+    factor. General matrix-chain reordering is deliberately not attempted."""
+    left, right = expr.args
+    # Reassociation is only valid while every intermediate stays 2-D: a 1-D
+    # operand contracts to an inner product under numpy's matmul rules, and
+    # (a @ b) @ c != a @ (b @ c) across that collapse (the rewritten factor
+    # can be shape-invalid). A 2-D left guarantees both its factors are 2-D.
+    if len(left.shape) != 2:
+        return expr
+    if _is_plain_constant(right) and not left.is_constant():
+        return _apply_constant_right(left, right)
+    return expr
 
 
 def convert_matmul(expr, children, var_dict, n_vars, param_dict):
@@ -116,6 +180,14 @@ def convert_expr(expr, var_dict, n_vars, param_dict=None):
 
     # Recursive case: atoms
     atom_name = type(expr).__name__
+
+    # Reassociate a matmul chain that ends in a plain-constant factor, so the
+    # constants fold together instead of the chain dragging wide intermediates.
+    if atom_name == "MulExpression":
+        expr = _normalize_matmul(expr)
+        if type(expr).__name__ != "MulExpression":
+            return convert_expr(expr, var_dict, n_vars, param_dict)
+
     children = [convert_expr(arg, var_dict, n_vars, param_dict) for arg in expr.args]
 
     # matmul and multiply need param_dict for parameter support

--- a/cvxpy/tests/nlp_tests/stress_tests_diff_engine/test_matmul_reassoc.py
+++ b/cvxpy/tests/nlp_tests/stress_tests_diff_engine/test_matmul_reassoc.py
@@ -1,0 +1,92 @@
+"""
+Copyright, the CVXPY authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import numpy as np
+import pytest
+
+import cvxpy as cp
+from cvxpy.reductions.solvers.defines import INSTALLED_SOLVERS
+from cvxpy.reductions.solvers.nlp_solvers.diff_engine.converters import _normalize_matmul
+from cvxpy.tests.nlp_tests.derivative_checker import DerivativeChecker
+
+
+def _cases(rng):
+    """(expression, X) pairs covering each rewrite rule in _apply_constant_right."""
+    A = rng.standard_normal((3, 4))
+    C_sq = rng.standard_normal((4, 4))
+    C2 = rng.standard_normal((3, 2))
+    c_vec = rng.standard_normal(3)
+    c_vec4 = rng.standard_normal(4)
+    X = cp.Variable((4, 3))
+    return X, [
+        A @ X @ C2,               # (A @ X) @ C2: matmul recursion
+        (X + C_sq @ X) @ c_vec,   # AddExpression with a vector tail
+        (-X) @ c_vec,             # NegExpression push-through
+        X.T @ C_sq @ c_vec4,      # (E @ C) @ c: constants fold together
+    ]
+
+
+class TestNormalizeMatmul:
+    """_normalize_matmul rewrites a matmul chain ending in a plain constant.
+    The rewrite must fire (so the tests observe it, not just the answer) and
+    must be value-preserving.
+    """
+
+    def test_const_tail_rewritten_and_value_preserving(self):
+        rng = np.random.default_rng(0)
+        X, cases = _cases(rng)
+        X.value = rng.standard_normal((4, 3))
+        for expr in cases:
+            rewritten = _normalize_matmul(expr)
+            assert rewritten is not expr, f"rewrite did not fire for {expr}"
+            assert rewritten.shape == expr.shape
+            np.testing.assert_allclose(
+                np.asarray(rewritten.value), np.asarray(expr.value), atol=1e-10)
+
+    def test_1d_collapse_left_as_written(self):
+        """A chain contracting through a 1-D operand must not be touched:
+        (a @ b) @ c != a @ (b @ c) across numpy's 1-D collapse."""
+        rng = np.random.default_rng(0)
+        X = cp.Variable((2, 3))
+        expr = (X @ np.array([1.0, 2.0, 3.0])) @ np.array([1.0, 1.0])
+        assert _normalize_matmul(expr) is expr
+
+        y = cp.Variable(4)
+        expr2 = (rng.standard_normal((3, 4)) @ y) @ rng.standard_normal(3)
+        assert _normalize_matmul(expr2) is expr2
+
+    def test_parametric_tail_not_folded(self):
+        """A parametric tail must stay symbolic -- folding would freeze the
+        current value into a Constant."""
+        p = cp.Parameter((3, 2))
+        p.value = np.ones((3, 2))
+        expr = (np.ones((3, 4)) @ cp.Variable((4, 3))) @ p
+        assert _normalize_matmul(expr) is expr
+
+
+@pytest.mark.skipif('IPOPT' not in INSTALLED_SOLVERS, reason='IPOPT is not installed.')
+class TestReassociatedChainDerivatives:
+    """The engine must differentiate the rewritten tree correctly."""
+
+    def test_derivatives_match_on_reassociated_chains(self):
+        rng = np.random.default_rng(0)
+        X, cases = _cases(rng)
+        for expr in cases:
+            target = rng.standard_normal(expr.shape)
+            X.value = np.zeros((4, 3))
+            prob = cp.Problem(cp.Minimize(
+                cp.sum_squares(expr - target) + cp.sum_squares(X)))
+            DerivativeChecker(prob).run_and_assert()


### PR DESCRIPTION
Each engine node's Jacobian carries one row per output, so a chain like (A @ X) @ C builds its Jacobian over the wide A @ X intermediate before contracting -- the blow-up behind issue #2205. Pushing the trailing constant toward the leaves lets the constants fold together and keeps the intermediates narrow:

  constant @ c   -> Constant(value)
  (A @ B) @ c    -> A @ (B @ c)
  (-E) @ c       -> -(E @ c)
  (E1 + E2) @ c  -> E1 @ c + E2 @ c   (vector c only)

Only parameter-free constants fold, so a parametric tail is never frozen into a Constant. Reassociation also bails out unless the left factor is 2-D: a 1-D operand contracts to an inner product under numpy's matmul rules, and (a @ b) @ c != a @ (b @ c) across that collapse -- the rewritten factor can even be shape-invalid. General matrix-chain reordering is deliberately not attempted.

_normalize_matmul is a pure expression rewrite, so the tests check the decision directly: the rewrite fires and preserves .value on each rule, is a no-op on both 1-D-collapse shapes and on a parametric tail, and DerivativeChecker confirms the engine differentiates the rewritten tree. Verified that disabling the rewrite and dropping the 1-D guard each fail the corresponding test.

## Description
Please include a short summary of the change.
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.