### PR TITLE
Fix stale docstring examples; make power curvature follow the rational approximation

### DIFF
--- a/cvxpy/atoms/elementwise/power.py
+++ b/cvxpy/atoms/elementwise/power.py
@@ -123,18 +123,21 @@ class Power(Elementwise):
         >>> from cvxpy import Variable, power
         >>> x = Variable()
         >>> g = power(x, 1.001)
-        >>> g.p
+        >>> g.p_used
         Fraction(1001, 1000)
         >>> g
-        Expression(CONVEX, POSITIVE, (1, 1))
+        Expression(CONVEX, NONNEGATIVE, ())
+
         results in a convex atom with implicit constraint :math:`x \geq 0`, while
+
         >>> g = power(x, 1.0001)
-        >>> g.p
+        >>> g.p_used
         1
         >>> g
-        Expression(AFFINE, UNKNOWN, (1, 1))
+        Expression(AFFINE, UNKNOWN, ())
 
-        results in an affine atom with no constraint on ``x``.
+        results in an affine atom with no constraint on ``x``, because the
+        rational approximation to ``1.0001`` is exactly ``1``.
 
     - When :math:`p > 1` and ``p`` is not a power of two, the monotonically increasing version
       of the function with full domain,
@@ -195,7 +198,13 @@ class Power(Elementwise):
     def sign_from_args(self) -> tuple[bool, bool]:
         """Returns sign (is positive, is negative) of the expression.
         """
-        if self.p.value == 1:
+        # The sign follows the rational approximation p_used rather than the
+        # input exponent, matching is_incr/is_decr and is_atom_convex.
+        # p_used is None exactly when the exponent is non-constant (set in
+        # __init__), in which case p.value may be None and neither branch
+        # below applies, leaving the atom unconditionally positive.
+        p = self.p.value if self.p_used is None else self.p_used
+        if p == 1:
             # Same as input.
             return (self.args[0].is_nonneg(), self.args[0].is_nonpos())
         else:
@@ -215,7 +224,14 @@ class Power(Elementwise):
         # depends on the value of the power, not just the sign).
         #
         # p == 0 is affine here.
-        return _is_const(self.p) and (self.p.value <= 0 or self.p.value >= 1)
+        #
+        # Curvature is determined by the rational approximation p_used, not
+        # by the input exponent, so power(x, 1.0001) -- which approximates to
+        # p_used == 1 -- is affine just like power(x, 1). p_used is None
+        # exactly when the exponent is non-constant (set in __init__).
+        if self.p_used is None:
+            return False
+        return self.p_used <= 0 or self.p_used >= 1
 
     def is_atom_concave(self) -> bool:
         """Is the atom concave?
@@ -223,7 +239,12 @@ class Power(Elementwise):
         # Parametrized powers are not allowed for DCP.
         #
         # p == 0 is affine here.
-        return _is_const(self.p) and 0 <= self.p.value <= 1
+        #
+        # As in is_atom_convex, curvature follows the rational approximation
+        # p_used rather than the input exponent.
+        if self.p_used is None:
+            return False
+        return 0 <= self.p_used <= 1
 
     def is_atom_smooth(self) -> bool:
         """Is the atom smooth?"""

--- a/cvxpy/atoms/geo_mean.py
+++ b/cvxpy/atoms/geo_mean.py
@@ -161,7 +161,7 @@ class GeoMean(AxisAtom):
     >>> x = Variable(4, name='x')
     >>> g = geo_mean(x, [.1, Fraction(1,3), 0, 2])
     >>> print(g)
-    GeoMeanApprox(x, (3/73, 10/73, 0, 60/73))
+    GeoMeanApprox(x, (3/73, 10/73, 60/73))
     >>> g.approx_error <= 1e-10
     True
 

--- a/cvxpy/constraints/constraint.py
+++ b/cvxpy/constraints/constraint.py
@@ -108,7 +108,8 @@ class Constraint(u.Canonical):
 
         Examples
         --------
-        >>> x = cp.Variable(3)
+        >>> import cvxpy as cp
+        >>> x = cp.Variable(3, name="x")
         >>> # Using the method for chaining:
         >>> con = (x >= 0).set_label("non_negative")
         >>> # Using the property setter:

--- a/cvxpy/reductions/dgp2dcp/dgp2dcp.py
+++ b/cvxpy/reductions/dgp2dcp/dgp2dcp.py
@@ -32,26 +32,28 @@ class Dgp2Dcp(Canonicalization):
 
     >>> import cvxpy as cp
     >>>
-    >>> x1 = cp.Variable(pos=True)
-    >>> x2 = cp.Variable(pos=True)
-    >>> x3 = cp.Variable(pos=True)
+    >>> x_1 = cp.Variable(pos=True, name='x_1')
+    >>> x_2 = cp.Variable(pos=True, name='x_2')
+    >>> x_3 = cp.Variable(pos=True, name='x_3')
     >>>
     >>> monomial = 3.0 * x_1**0.4 * x_2 ** 0.2 * x_3 ** -1.4
     >>> posynomial = monomial + 2.0 * x_1 * x_2
     >>> dgp_problem = cp.Problem(cp.Minimize(posynomial), [monomial == 4.0])
     >>>
-    >>> dcp2cone = cvxpy.reductions.Dcp2Cone()
+    >>> dcp2cone = cp.reductions.Dcp2Cone()
     >>> assert not dcp2cone.accepts(dgp_problem)
     >>>
-    >>> gp2dcp = cvxpy.reductions.Dgp2Dcp(dgp_problem)
+    >>> gp2dcp = cp.reductions.Dgp2Dcp(dgp_problem)
     >>> dcp_problem = gp2dcp.reduce()
     >>>
     >>> assert dcp2cone.accepts(dcp_problem)
-    >>> dcp_problem.solve()
+    >>> _ = dcp_problem.solve()
     >>>
     >>> dgp_problem.unpack(gp2dcp.retrieve(dcp_problem.solution))
-    >>> print(dgp_problem.value)
-    >>> print(dgp_problem.variables())
+    >>> float(round(dgp_problem.value, 6))
+    4.0
+    >>> dgp_problem.variables()
+    [Variable((), x_1, pos=True), Variable((), x_2, pos=True), Variable((), x_3, pos=True)]
     """
     def __init__(self, problem=None) -> None:
         # Canonicalization of DGP is stateful; canon_methods created

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -189,6 +189,34 @@ class TestAtoms(BaseTest):
 
         assert cp.power(-1, 2).value == 1
 
+    def test_power_curvature_follows_rational_approximation(self) -> None:
+        """Curvature and sign follow p_used, not the input exponent.
+
+        ``power`` approximates ``p`` by a rational with denominator at most
+        ``max_denom``. An exponent that approximates to exactly 1 must behave
+        like ``power(x, 1)``, matching is_incr/is_decr, which already use
+        ``p_used``.
+        """
+        x = Variable()
+
+        # 1.0001 approximates to p_used == 1, so it is affine like power(x, 1).
+        near_one = cp.power(x, 1.0001)
+        self.assertEqual(near_one.p_used, 1)
+        self.assertEqual(near_one.curvature, s.AFFINE)
+        self.assertEqual(near_one.curvature, cp.power(x, 1).curvature)
+        self.assertEqual(near_one.sign, cp.power(x, 1).sign)
+
+        # 1.001 does not, so it stays convex and nonnegative.
+        approx = cp.power(x, 1.001)
+        self.assertEqual(approx.p_used, Fraction(1001, 1000))
+        self.assertEqual(approx.curvature, s.CONVEX)
+        self.assertEqual(approx.sign, s.NONNEG)
+
+        # A parametrized exponent has no approximation and stays unknown.
+        param = cp.power(x, Parameter())
+        self.assertIsNone(param.p_used)
+        self.assertEqual(param.curvature, s.UNKNOWN)
+
     # Test the xexp class
     def test_xexp(self) -> None:
         # Test for positive x

--- a/cvxpy/utilities/einsum_utilities.py
+++ b/cvxpy/utilities/einsum_utilities.py
@@ -139,19 +139,31 @@ def find_contraction(positions, input_sets, output_set):
     Examples
     --------
 
-    # A simple dot product test case
+    Sets are sorted below so the output does not depend on set iteration order.
+
+    A simple dot product test case:
+
     >>> pos = (0, 1)
     >>> isets = [set('ab'), set('bc')]
     >>> oset = set('ac')
-    >>> _find_contraction(pos, isets, oset)
-    ({'a', 'c'}, [{'a', 'c'}], {'b'}, {'a', 'b', 'c'})
+    >>> new_result, remaining, idx_removed, idx_contract = find_contraction(
+    ...     pos, isets, oset)
+    >>> sorted(new_result), [sorted(s) for s in remaining]
+    (['a', 'c'], [['a', 'c']])
+    >>> sorted(idx_removed), sorted(idx_contract)
+    (['b'], ['a', 'b', 'c'])
 
-    # A more complex case with additional terms in the contraction
+    A more complex case with additional terms in the contraction:
+
     >>> pos = (0, 2)
     >>> isets = [set('abd'), set('ac'), set('bdc')]
     >>> oset = set('ac')
-    >>> _find_contraction(pos, isets, oset)
-    ({'a', 'c'}, [{'a', 'c'}, {'a', 'c'}], {'b', 'd'}, {'a', 'b', 'c', 'd'})
+    >>> new_result, remaining, idx_removed, idx_contract = find_contraction(
+    ...     pos, isets, oset)
+    >>> sorted(new_result), [sorted(s) for s in remaining]
+    (['a', 'c'], [['a', 'c'], ['a', 'c']])
+    >>> sorted(idx_removed), sorted(idx_contract)
+    (['b', 'd'], ['a', 'b', 'c', 'd'])
     """
 
     idx_contract = set()
@@ -198,7 +210,7 @@ def optimal_path(input_sets, output_set, idx_dict, memory_limit):
     >>> isets = [set('abd'), set('ac'), set('bdc')]
     >>> oset = set()
     >>> idx_sizes = {'a': 1, 'b':2, 'c':3, 'd':4}
-    >>> _optimal_path(isets, oset, idx_sizes, 5000)
+    >>> optimal_path(isets, oset, idx_sizes, 5000)
     [(0, 2), (0, 1)]
     """
 
@@ -382,7 +394,7 @@ def greedy_path(input_sets, output_set, idx_dict, memory_limit):
     >>> isets = [set('abd'), set('ac'), set('bdc')]
     >>> oset = set()
     >>> idx_sizes = {'a': 1, 'b':2, 'c':3, 'd':4}
-    >>> _greedy_path(isets, oset, idx_sizes, 5000)
+    >>> greedy_path(isets, oset, idx_sizes, 5000)
     [(0, 2), (0, 1)]
     """
 
@@ -481,16 +493,26 @@ def parse_einsum_input(operands):
 
     Examples
     --------
-    The operand list is simplified to reduce printing:
+    Broadcast dimensions are assigned generated index symbols, and the exact
+    symbols chosen vary between runs (e.g. ``('za,xza', 'xz', [a, b])``), so
+    only the structure of the parse is checked below.
 
     >>> np.random.seed(123)
     >>> a = np.random.rand(4, 4)
     >>> b = np.random.rand(4, 4, 4)
-    >>> _parse_einsum_input(('...a,...a->...', a, b))
-    ('za,xza', 'xz', [a, b]) # may vary
+    >>> input_str, output_str, operands = parse_einsum_input(
+    ...     ('...a,...a->...', a, b))
+    >>> [len(term) for term in input_str.split(',')], len(output_str)
+    ([2, 3], 2)
+    >>> [op.shape for op in operands]
+    [(4, 4), (4, 4, 4)]
 
-    >>> _parse_einsum_input((a, [Ellipsis, 0], b, [Ellipsis, 0]))
-    ('za,xza', 'xz', [a, b]) # may vary
+    The interleaved ``(operand, subscript-list)`` form parses the same way:
+
+    >>> alt_in, alt_out, _ = parse_einsum_input(
+    ...     (a, [Ellipsis, 0], b, [Ellipsis, 0]))
+    >>> [len(term) for term in alt_in.split(',')], len(alt_out)
+    ([2, 3], 2)
     """
 
     if len(operands) == 0:


### PR DESCRIPTION
## Description
Five docstrings shipped `>>>` examples that no longer ran. Fixing the last of them
surfaced a real behaviour bug in `Power`, which is also fixed here.

**Docstring fixes**

- **`cvxpy/utilities/einsum_utilities.py`** — the vendored NumPy helpers were renamed to
  drop their leading underscore, but the examples still called `_find_contraction`,
  `_optimal_path`, `_greedy_path` and `_parse_einsum_input`, so every one raised
  `NameError`. They were also nondeterministic by construction: set repr ordering and the
  generated einsum index symbols both vary between processes, and the `# may vary` marker
  is a NumPy refguide-check convention that plain `doctest` does not honour. They now
  assert sorted and structural output instead.
- **`cvxpy/constraints/constraint.py`** — `Constraint.set_label` had no
  `import cvxpy as cp`, so all four examples raised `NameError`. The variable is now named
  so its repr does not depend on the global variable counter.
- **`cvxpy/atoms/geo_mean.py`** — zero-weight terms are dropped from `w`, so the expected
  output no longer lists the `0`.
- **`cvxpy/reductions/dgp2dcp/dgp2dcp.py`** — variables were defined as `x1`..`x3` but used
  as `x_1`..`x_3`; `cvxpy.reductions` was referenced with only `cp` imported; and three
  calls had no expected output.

**Behaviour fix in `Power`**

The `Power` docstring states that domain, sign, monotonicity and curvature are determined
by the rational approximation `p_used`, **not** the input exponent. `is_incr`/`is_decr`
already did this, but `is_atom_convex`, `is_atom_concave` and `sign_from_args` still read
`self.p.value`. So two exponents that reduce to the same `p_used` were classified
differently:

```
                  before                after
power(x, 1)       AFFINE, UNKNOWN       AFFINE, UNKNOWN
power(x, 1.0001)  CONVEX, NONNEGATIVE   AFFINE, UNKNOWN
power(x, 1.001)   CONVEX, NONNEGATIVE   CONVEX, NONNEGATIVE
```

`power(x, 1.0001)` has `p_used == 1` — mathematically identical to `power(x, 1)` after
approximation — yet was treated as convex with an implicit `x >= 0`. Those three methods
now consult `p_used`, following the pattern already established by `is_incr`/`is_decr`.
Parametrized exponents are unaffected: `p_used is None` keeps the previous fallback.

Note this is a semantic change to DCP curvature analysis and deserves a careful look,
even though the suite is green.

Issue link (if applicable): n/a

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [x] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

Checklist notes, for transparency:

- *Add our license to new files* — no new files are added, so this does not apply.
- *Write unittests* — `test_power_curvature_follows_rational_approximation` in
  `cvxpy/tests/test_atoms.py` covers the curvature change. It was verified to fail against
  the previous behaviour (`AssertionError: 'CONVEX' != 'AFFINE'`) and pass after. The
  docstring fixes are covered by the restored doctests themselves.
- *Run the unittests* — 2670 passed, 879 skipped, 0 failed locally. **The 879 skips are
  solver-gated**: only CLARABEL, SCS, SCIPY, HIGHS and OSQP were installed, so the
  commercial-solver paths through `power` were not exercised here and rely on CI.
- *Run the benchmarks* — **not run.** Left unchecked deliberately.

Also verified: `pyright` reports 0 errors, and all pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
