### PR TITLE
Record and enforce docstring coverage with interrogate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,18 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
 
+  - repo: https://github.com/econchick/interrogate
+    rev: 1.7.0
+    hooks:
+      - id: interrogate
+        # Docstring coverage is a whole-package number, so run over `cvxpy`
+        # as a unit rather than over the staged files -- the hook passes
+        # filenames by default, which would measure only what changed and
+        # make the fail-under threshold meaningless. Exclusions and the
+        # threshold come from [tool.interrogate] in pyproject.toml.
+        pass_filenames: false
+        args: [cvxpy]
+
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.31.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,17 @@ reportGeneralTypeIssues = false     # 27 errors
 reportIndexIssue = false            # 17 errors
 reportOperatorIssue = false         # 48 errors
 
+[tool.interrogate]
+# Docstring coverage. The SWIG-generated C++ core and the test suite are
+# excluded, matching the exclusions declared for pyright above.
+exclude = ["cvxpy/cvxcore", "cvxpy/tests"]
+# Set to the coverage measured when this gate was introduced (2803 of 3923
+# nodes documented). It is a ratchet: raise it as coverage improves, never
+# lower it to make a change pass. There is no headroom at this value, so a
+# new undocumented public function will fail the gate -- document it, or
+# raise coverage elsewhere first.
+fail-under = 71.5
+
 [tool.pytest.ini_options]
 testpaths = [
     "cvxpy/tests/"


### PR DESCRIPTION
## Description
Adds a committed `[tool.interrogate]` config and wires `interrogate` into the existing
pre-commit hook set, so docstring coverage becomes a recorded, enforced standard.

**Why a committed config.** Without one, `interrogate` applies its own built-in 80%
default and reports `FAILED` against a standard the project never adopted. It also has no
idea what to exclude, so the measured number swings widely depending on who runs it and
how:

| Scope / settings | Coverage |
|---|---:|
| `cvxpy/` with everything included | 56.6% |
| Excluding `cvxcore/` + `tests/` | **71.5%** |
| …also ignoring magic / `__init__` / private / nested | 77.8% |

None of those is more correct than the others — the point is that the project hasn't
recorded which one it means. This PR records it: exclude the SWIG-generated C++ core and
the test suite, matching the exclusions already declared for pyright, which gives
**2803 of 3923 nodes documented, 71.5%**. That is where `fail-under` is set, so the
number can only ratchet upward.

**Why also wire it in.** A config nothing runs is a file, not a gate. `pre-commit.yml`
already runs all hooks on every PR, so adding the hook is enough — no workflow change.

Two details in the hook that are not obvious:

- `pass_filenames: false` with an explicit `args: [cvxpy]`. The upstream hook passes
  staged filenames by default, which would compute coverage over only the changed files
  and make a whole-package `fail-under` meaningless.
- The explicit path also keeps `interrogate` out of `doc/`, which contains a file that is
  not valid Python 3 (`SyntaxError: 'u' and 'r' prefixes are incompatible`).

**There is no headroom at 71.5.** That is deliberate — it makes this a strict ratchet — but
it does mean a new undocumented public function fails the gate immediately rather than
after some slack is consumed. Happy to set it to 71.0 instead if reviewers would rather
have a little give.

For context on where the gap actually is (same exclusions):

| Area | Nodes | Missing | Covered |
|---|---:|---:|---:|
| `constraints` | 249 | 121 | 51.4% |
| `interface` | 64 | 25 | 60.9% |
| `reductions` | 1231 | 436 | 64.6% |
| `problems` | 116 | 38 | 67.2% |
| `atoms` | 1430 | 329 | 77.0% |
| `expressions` | 264 | 59 | 77.7% |
| `utilities` | 194 | 39 | 79.9% |
| `transforms` | 65 | 13 | 80.0% |
| `lin_ops` | 291 | 53 | 81.8% |

One caveat on `atoms`: many misses there are single-line DCP overrides
(`is_atom_convex`, `shape_from_args`) whose contract is documented once on the base class.
interrogate cannot see that inheritance, so it undercounts — `constraints` and
`reductions` are the more real gaps.

Issue link (if applicable): n/a

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [x] Run the unittests and check that they're passing.
- [ ] Run the benchmarks to make sure your change doesn't introduce a regression.

Checklist notes, for transparency:

- *Add our license to new files* — no new files; this changes `pyproject.toml` and
  `.pre-commit-config.yaml` only. Does not apply.
- *Write unittests* — **not applicable and left unchecked.** This PR adds no Python code.
  The gate was instead verified in both directions by hand: it passes on master, and
  appending one undocumented function produces
  `RESULT: FAILED (minimum: 71.5%, actual: 71.4%)` through `pre-commit run --all-files`.
- *Run the unittests* — full suite run, 2669 passed / 879 skipped / 0 failed. The 879
  skips are solver-gated (only CLARABEL, SCS, SCIPY, HIGHS and OSQP installed locally).
  No source code changes here, so no behaviour is affected either way.
- *Run the benchmarks* — **not run.** Left unchecked. This PR touches no runtime code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
